### PR TITLE
fix: nested Vec indexing produces garbage values for struct fields (#50)

### DIFF
--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -16,6 +16,7 @@ struct LowerCtx {
     struct_names: Vec<String>,
     struct_field_lists: Vec<Vec<String>>,
     struct_field_type_names: Vec<Vec<String>>,
+    struct_field_vec_elems: Vec<Vec<String>>,
     enum_names: Vec<String>,
     enum_variant_lists: Vec<Vec<String>>,
     tag_inst_ids: Vec<i64>,
@@ -53,6 +54,7 @@ fn lctx_new(name: String, return_ty: i64, effects: i64, arena: AstArena, str_eid
         struct_names: Vec::new(),
         struct_field_lists: Vec::new(),
         struct_field_type_names: Vec::new(),
+        struct_field_vec_elems: Vec::new(),
         enum_names: Vec::new(),
         enum_variant_lists: Vec::new(),
         tag_inst_ids: Vec::new(),
@@ -329,6 +331,16 @@ fn lctx_struct_field_type(ctx: LowerCtx, struct_name: String, field_idx: i64) ->
     let type_names: Vec<String> = ctx.struct_field_type_names[sidx];
     if field_idx < type_names.len() {
         return type_names[field_idx];
+    }
+    String::from("")
+}
+
+fn lctx_struct_field_vec_elem(ctx: LowerCtx, struct_name: String, field_idx: i64) -> String {
+    let sidx: i64 = lctx_find_struct(ctx, struct_name);
+    if sidx == -1 { return String::from(""); }
+    let vec_elems: Vec<String> = ctx.struct_field_vec_elems[sidx];
+    if field_idx < vec_elems.len() {
+        return vec_elems[field_idx];
     }
     String::from("")
 }
@@ -1102,6 +1114,10 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             if field_type != String::from("i32") && field_type != String::from("i64") && field_type != String::from("f32") && field_type != String::from("f64") && field_type != String::from("bool") {
                 lctx_tag(ctx, result, field_type);
             }
+        }
+        let vec_elem: String = lctx_struct_field_vec_elem(ctx, recv_tag_str, fidx);
+        if vec_elem.len() > 0 {
+            lctx_tag_vec_elem(ctx, result, vec_elem);
         }
         return result;
     }
@@ -2302,6 +2318,7 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>) -> IrModule {
     let struct_names: Vec<String> = Vec::new();
     let struct_field_lists: Vec<Vec<String>> = Vec::new();
     let struct_field_type_names: Vec<Vec<String>> = Vec::new();
+    let struct_field_vec_elems: Vec<Vec<String>> = Vec::new();
     let enum_names: Vec<String> = Vec::new();
     let enum_variant_lists: Vec<Vec<String>> = Vec::new();
 
@@ -2325,6 +2342,7 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>) -> IrModule {
             let nf: i64 = list_len(a, fields_lid) / 2;
             let fnames: Vec<String> = Vec::new();
             let ftypes: Vec<String> = Vec::new();
+            let fvec_elems: Vec<String> = Vec::new();
             let ir_fields: Vec<IrFieldLayout> = Vec::new();
             let mut fi: i64 = 0;
             while fi < nf {
@@ -2346,6 +2364,42 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>) -> IrModule {
                     }
                 };
                 ftypes.push(ftype_name);
+                let fve: String = {
+                    if ftid != -1 {
+                        let ftag: i64 = type_tag(a, ftid);
+                        if ftag == TY_GENERIC() {
+                            let ftn_sid: i64 = type_a(a, ftid);
+                            let ftn: String = arena_str(a, ftn_sid);
+                            if ftn == String::from("Vec") {
+                                let args_lid: i64 = type_b(a, ftid);
+                                if list_len(a, args_lid) > 0 {
+                                    let elem_tid: i64 = list_get(a, args_lid, 0);
+                                    let etag: i64 = type_tag(a, elem_tid);
+                                    if etag == TY_NAMED() {
+                                        let en_sid: i64 = type_a(a, elem_tid);
+                                        let en: String = arena_str(a, en_sid);
+                                        if en != String::from("i32") && en != String::from("i64") && en != String::from("u64") && en != String::from("f32") && en != String::from("f64") && en != String::from("bool") {
+                                            en
+                                        } else {
+                                            String::from("")
+                                        }
+                                    } else {
+                                        String::from("")
+                                    }
+                                } else {
+                                    String::from("")
+                                }
+                            } else {
+                                String::from("")
+                            }
+                        } else {
+                            String::from("")
+                        }
+                    } else {
+                        String::from("")
+                    }
+                };
+                fvec_elems.push(fve);
                 let ir_ty: i64 = lower_ast_ty(a, ftid);
                 let fl: IrFieldLayout = IrFieldLayout { name: fname, ty: ir_ty };
                 ir_fields.push(fl);
@@ -2354,6 +2408,7 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>) -> IrModule {
             struct_names.push(sname);
             struct_field_lists.push(fnames);
             struct_field_type_names.push(ftypes);
+            struct_field_vec_elems.push(fvec_elems);
             let is_linear: i64 = a.sdef_data[iid * 4 + 2];
             let sl: IrStructLayout = IrStructLayout { name: sname, fields: ir_fields, is_linear: is_linear };
             ir_mod.struct_layouts.push(sl);
@@ -2435,6 +2490,7 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>) -> IrModule {
     ctx.struct_names = struct_names;
     ctx.struct_field_lists = struct_field_lists;
     ctx.struct_field_type_names = struct_field_type_names;
+    ctx.struct_field_vec_elems = struct_field_vec_elems;
     ctx.enum_names = enum_names;
     ctx.enum_variant_lists = enum_variant_lists;
     ctx.const_names = cnames;

--- a/examples/vec_nested_index.vow
+++ b/examples/vec_nested_index.vow
@@ -1,0 +1,37 @@
+module VecNestedIndex
+
+pub struct Inner {
+    a: i64,
+    b: i64,
+    c: i64,
+}
+
+pub struct Outer {
+    name: i64,
+    items: Vec<Inner>,
+}
+
+fn main() -> i32 [io] {
+    let inners: Vec<Inner> = Vec::new();
+    inners.push(Inner { a: 10, b: 20, c: 30 });
+    inners.push(Inner { a: 40, b: 50, c: 60 });
+
+    let outers: Vec<Outer> = Vec::new();
+    outers.push(Outer { name: 1, items: inners });
+
+    // Nested Vec indexing: outers[0].items[i].field
+    print_i64(outers[0].items[0].a);
+    print_str(" ");
+    print_i64(outers[0].items[0].b);
+    print_str(" ");
+    print_i64(outers[0].items[0].c);
+    print_str(" ");
+    print_i64(outers[0].items[1].a);
+    print_str(" ");
+    print_i64(outers[0].items[1].b);
+    print_str(" ");
+    print_i64(outers[0].items[1].c);
+    print_str("\n");
+
+    0
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -92,6 +92,7 @@ sha_vowc3=$(sha256sum ./vowc3 | awk '{print $1}')
 
 if [ "$sha_vowc2" = "$sha_vowc3" ]; then
     printf "  ${GREEN}MATCH${RESET}  %s\n" "$sha_vowc2"
+    mv ./vowc2 ./vowc
     rm -f ./vowc3
     printf "\n${GREEN}${BOLD}Bootstrap successful.${RESET} ./vowc is the self-hosted compiler.\n"
 else


### PR DESCRIPTION
## Summary

- Fix nested Vec indexing (`outer_vec[i].inner_vec[j].field`) producing garbage values in the self-hosted compiler
- Add `struct_field_vec_elems` tracking to propagate Vec element types through `FieldGet` in `compiler/lower.vow`
- Fix `scripts/bootstrap.sh` to use the self-compiled fixed-point binary (`vowc2`) as production `./vowc`

## Root Cause

The self-hosted compiler's `EXPR_FIELD` handler tagged `FieldGet` results with the field type name (`"Vec"`) but not the Vec element type (`"Inner"`). Subsequent Vec indexing couldn't determine the element struct type, so all field accesses defaulted to index 0.

The Rust compiler already had this propagation (`struct_field_vec_elems`, added in #45). Only the self-hosted compiler was affected.

## Test plan

- [x] Reproducer `outers[0].items[0].{a,b,c}` returns correct values (10, 20, 30)
- [x] `cargo test --all` passes
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `scripts/full_test.sh`: 115 passed, 0 failed, 3 skipped
- [x] Bootstrap triple test: SHA-256 fixed point verified

Closes #50