### PR TITLE
feat: implement break-with-value for loop expressions (#13)

### DIFF
--- a/compiler/ast.vow
+++ b/compiler/ast.vow
@@ -24,6 +24,7 @@ fn EXPR_QUESTION() -> i64 vow { ensures: result >= 0 } { 20 }
 fn EXPR_TUPLE() -> i64 vow { ensures: result >= 0 } { 21 }
 fn EXPR_RESULT() -> i64 vow { ensures: result >= 0 } { 22 }
 fn EXPR_CAST() -> i64 vow { ensures: result >= 0 } { 23 }
+fn EXPR_LOOP() -> i64 vow { ensures: result >= 0 } { 24 }
 
 fn CLAUSE_REQUIRES() -> i64 vow { ensures: result >= 0 } { 0 }
 fn CLAUSE_ENSURES() -> i64 vow { ensures: result >= 0 } { 1 }

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -735,6 +735,7 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
                 } else {
                     if !is_coercible(e.ts, btid, loop_tid) {
                         env_emit_error(e, String::from("break type mismatch in loop"), expr_span(a, eid));
+                        break;
                     }
                 }
             }

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -709,14 +709,48 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
         let cond_eid: i64 = expr_a(a, eid);
         let body_bid: i64 = expr_b(a, eid);
         let _cond_tid: i64 = check_expr(e, m, cond_eid);
+        e.loop_kind_stack.push(0);
+        e.break_counts.push(0);
         let _body_tid: i64 = check_block(e, m, body_bid);
+        e.break_counts.pop();
+        e.loop_kind_stack.pop();
         return CTY_UNIT();
     }
 
     if tag == EXPR_LOOP() {
         let body_bid: i64 = expr_a(a, eid);
+        let break_start: i64 = e.break_tids.len();
+        e.loop_kind_stack.push(1);
+        e.break_counts.push(0);
         let _body_tid: i64 = check_block(e, m, body_bid);
-        return CTY_NEVER();
+        let bc_idx: i64 = e.break_counts.len() - 1;
+        let bc: i64 = e.break_counts[bc_idx];
+        let mut loop_tid: i64 = CTY_NEVER();
+        let mut bi: i64 = 0;
+        while bi < bc {
+            let btid: i64 = e.break_tids[break_start + bi];
+            if !is_opaque(btid) {
+                if is_opaque(loop_tid) {
+                    loop_tid = btid;
+                } else {
+                    if !is_coercible(e.ts, btid, loop_tid) {
+                        env_emit_error(e, String::from("break type mismatch in loop"), expr_span(a, eid));
+                    }
+                }
+            }
+            bi = bi + 1;
+        }
+        if is_opaque(loop_tid) {
+            loop_tid = CTY_UNIT();
+        }
+        let mut ti: i64 = 0;
+        while ti < bc {
+            e.break_tids.pop();
+            ti = ti + 1;
+        }
+        e.break_counts.pop();
+        e.loop_kind_stack.pop();
+        return loop_tid;
     }
 
     if tag == EXPR_MATCH() {
@@ -759,8 +793,23 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
 
     if tag == EXPR_BREAK() {
         let val_eid: i64 = expr_a(a, eid);
+        let mut val_tid: i64 = CTY_UNIT();
         if val_eid != -1 {
-            let _val_tid: i64 = check_expr(e, m, val_eid);
+            val_tid = check_expr(e, m, val_eid);
+            let nk: i64 = e.loop_kind_stack.len();
+            if nk > 0 {
+                if e.loop_kind_stack[nk - 1] == 0 {
+                    env_emit_error(e, String::from("`break` with a value is only allowed inside `loop`, not `while`"), expr_span(a, eid));
+                }
+            }
+        }
+        let nk2: i64 = e.loop_kind_stack.len();
+        if nk2 > 0 {
+            if e.loop_kind_stack[nk2 - 1] == 1 {
+                e.break_tids.push(val_tid);
+                let cnt_idx: i64 = e.break_counts.len() - 1;
+                e.break_counts[cnt_idx] = e.break_counts[cnt_idx] + 1;
+            }
         }
         return CTY_NEVER();
     }

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -713,6 +713,12 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
         return CTY_UNIT();
     }
 
+    if tag == EXPR_LOOP() {
+        let body_bid: i64 = expr_a(a, eid);
+        let _body_tid: i64 = check_block(e, m, body_bid);
+        return CTY_NEVER();
+    }
+
     if tag == EXPR_MATCH() {
         let scrutinee_eid: i64 = expr_a(a, eid);
         let arms_lid: i64 = expr_b(a, eid);
@@ -752,6 +758,10 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
     }
 
     if tag == EXPR_BREAK() {
+        let val_eid: i64 = expr_a(a, eid);
+        if val_eid != -1 {
+            let _val_tid: i64 = check_expr(e, m, val_eid);
+        }
         return CTY_NEVER();
     }
 
@@ -935,6 +945,11 @@ fn collect_calls_in_expr(e: CheckEnv, m: Module, eid: i64, calls: Vec<String>) [
     if tag == EXPR_WHILE() {
         collect_calls_in_expr(e, m, expr_a(a, eid), calls);
         collect_calls_in_block(e, m, expr_b(a, eid), calls);
+        return;
+    }
+
+    if tag == EXPR_LOOP() {
+        collect_calls_in_block(e, m, expr_a(a, eid), calls);
         return;
     }
 

--- a/compiler/env.vow
+++ b/compiler/env.vow
@@ -42,6 +42,10 @@ struct CheckEnv {
     cur_file: String,
 
     expr_str_eids: Vec<i64>,
+
+    loop_kind_stack: Vec<i64>,
+    break_tids: Vec<i64>,
+    break_counts: Vec<i64>,
 }
 
 fn has_eff_bit(val: i64, bit_val: i64) -> bool vow {
@@ -143,6 +147,9 @@ fn env_new(dctx: DiagCtx, file: String) -> CheckEnv {
         cur_fn_name: String::from(""),
         cur_file: file,
         expr_str_eids: Vec::new(),
+        loop_kind_stack: Vec::new(),
+        break_tids: Vec::new(),
+        break_counts: Vec::new(),
     };
 
     let str_tid: i64 = CTY_STR();

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1171,7 +1171,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             }
             return break_phi;
         }
-        // Trim break arrays (no breaks)
         let u_args2: Vec<i64> = Vec::new();
         return lctx_emit(ctx, IOP_CONST_UNIT(), ITY_UNIT(), u_args2, IDATA_NONE(), 0, 0, String::from(""));
     }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -28,6 +28,11 @@ struct LowerCtx {
     const_values: Vec<i64>,
     const_tids: Vec<i64>,
     loop_exit_blocks: Vec<i64>,
+    loop_is_loop: Vec<i64>,
+    loop_break_up_ids: Vec<i64>,
+    loop_break_up_blocks: Vec<i64>,
+    loop_break_up_tys: Vec<i64>,
+    loop_break_counts: Vec<i64>,
     vec_elem_inst_ids: Vec<i64>,
     vec_elem_names: Vec<String>,
 }
@@ -67,6 +72,11 @@ fn lctx_new(name: String, return_ty: i64, effects: i64, arena: AstArena, str_eid
         const_values: Vec::new(),
         const_tids: Vec::new(),
         loop_exit_blocks: Vec::new(),
+        loop_is_loop: Vec::new(),
+        loop_break_up_ids: Vec::new(),
+        loop_break_up_blocks: Vec::new(),
+        loop_break_up_tys: Vec::new(),
+        loop_break_counts: Vec::new(),
         vec_elem_inst_ids: Vec::new(),
         vec_elem_names: Vec::new(),
     }
@@ -539,6 +549,9 @@ fn collect_assigned_in_expr(ctx: LowerCtx, eid: i64, out: Vec<String>) {
     } else if tag == EXPR_WHILE() {
         let body_bid: i64 = expr_b(a, eid);
         collect_assigned_in_block(ctx, body_bid, out);
+    } else if tag == EXPR_LOOP() {
+        let body_bid: i64 = expr_a(a, eid);
+        collect_assigned_in_block(ctx, body_bid, out);
     } else if tag == EXPR_MATCH() {
         let arms_lid: i64 = expr_b(a, eid);
         let n_arms: i64 = list_len(a, arms_lid) / 2;
@@ -1010,7 +1023,11 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
 
         lctx_switch_to_block(ctx, body_block);
         ctx.loop_exit_blocks.push(exit_block);
+        ctx.loop_is_loop.push(0);
+        ctx.loop_break_counts.push(0);
         lower_block(ctx, body_bid);
+        ctx.loop_break_counts.pop();
+        ctx.loop_is_loop.pop();
         ctx.loop_exit_blocks.pop();
 
         if !lctx_is_terminated(ctx) {
@@ -1042,6 +1059,121 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
 
         let u_args: Vec<i64> = Vec::new();
         return lctx_emit(ctx, IOP_CONST_UNIT(), ITY_UNIT(), u_args, IDATA_NONE(), 0, 0, String::from(""));
+    }
+
+    if tag == EXPR_LOOP() {
+        let body_bid: i64 = expr_a(a, eid);
+        let vow_lid: i64 = expr_b(a, eid);
+
+        let assigned: Vec<String> = collect_assigned_vars(ctx, eid);
+
+        let header_block: i64 = lctx_new_block(ctx);
+        let exit_block: i64 = lctx_new_block(ctx);
+
+        let nassigned: i64 = assigned.len();
+        let phi_ids: Vec<i64> = Vec::new();
+        let pre_up_ids: Vec<i64> = Vec::new();
+        let pre_header_block: i64 = ctx.current_block;
+
+        let mut ai: i64 = 0;
+        while ai < nassigned {
+            let vname: String = assigned[ai];
+            let cur_val: i64 = lctx_lookup(ctx, vname);
+            let val_ty: i64 = ITY_I64();
+            let up_args: Vec<i64> = Vec::new();
+            up_args.push(cur_val);
+            let up_id: i64 = lctx_emit(ctx, IOP_UPSILON(), val_ty, up_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
+            pre_up_ids.push(up_id);
+            ai = ai + 1;
+        }
+
+        let jmp_args: Vec<i64> = Vec::new();
+        lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args, IDATA_JUMP_TARGET(), header_block, 0, String::from(""));
+
+        lctx_switch_to_block(ctx, header_block);
+
+        let mut ai2: i64 = 0;
+        while ai2 < nassigned {
+            let vname: String = assigned[ai2];
+            let phi_args: Vec<i64> = Vec::new();
+            let phi_id: i64 = lctx_emit(ctx, IOP_PHI(), ITY_I64(), phi_args, IDATA_NONE(), 0, 0, String::from(""));
+            phi_ids.push(phi_id);
+            lctx_assign(ctx, vname, phi_id);
+            ai2 = ai2 + 1;
+        }
+
+        if vow_lid != -1 {
+            lower_invariant_clauses(ctx, vow_lid);
+        }
+
+        let mut bpi: i64 = 0;
+        while bpi < nassigned {
+            backpatch_upsilon(ctx, pre_header_block, pre_up_ids[bpi], phi_ids[bpi]);
+            bpi = bpi + 1;
+        }
+
+        ctx.loop_exit_blocks.push(exit_block);
+        ctx.loop_is_loop.push(1);
+        ctx.loop_break_counts.push(0);
+        let break_start: i64 = ctx.loop_break_up_ids.len();
+        lower_block(ctx, body_bid);
+        let break_count_idx: i64 = ctx.loop_break_counts.len() - 1;
+        let break_count: i64 = ctx.loop_break_counts[break_count_idx];
+        ctx.loop_break_counts.pop();
+        ctx.loop_is_loop.pop();
+        ctx.loop_exit_blocks.pop();
+
+        if !lctx_is_terminated(ctx) {
+            let mut ai3: i64 = 0;
+            while ai3 < nassigned {
+                let vname: String = assigned[ai3];
+                let new_val: i64 = lctx_lookup(ctx, vname);
+                let val_ty: i64 = ITY_I64();
+                let up_args: Vec<i64> = Vec::new();
+                up_args.push(new_val);
+                lctx_emit(ctx, IOP_UPSILON(), val_ty, up_args, IDATA_PHI_TARGET(), phi_ids[ai3], 0, String::from(""));
+                ai3 = ai3 + 1;
+            }
+        }
+
+        if !lctx_is_terminated(ctx) {
+            let jmp_args2: Vec<i64> = Vec::new();
+            lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args2, IDATA_JUMP_TARGET(), header_block, 0, String::from(""));
+        }
+
+        let mut ai4: i64 = 0;
+        while ai4 < nassigned {
+            let vname: String = assigned[ai4];
+            lctx_assign(ctx, vname, phi_ids[ai4]);
+            ai4 = ai4 + 1;
+        }
+
+        lctx_switch_to_block(ctx, exit_block);
+
+        if break_count > 0 {
+            let first_ty: i64 = ctx.loop_break_up_tys[break_start];
+            let phi_args2: Vec<i64> = Vec::new();
+            let break_phi: i64 = lctx_emit(ctx, IOP_PHI(), first_ty, phi_args2, IDATA_NONE(), 0, 0, String::from(""));
+            let mut bi: i64 = 0;
+            while bi < break_count {
+                let up_id: i64 = ctx.loop_break_up_ids[break_start + bi];
+                let up_block: i64 = ctx.loop_break_up_blocks[break_start + bi];
+                backpatch_upsilon(ctx, up_block, up_id, break_phi);
+                bi = bi + 1;
+            }
+            // Trim the break upsilon flat arrays
+            let mut ti: i64 = 0;
+            while ti < break_count {
+                ctx.loop_break_up_ids.pop();
+                ctx.loop_break_up_blocks.pop();
+                ctx.loop_break_up_tys.pop();
+                ti = ti + 1;
+            }
+            return break_phi;
+        }
+        // Trim break arrays (no breaks)
+        let u_args2: Vec<i64> = Vec::new();
+        return lctx_emit(ctx, IOP_CONST_UNIT(), ITY_UNIT(), u_args2, IDATA_NONE(), 0, 0, String::from(""));
     }
 
     if tag == EXPR_BLOCK() {
@@ -1772,6 +1904,25 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         let nle: i64 = ctx.loop_exit_blocks.len();
         if nle > 0 {
             let exit_block: i64 = ctx.loop_exit_blocks[nle - 1];
+            let val_eid: i64 = expr_a(a, eid);
+            if val_eid != -1 {
+                let val_id: i64 = lower_expr(ctx, val_eid);
+                let is_loop_idx: i64 = ctx.loop_is_loop.len() - 1;
+                let is_loop: i64 = ctx.loop_is_loop[is_loop_idx];
+                if is_loop == 1 {
+                    let val_ty: i64 = lctx_inst_ty(ctx, val_id);
+                    let up_args: Vec<i64> = Vec::new();
+                    up_args.push(val_id);
+                    let up_id: i64 = lctx_emit(ctx, IOP_UPSILON(), val_ty, up_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
+                    let cur_block: i64 = ctx.current_block;
+                    ctx.loop_break_up_ids.push(up_id);
+                    ctx.loop_break_up_blocks.push(cur_block);
+                    ctx.loop_break_up_tys.push(val_ty);
+                    let cnt_idx: i64 = ctx.loop_break_counts.len() - 1;
+                    let old_cnt: i64 = ctx.loop_break_counts[cnt_idx];
+                    ctx.loop_break_counts[cnt_idx] = old_cnt + 1;
+                }
+            }
             let jmp_args: Vec<i64> = Vec::new();
             return lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args, IDATA_JUMP_TARGET(), exit_block, 0, String::from(""));
         }

--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -538,7 +538,7 @@ fn tok_to_binop(tag: i64) -> i64 {
 
 fn is_block_expr(a: AstArena, eid: i64) -> bool {
     let tag: i64 = expr_tag(a, eid);
-    tag == EXPR_IF() || tag == EXPR_WHILE() || tag == EXPR_MATCH() || tag == EXPR_BLOCK()
+    tag == EXPR_IF() || tag == EXPR_WHILE() || tag == EXPR_LOOP() || tag == EXPR_MATCH() || tag == EXPR_BLOCK()
 }
 
 fn parse_expr_prec(p: Parser, min_prec: i64) -> i64 {
@@ -696,9 +696,16 @@ fn parse_primary(p: Parser) -> i64 {
             let val: i64 = parse_expr(p);
             arena_add_expr(p.arena, EXPR_RETURN(), val, 0, 0, 0)
         }
+    } else if tag == tok_kw_loop() {
+        parse_loop_expr(p)
     } else if tag == tok_kw_break() {
         let _kw: Token = advance(p);
-        arena_add_expr(p.arena, EXPR_BREAK(), -1, 0, 0, 0)
+        if at(p, tok_semicolon()) || at(p, tok_rbrace()) {
+            arena_add_expr(p.arena, EXPR_BREAK(), -1, 0, 0, 0)
+        } else {
+            let val: i64 = parse_expr(p);
+            arena_add_expr(p.arena, EXPR_BREAK(), val, 0, 0, 0)
+        }
     } else if tag == tok_lbrace() {
         let bid: i64 = parse_block(p);
         arena_add_expr(p.arena, EXPR_BLOCK(), bid, 0, 0, 0)
@@ -806,6 +813,13 @@ fn parse_while_expr(p: Parser) -> i64 {
     let vow_lid: i64 = parse_vow_block(p);
     let body_bid: i64 = parse_block(p);
     arena_add_expr(p.arena, EXPR_WHILE(), cond, body_bid, vow_lid, 0)
+}
+
+fn parse_loop_expr(p: Parser) -> i64 {
+    let _kw: bool = expect(p, tok_kw_loop());
+    let vow_lid: i64 = parse_vow_block(p);
+    let body_bid: i64 = parse_block(p);
+    arena_add_expr(p.arena, EXPR_LOOP(), body_bid, vow_lid, 0, 0)
 }
 
 fn parse_match_expr(p: Parser) -> i64 {

--- a/docs/skill/examples.md
+++ b/docs/skill/examples.md
@@ -1,6 +1,6 @@
-# Worked CEGIS Examples
+# Worked Examples
 
-Three complete Counterexample-Guided Inductive Synthesis (CEGIS) cycles. Each example shows the full workflow: write spec, build, read JSON, diagnose, fix, verify.
+Verification workflow examples. The first three demonstrate Counterexample-Guided Inductive Synthesis (CEGIS) cycles: write spec, build, read JSON, diagnose, fix, verify. The fourth shows break-with-value in loop expressions.
 
 ## 1. Safe Division — Requires Pattern
 
@@ -190,3 +190,66 @@ $ vow build examples/vec_fill.vow
 - `requires: n <= 8` keeps iterations within ESBMC's unwind bound (10)
 - `invariant: i >= 0, invariant: i <= n` is inductive: true on entry, preserved by the loop body
 - The Vec model tracks `len`, so ESBMC can reason about `result.len() == n`
+
+---
+
+## 4. Linear Search — Break-with-Value
+
+### Goal
+
+Search a vector for a target value and return its index, or `-1` if not found. Uses `loop` with `break <value>` to produce a result directly from the loop expression.
+
+### Step 1: Write the spec
+
+```vow
+module Search
+
+fn linear_search(data: Vec<i64>, target: i64) -> i64
+    vow { requires: data.len() > 0 }
+{
+    let mut i: i64 = 0;
+    let n: i64 = data.len();
+    let result: i64 = loop {
+        if i >= n {
+            break -1;
+        }
+        if data[i] == target {
+            break i;
+        }
+        i = i + 1;
+    };
+    result
+}
+
+fn main() -> i32 [io] {
+    let data: Vec<i64> = Vec::new();
+    data.push(10);
+    data.push(20);
+    data.push(30);
+    data.push(40);
+    data.push(50);
+
+    let idx: i64 = linear_search(data, 30);
+    print_i64(idx);
+
+    let idx2: i64 = linear_search(data, 99);
+    print_i64(idx2);
+    0
+}
+```
+
+### Step 2: Build and verify
+
+```
+$ vow build examples/search.vow
+```
+
+```json
+{"status":"Verified","executable":"examples/search","diagnostics":[],"counterexamples":[]}
+```
+
+**Key points:**
+- `loop { ... break <value>; ... }` is an expression that evaluates to the break value
+- All `break` expressions in a `loop` must produce the same type (`i64` here)
+- `break <value>` is only allowed in `loop`, not in `while` (which always evaluates to `()`)
+- The result is bound with `let result: i64 = loop { ... };`

--- a/docs/skill/grammar.md
+++ b/docs/skill/grammar.md
@@ -308,21 +308,27 @@ while i < n vow {
 
 ### Loop (Infinite)
 
+`loop` creates an infinite loop. The expression returns the type of the `break` value:
+
 ```vow
-loop {
-    if done {
-        break result_value;
+let idx: i64 = loop {
+    if data[i] == target {
+        break i;
     }
-}
+    i = i + 1;
+    if i >= n { break -1; }
+};
 ```
 
 ESBMC cannot verify unbounded `loop` constructs — use `while` with invariants for verifiable loops.
 
 ### Break
 
+`break` exits the innermost loop. Inside `loop`, `break value` sets the loop's result:
+
 ```vow
-break;
-break value;
+break;           // exit while or loop (loop returns Unit)
+break value;     // exit loop with a value (only inside loop, not while)
 ```
 
 ### Return

--- a/examples/search.vow
+++ b/examples/search.vow
@@ -1,0 +1,34 @@
+module Search
+
+fn linear_search(data: Vec<i64>, target: i64) -> i64
+    vow { requires: data.len() > 0 }
+{
+    let mut i: i64 = 0;
+    let n: i64 = data.len();
+    let result: i64 = loop {
+        if i >= n {
+            break -1;
+        }
+        if data[i] == target {
+            break i;
+        }
+        i = i + 1;
+    };
+    result
+}
+
+fn main() -> i32 [io] {
+    let data: Vec<i64> = Vec::new();
+    data.push(10);
+    data.push(20);
+    data.push(30);
+    data.push(40);
+    data.push(50);
+
+    let idx: i64 = linear_search(data, 30);
+    print_i64(idx);
+
+    let idx2: i64 = linear_search(data, 99);
+    print_i64(idx2);
+    0
+}

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -111,6 +111,9 @@ pub struct LowerCtx {
     const_map: HashMap<String, (i64, Ty)>,
     // loop exit block stack for break
     loop_exit_blocks: Vec<BlockId>,
+    // Per-loop break-value Upsilon collector.  `Some(vec)` for `loop` (collects
+    // (source_block, upsilon_id, value_ty)), `None` for `while`.
+    loop_break_upsilons: Vec<Option<Vec<(BlockId, InstId, Ty)>>>,
     // InstId of a Vec allocation → element type name (for struct-in-Vec field access)
     inst_vec_elem_type: HashMap<InstId, String>,
     // struct name → per-field Vec element type name (for FieldGet → Vec propagation)
@@ -173,6 +176,7 @@ impl LowerCtx {
             string_exprs,
             const_map: HashMap::new(),
             loop_exit_blocks: Vec::new(),
+            loop_break_upsilons: Vec::new(),
             inst_vec_elem_type: HashMap::new(),
             struct_field_vec_elems,
         }
@@ -377,6 +381,14 @@ fn collect_assigned_in_expr(expr: &Expr, seen: &mut HashSet<String>, out: &mut V
             condition, body, ..
         } => {
             collect_assigned_in_expr(condition, seen, out);
+            for s in &body.stmts {
+                collect_assigned_in_stmt(s, seen, out);
+            }
+            if let Some(e) = &body.trailing_expr {
+                collect_assigned_in_expr(e, seen, out);
+            }
+        }
+        ExprKind::Loop { body, .. } => {
             for s in &body.stmts {
                 collect_assigned_in_stmt(s, seen, out);
             }
@@ -884,7 +896,9 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             // Body: lower body (push/pop scope handles lets inside body).
             ctx.switch_to_block(body_block);
             ctx.loop_exit_blocks.push(exit_block);
+            ctx.loop_break_upsilons.push(None);
             lower_block(ctx, body);
+            ctx.loop_break_upsilons.pop();
             ctx.loop_exit_blocks.pop();
 
             // Emit back-edge Upsilons with the current scope values.
@@ -972,7 +986,9 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             }
 
             ctx.loop_exit_blocks.push(exit_block);
+            ctx.loop_break_upsilons.push(Some(Vec::new()));
             lower_block(ctx, body);
+            let break_ups = ctx.loop_break_upsilons.pop().unwrap();
             ctx.loop_exit_blocks.pop();
 
             // Back-edge Upsilons
@@ -1002,7 +1018,23 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             }
 
             ctx.switch_to_block(exit_block);
-            ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
+
+            // If any break carried a value, emit a Phi to merge them.
+            if let Some(ups) = break_ups {
+                if ups.is_empty() {
+                    ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
+                } else {
+                    let ty = ups[0].2;
+                    let phi_id =
+                        ctx.emit(Opcode::Phi, ty, vec![], InstData::None, span);
+                    for (block, up_id, _) in &ups {
+                        backpatch_upsilon(ctx, *block, *up_id, phi_id);
+                    }
+                    phi_id
+                }
+            } else {
+                ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
+            }
         }
         ExprKind::Break { value } => {
             let exit_block = ctx
@@ -1010,9 +1042,27 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .last()
                 .copied()
                 .expect("break outside of loop");
+
             if let Some(val_expr) = value {
-                lower_expr(ctx, val_expr);
+                let val_id = lower_expr(ctx, val_expr);
+                // If inside a `loop` (Some), emit Upsilon for the break-value Phi.
+                let is_loop = matches!(ctx.loop_break_upsilons.last(), Some(Some(_)));
+                if is_loop {
+                    let val_ty = ctx.inst_ty(val_id);
+                    let up_id = ctx.emit(
+                        Opcode::Upsilon,
+                        val_ty,
+                        vec![val_id],
+                        InstData::PhiTarget(InstId(u32::MAX)),
+                        span,
+                    );
+                    let block = ctx.current_block;
+                    if let Some(Some(ups)) = ctx.loop_break_upsilons.last_mut() {
+                        ups.push((block, up_id, val_ty));
+                    }
+                }
             }
+
             ctx.emit(
                 Opcode::Jump,
                 Ty::Unit,

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -50,6 +50,9 @@ pub struct Checker<'e> {
     pub(crate) emitter: &'e mut dyn DiagnosticEmitter,
     string_exprs: StringExprSet,
     in_loop: u32,
+    /// Stack of break-value type collectors. `Some(vec)` for `loop` (collects
+    /// break types), `None` for `while` (break-with-value is an error).
+    break_types_stack: Vec<Option<Vec<Ty>>>,
     pub const_values: HashMap<String, i64>,
     pub const_types: HashMap<String, Ty>,
 }
@@ -65,6 +68,7 @@ impl<'e> Checker<'e> {
             emitter,
             string_exprs: HashSet::new(),
             in_loop: 0,
+            break_types_stack: Vec::new(),
             const_values: HashMap::new(),
             const_types: HashMap::new(),
         }
@@ -969,15 +973,23 @@ impl<'e> Checker<'e> {
             } => {
                 self.check_expr(condition);
                 self.in_loop += 1;
+                self.break_types_stack.push(None);
                 self.check_block(body);
+                self.break_types_stack.pop();
                 self.in_loop -= 1;
                 Ty::Unit
             }
             ExprKind::Loop { body, .. } => {
                 self.in_loop += 1;
+                self.break_types_stack.push(Some(Vec::new()));
                 self.check_block(body);
+                let break_tys = self.break_types_stack.pop().unwrap();
                 self.in_loop -= 1;
-                Ty::Unit
+                if let Some(tys) = break_tys {
+                    tys.into_iter().find(|t| *t != Ty::Never).unwrap_or(Ty::Unit)
+                } else {
+                    Ty::Unit
+                }
             }
             ExprKind::Break { value } => {
                 if self.in_loop == 0 {
@@ -987,8 +999,24 @@ impl<'e> Checker<'e> {
                         expr.span,
                     );
                 }
-                if let Some(v) = value {
-                    self.check_expr(v);
+                let val_ty = if let Some(v) = value {
+                    let ty = self.check_expr(v);
+                    // break-with-value only allowed inside `loop`, not `while`
+                    if let Some(top) = self.break_types_stack.last()
+                        && top.is_none()
+                    {
+                        self.emit_error(
+                            ErrorCode::TypeMismatch,
+                            "`break` with a value is only allowed inside `loop`, not `while`",
+                            expr.span,
+                        );
+                    }
+                    ty
+                } else {
+                    Ty::Unit
+                };
+                if let Some(Some(tys)) = self.break_types_stack.last_mut() {
+                    tys.push(val_ty);
                 }
                 Ty::Never
             }
@@ -1989,6 +2017,43 @@ mod tests {
         let mut checker = new_checker(&mut emitter);
         let ty = checker.check_expr(&make_expr(ExprKind::Break { value: None }));
         assert_eq!(ty, Ty::Never);
+    }
+
+    #[test]
+    fn loop_with_break_value_returns_break_type() {
+        let mut emitter = TestEmitter(vec![]);
+        let mut checker = new_checker(&mut emitter);
+        // loop { break 42; }  →  should have type I32
+        let ty = checker.check_expr(&make_expr(ExprKind::Loop {
+            vow: None,
+            body: Box::new(Block {
+                stmts: vec![],
+                trailing_expr: Some(Box::new(make_expr(ExprKind::Break {
+                    value: Some(Box::new(int_lit())),
+                }))),
+                span: dummy_span(),
+            }),
+        }));
+        assert_eq!(ty, Ty::I32);
+        assert!(!checker.has_errors());
+    }
+
+    #[test]
+    fn break_with_value_in_while_is_error() {
+        let mut emitter = TestEmitter(vec![]);
+        let mut checker = new_checker(&mut emitter);
+        checker.check_expr(&make_expr(ExprKind::While {
+            condition: Box::new(bool_lit()),
+            vow: None,
+            body: Box::new(Block {
+                stmts: vec![],
+                trailing_expr: Some(Box::new(make_expr(ExprKind::Break {
+                    value: Some(Box::new(int_lit())),
+                }))),
+                span: dummy_span(),
+            }),
+        }));
+        assert!(checker.has_errors());
     }
 
     // --- Return ---

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -986,7 +986,32 @@ impl<'e> Checker<'e> {
                 let break_tys = self.break_types_stack.pop().unwrap();
                 self.in_loop -= 1;
                 if let Some(tys) = break_tys {
-                    tys.into_iter().find(|t| *t != Ty::Never).unwrap_or(Ty::Unit)
+                    let mut result_ty = Ty::Unit;
+                    let mut found = false;
+                    for ty in &tys {
+                        if *ty == Ty::Never {
+                            continue;
+                        }
+                        if !found {
+                            result_ty = ty.clone();
+                            found = true;
+                        } else {
+                            let ok = *ty == result_ty
+                                || (*ty == Ty::I32 && result_ty.is_integer())
+                                || (result_ty == Ty::I32 && ty.is_integer());
+                            if !ok {
+                                self.emit_error(
+                                    ErrorCode::TypeMismatch,
+                                    format!(
+                                        "break type mismatch: expected `{result_ty}`, found `{ty}`"
+                                    ),
+                                    expr.span,
+                                );
+                                break;
+                            }
+                        }
+                    }
+                    result_ty
                 } else {
                     Ty::Unit
                 }
@@ -2054,6 +2079,31 @@ mod tests {
             }),
         }));
         assert!(checker.has_errors());
+    }
+
+    #[test]
+    fn break_type_mismatch_is_error() {
+        let mut emitter = TestEmitter(vec![]);
+        let mut checker = new_checker(&mut emitter);
+        // loop { break 42; break true; } — mismatched break types
+        checker.check_expr(&make_expr(ExprKind::Loop {
+            vow: None,
+            body: Box::new(Block {
+                stmts: vec![Stmt::Expr {
+                    expr: make_expr(ExprKind::Break {
+                        value: Some(Box::new(int_lit())),
+                    }),
+                    has_semicolon: true,
+                    span: dummy_span(),
+                }],
+                trailing_expr: Some(Box::new(make_expr(ExprKind::Break {
+                    value: Some(Box::new(bool_lit())),
+                }))),
+                span: dummy_span(),
+            }),
+        }));
+        assert!(checker.has_errors());
+        assert!(emitter.0.iter().any(|d| d.message.contains("break type mismatch")));
     }
 
     // --- Return ---


### PR DESCRIPTION
## Summary

- `loop` expressions now return the type of their `break` values, enabling type-safe early exit from search/validation patterns without sentinel variables
- `break expr` inside `loop` propagates the value via Phi/Upsilon in the exit block; `break expr` inside `while` is now a type error
- Both Rust and self-hosted compilers updated (type checker, IR lowering, parser, AST)
- No changes needed in codegen, C emitter, or verification pipeline — they handle Phi/Upsilon generically
- Added `examples/search.vow` demonstrating linear search with `loop { break value; }`

Closes #13

## Test plan

- [x] `cargo test -p vow-types -p vow-ir`: 58 + 51 tests pass (includes 2 new break-with-value tests)
- [x] `cargo clippy --all -- -D warnings`: clean
- [x] `scripts/bootstrap.sh --no-verify`: fixed-point match
- [x] `scripts/full_test.sh`: 113 passed, 0 failed, 3 skipped
- [x] Help coverage checks pass for both compilers
- [x] `examples/search.vow`: compiles, runs correctly, contracts verified