### PR TITLE
Add PreToolUse hook to enforce ulimit for vowc

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/check-ulimit-vowc.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/scripts/check-ulimit-vowc.sh
+++ b/scripts/check-ulimit-vowc.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # PreToolUse hook: block Bash commands that run ./vowc or self-compiled
-# binaries without ulimit -v to prevent memory exhaustion.
+# binaries without ulimit -v 2000000 to prevent memory exhaustion.
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "BLOCK: jq is required for the ulimit safety hook but is not installed." >&2
+  exit 2
+fi
 
 input=$(cat)
 CMD=$(echo "$input" | jq -r '.tool_input.command // empty')
 [ -z "$CMD" ] && exit 0
 
-if echo "$CMD" | grep -qP '(\./vowc|/tmp/vow_|/tmp/compiler_)'; then
-  if ! echo "$CMD" | grep -qP 'ulimit\s+-v'; then
+if echo "$CMD" | grep -qP '(\./vowc|/tmp/vow_|/tmp/compiler_|/tmp/lexer\b)'; then
+  if ! echo "$CMD" | grep -qP 'ulimit\s+-v\s+2000000\b'; then
     echo "BLOCK: Running ./vowc or self-compiled binaries without 'ulimit -v 2000000' risks exhausting all system memory." >&2
     echo "Prefix your command with: ulimit -v 2000000;" >&2
     exit 2

--- a/scripts/check-ulimit-vowc.sh
+++ b/scripts/check-ulimit-vowc.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block Bash commands that run ./vowc or self-compiled
+# binaries without ulimit -v to prevent memory exhaustion.
+
+CMD=$(echo "$TOOL_INPUT" | jq -r '.command // empty')
+[ -z "$CMD" ] && exit 0
+
+# Check if command references vowc or self-compiled binaries
+if echo "$CMD" | grep -qP '(\./vowc|/tmp/vow_|/tmp/compiler_)'; then
+  # Allow if ulimit is present
+  if ! echo "$CMD" | grep -qP 'ulimit'; then
+    echo "BLOCK: Running ./vowc or self-compiled binaries without 'ulimit -v 2000000' risks exhausting all system memory." >&2
+    echo "Prefix your command with: ulimit -v 2000000;" >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/scripts/check-ulimit-vowc.sh
+++ b/scripts/check-ulimit-vowc.sh
@@ -2,13 +2,12 @@
 # PreToolUse hook: block Bash commands that run ./vowc or self-compiled
 # binaries without ulimit -v to prevent memory exhaustion.
 
-CMD=$(echo "$TOOL_INPUT" | jq -r '.command // empty')
+input=$(cat)
+CMD=$(echo "$input" | jq -r '.tool_input.command // empty')
 [ -z "$CMD" ] && exit 0
 
-# Check if command references vowc or self-compiled binaries
 if echo "$CMD" | grep -qP '(\./vowc|/tmp/vow_|/tmp/compiler_)'; then
-  # Allow if ulimit is present
-  if ! echo "$CMD" | grep -qP 'ulimit'; then
+  if ! echo "$CMD" | grep -qP 'ulimit\s+-v'; then
     echo "BLOCK: Running ./vowc or self-compiled binaries without 'ulimit -v 2000000' risks exhausting all system memory." >&2
     echo "Prefix your command with: ulimit -v 2000000;" >&2
     exit 2


### PR DESCRIPTION
## Summary
- Adds a `PreToolUse` hook on `Bash` commands that blocks running `./vowc`, `/tmp/vow_*`, or `/tmp/compiler_*` without `ulimit -v 2000000`
- New script `scripts/check-ulimit-vowc.sh` parses `$TOOL_INPUT` JSON, checks for vowc-related commands, and exits with code 2 (block) if ulimit is missing

## Test plan
- [ ] Run `./vowc build examples/hello.vow` without ulimit — should be blocked by hook
- [ ] Run `ulimit -v 2000000; ./vowc build examples/hello.vow` — should pass through
- [ ] Run unrelated Bash commands — should not be affected