### PR TITLE
feat: P4 longer-term improvements — effects, CEGIS, FFI, dealloc (#42)

### DIFF
--- a/bench/prompts.py
+++ b/bench/prompts.py
@@ -41,7 +41,142 @@ Fill in the function bodies so that all contracts verify. Return ONLY the comple
 Return the complete .vow file with function bodies filled in. Do not change the module name, function signatures, or contracts."""
 
 
-def build_cegis_user_prompt(verify_output: str) -> str:
+def _classify_violation(violation: str) -> str:
+    """Classify a violation string as requires/ensures/invariant."""
+    v = violation.lower()
+    if "require" in v:
+        return "requires"
+    if "ensure" in v:
+        return "ensures"
+    if "invariant" in v:
+        return "invariant"
+    return "contract"
+
+
+def _format_values(values: dict[str, str]) -> str:
+    """Format variable bindings into a readable string."""
+    if not values:
+        return "(no concrete values available)"
+    return ", ".join(f"{k}={v}" for k, v in values.items())
+
+
+def curate_verify_output(
+    parsed_json: dict,
+    iteration: int,
+    previous_violations: list[str],
+) -> str:
+    """Transform raw verify JSON into a curated CEGIS feedback message."""
+    status = parsed_json.get("status", "")
+    parts: list[str] = []
+
+    if status == "CompileFailed":
+        diagnostics = parsed_json.get("diagnostics", [])
+        parts.append("**Compilation failed.** Fix the following errors:\n")
+        for d in diagnostics:
+            msg = d.get("message", "")
+            code = d.get("error_code", "")
+            hints = d.get("hints", [])
+            parts.append(f"- [{code}] {msg}")
+            for h in hints:
+                parts.append(f"  Hint: {h}")
+        parts.append(
+            "\nFix the implementation so it compiles and all contracts verify. "
+            "Return ONLY the complete updated .vow file, no explanation."
+        )
+        return "\n".join(parts)
+
+    counterexamples = parsed_json.get("counterexamples", [])
+    func = parsed_json.get("function", "unknown")
+
+    if not counterexamples:
+        parts.append(f"Verification failed on function `{func}` but no counterexample was produced.")
+        parts.append(f"\nRaw output:\n```json\n{_json_compact(parsed_json)}\n```")
+    else:
+        parts.append(f"**Verification failed** on function `{func}` (CEGIS iteration {iteration}).\n")
+        for i, ce in enumerate(counterexamples):
+            violation = ce.get("violation", "unknown")
+            blame = ce.get("blame", "unknown")
+            values = ce.get("values", {})
+            vow_id = ce.get("vow_id", "?")
+            vtype = _classify_violation(violation)
+
+            parts.append(f"**Counterexample {i + 1}:**")
+            parts.append(f"- Violation: `{vtype}: {violation}` (vow_id={vow_id}, blame={blame})")
+            parts.append(f"- Variable values at failure: {_format_values(values)}")
+
+            exec_path = ce.get("execution_path", [])
+            if exec_path:
+                blocks = [str(step.get("block_id", "?")) for step in exec_path]
+                parts.append(f"- Execution path (blocks visited): {' → '.join(blocks)}")
+
+            branch_decisions = ce.get("branch_decisions", [])
+            if branch_decisions:
+                decisions = [f"branch@{bd.get('condition_offset', '?')}→{bd.get('taken', '?')}"
+                             for bd in branch_decisions]
+                parts.append(f"- Branch decisions: {', '.join(decisions)}")
+            parts.append("")
+
+    if previous_violations:
+        parts.append("**Previous failed attempts:**")
+        for j, pv in enumerate(previous_violations):
+            parts.append(f"- Iteration {j + 1}: {pv}")
+        parts.append("")
+        parts.append("Do NOT repeat the same approach. Try a different invariant or algorithm.")
+        parts.append("")
+
+    # Generate targeted hints based on violation type
+    if counterexamples:
+        ce0 = counterexamples[0]
+        violation = ce0.get("violation", "")
+        values = ce0.get("values", {})
+        vtype = _classify_violation(violation)
+        if vtype == "invariant" and values:
+            var_hints = []
+            for k, v in values.items():
+                var_hints.append(f"`{k}`={v}")
+            parts.append(
+                f"**Hint:** The loop invariant `{violation}` was falsified with "
+                f"{', '.join(var_hints)}. Tighten the invariant or strengthen the loop guard."
+            )
+        elif vtype == "requires" and values:
+            parts.append(
+                f"**Hint:** The precondition `{violation}` was violated by the caller. "
+                f"Add bounds to the function's `requires` clause to exclude this input."
+            )
+        elif vtype == "ensures" and values:
+            parts.append(
+                f"**Hint:** The postcondition `{violation}` was not satisfied. "
+                f"Check the algorithm logic for the case where "
+                f"{_format_values(values)}."
+            )
+
+    parts.append(
+        "\nFix the implementation so all contracts verify. "
+        "Return ONLY the complete updated .vow file, no explanation."
+    )
+    return "\n".join(parts)
+
+
+def _json_compact(d: dict) -> str:
+    """Compact JSON for fallback display."""
+    import json
+    return json.dumps(d, indent=2)
+
+
+def build_cegis_user_prompt(
+    verify_output: str,
+    iteration: int = 1,
+    previous_violations: list[str] | None = None,
+    parsed: dict | None = None,
+) -> str:
+    """Build a curated CEGIS feedback prompt.
+
+    Falls back to raw JSON if parsed data is not available.
+    """
+    if parsed is not None:
+        return curate_verify_output(parsed, iteration, previous_violations or [])
+
+    # Fallback: raw JSON (backwards compatible)
     return f"""Verification failed. Here is the full JSON output from `vow verify`:
 
 ```json

--- a/bench/runner.py
+++ b/bench/runner.py
@@ -96,6 +96,7 @@ def run_benchmark(
     messages: list[dict[str, str]] = []
     raw_responses: list[str] = []
     verify_outputs: list[str] = []
+    previous_violations: list[str] = []
     total_input = 0
     total_output = 0
     final_code = ""
@@ -155,9 +156,31 @@ def run_benchmark(
                 verify_outputs=verify_outputs,
             )
 
+        # Track violation summary for previous-attempt context
+        violation_summary = ""
+        if vr.parsed:
+            ces = vr.parsed.get("counterexamples", [])
+            if ces:
+                ce0 = ces[0]
+                violation_summary = f"violation: {ce0.get('violation', '?')}"
+                vals = ce0.get("values", {})
+                if vals:
+                    val_str = ", ".join(f"{k}={v}" for k, v in vals.items())
+                    violation_summary += f" ({val_str})"
+            elif vr.parsed.get("status") == "CompileFailed":
+                diags = vr.parsed.get("diagnostics", [])
+                if diags:
+                    violation_summary = f"compile error: {diags[0].get('message', '?')}"
+        previous_violations.append(violation_summary)
+
         # Not verified — if iterations remain, send CEGIS feedback
         if iteration < max_iters:
-            cegis_msg = build_cegis_user_prompt(vr.raw_json)
+            cegis_msg = build_cegis_user_prompt(
+                vr.raw_json,
+                iteration=iteration,
+                previous_violations=previous_violations,
+                parsed=vr.parsed,
+            )
             messages.append({"role": "user", "content": cegis_msg})
 
     # Exhausted iterations

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -607,6 +607,22 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
                     env_emit_error_code(e, EC_UNKNOWN_METHOD(), verr_msg, expr_span(a, eid));
                     return CTY_UNIT();
                 }
+                if base_name == String::from("Option") || base_name == String::from("Result") {
+                    let hargs_lid: i64 = ty_b(e.ts, recv_tid);
+                    let inner_tid: i64 = if ts_arg_len(e.ts, hargs_lid) > 0 {
+                        ts_arg_get(e.ts, hargs_lid, 0)
+                    } else {
+                        CTY_UNIT()
+                    };
+                    if mname == String::from("unwrap") { return inner_tid; }
+                    let oerr_msg: String = String::from("unknown method '");
+                    oerr_msg.push_str(mname);
+                    oerr_msg.push_str(String::from("' on type '"));
+                    oerr_msg.push_str(base_name);
+                    oerr_msg.push_str(String::from("'"));
+                    env_emit_error_code(e, EC_UNKNOWN_METHOD(), oerr_msg, expr_span(a, eid));
+                    return CTY_UNIT();
+                }
                 if base_name == String::from("HashMap") {
                     let hargs_lid: i64 = ty_b(e.ts, recv_tid);
                     let val_tid: i64 = if ts_arg_len(e.ts, hargs_lid) > 1 {
@@ -997,6 +1013,7 @@ fn collect_calls_in_expr(e: CheckEnv, m: Module, eid: i64, calls: Vec<String>) [
 
     if tag == EXPR_METHOD() {
         let recv_eid: i64 = expr_a(a, eid);
+        let mname_sid: i64 = expr_b(a, eid);
         let args_lid: i64 = expr_c(a, eid);
         collect_calls_in_expr(e, m, recv_eid, calls);
         let n: i64 = list_len(a, args_lid);
@@ -1004,6 +1021,10 @@ fn collect_calls_in_expr(e: CheckEnv, m: Module, eid: i64, calls: Vec<String>) [
         while i < n {
             collect_calls_in_expr(e, m, list_get(a, args_lid, i), calls);
             i = i + 1;
+        }
+        let mname: String = arena_str(a, mname_sid);
+        if mname == String::from("unwrap") {
+            calls.push(String::from("__unwrap__"));
         }
         return;
     }
@@ -1158,13 +1179,20 @@ fn check_effects_fn(e: CheckEnv, m: Module, fid: i64) [io] {
     collect_calls_in_block(e, m, body_bid, calls);
     let n: i64 = calls.len();
     let mut i: i64 = 0;
+    let eff_panic: i64 = 2;
     while i < n {
         let cname: String = calls[i];
-        let fidx: i64 = env_lookup_fn(e, cname);
-        if fidx != -1 {
-            let needed_eff: i64 = e.fn_effects[fidx];
-            if needed_eff != 0 && !effect_covered(declared_eff, needed_eff) {
-                env_emit_error(e, String::from("effectful call from pure function"), fn_span(a, fid));
+        if cname == String::from("__unwrap__") {
+            if !has_eff_bit(declared_eff, eff_panic) {
+                env_emit_error(e, String::from(".unwrap() requires [panic] effect"), fn_span(a, fid));
+            }
+        } else {
+            let fidx: i64 = env_lookup_fn(e, cname);
+            if fidx != -1 {
+                let needed_eff: i64 = e.fn_effects[fidx];
+                if needed_eff != 0 && !effect_covered(declared_eff, needed_eff) {
+                    env_emit_error(e, String::from("effectful call from pure function"), fn_span(a, fid));
+                }
             }
         }
         i = i + 1;

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -36,6 +36,10 @@ struct LowerCtx {
     vec_elem_inst_ids: Vec<i64>,
     vec_elem_names: Vec<String>,
     warnings: Vec<String>,
+    alloc_ids: Vec<i64>,
+    alloc_tags: Vec<String>,
+    escaped_ids: Vec<i64>,
+    branch_depth: i64,
 }
 
 struct ScopeSnap {
@@ -81,6 +85,10 @@ fn lctx_new(name: String, return_ty: i64, effects: i64, arena: AstArena, str_eid
         vec_elem_inst_ids: Vec::new(),
         vec_elem_names: Vec::new(),
         warnings: Vec::new(),
+        alloc_ids: Vec::new(),
+        alloc_tags: Vec::new(),
+        escaped_ids: Vec::new(),
+        branch_depth: 0,
     }
 }
 

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -808,7 +808,7 @@ fn skill_json() -> String {
     r.push_str(String::from("      \"visibility\": \"pub fn \\u2014 public functions visible to importers\"\n"));
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"type_aliases\": \"type Name = Type\",\n"));
-    r.push_str(String::from("    \"extern_blocks\": \"extern { fn c_function(x: i64) -> i64 [unsafe] }\",\n"));
+    r.push_str(String::from("    \"extern_blocks\": \"extern \\\"C\\\" vow { requires: ... } { fn name(x: i64) -> i64 [unsafe] }\",\n"));
     r.push_str(String::from("    \"methods\": {\n"));
     r.push_str(String::from("      \"Vec<T>\": [\n"));
     r.push_str(String::from("        \"Vec::new()\",\n"));

--- a/docs/skill/contracts.md
+++ b/docs/skill/contracts.md
@@ -284,3 +284,19 @@ vow {
 ```
 
 ESBMC verifies `u64` contracts using `uint64_t` and unsigned nondet values.
+
+## Extern Block Contracts
+
+Every `extern "C"` block **must** include a `vow { ... }` contract specifying the expected behavior of foreign functions. Omitting the contract is a `MissingContract` error.
+
+```vow
+extern "C" vow {
+    requires: fd >= 0
+    ensures: return >= 0
+}
+{
+    fn write(fd: i32, ptr: i64, len: i64) -> i64 [io]
+}
+```
+
+The contract applies to all functions declared in the block. ESBMC uses `requires` as assumptions and `ensures` as assertions when verifying callers of extern functions.

--- a/docs/skill/errors.md
+++ b/docs/skill/errors.md
@@ -144,6 +144,21 @@ trait Foo {
 
 **Fix:** Remove the unsupported construct. Vow does not support traits or impl blocks.
 
+### MissingContract
+
+**Phase:** Type Checker
+**Meaning:** An `extern "C"` block was declared without a `vow { ... }` contract. Every foreign function call requires a mandatory contract specifying expected behavior.
+
+```vow
+extern "C" {
+    fn write(fd: i32, ptr: i64, len: i64) -> i64 [io];
+}
+```
+
+**Output:** `extern block requires a vow contract`
+
+**Fix:** Add a `vow { ... }` block to the extern declaration with `requires` and/or `ensures` clauses.
+
 ### VowRequiresViolated
 
 **Phase:** Verification (ESBMC)

--- a/docs/skill/grammar.md
+++ b/docs/skill/grammar.md
@@ -506,13 +506,19 @@ v[i] = new_val;
 
 ## Extern Blocks
 
-Declare external C functions:
+Declare external C functions (a `vow` contract block is required):
 
 ```vow
-extern {
-    fn c_function(x: i64) -> i64 [unsafe]
+extern "C" vow {
+    requires: fd >= 0
+    ensures: return >= 0
+}
+{
+    fn write(fd: i32, ptr: i64, len: i64) -> i64 [io]
 }
 ```
+
+Omitting the `vow` block produces a `MissingContract` error (see [errors.md](errors.md)).
 
 ## Type Aliases
 

--- a/scripts/generate_help.py
+++ b/scripts/generate_help.py
@@ -243,7 +243,7 @@ def build_help_json(grammar: str, cli: str, contracts: str) -> dict:
                 "visibility": "pub fn \u2014 public functions visible to importers",
             },
             "type_aliases": "type Name = Type",
-            "extern_blocks": "extern { fn c_function(x: i64) -> i64 [unsafe] }",
+            "extern_blocks": "extern \"C\" vow { requires: ... } { fn name(x: i64) -> i64 [unsafe] }",
             "methods": {
                 "Vec<T>": vec_methods,
                 "String": string_methods,

--- a/vow-diag/src/lib.rs
+++ b/vow-diag/src/lib.rs
@@ -56,6 +56,8 @@ pub enum ErrorCode {
     UnsupportedFeature,
     // Lowering warnings
     LoweringWarning,
+    // Contract errors
+    MissingContract,
     // IO errors
     IoError,
 }

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -255,6 +255,7 @@ impl LowerCtx {
     }
 
     pub(super) fn emit_string_free(&mut self, id: InstId, span: Span) {
+        self.escaped_allocs.insert(id);
         self.emit(
             Opcode::Call,
             Ty::Unit,
@@ -1476,6 +1477,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     }
                 } as u32;
                 let val_id = lower_expr(ctx, field_expr);
+                ctx.mark_escaped(val_id);
                 ctx.emit(
                     Opcode::FieldSet,
                     Ty::Unit,
@@ -1568,6 +1570,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             );
             for (i, field_expr) in fields.iter().enumerate() {
                 let val_id = lower_expr(ctx, field_expr);
+                ctx.mark_escaped(val_id);
                 ctx.emit(
                     Opcode::FieldSet,
                     Ty::Unit,

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -16,6 +16,20 @@ use crate::types::{
     Opcode, StructLayout, Ty, VariantLayout, VowEntry, VowId,
 };
 
+fn builtin_alloc_tag(sym: &str) -> &'static str {
+    match sym {
+        "__vow_fs_read" | "__vow_string_substr" | "__vow_string_trim"
+        | "__vow_string_to_upper" | "__vow_string_to_lower" | "__vow_string_replace"
+        | "__vow_string_join" | "__vow_string_from_i64" | "__vow_stdin_read"
+        | "__vow_process_get_stdout" | "__vow_process_get_stderr"
+        | "__vow_process_stdout_for" | "__vow_process_stderr_for"
+        | "__vow_hex_encode" => "String",
+        "__vow_fs_listdir" | "__vow_string_split" | "__vow_vec_sort"
+        | "__vow_hex_decode" | "__vow_args" => "Vec",
+        _ => "",
+    }
+}
+
 fn vow_builtin_to_runtime(name: &str) -> Option<(&'static str, Ty)> {
     match name {
         "print_str" => Some(("__vow_string_print", Ty::Unit)),
@@ -119,6 +133,10 @@ pub struct LowerCtx {
     // struct name → per-field Vec element type name (for FieldGet → Vec propagation)
     struct_field_vec_elems: HashMap<String, Vec<String>>,
     warnings: Vec<vow_diag::Diagnostic>,
+    // Function-exit deallocation: heap allocations made at top-level (branch_depth==0)
+    local_heap_allocs: Vec<(InstId, String)>,
+    escaped_allocs: HashSet<InstId>,
+    branch_depth: u32,
 }
 
 impl LowerCtx {
@@ -181,6 +199,40 @@ impl LowerCtx {
             inst_vec_elem_type: HashMap::new(),
             struct_field_vec_elems,
             warnings: Vec::new(),
+            local_heap_allocs: Vec::new(),
+            escaped_allocs: HashSet::new(),
+            branch_depth: 0,
+        }
+    }
+
+    pub(super) fn track_heap_alloc(&mut self, id: InstId, tag: &str) {
+        if self.branch_depth == 0 {
+            self.local_heap_allocs.push((id, tag.to_string()));
+        }
+    }
+
+    pub(super) fn mark_escaped(&mut self, id: InstId) {
+        self.escaped_allocs.insert(id);
+    }
+
+    pub(super) fn emit_return_frees(&mut self, return_val: InstId, span: Span) {
+        for (id, tag) in self.local_heap_allocs.clone() {
+            if self.escaped_allocs.contains(&id) || id == return_val {
+                continue;
+            }
+            let sym = match tag.as_str() {
+                "String" => "__vow_string_free",
+                "Vec" => "__vow_vec_free_val",
+                "HashMap" => "__vow_map_free",
+                _ => continue,
+            };
+            self.emit(
+                Opcode::Call,
+                Ty::Unit,
+                vec![id],
+                InstData::CallExtern(sym.to_string()),
+                span,
+            );
         }
     }
 
@@ -510,6 +562,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     span,
                 );
                 ctx.inst_struct_type.insert(vow_str, "String".to_string());
+                ctx.track_heap_alloc(vow_str, "String");
                 vow_str
             }
         },
@@ -589,6 +642,9 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             };
             let call_info = ctx.func_index.get(&callee_name).copied();
             if let Some((fid, ret_ty)) = call_info {
+                for &aid in &arg_ids {
+                    ctx.mark_escaped(aid);
+                }
                 ctx.emit(
                     Opcode::Call,
                     ret_ty,
@@ -597,14 +653,27 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     span,
                 )
             } else if let Some((sym, ret_ty)) = vow_builtin_to_runtime(&callee_name) {
-                ctx.emit(
+                for &aid in &arg_ids {
+                    ctx.mark_escaped(aid);
+                }
+                let result = ctx.emit(
                     Opcode::Call,
                     ret_ty,
                     arg_ids,
                     InstData::CallExtern(sym.to_string()),
                     span,
-                )
+                );
+                if ret_ty == Ty::Ptr {
+                    let tag = builtin_alloc_tag(sym);
+                    if !tag.is_empty() {
+                        ctx.track_heap_alloc(result, tag);
+                    }
+                }
+                result
             } else {
+                for &aid in &arg_ids {
+                    ctx.mark_escaped(aid);
+                }
                 ctx.emit(
                     Opcode::Call,
                     Ty::Unit,
@@ -641,6 +710,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
 
             // Snapshot scope so then-branch mutations don't bleed into else-branch.
             let scope_snap = ctx.snapshot_scope();
+            ctx.branch_depth += 1;
 
             // Lower then-branch.
             ctx.switch_to_block(then_block);
@@ -710,6 +780,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
 
             // Restore scope before building merge.
             ctx.restore_scope(scope_snap);
+            ctx.branch_depth -= 1;
 
             ctx.switch_to_block(merge_block);
 
@@ -788,12 +859,14 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 if let Some(vow_block) = ctx.vow_block.clone() {
                     vow::lower_ensures(ctx, &vow_block, val);
                 }
+                ctx.emit_return_frees(val, span);
                 ctx.emit(Opcode::Return, Ty::Unit, vec![val], InstData::None, span)
             } else {
                 let unit = ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span);
                 if let Some(vow_block) = ctx.vow_block.clone() {
                     vow::lower_ensures(ctx, &vow_block, unit);
                 }
+                ctx.emit_return_frees(unit, span);
                 ctx.emit(Opcode::Return, Ty::Unit, vec![unit], InstData::None, span)
             }
         }
@@ -838,6 +911,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         }
                         0
                     } as u32;
+                    ctx.mark_escaped(new_val);
                     ctx.emit(
                         Opcode::FieldSet,
                         Ty::Unit,
@@ -849,6 +923,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 ExprKind::Index { base, index } => {
                     let vec_ptr = lower_expr(ctx, base);
                     let idx_id = lower_expr(ctx, index);
+                    ctx.mark_escaped(new_val);
                     ctx.emit(
                         Opcode::Call,
                         Ty::Unit,
@@ -940,8 +1015,10 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.switch_to_block(body_block);
             ctx.loop_exit_blocks.push(exit_block);
             ctx.loop_break_upsilons.push(None);
+            ctx.branch_depth += 1;
             lower_block(ctx, body);
             ctx.loop_break_upsilons.pop();
+            ctx.branch_depth -= 1;
             ctx.loop_exit_blocks.pop();
 
             // Emit back-edge Upsilons with the current scope values.
@@ -1219,8 +1296,10 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
 
             ctx.loop_exit_blocks.push(exit_block);
             ctx.loop_break_upsilons.push(Some(Vec::new()));
+            ctx.branch_depth += 1;
             lower_block(ctx, body);
             let break_ups = ctx.loop_break_upsilons.pop().unwrap();
+            ctx.branch_depth -= 1;
             ctx.loop_exit_blocks.pop();
 
             // Back-edge Upsilons
@@ -1428,6 +1507,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     span,
                 );
                 ctx.inst_struct_type.insert(result, "HashMap".to_string());
+                ctx.track_heap_alloc(result, "HashMap");
                 return result;
             }
             // Vec::new() builtin
@@ -1446,13 +1526,16 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     InstData::ConstI64(8),
                     span,
                 );
-                return ctx.emit(
+                let result = ctx.emit(
                     Opcode::Call,
                     Ty::Ptr,
                     vec![size_val, align_val],
                     InstData::CallExtern("__vow_vec_new".to_string()),
                     span,
                 );
+                ctx.inst_struct_type.insert(result, "Vec".to_string());
+                ctx.track_heap_alloc(result, "Vec");
+                return result;
             }
             let tag = ctx
                 .enum_variant_map
@@ -1521,6 +1604,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             };
 
             let scope_snap = ctx.snapshot_scope();
+            ctx.branch_depth += 1;
 
             // Per-arm tracking: (exit_block, result_upsilon, result_ty, mut_vals)
             let mut arm_results: Vec<(BlockId, InstId, Ty, Vec<InstId>)> = Vec::new();
@@ -1675,6 +1759,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             }
 
             ctx.restore_scope(scope_snap);
+            ctx.branch_depth -= 1;
             ctx.switch_to_block(merge_block);
 
             // Create Phis for mutated variables.
@@ -1717,6 +1802,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             args,
         } => {
             let recv_id = lower_expr(ctx, receiver);
+            ctx.mark_escaped(recv_id);
             let recv_struct = ctx.inst_struct_type.get(&recv_id).cloned().or_else(|| {
                 if ctx.string_exprs.contains(&(receiver.as_ref() as *const Expr as usize)) {
                     Some("String".to_string())
@@ -1850,6 +1936,8 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     let v_id = args.get(1).map(|e| lower_expr(ctx, e)).unwrap_or_else(|| {
                         ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
                     });
+                    ctx.mark_escaped(k_id);
+                    ctx.mark_escaped(v_id);
                     ctx.emit(
                         Opcode::Call,
                         Ty::Unit,
@@ -1905,6 +1993,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     let elem_id = args.first().map(|e| lower_expr(ctx, e)).unwrap_or_else(|| {
                         ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
                     });
+                    ctx.mark_escaped(elem_id);
                     ctx.emit(
                         Opcode::Call,
                         Ty::Unit,
@@ -2012,6 +2101,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             if let Some(vow_block) = ctx.vow_block.clone() {
                 vow::lower_ensures(ctx, &vow_block, none_ptr);
             }
+            ctx.emit_return_frees(none_ptr, span);
             ctx.emit(
                 Opcode::Return,
                 Ty::Unit,
@@ -2286,6 +2376,7 @@ pub fn lower_function(
         if let Some(vow_block) = &fn_def.vow {
             vow::lower_ensures(&mut ctx, vow_block, trailing);
         }
+        ctx.emit_return_frees(trailing, span);
         ctx.emit(
             Opcode::Return,
             Ty::Unit,

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -776,6 +776,23 @@ impl<'e> Checker<'e> {
                         _ => None,
                     };
                     (methods, ty)
+                } else if let Ty::Applied(base, type_args) = &recv_ty {
+                    let is_option_or_result = matches!(
+                        base.as_ref(),
+                        Ty::Enum(n) if n == "Option" || n == "Result"
+                    );
+                    if is_option_or_result {
+                        let methods: &[&str] = &["unwrap"];
+                        let ty = match method.as_str() {
+                            "unwrap" => Some(
+                                type_args.first().cloned().unwrap_or(Ty::Unit),
+                            ),
+                            _ => None,
+                        };
+                        (methods, ty)
+                    } else {
+                        (&[] as &[&str], None)
+                    }
                 } else {
                     (&[] as &[&str], None)
                 };
@@ -788,6 +805,10 @@ impl<'e> Checker<'e> {
                             "HashMap".to_string()
                         } else if is_vec {
                             "Vec".to_string()
+                        } else if matches!(&recv_ty, Ty::Applied(base, _) if matches!(base.as_ref(), Ty::Enum(n) if n == "Option")) {
+                            "Option".to_string()
+                        } else if matches!(&recv_ty, Ty::Applied(base, _) if matches!(base.as_ref(), Ty::Enum(n) if n == "Result")) {
+                            "Result".to_string()
                         } else {
                             format!("{recv_ty}")
                         };

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -333,6 +333,16 @@ impl<'e> Checker<'e> {
                     );
                 }
                 Item::Extern(block) => {
+                    if block.vow.is_none() && !block.fns.is_empty() {
+                        self.emit_error_with_hints(
+                            ErrorCode::MissingContract,
+                            "extern block requires a vow contract",
+                            block.span,
+                            vec![
+                                "add a `vow { ... }` block specifying contracts for foreign functions".to_string(),
+                            ],
+                        );
+                    }
                     for f in &block.fns {
                         let params = f
                             .params

--- a/vow-types/src/effects.rs
+++ b/vow-types/src/effects.rs
@@ -13,111 +13,127 @@ fn effect_covered(declared: &[Effect], needed: &Effect) -> bool {
     false
 }
 
-fn collect_calls_in_expr<'a>(expr: &'a Expr, calls: &mut Vec<(&'a Expr, &'a str)>) {
+fn collect_calls_in_expr<'a>(
+    expr: &'a Expr,
+    calls: &mut Vec<(&'a Expr, &'a str)>,
+    panic_exprs: &mut Vec<&'a Expr>,
+) {
     match &expr.kind {
         ExprKind::Call { callee, args } => {
             if let ExprKind::Ident(name) = &callee.kind {
                 calls.push((callee, name.as_str()));
             }
             for arg in args {
-                collect_calls_in_expr(arg, calls);
+                collect_calls_in_expr(arg, calls, panic_exprs);
             }
         }
         ExprKind::BinaryOp { lhs, rhs, .. } => {
-            collect_calls_in_expr(lhs, calls);
-            collect_calls_in_expr(rhs, calls);
+            collect_calls_in_expr(lhs, calls, panic_exprs);
+            collect_calls_in_expr(rhs, calls, panic_exprs);
         }
-        ExprKind::UnaryOp { operand, .. } => collect_calls_in_expr(operand, calls),
-        ExprKind::MethodCall { receiver, args, .. } => {
-            collect_calls_in_expr(receiver, calls);
+        ExprKind::UnaryOp { operand, .. } => collect_calls_in_expr(operand, calls, panic_exprs),
+        ExprKind::MethodCall {
+            receiver,
+            method,
+            args,
+        } => {
+            collect_calls_in_expr(receiver, calls, panic_exprs);
             for arg in args {
-                collect_calls_in_expr(arg, calls);
+                collect_calls_in_expr(arg, calls, panic_exprs);
+            }
+            if method == "unwrap" {
+                panic_exprs.push(expr);
             }
         }
-        ExprKind::Block(block) => collect_calls_in_block(block, calls),
+        ExprKind::Block(block) => collect_calls_in_block(block, calls, panic_exprs),
         ExprKind::If {
             condition,
             then_branch,
             else_branch,
         } => {
-            collect_calls_in_expr(condition, calls);
-            collect_calls_in_block(then_branch, calls);
+            collect_calls_in_expr(condition, calls, panic_exprs);
+            collect_calls_in_block(then_branch, calls, panic_exprs);
             if let Some(e) = else_branch {
-                collect_calls_in_expr(e, calls);
+                collect_calls_in_expr(e, calls, panic_exprs);
             }
         }
         ExprKind::Match { scrutinee, arms } => {
-            collect_calls_in_expr(scrutinee, calls);
+            collect_calls_in_expr(scrutinee, calls, panic_exprs);
             for arm in arms {
-                collect_calls_in_expr(&arm.body, calls);
+                collect_calls_in_expr(&arm.body, calls, panic_exprs);
             }
         }
         ExprKind::While {
             condition, body, ..
         } => {
-            collect_calls_in_expr(condition, calls);
-            collect_calls_in_block(body, calls);
+            collect_calls_in_expr(condition, calls, panic_exprs);
+            collect_calls_in_block(body, calls, panic_exprs);
         }
+<<<<<<< HEAD
         ExprKind::ForEach {
             iterable, body, ..
         } => {
-            collect_calls_in_expr(iterable, calls);
-            collect_calls_in_block(body, calls);
+            collect_calls_in_expr(iterable, calls, panic_exprs);
+            collect_calls_in_block(body, calls, panic_exprs);
         }
-        ExprKind::Loop { body, .. } => collect_calls_in_block(body, calls),
+        ExprKind::Loop { body, .. } => collect_calls_in_block(body, calls, panic_exprs),
         ExprKind::Return { value } => {
             if let Some(v) = value {
-                collect_calls_in_expr(v, calls);
+                collect_calls_in_expr(v, calls, panic_exprs);
             }
         }
         ExprKind::Borrow { expr } | ExprKind::Question { expr } => {
-            collect_calls_in_expr(expr, calls);
+            collect_calls_in_expr(expr, calls, panic_exprs);
         }
         ExprKind::FieldAccess { base, .. } => {
-            collect_calls_in_expr(base, calls);
+            collect_calls_in_expr(base, calls, panic_exprs);
         }
         ExprKind::Index { base, index } => {
-            collect_calls_in_expr(base, calls);
-            collect_calls_in_expr(index, calls);
+            collect_calls_in_expr(base, calls, panic_exprs);
+            collect_calls_in_expr(index, calls, panic_exprs);
         }
         ExprKind::Assign { lhs, rhs } => {
-            collect_calls_in_expr(lhs, calls);
-            collect_calls_in_expr(rhs, calls);
+            collect_calls_in_expr(lhs, calls, panic_exprs);
+            collect_calls_in_expr(rhs, calls, panic_exprs);
         }
         ExprKind::Tuple(exprs) => {
             for e in exprs {
-                collect_calls_in_expr(e, calls);
+                collect_calls_in_expr(e, calls, panic_exprs);
             }
         }
         ExprKind::Break { value } => {
             if let Some(v) = value {
-                collect_calls_in_expr(v, calls);
+                collect_calls_in_expr(v, calls, panic_exprs);
             }
         }
         ExprKind::Lit(_) | ExprKind::Ident(_) | ExprKind::Result => {}
         ExprKind::StructLiteral { fields, .. } => {
             for (_, e) in fields {
-                collect_calls_in_expr(e, calls);
+                collect_calls_in_expr(e, calls, panic_exprs);
             }
         }
         ExprKind::EnumConstruct { fields, .. } => {
             for e in fields {
-                collect_calls_in_expr(e, calls);
+                collect_calls_in_expr(e, calls, panic_exprs);
             }
         }
-        ExprKind::Cast { expr, .. } => collect_calls_in_expr(expr, calls),
+        ExprKind::Cast { expr, .. } => collect_calls_in_expr(expr, calls, panic_exprs),
     }
 }
 
-fn collect_calls_in_block<'a>(block: &'a Block, calls: &mut Vec<(&'a Expr, &'a str)>) {
+fn collect_calls_in_block<'a>(
+    block: &'a Block,
+    calls: &mut Vec<(&'a Expr, &'a str)>,
+    panic_exprs: &mut Vec<&'a Expr>,
+) {
     for stmt in &block.stmts {
         match stmt {
-            Stmt::Let { init, .. } => collect_calls_in_expr(init, calls),
-            Stmt::Expr { expr, .. } => collect_calls_in_expr(expr, calls),
+            Stmt::Let { init, .. } => collect_calls_in_expr(init, calls, panic_exprs),
+            Stmt::Expr { expr, .. } => collect_calls_in_expr(expr, calls, panic_exprs),
         }
     }
     if let Some(e) = &block.trailing_expr {
-        collect_calls_in_expr(e, calls);
+        collect_calls_in_expr(e, calls, panic_exprs);
     }
 }
 
@@ -143,7 +159,8 @@ pub fn check_fn_effects(
     emitter: &mut dyn DiagnosticEmitter,
 ) {
     let mut calls = Vec::new();
-    collect_calls_in_block(&fn_def.body, &mut calls);
+    let mut panic_exprs = Vec::new();
+    collect_calls_in_block(&fn_def.body, &mut calls, &mut panic_exprs);
 
     for (callee_expr, callee_name) in &calls {
         if let Some(sig) = env.lookup_fn(callee_name) {
@@ -179,6 +196,32 @@ pub fn check_fn_effects(
         }
     }
 
+    if !panic_exprs.is_empty() && !effect_covered(&fn_def.effects, &Effect::Panic) {
+        for panic_expr in &panic_exprs {
+            let msg = format!(
+                "function `{}` is declared with effects {} but calls `.unwrap()` which requires effect `Panic`",
+                fn_def.name,
+                effects_display(&fn_def.effects),
+            );
+            emitter.emit(&Diagnostic {
+                severity: Severity::Error,
+                code: ErrorCode::EffectViolation,
+                message: msg,
+                primary: SourceLocation {
+                    file: file.to_string(),
+                    byte_offset: panic_expr.span.start,
+                    byte_len: panic_expr.span.len,
+                },
+                secondary: vec![],
+                blame: Blame::None,
+                hints: vec![format!(
+                    "add 'Panic' to `{}`'s effect list, or use `?` to propagate the error instead",
+                    fn_def.name,
+                )],
+            });
+        }
+    }
+
     if let Some(vow_block) = &fn_def.vow {
         check_vow_purity(vow_block, env, file, emitter);
     }
@@ -198,7 +241,8 @@ pub fn check_vow_purity(
         };
 
         let mut calls = Vec::new();
-        collect_calls_in_expr(expr, &mut calls);
+        let mut panic_exprs = Vec::new();
+        collect_calls_in_expr(expr, &mut calls, &mut panic_exprs);
 
         for (callee_expr, callee_name) in &calls {
             if let Some(sig) = env.lookup_fn(callee_name)
@@ -622,6 +666,66 @@ mod tests {
         assert!(
             emitter.0[0].hints.iter().any(|h| h.contains("pure")),
             "expected hint about purity"
+        );
+    }
+
+    fn unwrap_method_call() -> Expr {
+        Expr {
+            kind: ExprKind::MethodCall {
+                receiver: Box::new(Expr {
+                    kind: ExprKind::Ident("opt".to_string()),
+                    span: dummy_span(),
+                }),
+                method: "unwrap".to_string(),
+                args: vec![],
+            },
+            span: dummy_span(),
+        }
+    }
+
+    fn body_with_unwrap() -> Block {
+        Block {
+            stmts: vec![Stmt::Expr {
+                expr: unwrap_method_call(),
+                has_semicolon: true,
+                span: dummy_span(),
+            }],
+            trailing_expr: None,
+            span: dummy_span(),
+        }
+    }
+
+    #[test]
+    fn unwrap_without_panic_effect_emits_violation() {
+        let env = TypeEnv::new();
+        let caller = make_fn("caller", vec![], body_with_unwrap());
+        let mut emitter = TestEmitter(vec![]);
+        check_fn_effects(&caller, &env, "test.vow", &mut emitter);
+        assert_eq!(emitter.0.len(), 1);
+        assert_eq!(emitter.0[0].code, ErrorCode::EffectViolation);
+        assert!(emitter.0[0].message.contains(".unwrap()"));
+        assert!(emitter.0[0].message.contains("Panic"));
+    }
+
+    #[test]
+    fn unwrap_with_panic_effect_no_error() {
+        let env = TypeEnv::new();
+        let caller = make_fn("caller", vec![Effect::Panic], body_with_unwrap());
+        let mut emitter = TestEmitter(vec![]);
+        check_fn_effects(&caller, &env, "test.vow", &mut emitter);
+        assert!(emitter.0.is_empty());
+    }
+
+    #[test]
+    fn unwrap_violation_includes_hint() {
+        let env = TypeEnv::new();
+        let caller = make_fn("caller", vec![], body_with_unwrap());
+        let mut emitter = TestEmitter(vec![]);
+        check_fn_effects(&caller, &env, "test.vow", &mut emitter);
+        assert_eq!(emitter.0.len(), 1);
+        assert!(
+            emitter.0[0].hints.iter().any(|h| h.contains("Panic") || h.contains("?")),
+            "expected hint about adding Panic or using ?"
         );
     }
 }

--- a/vow-types/src/effects.rs
+++ b/vow-types/src/effects.rs
@@ -69,7 +69,6 @@ fn collect_calls_in_expr<'a>(
             collect_calls_in_expr(condition, calls, panic_exprs);
             collect_calls_in_block(body, calls, panic_exprs);
         }
-<<<<<<< HEAD
         ExprKind::ForEach {
             iterable, body, ..
         } => {

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -302,7 +302,7 @@ fn skill_json() -> String {
       "visibility": "pub fn \u2014 public functions visible to importers"
     },
     "type_aliases": "type Name = Type",
-    "extern_blocks": "extern { fn c_function(x: i64) -> i64 [unsafe] }",
+    "extern_blocks": "extern \"C\" vow { requires: ... } { fn name(x: i64) -> i64 [unsafe] }",
     "methods": {
       "Vec<T>": [
         "Vec::new()",


### PR DESCRIPTION
## Summary

Implements 3 of 4 tasks from issue #42 (P4 longer-term improvements), plus Phase 1 of the 4th:

- **`[Panic]` effect enforcement**: `.unwrap()` on Option/Result now requires `[Panic]` effect. Both compilers updated with 3 new tests.
- **CEGIS prompt curation**: Structured counterexample feedback replaces raw JSON dump. Extracts violation type, variable values, execution path, and generates targeted hints with previous-attempt tracking.
- **Extern contract enforcement**: `extern "C"` blocks without `vow { ... }` now emit `MissingContract` error. New error code documented in `docs/skill/errors.md`.
- **Function-exit deallocation (Rust compiler)**: Tracks heap allocations (String, Vec, HashMap) with conservative escape analysis. Emits typed free calls before every Return for non-escaped values. Self-hosted struct fields added as infrastructure; wiring deferred.

Task 1 (scope-exit deallocation) Phase 2 — self-hosted tracking and scope-level freeing — is future work.

## Test plan

- [x] `cargo test --all` — 569 tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `scripts/bootstrap.sh --no-verify` — binary fixed point
- [x] `scripts/full_test.sh` — 113 passed, 0 failed