### PR TITLE
feat: add for-each loop over Vec<T>

### DIFF
--- a/compiler/ast.vow
+++ b/compiler/ast.vow
@@ -25,6 +25,7 @@ fn EXPR_TUPLE() -> i64 vow { ensures: result >= 0 } { 21 }
 fn EXPR_RESULT() -> i64 vow { ensures: result >= 0 } { 22 }
 fn EXPR_CAST() -> i64 vow { ensures: result >= 0 } { 23 }
 fn EXPR_LOOP() -> i64 vow { ensures: result >= 0 } { 24 }
+fn EXPR_FOR() -> i64 vow { ensures: result >= 0 } { 25 }
 
 fn CLAUSE_REQUIRES() -> i64 vow { ensures: result >= 0 } { 0 }
 fn CLAUSE_ENSURES() -> i64 vow { ensures: result >= 0 } { 1 }

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -754,6 +754,54 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
         return loop_tid;
     }
 
+    if tag == EXPR_FOR() {
+        let iterable_eid: i64 = expr_a(a, eid);
+        let body_bid: i64 = expr_b(a, eid);
+        let info_lid: i64 = expr_c(a, eid);
+        let name_sid: i64 = list_get(a, info_lid, 0);
+        let binding_name: String = arena_str(a, name_sid);
+        let iter_tid: i64 = check_expr(e, m, iterable_eid);
+        let mut elem_tid: i64 = CTY_I64();
+        if is_opaque(iter_tid) {
+            elem_tid = iter_tid;
+        } else {
+            let iter_tag: i64 = ty_tag(e.ts, iter_tid);
+            if iter_tag == CTY_APPLIED() {
+                let base_tid: i64 = ty_a(e.ts, iter_tid);
+                let base_tag: i64 = ty_tag(e.ts, base_tid);
+                if base_tag == CTY_ENUM() || base_tag == CTY_STRUCT() {
+                    let base_name: String = ty_struct_name(e.ts, base_tid);
+                    if base_name == String::from("Vec") {
+                        let hargs_lid: i64 = ty_b(e.ts, iter_tid);
+                        if ts_arg_len(e.ts, hargs_lid) > 0 {
+                            elem_tid = ts_arg_get(e.ts, hargs_lid, 0);
+                        }
+                    } else {
+                        let ferr_msg: String = String::from("for-each requires `Vec<T>` iterable, got `");
+                        ferr_msg.push_str(base_name);
+                        ferr_msg.push_str(String::from("`"));
+                        env_emit_error_code(e, EC_TYPE_MISMATCH(), ferr_msg, expr_span(a, eid));
+                    }
+                } else {
+                    let ferr2_msg: String = String::from("for-each requires `Vec<T>` iterable");
+                    env_emit_error_code(e, EC_TYPE_MISMATCH(), ferr2_msg, expr_span(a, eid));
+                }
+            } else {
+                let ferr3_msg: String = String::from("for-each requires `Vec<T>` iterable");
+                env_emit_error_code(e, EC_TYPE_MISMATCH(), ferr3_msg, expr_span(a, eid));
+            }
+        }
+        env_push_scope(e);
+        env_define_var(e, binding_name, elem_tid);
+        e.loop_kind_stack.push(0);
+        e.break_counts.push(0);
+        let _body_tid: i64 = check_block(e, m, body_bid);
+        e.break_counts.pop();
+        e.loop_kind_stack.pop();
+        env_pop_scope(e);
+        return CTY_UNIT();
+    }
+
     if tag == EXPR_MATCH() {
         let scrutinee_eid: i64 = expr_a(a, eid);
         let arms_lid: i64 = expr_b(a, eid);
@@ -1000,6 +1048,12 @@ fn collect_calls_in_expr(e: CheckEnv, m: Module, eid: i64, calls: Vec<String>) [
 
     if tag == EXPR_LOOP() {
         collect_calls_in_block(e, m, expr_a(a, eid), calls);
+        return;
+    }
+
+    if tag == EXPR_FOR() {
+        collect_calls_in_expr(e, m, expr_a(a, eid), calls);
+        collect_calls_in_block(e, m, expr_b(a, eid), calls);
         return;
     }
 

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -570,6 +570,9 @@ fn collect_assigned_in_expr(ctx: LowerCtx, eid: i64, out: Vec<String>) {
     } else if tag == EXPR_LOOP() {
         let body_bid: i64 = expr_a(a, eid);
         collect_assigned_in_block(ctx, body_bid, out);
+    } else if tag == EXPR_FOR() {
+        let body_bid: i64 = expr_b(a, eid);
+        collect_assigned_in_block(ctx, body_bid, out);
     } else if tag == EXPR_MATCH() {
         let arms_lid: i64 = expr_b(a, eid);
         let n_arms: i64 = list_len(a, arms_lid) / 2;
@@ -1179,7 +1182,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 backpatch_upsilon(ctx, up_block, up_id, break_phi);
                 bi = bi + 1;
             }
-            // Trim the break upsilon flat arrays
             let mut ti: i64 = 0;
             while ti < break_count {
                 ctx.loop_break_up_ids.pop();
@@ -1191,6 +1193,150 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         }
         let u_args2: Vec<i64> = Vec::new();
         return lctx_emit(ctx, IOP_CONST_UNIT(), ITY_UNIT(), u_args2, IDATA_NONE(), 0, 0, String::from(""));
+    }
+
+    if tag == EXPR_FOR() {
+        let iterable_eid: i64 = expr_a(a, eid);
+        let body_bid: i64 = expr_b(a, eid);
+        let info_lid: i64 = expr_c(a, eid);
+        let name_sid: i64 = list_get(a, info_lid, 0);
+        let vow_lid: i64 = list_get(a, info_lid, 1);
+        let binding_name: String = arena_str(a, name_sid);
+
+        let iter_id: i64 = lower_expr(ctx, iterable_eid);
+
+        let len_args: Vec<i64> = Vec::new();
+        len_args.push(iter_id);
+        let len_id: i64 = lctx_emit(ctx, IOP_CALL(), ITY_I64(), len_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_len"));
+
+        let idx_init_args: Vec<i64> = Vec::new();
+        let idx_init: i64 = lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), idx_init_args, IDATA_CONST_I64(), 0, 0, String::from(""));
+
+        let assigned: Vec<String> = collect_assigned_vars(ctx, eid);
+
+        let header_block: i64 = lctx_new_block(ctx);
+        let body_block: i64 = lctx_new_block(ctx);
+        let exit_block: i64 = lctx_new_block(ctx);
+
+        let nassigned: i64 = assigned.len();
+        let phi_ids: Vec<i64> = Vec::new();
+        let pre_up_ids: Vec<i64> = Vec::new();
+        let pre_header_block: i64 = ctx.current_block;
+
+        let idx_up_args: Vec<i64> = Vec::new();
+        idx_up_args.push(idx_init);
+        let idx_up: i64 = lctx_emit(ctx, IOP_UPSILON(), ITY_I64(), idx_up_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
+
+        let mut ai: i64 = 0;
+        while ai < nassigned {
+            let vname: String = assigned[ai];
+            let cur_val: i64 = lctx_lookup(ctx, vname);
+            let val_ty: i64 = ITY_I64();
+            let up_args: Vec<i64> = Vec::new();
+            up_args.push(cur_val);
+            let up_id: i64 = lctx_emit(ctx, IOP_UPSILON(), val_ty, up_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
+            pre_up_ids.push(up_id);
+            ai = ai + 1;
+        }
+
+        let jmp_args: Vec<i64> = Vec::new();
+        lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args, IDATA_JUMP_TARGET(), header_block, 0, String::from(""));
+
+        lctx_switch_to_block(ctx, header_block);
+        let idx_phi_args: Vec<i64> = Vec::new();
+        let idx_phi: i64 = lctx_emit(ctx, IOP_PHI(), ITY_I64(), idx_phi_args, IDATA_NONE(), 0, 0, String::from(""));
+
+        let mut ai2: i64 = 0;
+        while ai2 < nassigned {
+            let vname: String = assigned[ai2];
+            let phi_args: Vec<i64> = Vec::new();
+            let phi_id: i64 = lctx_emit(ctx, IOP_PHI(), ITY_I64(), phi_args, IDATA_NONE(), 0, 0, String::from(""));
+            phi_ids.push(phi_id);
+            lctx_assign(ctx, vname, phi_id);
+            ai2 = ai2 + 1;
+        }
+
+        if vow_lid != -1 {
+            lower_invariant_clauses(ctx, vow_lid);
+        }
+
+        let cond_args: Vec<i64> = Vec::new();
+        cond_args.push(idx_phi);
+        cond_args.push(len_id);
+        let cond_id: i64 = lctx_emit(ctx, IOP_LT_I64(), ITY_BOOL(), cond_args, IDATA_NONE(), 0, 0, String::from(""));
+        let br_args: Vec<i64> = Vec::new();
+        br_args.push(cond_id);
+        lctx_emit(ctx, IOP_BRANCH(), ITY_UNIT(), br_args, IDATA_BRANCH_TARGETS(), body_block, exit_block, String::from(""));
+
+        backpatch_upsilon(ctx, pre_header_block, idx_up, idx_phi);
+        let mut bpi: i64 = 0;
+        while bpi < nassigned {
+            backpatch_upsilon(ctx, pre_header_block, pre_up_ids[bpi], phi_ids[bpi]);
+            bpi = bpi + 1;
+        }
+
+        lctx_switch_to_block(ctx, body_block);
+        let get_args: Vec<i64> = Vec::new();
+        get_args.push(iter_id);
+        get_args.push(idx_phi);
+        let elem_id: i64 = lctx_emit(ctx, IOP_CALL(), ITY_I64(), get_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_get_val"));
+        let elem_tag: String = lctx_get_vec_elem(ctx, iter_id);
+        if elem_tag.len() > 0 {
+            lctx_tag(ctx, elem_id, elem_tag);
+        }
+
+        lctx_push_scope(ctx);
+        lctx_define(ctx, binding_name, elem_id);
+
+        ctx.loop_exit_blocks.push(exit_block);
+        ctx.loop_is_loop.push(0);
+        ctx.loop_break_counts.push(0);
+        lower_block(ctx, body_bid);
+        ctx.loop_break_counts.pop();
+        ctx.loop_is_loop.pop();
+        ctx.loop_exit_blocks.pop();
+
+        lctx_pop_scope(ctx);
+
+        if !lctx_is_terminated(ctx) {
+            let one_args: Vec<i64> = Vec::new();
+            let one: i64 = lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), one_args, IDATA_CONST_I64(), 1, 0, String::from(""));
+            let add_args: Vec<i64> = Vec::new();
+            add_args.push(idx_phi);
+            add_args.push(one);
+            let idx_next: i64 = lctx_emit(ctx, IOP_WADD_I64(), ITY_I64(), add_args, IDATA_NONE(), 0, 0, String::from(""));
+            let idx_up_back_args: Vec<i64> = Vec::new();
+            idx_up_back_args.push(idx_next);
+            lctx_emit(ctx, IOP_UPSILON(), ITY_I64(), idx_up_back_args, IDATA_PHI_TARGET(), idx_phi, 0, String::from(""));
+
+            let mut ai3: i64 = 0;
+            while ai3 < nassigned {
+                let vname: String = assigned[ai3];
+                let new_val: i64 = lctx_lookup(ctx, vname);
+                let val_ty: i64 = ITY_I64();
+                let up_args: Vec<i64> = Vec::new();
+                up_args.push(new_val);
+                lctx_emit(ctx, IOP_UPSILON(), val_ty, up_args, IDATA_PHI_TARGET(), phi_ids[ai3], 0, String::from(""));
+                ai3 = ai3 + 1;
+            }
+        }
+
+        if !lctx_is_terminated(ctx) {
+            let jmp_args: Vec<i64> = Vec::new();
+            lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args, IDATA_JUMP_TARGET(), header_block, 0, String::from(""));
+        }
+
+        let mut ai4: i64 = 0;
+        while ai4 < nassigned {
+            let vname: String = assigned[ai4];
+            lctx_assign(ctx, vname, phi_ids[ai4]);
+            ai4 = ai4 + 1;
+        }
+
+        lctx_switch_to_block(ctx, exit_block);
+
+        let u_args: Vec<i64> = Vec::new();
+        return lctx_emit(ctx, IOP_CONST_UNIT(), ITY_UNIT(), u_args, IDATA_NONE(), 0, 0, String::from(""));
     }
 
     if tag == EXPR_BLOCK() {

--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -538,7 +538,7 @@ fn tok_to_binop(tag: i64) -> i64 {
 
 fn is_block_expr(a: AstArena, eid: i64) -> bool {
     let tag: i64 = expr_tag(a, eid);
-    tag == EXPR_IF() || tag == EXPR_WHILE() || tag == EXPR_LOOP() || tag == EXPR_MATCH() || tag == EXPR_BLOCK()
+    tag == EXPR_IF() || tag == EXPR_WHILE() || tag == EXPR_LOOP() || tag == EXPR_FOR() || tag == EXPR_MATCH() || tag == EXPR_BLOCK()
 }
 
 fn parse_expr_prec(p: Parser, min_prec: i64) -> i64 {
@@ -686,6 +686,8 @@ fn parse_primary(p: Parser) -> i64 {
         parse_if_expr(p)
     } else if tag == tok_kw_while() {
         parse_while_expr(p)
+    } else if tag == tok_kw_for() {
+        parse_for_expr(p)
     } else if tag == tok_kw_match() {
         parse_match_expr(p)
     } else if tag == tok_kw_return() {
@@ -820,6 +822,21 @@ fn parse_loop_expr(p: Parser) -> i64 {
     let vow_lid: i64 = parse_vow_block(p);
     let body_bid: i64 = parse_block(p);
     arena_add_expr(p.arena, EXPR_LOOP(), body_bid, vow_lid, 0, 0)
+}
+
+fn parse_for_expr(p: Parser) -> i64 {
+    let _kw: bool = expect(p, tok_kw_for());
+    let name_tok: Token = advance(p);
+    let name_sid: i64 = arena_intern_str(p.arena, name_tok.str_val);
+    let _in: bool = expect(p, tok_kw_in());
+    let iterable: i64 = parse_expr(p);
+    let vow_lid: i64 = parse_vow_block(p);
+    let body_bid: i64 = parse_block(p);
+    let info_items: Vec<i64> = Vec::new();
+    info_items.push(name_sid);
+    info_items.push(vow_lid);
+    let info_lid: i64 = arena_add_list(p.arena, info_items);
+    arena_add_expr(p.arena, EXPR_FOR(), iterable, body_bid, info_lid, 0)
 }
 
 fn parse_match_expr(p: Parser) -> i64 {

--- a/docs/skill/grammar.md
+++ b/docs/skill/grammar.md
@@ -306,6 +306,26 @@ while i < n vow {
 }
 ```
 
+### For-Each Loop
+
+```vow
+for x in vec {
+    print_i64(x);
+}
+```
+
+Iterates over each element of a `Vec<T>`. The loop variable `x` is bound to each element in turn. Desugars to a `while` loop with index arithmetic — zero verification overhead.
+
+### For-Each Loop with Invariant
+
+```vow
+for x in vec vow {
+    invariant: total >= 0
+} {
+    total = total + x;
+}
+```
+
 ### Loop (Infinite)
 
 `loop` creates an infinite loop. The expression returns the type of the `break` value:

--- a/examples/foreach.vow
+++ b/examples/foreach.vow
@@ -1,0 +1,19 @@
+module ForEach
+
+fn sum_vec(v: Vec<i64>) -> i64 {
+    let mut total: i64 = 0;
+    for x in v {
+        total = total + x;
+    }
+    total
+}
+
+fn main() -> i32 [io] {
+    let nums: Vec<i64> = Vec::new();
+    nums.push(10);
+    nums.push(20);
+    nums.push(30);
+    let result: i64 = sum_vec(nums);
+    print_i64(result);
+    0
+}

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -414,6 +414,14 @@ fn collect_assigned_in_expr(expr: &Expr, seen: &mut HashSet<String>, out: &mut V
                 collect_assigned_in_expr(e, seen, out);
             }
         }
+        ExprKind::ForEach { body, .. } => {
+            for s in &body.stmts {
+                collect_assigned_in_stmt(s, seen, out);
+            }
+            if let Some(e) = &body.trailing_expr {
+                collect_assigned_in_expr(e, seen, out);
+            }
+        }
         ExprKind::BinaryOp { lhs, rhs, .. } => {
             collect_assigned_in_expr(lhs, seen, out);
             collect_assigned_in_expr(rhs, seen, out);
@@ -964,6 +972,195 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             }
 
             // Exit block.
+            ctx.switch_to_block(exit_block);
+            ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
+        }
+        ExprKind::ForEach {
+            binding,
+            iterable,
+            body,
+            vow: for_vow,
+        } => {
+            // Desugar: for <binding> in <iterable> { <body> }
+            // into:    let iter = <iterable>; let len = iter.len(); let idx = 0;
+            //          while idx < len { let <binding> = iter[idx]; <body>; idx = idx + 1; }
+
+            let iter_id = lower_expr(ctx, iterable);
+            ctx.inst_struct_type
+                .insert(iter_id, "Vec".to_string());
+
+            let len_id = ctx.emit(
+                Opcode::Call,
+                Ty::I64,
+                vec![iter_id],
+                InstData::CallExtern("__vow_vec_len".to_string()),
+                span,
+            );
+            let idx_init = ctx.emit(
+                Opcode::ConstI64,
+                Ty::I64,
+                vec![],
+                InstData::ConstI64(0),
+                span,
+            );
+
+            let mutated = collect_assigned_vars(body);
+            let loop_vars: Vec<(String, InstId)> = mutated
+                .into_iter()
+                .filter_map(|name| ctx.lookup(&name).map(|id| (name, id)))
+                .collect();
+
+            let pre_header_block = ctx.current_block;
+            let header_block = ctx.new_block();
+            let body_block = ctx.new_block();
+            let exit_block = ctx.new_block();
+
+            // Pre-header: Upsilon for index
+            let idx_up = ctx.emit(
+                Opcode::Upsilon,
+                Ty::I64,
+                vec![idx_init],
+                InstData::PhiTarget(InstId(u32::MAX)),
+                span,
+            );
+
+            // Pre-header: Upsilons for user mutated vars
+            let mut upsilon_ids: Vec<(String, InstId)> = vec![];
+            for (name, pre_val) in &loop_vars {
+                let ty = ctx.inst_ty(*pre_val);
+                let up_id = ctx.emit(
+                    Opcode::Upsilon,
+                    ty,
+                    vec![*pre_val],
+                    InstData::PhiTarget(InstId(u32::MAX)),
+                    span,
+                );
+                upsilon_ids.push((name.clone(), up_id));
+            }
+            ctx.emit(
+                Opcode::Jump,
+                Ty::Unit,
+                vec![],
+                InstData::JumpTarget(header_block),
+                span,
+            );
+
+            // Header: Phi for index
+            ctx.switch_to_block(header_block);
+            let idx_phi = ctx.emit(Opcode::Phi, Ty::I64, vec![], InstData::None, span);
+            backpatch_upsilon(ctx, pre_header_block, idx_up, idx_phi);
+
+            // Header: Phi for user mutated vars
+            let mut phi_ids: Vec<(String, InstId)> = vec![];
+            for (name, pre_val) in &loop_vars {
+                let ty = ctx.inst_ty(*pre_val);
+                let phi_id = ctx.emit(Opcode::Phi, ty, vec![], InstData::None, span);
+                phi_ids.push((name.clone(), phi_id));
+            }
+            for (name, up_id) in &upsilon_ids {
+                let phi_id = phi_ids.iter().find(|(n, _)| n == name).unwrap().1;
+                backpatch_upsilon(ctx, pre_header_block, *up_id, phi_id);
+            }
+
+            // Update scope: rebind mutated vars to their Phis
+            for (name, phi_id) in &phi_ids {
+                ctx.assign(name, *phi_id);
+            }
+
+            // Lower vow invariant at top of header (before condition)
+            if let Some(wv) = for_vow {
+                vow::lower_invariant(ctx, wv);
+            }
+
+            // Condition: idx < len
+            let cond_id = ctx.emit(
+                Opcode::LtI64,
+                Ty::Bool,
+                vec![idx_phi, len_id],
+                InstData::None,
+                span,
+            );
+            ctx.emit(
+                Opcode::Branch,
+                Ty::Unit,
+                vec![cond_id],
+                InstData::BranchTargets {
+                    then_block: body_block,
+                    else_block: exit_block,
+                },
+                span,
+            );
+
+            // Body: get element and bind to loop variable
+            ctx.switch_to_block(body_block);
+            let elem_id = ctx.emit(
+                Opcode::Call,
+                Ty::I64,
+                vec![iter_id, idx_phi],
+                InstData::CallExtern("__vow_vec_get_val".to_string()),
+                span,
+            );
+            if let Some(elem_name) = ctx.inst_vec_elem_type.get(&iter_id).cloned() {
+                ctx.inst_struct_type.insert(elem_id, elem_name);
+            }
+
+            ctx.push_scope();
+            ctx.define(binding.clone(), elem_id);
+
+            ctx.loop_exit_blocks.push(exit_block);
+            lower_block(ctx, body);
+            ctx.loop_exit_blocks.pop();
+
+            ctx.pop_scope();
+
+            // Increment index and emit back-edge
+            if !ctx.is_terminated() {
+                let one = ctx.emit(
+                    Opcode::ConstI64,
+                    Ty::I64,
+                    vec![],
+                    InstData::ConstI64(1),
+                    span,
+                );
+                let idx_next = ctx.emit(
+                    Opcode::WrappingAddI64,
+                    Ty::I64,
+                    vec![idx_phi, one],
+                    InstData::None,
+                    span,
+                );
+                ctx.emit(
+                    Opcode::Upsilon,
+                    Ty::I64,
+                    vec![idx_next],
+                    InstData::PhiTarget(idx_phi),
+                    span,
+                );
+                for (name, phi_id) in &phi_ids {
+                    if let Some(cur_val) = ctx.lookup(name) {
+                        ctx.emit(
+                            Opcode::Upsilon,
+                            ctx.inst_ty(cur_val),
+                            vec![cur_val],
+                            InstData::PhiTarget(*phi_id),
+                            span,
+                        );
+                    }
+                }
+                ctx.emit(
+                    Opcode::Jump,
+                    Ty::Unit,
+                    vec![],
+                    InstData::JumpTarget(header_block),
+                    span,
+                );
+            }
+
+            // Restore scope to Phi values for exit
+            for (name, phi_id) in &phi_ids {
+                ctx.assign(name, *phi_id);
+            }
+
             ctx.switch_to_block(exit_block);
             ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
         }

--- a/vow-syntax/src/ast.rs
+++ b/vow-syntax/src/ast.rs
@@ -288,6 +288,12 @@ pub enum ExprKind {
         vow: Option<VowBlock>,
         body: Box<Block>,
     },
+    ForEach {
+        binding: String,
+        iterable: Box<Expr>,
+        vow: Option<VowBlock>,
+        body: Box<Block>,
+    },
     Loop {
         vow: Option<VowBlock>,
         body: Box<Block>,

--- a/vow-syntax/src/parser/expr.rs
+++ b/vow-syntax/src/parser/expr.rs
@@ -61,6 +61,7 @@ impl Parser {
             lhs.kind,
             ExprKind::If { .. }
                 | ExprKind::While { .. }
+                | ExprKind::ForEach { .. }
                 | ExprKind::Loop { .. }
                 | ExprKind::Block(_)
                 | ExprKind::Match { .. }
@@ -257,6 +258,7 @@ impl Parser {
             }
             TokenKind::KwIf => self.parse_if_expr(),
             TokenKind::KwWhile => self.parse_while_expr(),
+            TokenKind::KwFor => self.parse_for_expr(),
             TokenKind::KwLoop => self.parse_loop_expr(),
             TokenKind::KwBreak => {
                 self.advance();
@@ -477,6 +479,32 @@ impl Parser {
         }
     }
 
+    fn parse_for_expr(&mut self) -> Expr {
+        let start = self.current_span();
+        self.expect(TokenKind::KwFor);
+        let (binding, _) = self
+            .expect_ident()
+            .unwrap_or(("<error>".to_string(), self.current_span()));
+        self.expect(TokenKind::KwIn);
+        let iterable = self.parse_expr_inner(0);
+        let vow = if self.at(&TokenKind::KwVow) {
+            self.parse_vow_block()
+        } else {
+            None
+        };
+        let body = self.parse_block_required();
+        let end = body.span;
+        Expr {
+            kind: ExprKind::ForEach {
+                binding,
+                iterable: Box::new(iterable),
+                vow,
+                body: Box::new(body),
+            },
+            span: start.merge(end),
+        }
+    }
+
     fn parse_loop_expr(&mut self) -> Expr {
         let start = self.current_span();
         self.expect(TokenKind::KwLoop);
@@ -546,6 +574,7 @@ impl Parser {
                 | TokenKind::LBrace
                 | TokenKind::KwIf
                 | TokenKind::KwWhile
+                | TokenKind::KwFor
                 | TokenKind::KwLoop
                 | TokenKind::KwMatch
         )

--- a/vow-syntax/src/parser/mod.rs
+++ b/vow-syntax/src/parser/mod.rs
@@ -530,6 +530,7 @@ impl Parser {
                             expr.kind,
                             ExprKind::If { .. }
                                 | ExprKind::While { .. }
+                                | ExprKind::ForEach { .. }
                                 | ExprKind::Loop { .. }
                                 | ExprKind::Block(_)
                                 | ExprKind::Match { .. }

--- a/vow-syntax/src/printer.rs
+++ b/vow-syntax/src/printer.rs
@@ -608,6 +608,39 @@ pub fn print_expr(expr: &Expr) -> String {
             out.push_str(&print_block(body, 0));
             out
         }
+        ExprKind::ForEach {
+            binding,
+            iterable,
+            vow,
+            body,
+        } => {
+            let mut out = format!("for {} in {}", binding, print_expr(iterable));
+            if let Some(v) = vow {
+                out.push_str(" vow {\n");
+                for clause in &v.clauses {
+                    match clause {
+                        VowClause::Requires { expr, .. } => {
+                            out.push_str(&format!("{}requires: {}\n", indent(1), print_expr(expr)));
+                        }
+                        VowClause::Ensures { expr, .. } => {
+                            out.push_str(&format!("{}ensures: {}\n", indent(1), print_expr(expr)));
+                        }
+                        VowClause::Invariant { expr, .. } => {
+                            out.push_str(&format!(
+                                "{}invariant: {}\n",
+                                indent(1),
+                                print_expr(expr)
+                            ));
+                        }
+                    }
+                }
+                out.push_str("} ");
+            } else {
+                out.push(' ');
+            }
+            out.push_str(&print_block(body, 0));
+            out
+        }
         ExprKind::Loop { vow, body } => {
             let mut out = "loop".to_string();
             if let Some(v) = vow {

--- a/vow-syntax/tests/integration.rs
+++ b/vow-syntax/tests/integration.rs
@@ -106,6 +106,17 @@ fn strip_expr(expr: Expr) -> Expr {
             vow: vow.map(strip_vow_block),
             body: Box::new(strip_block(*body)),
         },
+        ExprKind::ForEach {
+            binding,
+            iterable,
+            vow,
+            body,
+        } => ExprKind::ForEach {
+            binding,
+            iterable: Box::new(strip_expr(*iterable)),
+            vow: vow.map(strip_vow_block),
+            body: Box::new(strip_block(*body)),
+        },
         ExprKind::Loop { vow, body } => ExprKind::Loop {
             vow: vow.map(strip_vow_block),
             body: Box::new(strip_block(*body)),

--- a/vow-syntax/tests/proptest_roundtrip.rs
+++ b/vow-syntax/tests/proptest_roundtrip.rs
@@ -103,6 +103,17 @@ fn strip_expr(expr: Expr) -> Expr {
             vow: vow.map(strip_vow_block),
             body: Box::new(strip_block(*body)),
         },
+        ExprKind::ForEach {
+            binding,
+            iterable,
+            vow,
+            body,
+        } => ExprKind::ForEach {
+            binding,
+            iterable: Box::new(strip_expr(*iterable)),
+            vow: vow.map(strip_vow_block),
+            body: Box::new(strip_block(*body)),
+        },
         ExprKind::Loop { vow, body } => ExprKind::Loop {
             vow: vow.map(strip_vow_block),
             body: Box::new(strip_block(*body)),

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -979,6 +979,37 @@ impl<'e> Checker<'e> {
                 self.in_loop -= 1;
                 Ty::Unit
             }
+            ExprKind::ForEach {
+                binding,
+                iterable,
+                body,
+                ..
+            } => {
+                let iter_ty = self.check_expr(iterable);
+                let elem_ty = match &iter_ty {
+                    Ty::Applied(base, args) if **base == Ty::Struct("Vec".to_string()) => {
+                        args.first().cloned().unwrap_or(Ty::I64)
+                    }
+                    Ty::Never => Ty::Never,
+                    _ => {
+                        self.emit_error(
+                            ErrorCode::TypeMismatch,
+                            format!(
+                                "for-each requires `Vec<T>` iterable, got `{iter_ty}`"
+                            ),
+                            expr.span,
+                        );
+                        Ty::I64
+                    }
+                };
+                self.env.push_scope();
+                self.env.define(binding, elem_ty);
+                self.in_loop += 1;
+                self.check_block(body);
+                self.in_loop -= 1;
+                self.env.pop_scope();
+                Ty::Unit
+            }
             ExprKind::Loop { body, .. } => {
                 self.in_loop += 1;
                 self.break_types_stack.push(Some(Vec::new()));

--- a/vow-types/src/effects.rs
+++ b/vow-types/src/effects.rs
@@ -58,6 +58,12 @@ fn collect_calls_in_expr<'a>(expr: &'a Expr, calls: &mut Vec<(&'a Expr, &'a str)
             collect_calls_in_expr(condition, calls);
             collect_calls_in_block(body, calls);
         }
+        ExprKind::ForEach {
+            iterable, body, ..
+        } => {
+            collect_calls_in_expr(iterable, calls);
+            collect_calls_in_block(body, calls);
+        }
         ExprKind::Loop { body, .. } => collect_calls_in_block(body, calls),
         ExprKind::Return { value } => {
             if let Some(v) = value {

--- a/vow-types/src/linear.rs
+++ b/vow-types/src/linear.rs
@@ -188,6 +188,15 @@ fn check_expr(
             check_block(body, tracker, env, file, emitter);
             tracker.in_loop = was_in_loop;
         }
+        ExprKind::ForEach {
+            iterable, body, ..
+        } => {
+            check_expr(iterable, tracker, env, file, emitter, false);
+            let was_in_loop = tracker.in_loop;
+            tracker.in_loop = true;
+            check_block(body, tracker, env, file, emitter);
+            tracker.in_loop = was_in_loop;
+        }
         ExprKind::Loop { body, .. } => {
             let was_in_loop = tracker.in_loop;
             tracker.in_loop = true;


### PR DESCRIPTION
## Summary
- Adds `for x in vec { body }` syntax that desugars to a `while` loop with index arithmetic at IR lowering time — zero verifier impact
- Implemented in both the Rust compiler and the self-hosted compiler (`compiler/*.vow`)
- Updated grammar docs (`docs/skill/grammar.md`) and added `examples/foreach.vow`

Closes #10

## Changes

**Rust compiler (9 files):**
- `vow-syntax`: `ForEach` AST variant, parser (`parse_for_expr`), canonical printer, block-like expression handling
- `vow-types`: Type checker (validates iterable is `Vec<T>`, binds element type), effects checker, linear checker
- `vow-ir`: IR lowering (desugars to while-loop pattern with Phi/Upsilon/Branch), `collect_assigned_in_expr`

**Self-hosted compiler (4 files):**
- `compiler/ast.vow`: `EXPR_FOR()` tag (24)
- `compiler/parser.vow`: `parse_for_expr`, `is_block_expr` update
- `compiler/checker.vow`: Type checking + effect collection for `EXPR_FOR`
- `compiler/lower.vow`: IR desugaring (mirrors Rust implementation)

## Test plan
- [x] `cargo test -p vow-syntax -p vow-types -p vow-ir` — all pass
- [x] `cargo clippy -p vow-syntax -p vow-types -p vow-ir -- -D warnings` — clean
- [x] `scripts/full_test.sh` — 115 passed, 0 failed, 3 skipped
- [x] Bootstrap triple test — binary fixed point
- [x] `examples/foreach.vow` compiles and runs correctly under both compilers (output: 60)
- [x] `vowc verify examples/foreach.vow` — verified
- [x] Help coverage check passes for both compilers