### PR TITLE
feat: constant-function inlining for cross-function verification

### DIFF
--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -1,6 +1,51 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use vow_ir::{Function, Inst, InstData, Opcode, Ty};
+use vow_ir::{FuncId, Function, Inst, InstData, Module, Opcode, Ty};
+
+// ---------------------------------------------------------------------------
+// Constant-function detection (for cross-function verification inlining)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub enum ConstantValue {
+    I32(i32),
+    I64(i64),
+    Bool(bool),
+}
+
+pub fn detect_constant_functions(module: &Module) -> HashMap<FuncId, ConstantValue> {
+    let mut result = HashMap::new();
+    for func in &module.functions {
+        if func.blocks.len() != 1 {
+            continue;
+        }
+        let block = &func.blocks[0];
+        let non_arg: Vec<_> = block
+            .insts
+            .iter()
+            .filter(|i| i.opcode != Opcode::GetArg)
+            .collect();
+        if non_arg.len() != 2 {
+            continue;
+        }
+        let const_inst = non_arg[0];
+        let ret_inst = non_arg[1];
+        if ret_inst.opcode != Opcode::Return {
+            continue;
+        }
+        if ret_inst.args.first().copied() != Some(const_inst.id) {
+            continue;
+        }
+        let val = match (&const_inst.opcode, &const_inst.data) {
+            (Opcode::ConstI32, InstData::ConstI32(v)) => ConstantValue::I32(*v),
+            (Opcode::ConstI64, InstData::ConstI64(v)) => ConstantValue::I64(*v),
+            (Opcode::ConstBool, InstData::ConstBool(v)) => ConstantValue::Bool(*v),
+            _ => continue,
+        };
+        result.insert(func.id, val);
+    }
+    result
+}
 
 // ---------------------------------------------------------------------------
 // Vec model capacity for bounded model checking
@@ -200,6 +245,7 @@ fn emit_inst(
     vec_vars: &HashSet<u32>,
     string_vars: &HashSet<u32>,
     hashmap_vars: &HashSet<u32>,
+    const_fns: &HashMap<FuncId, ConstantValue>,
 ) {
     let id = inst.id.0;
     match inst.opcode {
@@ -647,6 +693,24 @@ fn emit_inst(
             }
         }
 
+        // Constant-function inlining: replace CallTarget with the known constant
+        Opcode::Call if matches!(&inst.data, InstData::CallTarget(fid) if const_fns.contains_key(fid)) => {
+            if let InstData::CallTarget(fid) = &inst.data {
+                let val = &const_fns[fid];
+                match val {
+                    ConstantValue::I32(v) => {
+                        out.push_str(&format!("  int32_t v{} = {};\n", id, v));
+                    }
+                    ConstantValue::I64(v) => {
+                        out.push_str(&format!("  int64_t v{} = {}LL;\n", id, v));
+                    }
+                    ConstantValue::Bool(v) => {
+                        out.push_str(&format!("  _Bool v{} = {};\n", id, *v as i32));
+                    }
+                }
+            }
+        }
+
         // Other calls, memory, region/linear/field ops — not yet supported for verification
         Opcode::Call
         | Opcode::Load
@@ -722,7 +786,7 @@ fn c_nondet_suffix(ty: Ty) -> &'static str {
 // Function emission
 // ---------------------------------------------------------------------------
 
-pub fn emit_c_function(func: &Function) -> String {
+pub fn emit_c_function(func: &Function, const_fns: &HashMap<FuncId, ConstantValue>) -> String {
     let mut out = String::new();
     let vec_vars = collect_vec_vars(func);
     let string_vars = collect_string_vars(func);
@@ -828,7 +892,14 @@ pub fn emit_c_function(func: &Function) -> String {
         out.push_str(&format!("  __blk_{} = 1;\n", block.id.0));
         for inst in &block.insts {
             if inst.opcode != Opcode::GetArg {
-                emit_inst(inst, &mut out, &vec_vars, &string_vars, &hashmap_vars);
+                emit_inst(
+                    inst,
+                    &mut out,
+                    &vec_vars,
+                    &string_vars,
+                    &hashmap_vars,
+                    const_fns,
+                );
             }
         }
     }
@@ -837,7 +908,7 @@ pub fn emit_c_function(func: &Function) -> String {
     out
 }
 
-pub fn emit_c_module(funcs: &[&Function]) -> String {
+pub fn emit_c_module(funcs: &[&Function], const_fns: &HashMap<FuncId, ConstantValue>) -> String {
     let mut out = String::new();
     out.push_str("#include <stdint.h>\n");
     out.push_str("#include <stdbool.h>\n");
@@ -862,7 +933,7 @@ pub fn emit_c_module(funcs: &[&Function]) -> String {
     ));
 
     for func in funcs {
-        out.push_str(&emit_c_function(func));
+        out.push_str(&emit_c_function(func, const_fns));
         out.push('\n');
     }
     out
@@ -916,7 +987,7 @@ mod tests {
                 ],
             }],
         };
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("int64_t add("), "signature: {c}");
         assert!(c.contains("v2 = v0 + v1"), "add: {c}");
         assert!(c.contains("return v2"), "return: {c}");
@@ -965,7 +1036,7 @@ mod tests {
                 ],
             }],
         };
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("__ESBMC_assume(v3)"), "requires: {c}");
         assert!(!c.contains("__ESBMC_assert"), "no assert for requires: {c}");
     }
@@ -1051,7 +1122,7 @@ mod tests {
                 inst(7, Opcode::Return, Ty::Unit, vec![], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("int32_t v0 = 7"), "ConstI32: {c}");
         assert!(c.contains("float v1 = 1.5f"), "ConstF32: {c}");
         assert!(c.contains("double v2 = 2"), "ConstF64: {c}");
@@ -1136,7 +1207,7 @@ mod tests {
                 inst(11, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("v0 - v1"), "sub: {c}");
         assert!(c.contains("v0 * v1"), "mul: {c}");
         assert!(c.contains("v0 / v1"), "div: {c}");
@@ -1165,7 +1236,7 @@ mod tests {
                 inst(12, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("v0 + v1"), "fadd: {c}");
         assert!(c.contains("v0 - v1"), "fsub: {c}");
         assert!(c.contains("v0 * v1"), "fmul: {c}");
@@ -1198,7 +1269,7 @@ mod tests {
                 inst(14, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("v0 == v1"), "eq: {c}");
         assert!(c.contains("v0 != v1"), "ne: {c}");
         assert!(c.contains("v0 < v1"), "lt: {c}");
@@ -1222,7 +1293,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("!v0"), "not: {c}");
         assert!(c.contains("v0 && v1"), "and: {c}");
         assert!(c.contains("v0 || v1"), "or: {c}");
@@ -1276,7 +1347,7 @@ mod tests {
                 },
             ],
         };
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("if (v0) goto block1; else goto block2;"),
             "branch: {c}"
@@ -1313,7 +1384,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("int64_t v0;"), "phi declaration: {c}");
         assert!(c.contains("v0 = v1;"), "upsilon assignment: {c}");
     }
@@ -1345,7 +1416,7 @@ mod tests {
                 inst(2, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("not modelled"), "not modelled comment: {c}");
         assert!(c.contains("__VERIFIER_nondet_long"), "nondet for I64: {c}");
     }
@@ -1376,7 +1447,7 @@ mod tests {
                 inst(2, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("__ESBMC_assert(v0, \"vow:2\")"),
             "invariant assert: {c}"
@@ -1391,7 +1462,7 @@ mod tests {
             Ty::Unit,
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("return 0;"), "void return: {c}");
     }
 
@@ -1412,7 +1483,7 @@ mod tests {
                 inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let out = emit_c_module(&[&f1, &f2]);
+        let out = emit_c_module(&[&f1, &f2], &HashMap::new());
         assert!(out.contains("#include <stdint.h>"), "includes: {out}");
         assert!(out.contains("__ESBMC_assume"), "esbmc assume: {out}");
         assert!(out.contains("void f1(void)"), "f1 signature: {out}");
@@ -1458,7 +1529,7 @@ mod tests {
                 ],
             }],
         };
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("__ESBMC_assert(v0"), "ensures: {c}");
     }
 
@@ -1470,7 +1541,7 @@ mod tests {
             Ty::Unit,
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
-        let out = emit_c_module(&[&f]);
+        let out = emit_c_module(&[&f], &HashMap::new());
         assert!(out.contains("__vow_vec_t"), "vec typedef: {out}");
         assert!(out.contains("int64_t len"), "vec len field: {out}");
         assert!(out.contains("int64_t data["), "vec data field: {out}");
@@ -1497,7 +1568,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("__vow_vec_t v2;"), "vec struct decl: {c}");
         assert!(c.contains("v2.len = 0;"), "vec len init: {c}");
         assert!(
@@ -1536,7 +1607,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("__ESBMC_assert(v2.len < 128, \"vec capacity\")"),
             "push capacity: {c}"
@@ -1574,7 +1645,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("int64_t v3 = v2.len;"), "vec len: {c}");
     }
 
@@ -1608,7 +1679,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("__ESBMC_assert(v3 >= 0 && v3 < v2.len"),
             "bounds check: {c}"
@@ -1645,7 +1716,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("v2.len--;"), "pop decrement: {c}");
     }
 
@@ -1680,7 +1751,7 @@ mod tests {
                 inst(6, Opcode::Return, Ty::Unit, vec![], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("__ESBMC_assert(v3 >= 0 && v3 < v2.len"),
             "bounds check: {c}"
@@ -1732,7 +1803,7 @@ mod tests {
                 ],
             }],
         };
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("__vow_vec_t v0;"), "phi uses vec type: {c}");
     }
 
@@ -1755,7 +1826,7 @@ mod tests {
                 inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("not modelled"), "non-vec call still nondet: {c}");
         assert!(
             c.contains("__VERIFIER_nondet_long"),
@@ -1771,7 +1842,7 @@ mod tests {
             Ty::Unit,
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
-        let out = emit_c_module(&[&f]);
+        let out = emit_c_module(&[&f], &HashMap::new());
         assert!(out.contains("__vow_string_t"), "string typedef: {out}");
         assert!(out.contains("int8_t data["), "string data field: {out}");
     }
@@ -1796,7 +1867,7 @@ mod tests {
                 inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("__vow_string_t v1;"), "string struct decl: {c}");
         assert!(
             c.contains("v1.len = __VERIFIER_nondet_long()"),
@@ -1840,7 +1911,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("int64_t v2 = v1.len;"), "string len: {c}");
     }
 
@@ -1873,7 +1944,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![1], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("__ESBMC_assert(v1.len < 256, \"string capacity\")"),
             "push_byte capacity: {c}"
@@ -1922,7 +1993,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![1], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("v1.len += v3.len;"), "push_str: {c}");
     }
 
@@ -1955,7 +2026,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("__ESBMC_assert(v2 >= 0 && v2 < v1.len"),
             "bounds check: {c}"
@@ -2003,7 +2074,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("_Bool v4 = (v1.len == v3.len)"),
             "string eq length check: {c}"
@@ -2051,7 +2122,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("_Bool v4 = 0;"), "contains init: {c}");
         assert!(
             c.contains("v1.data[__i + __j] != v3.data[__j]"),
@@ -2102,7 +2173,7 @@ mod tests {
                 ],
             }],
         };
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("__vow_string_t v0;"),
             "phi uses string type: {c}"
@@ -2137,7 +2208,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("string print not modelled"),
             "print not modelled: {c}"
@@ -2165,7 +2236,7 @@ mod tests {
                 inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("__vow_hashmap_t v0;"), "hashmap decl: {c}");
         assert!(c.contains("v0.len = 0;"), "hashmap len init: {c}");
         assert!(
@@ -2201,7 +2272,7 @@ mod tests {
                 inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("int64_t v1 = v0.len;"), "hashmap len: {c}");
     }
 
@@ -2234,7 +2305,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("v0.keys[__i] == v1"), "key search: {c}");
         assert!(c.contains("v0.vals[__i] = v2"), "update existing: {c}");
         assert!(
@@ -2274,7 +2345,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("int64_t v2 = 0;"), "get default: {c}");
         assert!(c.contains("v0.keys[__i] == v1"), "get key search: {c}");
         assert!(c.contains("v2 = v0.vals[__i]"), "get reads value: {c}");
@@ -2308,7 +2379,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("_Bool v2 = 0;"), "contains default: {c}");
         assert!(c.contains("v0.keys[__i] == v1"), "contains key search: {c}");
         assert!(c.contains("v2 = 1"), "contains sets true: {c}");
@@ -2342,7 +2413,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("v0.keys[__i] == v1"), "remove key search: {c}");
         assert!(c.contains("v0.len--"), "remove decrements len: {c}");
     }
@@ -2389,7 +2460,7 @@ mod tests {
                 ],
             }],
         };
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(
             c.contains("__vow_hashmap_t v0;"),
             "phi uses hashmap type: {c}"
@@ -2404,7 +2475,7 @@ mod tests {
             Ty::Unit,
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
-        let c = emit_c_module(&[&func]);
+        let c = emit_c_module(&[&func], &HashMap::new());
         assert!(
             c.contains("__vow_hashmap_t"),
             "hashmap typedef in header: {c}"
@@ -2458,12 +2529,183 @@ mod tests {
                 },
             ],
         };
-        let c = emit_c_function(&func);
+        let c = emit_c_function(&func, &HashMap::new());
         assert!(c.contains("int __blk_0 = 0;"), "blk_0 decl: {c}");
         assert!(c.contains("int __blk_1 = 0;"), "blk_1 decl: {c}");
         assert!(c.contains("int __blk_2 = 0;"), "blk_2 decl: {c}");
         assert!(c.contains("__blk_0 = 1;"), "blk_0 set: {c}");
         assert!(c.contains("__blk_1 = 1;"), "blk_1 set: {c}");
         assert!(c.contains("__blk_2 = 1;"), "blk_2 set: {c}");
+    }
+
+    // --- Constant-function detection tests ---
+
+    fn make_constant_func(fid: u32, name: &str, val: i64) -> Function {
+        Function {
+            id: FuncId(fid),
+            name: name.to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(
+                        0,
+                        Opcode::ConstI64,
+                        Ty::I64,
+                        vec![],
+                        InstData::ConstI64(val),
+                    ),
+                    inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                ],
+            }],
+        }
+    }
+
+    #[test]
+    fn detect_constant_functions_finds_simple() {
+        use vow_ir::Module;
+        let module = Module {
+            name: "test".to_string(),
+            functions: vec![make_constant_func(0, "forty_two", 42)],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+        };
+        let result = detect_constant_functions(&module);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&FuncId(0)));
+        assert!(matches!(result[&FuncId(0)], ConstantValue::I64(42)));
+    }
+
+    #[test]
+    fn detect_constant_functions_skips_multi_block() {
+        use vow_ir::Module;
+        let func = Function {
+            id: FuncId(0),
+            name: "multi".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    insts: vec![inst(
+                        0,
+                        Opcode::ConstI64,
+                        Ty::I64,
+                        vec![],
+                        InstData::ConstI64(1),
+                    )],
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    insts: vec![inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None)],
+                },
+            ],
+        };
+        let module = Module {
+            name: "test".to_string(),
+            functions: vec![func],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+        };
+        assert!(detect_constant_functions(&module).is_empty());
+    }
+
+    #[test]
+    fn detect_constant_functions_skips_non_trivial() {
+        use vow_ir::Module;
+        let func = Function {
+            id: FuncId(0),
+            name: "adder".to_string(),
+            params: vec![Ty::I64, Ty::I64],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                    inst(1, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(1)),
+                    inst(
+                        2,
+                        Opcode::WrappingAddI64,
+                        Ty::I64,
+                        vec![0, 1],
+                        InstData::None,
+                    ),
+                    inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+                ],
+            }],
+        };
+        let module = Module {
+            name: "test".to_string(),
+            functions: vec![func],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+        };
+        assert!(detect_constant_functions(&module).is_empty());
+    }
+
+    #[test]
+    fn emit_inlines_constant_call_target() {
+        let mut const_fns = HashMap::new();
+        const_fns.insert(FuncId(1), ConstantValue::I64(42));
+
+        let call_inst = Inst {
+            id: InstId(5),
+            opcode: Opcode::Call,
+            ty: Ty::I64,
+            args: vec![],
+            data: InstData::CallTarget(FuncId(1)),
+            origin: sp(),
+        };
+        let mut out = String::new();
+        emit_inst(
+            &call_inst,
+            &mut out,
+            &HashSet::new(),
+            &HashSet::new(),
+            &HashSet::new(),
+            &const_fns,
+        );
+        assert!(
+            out.contains("int64_t v5 = 42LL;"),
+            "inlined constant: {out}"
+        );
+    }
+
+    #[test]
+    fn emit_falls_back_for_unknown_call_target() {
+        let call_inst = Inst {
+            id: InstId(5),
+            opcode: Opcode::Call,
+            ty: Ty::I64,
+            args: vec![],
+            data: InstData::CallTarget(FuncId(99)),
+            origin: sp(),
+        };
+        let mut out = String::new();
+        emit_inst(
+            &call_inst,
+            &mut out,
+            &HashSet::new(),
+            &HashSet::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+        assert!(
+            out.contains("__VERIFIER_nondet_long()"),
+            "nondet fallback: {out}"
+        );
     }
 }

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -2,9 +2,11 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 
-use vow_ir::{Function, Ty};
+use std::collections::HashMap;
 
-use crate::c_emitter::emit_c_module;
+use vow_ir::{FuncId, Function, Module, Ty};
+
+use crate::c_emitter::{ConstantValue, detect_constant_functions, emit_c_module};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -180,12 +182,25 @@ fn parse_assignment_line(line: &str) -> Option<(String, String)> {
 // ---------------------------------------------------------------------------
 
 pub fn verify_function(func: &Function) -> VerificationResult {
+    let empty: HashMap<FuncId, ConstantValue> = HashMap::new();
+    verify_function_inner(func, &empty)
+}
+
+pub fn verify_function_with_module(func: &Function, module: &Module) -> VerificationResult {
+    let const_fns = detect_constant_functions(module);
+    verify_function_inner(func, &const_fns)
+}
+
+fn verify_function_inner(
+    func: &Function,
+    const_fns: &HashMap<FuncId, ConstantValue>,
+) -> VerificationResult {
     let esbmc = match find_esbmc() {
         Some(p) => p,
         None => return VerificationResult::ToolNotFound,
     };
 
-    let mut c_src = emit_c_module(&[func]);
+    let mut c_src = emit_c_module(&[func], const_fns);
     c_src.push_str(&emit_harness(func));
 
     let mut tmp = match tempfile::Builder::new().suffix(".c").tempfile() {

--- a/vow-verify/src/lib.rs
+++ b/vow-verify/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod c_emitter;
 pub mod esbmc;
 
-pub use esbmc::{Counterexample, VerificationResult, parse_esbmc_output, verify_function};
+pub use esbmc::{
+    Counterexample, VerificationResult, parse_esbmc_output, verify_function,
+    verify_function_with_module,
+};

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -13,7 +13,7 @@ use vow_codegen::cranelift_backend::CraneliftBackend;
 use vow_codegen::linker::{find_runtime_lib, find_shim_lib, link};
 use vow_codegen::{Backend, BuildMode, TraceMode};
 use vow_diag::{CollectingEmitter, Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
-use vow_verify::{Counterexample, VerificationResult, verify_function};
+use vow_verify::{Counterexample, VerificationResult, verify_function_with_module};
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -970,7 +970,7 @@ fn run_verification_sync(
         if func.vows.is_empty() {
             continue;
         }
-        match verify_function(func) {
+        match verify_function_with_module(func, ir_module) {
             VerificationResult::Failed(ce) => {
                 let sce = build_structured_counterexample(func, &ce, file, call_site_index);
                 return VerifyOutcome::Failed {


### PR DESCRIPTION
## Summary

- Adds `detect_constant_functions(module)` to identify functions whose IR body is a single constant + return
- Threads constant-function map through C emission so `CallTarget` instructions for known-constant callees emit the literal value instead of `__VERIFIER_nondet_*()`
- Adds `verify_function_with_module()` entry point that passes full module context to the emitter
- Updates the CLI driver to use `verify_function_with_module` so verification benefits from cross-function constant inlining

Fixes #20

## Test plan

- [x] `cargo build --all` compiles
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo test --all` passes (including 5 new tests for detection, inlining, and fallback)