### PR TITLE
fix: add guard slot to struct allocations to prevent field-access segfault

### DIFF
--- a/compiler/diag.vow
+++ b/compiler/diag.vow
@@ -21,6 +21,7 @@ fn EC_VOW_ENSURES_VIOLATED() -> i64 vow { ensures: result >= 0 } { 9 }
 fn EC_VOW_INVARIANT_VIOLATED() -> i64 vow { ensures: result >= 0 } { 10 }
 fn EC_UNKNOWN_METHOD() -> i64 vow { ensures: result >= 0 } { 12 }
 fn EC_UNSUPPORTED_FEATURE() -> i64 vow { ensures: result >= 0 } { 13 }
+fn EC_LOWERING_WARNING() -> i64 vow { ensures: result >= 0 } { 14 }
 fn EC_IO_ERROR() -> i64 vow { ensures: result >= 0 } { 11 }
 
 struct Diagnostic {
@@ -192,8 +193,11 @@ fn ec_name(code: i64) -> String {
     if code == EC_UNSUPPORTED_FEATURE() {
         String::from("UnsupportedFeature")
     } else {
+    if code == EC_LOWERING_WARNING() {
+        String::from("LoweringWarning")
+    } else {
         String::from("IoError")
-    }}}}}}}}}}}}}
+    }}}}}}}}}}}}}}
 }
 
 fn sev_name_lower(s: i64) -> String {

--- a/compiler/ir.vow
+++ b/compiler/ir.vow
@@ -227,6 +227,7 @@ struct IrModule {
     strings: Vec<String>,
     struct_layouts: Vec<IrStructLayout>,
     enum_layouts: Vec<IrEnumLayout>,
+    warnings: Vec<String>,
 }
 
 fn ir_inst_new(id: i64, op: i64, ty: i64, args: Vec<i64>, dk: i64, dv: i64, dv2: i64, ds: String) -> IrInst {
@@ -273,5 +274,6 @@ fn ir_module_new(name: String) -> IrModule {
         strings: Vec::new(),
         struct_layouts: Vec::new(),
         enum_layouts: Vec::new(),
+        warnings: Vec::new(),
     }
 }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -316,7 +316,15 @@ fn lctx_find_variant_tag(ctx: LowerCtx, enum_name: String, variant_name: String)
 
 fn lctx_struct_field_index(ctx: LowerCtx, struct_name: String, field_name: String) -> i64 {
     let sidx: i64 = lctx_find_struct(ctx, struct_name);
-    if sidx == -1 { return 0; }
+    if sidx == -1 {
+        if struct_name.len() > 0 {
+            let w: String = String::from("warning: struct '");
+            w.push_str(struct_name);
+            w.push_str(String::from("' not registered -- field lookup defaulting to index 0"));
+            ctx.warnings.push(w);
+        }
+        return 0;
+    }
     let fields: Vec<String> = ctx.struct_field_lists[sidx];
     let n: i64 = fields.len();
     let mut i: i64 = 0;
@@ -1243,7 +1251,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
 
         let tag_val: i64 = lctx_find_variant_tag(ctx, enum_name, variant_name);
         let n_payload: i64 = list_len(a, fields_lid);
-        let size: i64 = (1 + n_payload) * 8;
+        let size: i64 = (2 + n_payload) * 8;
         let alloc_args: Vec<i64> = Vec::new();
         let ptr_id: i64 = lctx_emit(ctx, IOP_REGION_ALLOC(), ITY_PTR(), alloc_args, IDATA_ALLOC_SIZE(), size, 8, String::from(""));
         lctx_tag(ctx, ptr_id, enum_name);
@@ -1774,7 +1782,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
 
         lctx_switch_to_block(ctx, early_block);
         let alloc_args: Vec<i64> = Vec::new();
-        let none_ptr: i64 = lctx_emit(ctx, IOP_REGION_ALLOC(), ITY_PTR(), alloc_args, IDATA_ALLOC_SIZE(), 8, 8, String::from(""));
+        let none_ptr: i64 = lctx_emit(ctx, IOP_REGION_ALLOC(), ITY_PTR(), alloc_args, IDATA_ALLOC_SIZE(), 16, 8, String::from(""));
         let none_tag_args: Vec<i64> = Vec::new();
         let none_tag: i64 = lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), none_tag_args, IDATA_CONST_I64(), 0, 0, String::from(""));
         let fs_args: Vec<i64> = Vec::new();

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -30,6 +30,7 @@ struct LowerCtx {
     loop_exit_blocks: Vec<i64>,
     vec_elem_inst_ids: Vec<i64>,
     vec_elem_names: Vec<String>,
+    warnings: Vec<String>,
 }
 
 struct ScopeSnap {
@@ -69,6 +70,7 @@ fn lctx_new(name: String, return_ty: i64, effects: i64, arena: AstArena, str_eid
         loop_exit_blocks: Vec::new(),
         vec_elem_inst_ids: Vec::new(),
         vec_elem_names: Vec::new(),
+        warnings: Vec::new(),
     }
 }
 
@@ -323,6 +325,14 @@ fn lctx_struct_field_index(ctx: LowerCtx, struct_name: String, field_name: Strin
             return i;
         }
         i = i + 1;
+    }
+    if struct_name.len() > 0 {
+        let w: String = String::from("warning: field '");
+        w.push_str(field_name);
+        w.push_str(String::from("' not found in struct '"));
+        w.push_str(struct_name);
+        w.push_str(String::from("' -- defaulting to index 0"));
+        ctx.warnings.push(w);
     }
     0
 }
@@ -1078,6 +1088,14 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let recv_id: i64 = lower_expr(ctx, recv_eid);
             let val_id: i64 = lower_expr(ctx, rhs_eid);
             let recv_tag_str: String = lctx_get_tag(ctx, recv_id);
+            if recv_tag_str.len() == 0 {
+                let w: String = String::from("warning: FieldSet on untagged instruction %");
+                w.push_str(i64_to_string(recv_id));
+                w.push_str(String::from(", field '"));
+                w.push_str(field_name);
+                w.push_str(String::from("' -- defaulting to index 0"));
+                ctx.warnings.push(w);
+            }
             let fidx: i64 = lctx_struct_field_index(ctx, recv_tag_str, field_name);
             let fs_args: Vec<i64> = Vec::new();
             fs_args.push(recv_id);
@@ -1111,6 +1129,14 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         let field_name: String = arena_str(a, field_sid);
         let recv_id: i64 = lower_expr(ctx, recv_eid);
         let recv_tag_str: String = lctx_get_tag(ctx, recv_id);
+        if recv_tag_str.len() == 0 {
+            let w: String = String::from("warning: FieldGet on untagged instruction %");
+            w.push_str(i64_to_string(recv_id));
+            w.push_str(String::from(", field '"));
+            w.push_str(field_name);
+            w.push_str(String::from("' -- defaulting to index 0"));
+            ctx.warnings.push(w);
+        }
         let fidx: i64 = lctx_struct_field_index(ctx, recv_tag_str, field_name);
         let fg_args: Vec<i64> = Vec::new();
         fg_args.push(recv_id);
@@ -1146,7 +1172,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         let actual_n: i64 = {
             if n_fields > nlit { n_fields } else { nlit }
         };
-        let alloc_size: i64 = actual_n * 8;
+        let alloc_size: i64 = (actual_n + 1) * 8;
         let alloc_args: Vec<i64> = Vec::new();
         let ptr_id: i64 = lctx_emit(ctx, IOP_REGION_ALLOC(), ITY_PTR(), alloc_args, IDATA_ALLOC_SIZE(), alloc_size, 8, String::from(""));
         lctx_tag(ctx, ptr_id, struct_name);
@@ -2558,5 +2584,11 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>) -> IrModule {
     }
 
     ir_mod.strings = all_strings;
+    let nw: i64 = ctx.warnings.len();
+    let mut wi: i64 = 0;
+    while wi < nw {
+        ir_mod.warnings.push(ctx.warnings[wi]);
+        wi = wi + 1;
+    }
     ir_mod
 }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -316,6 +316,15 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Ve
     all_proven
 }
 
+fn print_ir_warnings(ir_mod: IrModule) [io] {
+    let ws: Vec<String> = ir_mod.warnings;
+    let mut i: i64 = 0;
+    while i < ws.len() {
+        eprintln_str(ws[i]);
+        i = i + 1;
+    }
+}
+
 fn run_verify(argv: Vec<String>) -> i32 [io] {
     let fr: FrontendResult = run_frontend(argv, true);
     let path: String = fr.path;
@@ -337,6 +346,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     };
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     let ir_mod: IrModule = lower_module_vow(merged, str_eids);
+    print_ir_warnings(ir_mod);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
     let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, unwind, use_cache);
@@ -390,6 +400,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         else { 0 }
     };
     let ir_mod: IrModule = lower_module_vow(merged, str_eids);
+    print_ir_warnings(ir_mod);
     let do_verify: bool = !has_flag(argv, String::from("--no-verify"));
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     let unwind_str: String = get_flag_arg(argv, String::from("--unwind"));
@@ -570,6 +581,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             };
             let str_eids: Vec<i64> = e.expr_str_eids;
             let ir_mod: IrModule = lower_module_vow(merged, str_eids);
+            print_ir_warnings(ir_mod);
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
             let use_cache_leg: bool = !has_flag(argv, String::from("--no-cache"));
@@ -588,6 +600,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
         } else if emit_c {
             let str_eids: Vec<i64> = e.expr_str_eids;
             let ir_mod: IrModule = lower_module_vow(merged, str_eids);
+            print_ir_warnings(ir_mod);
             let c_code: String = emit_c_module(ir_mod);
             print_str(c_code);
         } else if has_output {
@@ -608,6 +621,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             };
             let str_eids: Vec<i64> = e.expr_str_eids;
             let ir_mod: IrModule = lower_module_vow(merged, str_eids);
+            print_ir_warnings(ir_mod);
             let result: i64 = clif_emit_module(ir_mod, out, mode, trace);
             if result == -1 {
                 eprintln_str(String::from("compilation failed"));
@@ -621,6 +635,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
         } else {
             let str_eids: Vec<i64> = e.expr_str_eids;
             let ir_mod: IrModule = lower_module_vow(merged, str_eids);
+            print_ir_warnings(ir_mod);
             let ir_text: String = print_module(ir_mod);
             print_str(ir_text);
         }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -316,10 +316,12 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Ve
     all_proven
 }
 
-fn print_ir_warnings(ir_mod: IrModule) [io] {
+fn emit_ir_warnings(ir_mod: IrModule, dctx: DiagCtx) [io] {
     let ws: Vec<String> = ir_mod.warnings;
     let mut i: i64 = 0;
     while i < ws.len() {
+        let d: Diagnostic = diag_new(SEV_WARNING(), EC_LOWERING_WARNING(), ws[i], String::from(""), 0, 0, DIAG_BLAME_NONE());
+        diag_ctx_emit(dctx, d);
         eprintln_str(ws[i]);
         i = i + 1;
     }
@@ -346,7 +348,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     };
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     let ir_mod: IrModule = lower_module_vow(merged, str_eids);
-    print_ir_warnings(ir_mod);
+    emit_ir_warnings(ir_mod, dctx);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
     let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, unwind, use_cache);
@@ -400,7 +402,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         else { 0 }
     };
     let ir_mod: IrModule = lower_module_vow(merged, str_eids);
-    print_ir_warnings(ir_mod);
+    emit_ir_warnings(ir_mod, dctx);
     let do_verify: bool = !has_flag(argv, String::from("--no-verify"));
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     let unwind_str: String = get_flag_arg(argv, String::from("--unwind"));
@@ -581,7 +583,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             };
             let str_eids: Vec<i64> = e.expr_str_eids;
             let ir_mod: IrModule = lower_module_vow(merged, str_eids);
-            print_ir_warnings(ir_mod);
+            emit_ir_warnings(ir_mod, dctx);
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
             let use_cache_leg: bool = !has_flag(argv, String::from("--no-cache"));
@@ -600,7 +602,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
         } else if emit_c {
             let str_eids: Vec<i64> = e.expr_str_eids;
             let ir_mod: IrModule = lower_module_vow(merged, str_eids);
-            print_ir_warnings(ir_mod);
+            emit_ir_warnings(ir_mod, dctx);
             let c_code: String = emit_c_module(ir_mod);
             print_str(c_code);
         } else if has_output {
@@ -621,7 +623,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             };
             let str_eids: Vec<i64> = e.expr_str_eids;
             let ir_mod: IrModule = lower_module_vow(merged, str_eids);
-            print_ir_warnings(ir_mod);
+            emit_ir_warnings(ir_mod, dctx);
             let result: i64 = clif_emit_module(ir_mod, out, mode, trace);
             if result == -1 {
                 eprintln_str(String::from("compilation failed"));
@@ -635,7 +637,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
         } else {
             let str_eids: Vec<i64> = e.expr_str_eids;
             let ir_mod: IrModule = lower_module_vow(merged, str_eids);
-            print_ir_warnings(ir_mod);
+            emit_ir_warnings(ir_mod, dctx);
             let ir_text: String = print_module(ir_mod);
             print_str(ir_text);
         }

--- a/docs/skill/errors.md
+++ b/docs/skill/errors.md
@@ -212,3 +212,12 @@ The `blame` field indicates who is at fault:
 ```
 
 **Fix:** Add a bounds check before indexing, or add contracts: `requires: i >= 0, requires: i < v.len()`.
+
+## Warnings
+
+### LoweringWarning
+
+**Phase:** IR Lowering
+**Meaning:** The IR lowerer could not resolve a struct type tag or field name, defaulting to index 0. This usually indicates a missing type annotation on a `let` binding, causing the compiler to lose track of which struct type a pointer refers to.
+
+**Fix:** Add an explicit type annotation: `let x: MyStruct = ...;` so the compiler can track struct type tags through the IR.

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -1792,6 +1792,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         }
     }
 

--- a/vow-codegen/tests/e2e.rs
+++ b/vow-codegen/tests/e2e.rs
@@ -56,6 +56,7 @@ fn make_main_returns_42() -> Module {
         strings: vec![],
         struct_layouts: vec![],
         enum_layouts: vec![],
+        warnings: vec![],
         functions: vec![Function {
             id: FuncId(0),
             name: "main".to_string(),
@@ -206,6 +207,7 @@ fn vow_violation_exits_with_code_1_and_blames_caller() {
         strings: vec![],
         struct_layouts: vec![],
         enum_layouts: vec![],
+        warnings: vec![],
         functions: vec![divide, main_fn],
     };
 
@@ -320,6 +322,7 @@ fn vow_violation_reports_variable_values() {
         strings: vec![],
         struct_layouts: vec![],
         enum_layouts: vec![],
+        warnings: vec![],
         functions: vec![nonneg, main_fn],
     };
 

--- a/vow-diag/src/lib.rs
+++ b/vow-diag/src/lib.rs
@@ -21,7 +21,7 @@ pub struct SourceLocation {
     pub byte_len: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Diagnostic {
     pub severity: Severity,
     pub code: ErrorCode,
@@ -54,6 +54,8 @@ pub enum ErrorCode {
     // Method/feature errors
     UnknownMethod,
     UnsupportedFeature,
+    // Lowering warnings
+    LoweringWarning,
     // IO errors
     IoError,
 }

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -115,6 +115,7 @@ pub struct LowerCtx {
     inst_vec_elem_type: HashMap<InstId, String>,
     // struct name → per-field Vec element type name (for FieldGet → Vec propagation)
     struct_field_vec_elems: HashMap<String, Vec<String>>,
+    warnings: Vec<vow_diag::Diagnostic>,
 }
 
 impl LowerCtx {
@@ -175,6 +176,7 @@ impl LowerCtx {
             loop_exit_blocks: Vec::new(),
             inst_vec_elem_type: HashMap::new(),
             struct_field_vec_elems,
+            warnings: Vec::new(),
         }
     }
 
@@ -314,8 +316,24 @@ impl LowerCtx {
             .unwrap_or(false)
     }
 
-    pub fn finish(self) -> (Function, Vec<String>) {
-        (self.func, self.string_pool)
+    fn warn(&mut self, message: String, span: Span) {
+        self.warnings.push(vow_diag::Diagnostic {
+            severity: vow_diag::Severity::Warning,
+            code: vow_diag::ErrorCode::LoweringWarning,
+            message,
+            primary: vow_diag::SourceLocation {
+                file: self.file.clone(),
+                byte_offset: span.start,
+                byte_len: span.len,
+            },
+            secondary: vec![],
+            blame: vow_diag::Blame::None,
+            hints: vec![],
+        });
+    }
+
+    pub fn finish(self) -> (Function, Vec<String>, Vec<vow_diag::Diagnostic>) {
+        (self.func, self.string_pool, self.warnings)
     }
 }
 
@@ -773,16 +791,27 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         .cloned()
                         .unwrap_or_default();
                     if struct_name.is_empty() {
-                        eprintln!(
-                            "warning: FieldSet on untagged instruction %{}, field '{}' — defaulting to index 0",
-                            ptr_id.0, field
+                        ctx.warn(
+                            format!("FieldSet on untagged instruction %{}, field '{}' -- defaulting to index 0", ptr_id.0, field),
+                            span,
                         );
                     }
-                    let field_idx = ctx
+                    let field_idx_opt = ctx
                         .struct_field_map
                         .get(&struct_name)
-                        .and_then(|names| names.iter().position(|n| n == field))
-                        .unwrap_or(0) as u32;
+                        .and_then(|names| names.iter().position(|n| n == field));
+                    let field_idx = match field_idx_opt {
+                        Some(idx) => idx,
+                        None => {
+                            if !struct_name.is_empty() {
+                                ctx.warn(
+                                    format!("field '{}' not found in struct '{}' -- defaulting to index 0", field, struct_name),
+                                    span,
+                                );
+                            }
+                            0
+                        }
+                    } as u32;
                     ctx.emit(
                         Opcode::FieldSet,
                         Ty::Unit,
@@ -1029,24 +1058,27 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .cloned()
                 .unwrap_or_default();
             if struct_name.is_empty() {
-                eprintln!(
-                    "warning: FieldGet on untagged instruction %{}, field '{}' — defaulting to index 0",
-                    ptr_id.0, field
+                ctx.warn(
+                    format!("FieldGet on untagged instruction %{}, field '{}' -- defaulting to index 0", ptr_id.0, field),
+                    span,
                 );
             }
-            let field_idx = ctx
+            let field_idx_opt = ctx
                 .struct_field_map
                 .get(&struct_name)
-                .and_then(|names| names.iter().position(|n| n == field))
-                .unwrap_or_else(|| {
+                .and_then(|names| names.iter().position(|n| n == field));
+            let field_idx = match field_idx_opt {
+                Some(idx) => idx,
+                None => {
                     if !struct_name.is_empty() {
-                        eprintln!(
-                            "warning: field '{}' not found in struct '{}' — defaulting to index 0",
-                            field, struct_name
+                        ctx.warn(
+                            format!("field '{}' not found in struct '{}' -- defaulting to index 0", field, struct_name),
+                            span,
                         );
                     }
                     0
-                }) as u32;
+                }
+            } as u32;
             let result_id = ctx.emit(
                 Opcode::FieldGet,
                 Ty::I64,
@@ -1089,13 +1121,17 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             );
             ctx.inst_struct_type.insert(ptr_id, name.clone());
             for (field_name, field_expr) in fields {
-                let idx = field_names
-                    .iter()
-                    .position(|n| n == field_name)
-                    .unwrap_or_else(|| {
-                        eprintln!("warning: StructLiteral field '{}' not found in struct '{}' — defaulting to index 0", field_name, name);
+                let idx_opt = field_names.iter().position(|n| n == field_name);
+                let idx = match idx_opt {
+                    Some(i) => i,
+                    None => {
+                        ctx.warn(
+                            format!("StructLiteral field '{}' not found in struct '{}' -- defaulting to index 0", field_name, name),
+                            span,
+                        );
                         0
-                    }) as u32;
+                    }
+                } as u32;
                 let val_id = lower_expr(ctx, field_expr);
                 ctx.emit(
                     Opcode::FieldSet,
@@ -1160,7 +1196,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .and_then(|vs| vs.iter().position(|v| v == variant_name))
                 .unwrap_or(0) as i64;
             let n_payload = fields.len();
-            let size = (1 + n_payload) as u32 * 8;
+            let size = (2 + n_payload) as u32 * 8;
             let ptr_id = ctx.emit(
                 Opcode::RegionAlloc,
                 Ty::Ptr,
@@ -1684,7 +1720,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
 
             // Early return: wrap as None and return
             ctx.switch_to_block(early_return_block);
-            let none_size: u32 = 8; // just the discriminant slot
+            let none_size: u32 = 16; // discriminant + guard slot
             let none_ptr = ctx.emit(
                 Opcode::RegionAlloc,
                 Ty::Ptr,
@@ -1904,7 +1940,7 @@ pub fn lower_function(
     struct_field_vec_elems: HashMap<String, Vec<String>>,
     string_exprs: &StringExprSet,
     const_map: &HashMap<String, (i64, Ty)>,
-) -> (Function, Vec<String>) {
+) -> (Function, Vec<String>, Vec<vow_diag::Diagnostic>) {
     let params: Vec<Ty> = fn_def.params.iter().map(|p| lower_ty(&p.ty)).collect();
     let param_names: Vec<String> = fn_def.params.iter().map(|p| p.name.clone()).collect();
     let return_ty = lower_ty(&fn_def.return_ty);
@@ -2149,11 +2185,12 @@ pub fn lower_module(module: &AstModule, file: &str, string_exprs: &StringExprSet
     }
 
     let mut all_strings: Vec<String> = Vec::new();
+    let mut all_warnings: Vec<vow_diag::Diagnostic> = Vec::new();
     let functions: Vec<Function> = fn_items
         .iter()
         .enumerate()
         .map(|(idx, fn_def)| {
-            let (mut func, pool) = lower_function(
+            let (mut func, pool, func_warnings) = lower_function(
                 fn_def,
                 file,
                 &func_index,
@@ -2176,6 +2213,7 @@ pub fn lower_module(module: &AstModule, file: &str, string_exprs: &StringExprSet
                 }
             }
             all_strings.extend(pool);
+            all_warnings.extend(func_warnings);
             func
         })
         .collect();
@@ -2186,6 +2224,7 @@ pub fn lower_module(module: &AstModule, file: &str, string_exprs: &StringExprSet
         struct_layouts,
         enum_layouts,
         functions,
+        warnings: all_warnings,
     }
 }
 
@@ -2279,7 +2318,7 @@ mod tests {
             span: sp(),
         };
         let fn_def = make_fn("const_fn", vec![], i64_ty(), body, vec![]);
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &HashMap::new(),
@@ -2324,7 +2363,7 @@ mod tests {
             body,
             vec![],
         );
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &HashMap::new(),
@@ -2372,7 +2411,7 @@ mod tests {
             span: sp(),
         };
         let fn_def = make_fn("let_fn", vec![], i64_ty(), body, vec![]);
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &HashMap::new(),
@@ -2415,7 +2454,7 @@ mod tests {
             span: sp(),
         };
         let fn_def = make_fn("if_fn", vec![], i64_ty(), body, vec![]);
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &HashMap::new(),
@@ -2459,7 +2498,7 @@ mod tests {
     #[test]
     fn lower_empty_function() {
         let fn_def = make_fn("empty_fn", vec![], unit_ty(), empty_block(), vec![]);
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &HashMap::new(),
@@ -2513,7 +2552,7 @@ mod tests {
             span: sp(),
             is_declaration: false,
         };
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &HashMap::new(),
@@ -2616,7 +2655,7 @@ mod tests {
         };
 
         let fn_def = make_fn("countdown", vec![param_n], i64_ty, body, vec![]);
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &HashMap::new(),
@@ -2668,5 +2707,84 @@ mod tests {
             func.blocks.len() >= 4,
             "expected entry+header+body+exit blocks"
         );
+    }
+
+    #[test]
+    fn struct_alloc_includes_guard_slot() {
+        let body = Block {
+            stmts: vec![],
+            trailing_expr: Some(Box::new(Expr {
+                kind: ExprKind::StructLiteral {
+                    name: "Point".to_string(),
+                    fields: vec![
+                        ("x".to_string(), int_expr(1)),
+                        ("y".to_string(), int_expr(2)),
+                        ("z".to_string(), int_expr(3)),
+                    ],
+                },
+                span: sp(),
+            })),
+            span: sp(),
+        };
+        let fn_def = make_fn("make_point", vec![], i64_ty(), body, vec![]);
+        let mut sfm = HashMap::new();
+        sfm.insert(
+            "Point".to_string(),
+            vec!["x".to_string(), "y".to_string(), "z".to_string()],
+        );
+        let (func, _, _) = lower_function(
+            &fn_def,
+            "",
+            &HashMap::new(),
+            sfm,
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+        let alloc = func
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .find(|i| i.opcode == Opcode::RegionAlloc)
+            .expect("expected RegionAlloc");
+        // 3 fields + 1 guard = 4 slots * 8 bytes = 32
+        assert_eq!(alloc.data, InstData::AllocSize { size: 32, align: 8 });
+    }
+
+    #[test]
+    fn enum_alloc_includes_guard_slot() {
+        let body = Block {
+            stmts: vec![],
+            trailing_expr: Some(Box::new(Expr {
+                kind: ExprKind::EnumConstruct {
+                    path: vec!["Option".to_string(), "Some".to_string()],
+                    fields: vec![int_expr(42)],
+                },
+                span: sp(),
+            })),
+            span: sp(),
+        };
+        let fn_def = make_fn("make_some", vec![], i64_ty(), body, vec![]);
+        let (func, _, _) = lower_function(
+            &fn_def,
+            "",
+            &HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+        let alloc = func
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .find(|i| i.opcode == Opcode::RegionAlloc)
+            .expect("expected RegionAlloc");
+        // 1 discriminant + 1 payload + 1 guard = 3 slots * 8 bytes = 24
+        assert_eq!(alloc.data, InstData::AllocSize { size: 24, align: 8 });
     }
 }

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -796,21 +796,27 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                             span,
                         );
                     }
-                    let field_idx_opt = ctx
-                        .struct_field_map
-                        .get(&struct_name)
-                        .and_then(|names| names.iter().position(|n| n == field));
-                    let field_idx = match field_idx_opt {
-                        Some(idx) => idx,
-                        None => {
-                            if !struct_name.is_empty() {
-                                ctx.warn(
-                                    format!("field '{}' not found in struct '{}' -- defaulting to index 0", field, struct_name),
-                                    span,
-                                );
+                    let field_idx = if let Some(names) = ctx.struct_field_map.get(&struct_name) {
+                        match names.iter().position(|n| n == field) {
+                            Some(idx) => idx,
+                            None => {
+                                if !struct_name.is_empty() {
+                                    ctx.warn(
+                                        format!("field '{}' not found in struct '{}' -- defaulting to index 0", field, struct_name),
+                                        span,
+                                    );
+                                }
+                                0
                             }
-                            0
                         }
+                    } else {
+                        if !struct_name.is_empty() {
+                            ctx.warn(
+                                format!("struct '{}' not registered -- field lookup defaulting to index 0", struct_name),
+                                span,
+                            );
+                        }
+                        0
                     } as u32;
                     ctx.emit(
                         Opcode::FieldSet,
@@ -1063,21 +1069,27 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     span,
                 );
             }
-            let field_idx_opt = ctx
-                .struct_field_map
-                .get(&struct_name)
-                .and_then(|names| names.iter().position(|n| n == field));
-            let field_idx = match field_idx_opt {
-                Some(idx) => idx,
-                None => {
-                    if !struct_name.is_empty() {
-                        ctx.warn(
-                            format!("field '{}' not found in struct '{}' -- defaulting to index 0", field, struct_name),
-                            span,
-                        );
+            let field_idx = if let Some(names) = ctx.struct_field_map.get(&struct_name) {
+                match names.iter().position(|n| n == field) {
+                    Some(idx) => idx,
+                    None => {
+                        if !struct_name.is_empty() {
+                            ctx.warn(
+                                format!("field '{}' not found in struct '{}' -- defaulting to index 0", field, struct_name),
+                                span,
+                            );
+                        }
+                        0
                     }
-                    0
                 }
+            } else {
+                if !struct_name.is_empty() {
+                    ctx.warn(
+                        format!("struct '{}' not registered -- field lookup defaulting to index 0", struct_name),
+                        span,
+                    );
+                }
+                0
             } as u32;
             let result_id = ctx.emit(
                 Opcode::FieldGet,
@@ -1103,12 +1115,16 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             result_id
         }
         ExprKind::StructLiteral { name, fields } => {
-            let field_names = ctx.struct_field_map.get(name).cloned().unwrap_or_default();
+            let field_names = if let Some(names) = ctx.struct_field_map.get(name) {
+                names.clone()
+            } else {
+                ctx.warn(
+                    format!("struct '{}' not registered -- field lookup defaulting to index 0", name),
+                    span,
+                );
+                vec![]
+            };
             let n_fields = field_names.len().max(fields.len());
-            // Allocate one extra guard slot (8 bytes) beyond the last field.
-            // This prevents SIGSEGV from off-by-one accesses past the end of
-            // the struct, which can happen when struct type tags are lost and
-            // field index lookups silently default to wrong indices.
             let ptr_id = ctx.emit(
                 Opcode::RegionAlloc,
                 Ty::Ptr,
@@ -1121,14 +1137,15 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             );
             ctx.inst_struct_type.insert(ptr_id, name.clone());
             for (field_name, field_expr) in fields {
-                let idx_opt = field_names.iter().position(|n| n == field_name);
-                let idx = match idx_opt {
+                let idx = match field_names.iter().position(|n| n == field_name) {
                     Some(i) => i,
                     None => {
-                        ctx.warn(
-                            format!("StructLiteral field '{}' not found in struct '{}' -- defaulting to index 0", field_name, name),
-                            span,
-                        );
+                        if !field_names.is_empty() {
+                            ctx.warn(
+                                format!("StructLiteral field '{}' not found in struct '{}' -- defaulting to index 0", field_name, name),
+                                span,
+                            );
+                        }
                         0
                     }
                 } as u32;

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -1038,7 +1038,15 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .struct_field_map
                 .get(&struct_name)
                 .and_then(|names| names.iter().position(|n| n == field))
-                .unwrap_or(0) as u32;
+                .unwrap_or_else(|| {
+                    if !struct_name.is_empty() {
+                        eprintln!(
+                            "warning: field '{}' not found in struct '{}' — defaulting to index 0",
+                            field, struct_name
+                        );
+                    }
+                    0
+                }) as u32;
             let result_id = ctx.emit(
                 Opcode::FieldGet,
                 Ty::I64,
@@ -1065,12 +1073,16 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
         ExprKind::StructLiteral { name, fields } => {
             let field_names = ctx.struct_field_map.get(name).cloned().unwrap_or_default();
             let n_fields = field_names.len().max(fields.len());
+            // Allocate one extra guard slot (8 bytes) beyond the last field.
+            // This prevents SIGSEGV from off-by-one accesses past the end of
+            // the struct, which can happen when struct type tags are lost and
+            // field index lookups silently default to wrong indices.
             let ptr_id = ctx.emit(
                 Opcode::RegionAlloc,
                 Ty::Ptr,
                 vec![],
                 InstData::AllocSize {
-                    size: n_fields as u32 * 8,
+                    size: (n_fields as u32 + 1) * 8,
                     align: 8,
                 },
                 span,

--- a/vow-ir/src/lower/vow.rs
+++ b/vow-ir/src/lower/vow.rs
@@ -346,7 +346,7 @@ mod tests {
             span: sp(),
         };
         let fn_def = make_fn_with_vow(Some(vow_block));
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &std::collections::HashMap::new(),
@@ -390,7 +390,7 @@ mod tests {
             span: sp(),
         };
         let fn_def = make_fn_with_vow(Some(vow_block));
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &std::collections::HashMap::new(),
@@ -431,7 +431,7 @@ mod tests {
             span: sp(),
         };
         let fn_def = make_fn_with_vow(Some(vow_block));
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &std::collections::HashMap::new(),
@@ -466,7 +466,7 @@ mod tests {
             span: sp(),
         };
         let fn_def = make_fn_with_vow(Some(vow_block));
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &std::collections::HashMap::new(),
@@ -545,7 +545,7 @@ mod tests {
             span: sp(),
             is_declaration: false,
         };
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &std::collections::HashMap::new(),
@@ -650,7 +650,7 @@ mod tests {
             span: sp(),
             is_declaration: false,
         };
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &std::collections::HashMap::new(),
@@ -747,7 +747,7 @@ mod tests {
             "Stack".to_string(),
             vec!["Vec".to_string(), "i64".to_string()],
         );
-        let (func, _) = lower_function(
+        let (func, _, _) = lower_function(
             &fn_def,
             "",
             &std::collections::HashMap::new(),

--- a/vow-ir/src/printer.rs
+++ b/vow-ir/src/printer.rs
@@ -414,6 +414,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let output = print_module(&module);
         assert!(output.contains("IO"));
@@ -640,6 +641,7 @@ mod tests {
                     },
                 ],
             }],
+            warnings: vec![],
         };
         let out = print_module(&module);
         assert!(out.contains("strings:"), "strings section: {out}");

--- a/vow-ir/src/types.rs
+++ b/vow-ir/src/types.rs
@@ -315,6 +315,7 @@ pub struct Module {
     pub strings: Vec<String>,
     pub struct_layouts: Vec<StructLayout>,
     pub enum_layouts: Vec<EnumLayout>,
+    pub warnings: Vec<vow_diag::Diagnostic>,
 }
 
 #[cfg(test)]
@@ -383,6 +384,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         assert_eq!(module.functions.len(), 1);
         assert_eq!(module.functions[0].blocks.len(), 1);

--- a/vow-ir/src/validator.rs
+++ b/vow-ir/src/validator.rs
@@ -214,6 +214,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         assert!(validate(&module).is_ok());
     }
@@ -227,6 +228,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let result = validate(&module);
         assert!(!result.is_ok());
@@ -258,6 +260,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let result = validate(&module);
         assert!(!result.is_ok());
@@ -293,6 +296,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let result = validate(&module);
         assert!(!result.is_ok());
@@ -321,6 +325,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let result = validate(&module);
         assert!(!result.is_ok());
@@ -355,6 +360,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let result = validate(&module);
         assert!(!result.is_ok());
@@ -403,6 +409,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let result = validate(&module);
         assert!(!result.is_ok());
@@ -431,6 +438,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let result = validate(&module);
         assert!(!result.is_ok());

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -985,6 +985,7 @@ pub fn emit_c_function(func: &Function, const_fns: &HashMap<FuncId, ConstantValu
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         },
     )
 }
@@ -2971,6 +2972,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let result = detect_constant_functions(&module);
         assert_eq!(result.len(), 1);
@@ -3013,6 +3015,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         assert!(detect_constant_functions(&module).is_empty());
     }
@@ -3051,6 +3054,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         assert!(detect_constant_functions(&module).is_empty());
     }
@@ -3074,6 +3078,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let mut out = String::new();
         emit_inst(
@@ -3098,6 +3103,7 @@ mod tests {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let call_inst = Inst {
             id: InstId(5),

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1131,11 +1131,16 @@ fn compile_frontend(source: &Path) -> Result<FrontendResult, Box<BuildOutput>> {
         }));
     }
 
-    let ir_module = Arc::new(vow_ir::lower_module(
+    let module = vow_ir::lower_module(
         &ast,
         &source.to_string_lossy(),
         &string_exprs,
-    ));
+    );
+    for w in &module.warnings {
+        stderr_emit.emit(w);
+    }
+    all_diagnostics.extend(module.warnings.iter().cloned());
+    let ir_module = Arc::new(module);
 
     Ok(FrontendResult {
         ir_module,
@@ -3953,6 +3958,7 @@ fn main() -> i32 {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
 
         let index = build_call_site_index(&module, "test.vow");
@@ -4282,6 +4288,7 @@ fn main() -> i32 {
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
+            warnings: vec![],
         };
         let index = build_call_site_index(&module, "test.vow");
         let sites = index.get("callee").expect("callee should have call sites");


### PR DESCRIPTION
## Summary
- Struct allocations now include one extra 8-byte guard slot beyond the last field, preventing SIGSEGV from off-by-one field accesses past the end of the struct
- Adds diagnostic warning in the Rust IR lowerer when a field name is not found in a known struct during FieldAccess lowering
- Both Rust compiler and self-hosted compiler updated; bootstrap triple test passes with binary fixed point

Closes #51

## Test plan
- [x] `cargo test --all` — all pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] Bootstrap triple test — binary fixed point (SHA-256 match)
- [x] `scripts/full_test.sh` — 113 passed, 0 failed, 3 skipped