### PR TITLE
feat: for-each loops, pub visibility, ESBMC bounds (#41)

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -796,6 +796,8 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"control_flow\": {\n"));
     r.push_str(String::from("      \"if_else\": \"if cond { expr } else { expr } \\u2014 expression, both branches same type\",\n"));
     r.push_str(String::from("      \"while\": \"while cond { body }\",\n"));
+    r.push_str(String::from("      \"for_each\": \"for item in vec { body } \\u2014 iterate Vec elements\",\n"));
+    r.push_str(String::from("      \"for_enumerate\": \"for i, item in vec { body } \\u2014 iterate with index\",\n"));
     r.push_str(String::from("      \"loop\": \"loop { ... break value; } \\u2014 infinite loop, break to exit\",\n"));
     r.push_str(String::from("      \"break\": \"break; or break value;\",\n"));
     r.push_str(String::from("      \"return\": \"return; or return value;\"\n"));
@@ -845,6 +847,12 @@ fn skill_json() -> String {
     r.push_str(String::from("      \"read\": \"v[i] \\u2014 Vec index access\",\n"));
     r.push_str(String::from("      \"write\": \"v[i] = val \\u2014 Vec index assignment\"\n"));
     r.push_str(String::from("    }\n"));
+    r.push_str(String::from("  },\n"));
+    r.push_str(String::from("  \"verification_limits\": {\n"));
+    r.push_str(String::from("    \"loop_unwind\": 10,\n"));
+    r.push_str(String::from("    \"Vec<T>\": 128,\n"));
+    r.push_str(String::from("    \"String\": 256,\n"));
+    r.push_str(String::from("    \"HashMap<K, V>\": 64\n"));
     r.push_str(String::from("  }\n"));
     r.push_str(String::from("}\n"));
     r
@@ -920,6 +928,12 @@ fn skill_human() -> String {
     r.push_str(String::from("METHODS   : Vec: Vec::new/push/pop/len/v[i]/v[i] = val   String: String::from/len/byte_at/push_byte/push_str/contains/eq/substring/parse_i64/parse_u64\n"));
     r.push_str(String::from("            HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap\n"));
     r.push_str(String::from("OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   - ! & ?\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("VERIFICATION LIMITS\n"));
+    r.push_str(String::from("  Loop unwind  : 10 iterations\n"));
+    r.push_str(String::from("  Vec<T>        : 128 max capacity\n"));
+    r.push_str(String::from("  String        : 256 max capacity\n"));
+    r.push_str(String::from("  HashMap<K, V> : 64 max capacity\n"));
     r
 }
 

--- a/examples/for_each.vow
+++ b/examples/for_each.vow
@@ -1,0 +1,15 @@
+module ForEach
+
+fn main() -> i32 [io] {
+    let v: Vec<i64> = Vec::new();
+    v.push(10);
+    v.push(20);
+    v.push(30);
+
+    let mut total: i64 = 0;
+    for x in v {
+        total = total + x;
+    }
+    print_i64(total);
+    0
+}

--- a/examples/for_enumerate.vow
+++ b/examples/for_enumerate.vow
@@ -1,0 +1,14 @@
+module ForEnumerate
+
+fn main() -> i32 [io] {
+    let v: Vec<i64> = Vec::new();
+    v.push(100);
+    v.push(200);
+    v.push(300);
+
+    for i, x in v {
+        print_i64(i);
+        print_i64(x);
+    }
+    0
+}

--- a/scripts/generate_help.py
+++ b/scripts/generate_help.py
@@ -21,6 +21,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 GRAMMAR = REPO / "docs" / "skill" / "grammar.md"
 CLI = REPO / "docs" / "skill" / "cli.md"
+CONTRACTS = REPO / "docs" / "skill" / "contracts.md"
 MAIN_RS = REPO / "vow" / "src" / "main.rs"
 MAIN_VOW = REPO / "compiler" / "main.vow"
 
@@ -73,7 +74,7 @@ def extract_table_col(text: str, heading: str, col: int = 0, **kw) -> list[str]:
 # Build JSON structure from grammar.md + cli.md
 # ---------------------------------------------------------------------------
 
-def build_help_json(grammar: str, cli: str) -> dict:
+def build_help_json(grammar: str, cli: str, contracts: str) -> dict:
     # --- Types ---
     prim_types = extract_table_col(grammar, "Primitive Types", 0)
     param_types = extract_table_col(grammar, "Built-in Parameterized Types", 0)
@@ -148,6 +149,17 @@ def build_help_json(grammar: str, cli: str) -> dict:
             flag, _default, desc = row[0], row[1], row[2]
             verify_options[flag] = desc
 
+    # --- Verification limits from contracts.md ---
+    collection_rows = extract_table(contracts, "Collection Models for Verification")
+    verification_limits: dict[str, str | int] = {
+        "loop_unwind": 10,
+    }
+    for row in collection_rows:
+        if len(row) >= 2:
+            type_name = row[0].strip()
+            capacity = int(row[1].strip())
+            verification_limits[type_name] = capacity
+
     return {
         "tool": "vow",
         "description": "Vow compiler: compiles Vow source to native executables with contract verification",
@@ -219,6 +231,8 @@ def build_help_json(grammar: str, cli: str) -> dict:
             "control_flow": {
                 "if_else": "if cond { expr } else { expr } \u2014 expression, both branches same type",
                 "while": "while cond { body }",
+                "for_each": "for item in vec { body } \u2014 iterate Vec elements",
+                "for_enumerate": "for i, item in vec { body } \u2014 iterate with index",
                 "loop": "loop { ... break value; } \u2014 infinite loop, break to exit",
                 "break": "break; or break value;",
                 "return": "return; or return value;",
@@ -241,6 +255,7 @@ def build_help_json(grammar: str, cli: str) -> dict:
                 "write": "v[i] = val \u2014 Vec index assignment",
             },
         },
+        "verification_limits": verification_limits,
     }
 
 
@@ -348,6 +363,15 @@ def build_help_human(data: dict) -> str:
     logical = " ".join(ops["logical"])
     unary = " ".join(ops["unary"])
     lines.append(f"OPERATORS : {arith}   {checked} (checked)   {comp}   {logical}   {unary}")
+    lines.append("")
+
+    vlimits = data.get("verification_limits", {})
+    if vlimits:
+        lines.append("VERIFICATION LIMITS")
+        lines.append(f"  Loop unwind  : {vlimits.get('loop_unwind', 10)} iterations")
+        for key, val in vlimits.items():
+            if key != "loop_unwind":
+                lines.append(f"  {key:<14s}: {val} max capacity")
 
     return "\n".join(lines)
 
@@ -429,8 +453,9 @@ def main() -> None:
 
     grammar = GRAMMAR.read_text()
     cli = CLI.read_text()
+    contracts = CONTRACTS.read_text()
 
-    data = build_help_json(grammar, cli)
+    data = build_help_json(grammar, cli, contracts)
     json_str = json.dumps(data, indent=2)
     human_str = build_help_human(data)
 

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -1010,6 +1010,42 @@ impl<'e> Checker<'e> {
                 self.env.pop_scope();
                 Ty::Unit
             }
+            ExprKind::For {
+                binding,
+                index_binding,
+                iterable,
+                body,
+                ..
+            } => {
+                let iter_ty = self.check_expr(iterable);
+                let elem_ty = match &iter_ty {
+                    Ty::Applied(base, args)
+                        if matches!(base.as_ref(), Ty::Struct(n) if n == "Vec")
+                            && !args.is_empty() =>
+                    {
+                        args[0].clone()
+                    }
+                    Ty::Never => Ty::Never,
+                    _ => {
+                        self.emit_error(
+                            ErrorCode::TypeMismatch,
+                            format!("for loop requires Vec<T>, found `{iter_ty}`"),
+                            expr.span,
+                        );
+                        Ty::Never
+                    }
+                };
+                self.env.push_scope();
+                if let Some(idx) = index_binding {
+                    self.env.define(idx, Ty::I64);
+                }
+                self.env.define(binding, elem_ty);
+                self.in_loop += 1;
+                self.check_block(body);
+                self.in_loop -= 1;
+                self.env.pop_scope();
+                Ty::Unit
+            }
             ExprKind::Loop { body, .. } => {
                 self.in_loop += 1;
                 self.break_types_stack.push(Some(Vec::new()));

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -290,6 +290,8 @@ fn skill_json() -> String {
     "control_flow": {
       "if_else": "if cond { expr } else { expr } \u2014 expression, both branches same type",
       "while": "while cond { body }",
+      "for_each": "for item in vec { body } \u2014 iterate Vec elements",
+      "for_enumerate": "for i, item in vec { body } \u2014 iterate with index",
       "loop": "loop { ... break value; } \u2014 infinite loop, break to exit",
       "break": "break; or break value;",
       "return": "return; or return value;"
@@ -339,6 +341,12 @@ fn skill_json() -> String {
       "read": "v[i] \u2014 Vec index access",
       "write": "v[i] = val \u2014 Vec index assignment"
     }
+  },
+  "verification_limits": {
+    "loop_unwind": 10,
+    "Vec<T>": 128,
+    "String": 256,
+    "HashMap<K, V>": 64
   }
 }"#
     .to_string()
@@ -413,7 +421,13 @@ BUILTINS  : print_str: fn(s: String) -> () [io]   print_i64: fn(v: i64) -> () [i
             eprintln_str: fn(s: String) -> () [io]   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> () [write]   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   process_exit: fn(code: i64) -> () [io]
 METHODS   : Vec: Vec::new/push/pop/len/v[i]/v[i] = val   String: String::from/len/byte_at/push_byte/push_str/contains/eq/substring/parse_i64/parse_u64
             HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap
-OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   - ! & ?"#
+OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   - ! & ?
+
+VERIFICATION LIMITS
+  Loop unwind  : 10 iterations
+  Vec<T>        : 128 max capacity
+  String        : 256 max capacity
+  HashMap<K, V> : 64 max capacity"#
         .to_string()
 }
 


### PR DESCRIPTION
## Summary

- **For-each loops**: `for item in vec { }` and `for i, item in vec { }` in both Rust and self-hosted compilers — desugars to while with index, supports vow invariants
- **Pub visibility tracking**: self-hosted parser now stores `pub` in AST instead of discarding it
- **ESBMC bounds in --help**: `verification_limits` section added to JSON and human-readable help output

Closes #41 (3 of 4 tasks; linear type parity deferred as separate work)

## Test plan

- [x] `cargo test --all` — all pass
- [x] `cargo clippy --all -- -D warnings` — zero warnings
- [x] Bootstrap triple test — SHA-256 fixed point match
- [x] `scripts/full_test.sh` — 117 passed, 0 failed, 3 skipped
- [x] `examples/for_each.vow` — prints 60 (sum of 10+20+30)
- [x] `examples/for_enumerate.vow` — prints index/value pairs
- [x] Both compilers produce identical output for for-each examples