### PR TITLE
fix: stop method receivers from preventing deallocation

### DIFF
--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1718,7 +1718,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         let args_lid: i64 = expr_c(a, eid);
         let method_name: String = arena_str(a, method_sid);
         let recv_id: i64 = lower_expr(ctx, recv_eid);
-        lctx_mark_escaped(ctx, recv_id);
         let mut recv_tag_str: String = lctx_get_tag(ctx, recv_id);
         if recv_tag_str == String::from("") && lctx_is_str_eid(ctx, recv_eid) {
             recv_tag_str = String::from("String");

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -1136,19 +1136,28 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
                     set_val!(iid, val);
                 }
                 IOP_LT_U64 => {
-                    let val = builder.ins().icmp(IntCC::UnsignedLessThan, arg!(0), arg!(1));
+                    let val = builder
+                        .ins()
+                        .icmp(IntCC::UnsignedLessThan, arg!(0), arg!(1));
                     set_val!(iid, val);
                 }
                 IOP_LE_U64 => {
-                    let val = builder.ins().icmp(IntCC::UnsignedLessThanOrEqual, arg!(0), arg!(1));
+                    let val = builder
+                        .ins()
+                        .icmp(IntCC::UnsignedLessThanOrEqual, arg!(0), arg!(1));
                     set_val!(iid, val);
                 }
                 IOP_GT_U64 => {
-                    let val = builder.ins().icmp(IntCC::UnsignedGreaterThan, arg!(0), arg!(1));
+                    let val = builder
+                        .ins()
+                        .icmp(IntCC::UnsignedGreaterThan, arg!(0), arg!(1));
                     set_val!(iid, val);
                 }
                 IOP_GE_U64 => {
-                    let val = builder.ins().icmp(IntCC::UnsignedGreaterThanOrEqual, arg!(0), arg!(1));
+                    let val =
+                        builder
+                            .ins()
+                            .icmp(IntCC::UnsignedGreaterThanOrEqual, arg!(0), arg!(1));
                     set_val!(iid, val);
                 }
 

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -417,7 +417,9 @@ fn lower_inst(
             ctx.value_map.insert(inst.id, val);
         }
         Opcode::LtU64 => {
-            let cmp = builder.ins().icmp(IntCC::UnsignedLessThan, arg!(0), arg!(1));
+            let cmp = builder
+                .ins()
+                .icmp(IntCC::UnsignedLessThan, arg!(0), arg!(1));
             let val = builder.ins().uextend(types::I64, cmp);
             ctx.value_map.insert(inst.id, val);
         }

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -18,14 +18,22 @@ use crate::types::{
 
 fn builtin_alloc_tag(sym: &str) -> &'static str {
     match sym {
-        "__vow_fs_read" | "__vow_string_substr" | "__vow_string_trim"
-        | "__vow_string_to_upper" | "__vow_string_to_lower" | "__vow_string_replace"
-        | "__vow_string_join" | "__vow_string_from_i64" | "__vow_stdin_read"
-        | "__vow_process_get_stdout" | "__vow_process_get_stderr"
-        | "__vow_process_stdout_for" | "__vow_process_stderr_for"
+        "__vow_fs_read"
+        | "__vow_string_substr"
+        | "__vow_string_trim"
+        | "__vow_string_to_upper"
+        | "__vow_string_to_lower"
+        | "__vow_string_replace"
+        | "__vow_string_join"
+        | "__vow_string_from_i64"
+        | "__vow_stdin_read"
+        | "__vow_process_get_stdout"
+        | "__vow_process_get_stderr"
+        | "__vow_process_stdout_for"
+        | "__vow_process_stderr_for"
         | "__vow_hex_encode" => "String",
-        "__vow_fs_listdir" | "__vow_string_split" | "__vow_vec_sort"
-        | "__vow_hex_decode" | "__vow_args" => "Vec",
+        "__vow_fs_listdir" | "__vow_string_split" | "__vow_vec_sort" | "__vow_hex_decode"
+        | "__vow_args" => "Vec",
         _ => "",
     }
 }
@@ -1097,8 +1105,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             //          while idx < len { let <binding> = iter[idx]; <body>; idx = idx + 1; }
 
             let iter_id = lower_expr(ctx, iterable);
-            ctx.inst_struct_type
-                .insert(iter_id, "Vec".to_string());
+            ctx.inst_struct_type.insert(iter_id, "Vec".to_string());
 
             let len_id = ctx.emit(
                 Opcode::Call,
@@ -1370,8 +1377,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
                 } else {
                     let ty = ups[0].2;
-                    let phi_id =
-                        ctx.emit(Opcode::Phi, ty, vec![], InstData::None, span);
+                    let phi_id = ctx.emit(Opcode::Phi, ty, vec![], InstData::None, span);
                     for (block, up_id, _) in &ups {
                         backpatch_upsilon(ctx, *block, *up_id, phi_id);
                     }
@@ -1425,7 +1431,10 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .unwrap_or_default();
             if struct_name.is_empty() {
                 ctx.warn(
-                    format!("FieldGet on untagged instruction %{}, field '{}' -- defaulting to index 0", ptr_id.0, field),
+                    format!(
+                        "FieldGet on untagged instruction %{}, field '{}' -- defaulting to index 0",
+                        ptr_id.0, field
+                    ),
                     span,
                 );
             }
@@ -1435,7 +1444,10 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     None => {
                         if !struct_name.is_empty() {
                             ctx.warn(
-                                format!("field '{}' not found in struct '{}' -- defaulting to index 0", field, struct_name),
+                                format!(
+                                    "field '{}' not found in struct '{}' -- defaulting to index 0",
+                                    field, struct_name
+                                ),
                                 span,
                             );
                         }
@@ -1445,7 +1457,10 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             } else {
                 if !struct_name.is_empty() {
                     ctx.warn(
-                        format!("struct '{}' not registered -- field lookup defaulting to index 0", struct_name),
+                        format!(
+                            "struct '{}' not registered -- field lookup defaulting to index 0",
+                            struct_name
+                        ),
                         span,
                     );
                 }
@@ -1469,8 +1484,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 && let Some(elem_name) = vec_elems.get(field_idx as usize)
                 && !elem_name.is_empty()
             {
-                ctx.inst_vec_elem_type
-                    .insert(result_id, elem_name.clone());
+                ctx.inst_vec_elem_type.insert(result_id, elem_name.clone());
             }
             result_id
         }
@@ -1479,7 +1493,10 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 names.clone()
             } else {
                 ctx.warn(
-                    format!("struct '{}' not registered -- field lookup defaulting to index 0", name),
+                    format!(
+                        "struct '{}' not registered -- field lookup defaulting to index 0",
+                        name
+                    ),
                     span,
                 );
                 vec![]
@@ -1841,9 +1858,11 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             args,
         } => {
             let recv_id = lower_expr(ctx, receiver);
-            ctx.mark_escaped(recv_id);
             let recv_struct = ctx.inst_struct_type.get(&recv_id).cloned().or_else(|| {
-                if ctx.string_exprs.contains(&(receiver.as_ref() as *const Expr as usize)) {
+                if ctx
+                    .string_exprs
+                    .contains(&(receiver.as_ref() as *const Expr as usize))
+                {
                     Some("String".to_string())
                 } else {
                     None
@@ -1924,10 +1943,22 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 }
                 (Some("String"), "substring") => {
                     let start_id = args.first().map(|e| lower_expr(ctx, e)).unwrap_or_else(|| {
-                        ctx.emit(Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0), span)
+                        ctx.emit(
+                            Opcode::ConstI64,
+                            Ty::I64,
+                            vec![],
+                            InstData::ConstI64(0),
+                            span,
+                        )
                     });
                     let end_id = args.get(1).map(|e| lower_expr(ctx, e)).unwrap_or_else(|| {
-                        ctx.emit(Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0), span)
+                        ctx.emit(
+                            Opcode::ConstI64,
+                            Ty::I64,
+                            vec![],
+                            InstData::ConstI64(0),
+                            span,
+                        )
                     });
                     let result = ctx.emit(
                         Opcode::Call,
@@ -2184,15 +2215,13 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         )
                     }
                 }
-                (Ty::U64, Ty::I64) => {
-                    ctx.emit(
-                        Opcode::CastU64ToI64,
-                        Ty::I64,
-                        vec![val],
-                        InstData::None,
-                        span,
-                    )
-                }
+                (Ty::U64, Ty::I64) => ctx.emit(
+                    Opcode::CastU64ToI64,
+                    Ty::I64,
+                    vec![val],
+                    InstData::None,
+                    span,
+                ),
                 _ => val,
             }
         }
@@ -2203,25 +2232,127 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
 fn binop_opcode(op: BinOp, operand_ty: &Ty) -> (Opcode, Ty) {
     let is_u64 = *operand_ty == Ty::U64;
     match op {
-        BinOp::Add => if is_u64 { (Opcode::WrappingAddU64, Ty::U64) } else { (Opcode::WrappingAddI64, Ty::I64) },
-        BinOp::Sub => if is_u64 { (Opcode::WrappingSubU64, Ty::U64) } else { (Opcode::WrappingSubI64, Ty::I64) },
-        BinOp::Mul => if is_u64 { (Opcode::WrappingMulU64, Ty::U64) } else { (Opcode::WrappingMulI64, Ty::I64) },
-        BinOp::Div => if is_u64 { (Opcode::WrappingDivU64, Ty::U64) } else { (Opcode::WrappingDivI64, Ty::I64) },
-        BinOp::Rem => if is_u64 { (Opcode::WrappingRemU64, Ty::U64) } else { (Opcode::WrappingRemI64, Ty::I64) },
-        BinOp::AddChecked => if is_u64 { (Opcode::CheckedAddU64, Ty::U64) } else { (Opcode::CheckedAddI64, Ty::I64) },
-        BinOp::SubChecked => if is_u64 { (Opcode::CheckedSubU64, Ty::U64) } else { (Opcode::CheckedSubI64, Ty::I64) },
-        BinOp::MulChecked => if is_u64 { (Opcode::CheckedMulU64, Ty::U64) } else { (Opcode::CheckedMulI64, Ty::I64) },
-        BinOp::DivChecked => if is_u64 { (Opcode::CheckedDivU64, Ty::U64) } else { (Opcode::CheckedDivI64, Ty::I64) },
-        BinOp::RemChecked => if is_u64 { (Opcode::CheckedRemU64, Ty::U64) } else { (Opcode::CheckedRemI64, Ty::I64) },
-        BinOp::Eq => if is_u64 { (Opcode::EqU64, Ty::Bool) } else { (Opcode::EqI64, Ty::Bool) },
-        BinOp::Ne => if is_u64 { (Opcode::NeU64, Ty::Bool) } else { (Opcode::NeI64, Ty::Bool) },
-        BinOp::Lt => if is_u64 { (Opcode::LtU64, Ty::Bool) } else { (Opcode::LtI64, Ty::Bool) },
-        BinOp::Le => if is_u64 { (Opcode::LeU64, Ty::Bool) } else { (Opcode::LeI64, Ty::Bool) },
-        BinOp::Gt => if is_u64 { (Opcode::GtU64, Ty::Bool) } else { (Opcode::GtI64, Ty::Bool) },
-        BinOp::Ge => if is_u64 { (Opcode::GeU64, Ty::Bool) } else { (Opcode::GeI64, Ty::Bool) },
+        BinOp::Add => {
+            if is_u64 {
+                (Opcode::WrappingAddU64, Ty::U64)
+            } else {
+                (Opcode::WrappingAddI64, Ty::I64)
+            }
+        }
+        BinOp::Sub => {
+            if is_u64 {
+                (Opcode::WrappingSubU64, Ty::U64)
+            } else {
+                (Opcode::WrappingSubI64, Ty::I64)
+            }
+        }
+        BinOp::Mul => {
+            if is_u64 {
+                (Opcode::WrappingMulU64, Ty::U64)
+            } else {
+                (Opcode::WrappingMulI64, Ty::I64)
+            }
+        }
+        BinOp::Div => {
+            if is_u64 {
+                (Opcode::WrappingDivU64, Ty::U64)
+            } else {
+                (Opcode::WrappingDivI64, Ty::I64)
+            }
+        }
+        BinOp::Rem => {
+            if is_u64 {
+                (Opcode::WrappingRemU64, Ty::U64)
+            } else {
+                (Opcode::WrappingRemI64, Ty::I64)
+            }
+        }
+        BinOp::AddChecked => {
+            if is_u64 {
+                (Opcode::CheckedAddU64, Ty::U64)
+            } else {
+                (Opcode::CheckedAddI64, Ty::I64)
+            }
+        }
+        BinOp::SubChecked => {
+            if is_u64 {
+                (Opcode::CheckedSubU64, Ty::U64)
+            } else {
+                (Opcode::CheckedSubI64, Ty::I64)
+            }
+        }
+        BinOp::MulChecked => {
+            if is_u64 {
+                (Opcode::CheckedMulU64, Ty::U64)
+            } else {
+                (Opcode::CheckedMulI64, Ty::I64)
+            }
+        }
+        BinOp::DivChecked => {
+            if is_u64 {
+                (Opcode::CheckedDivU64, Ty::U64)
+            } else {
+                (Opcode::CheckedDivI64, Ty::I64)
+            }
+        }
+        BinOp::RemChecked => {
+            if is_u64 {
+                (Opcode::CheckedRemU64, Ty::U64)
+            } else {
+                (Opcode::CheckedRemI64, Ty::I64)
+            }
+        }
+        BinOp::Eq => {
+            if is_u64 {
+                (Opcode::EqU64, Ty::Bool)
+            } else {
+                (Opcode::EqI64, Ty::Bool)
+            }
+        }
+        BinOp::Ne => {
+            if is_u64 {
+                (Opcode::NeU64, Ty::Bool)
+            } else {
+                (Opcode::NeI64, Ty::Bool)
+            }
+        }
+        BinOp::Lt => {
+            if is_u64 {
+                (Opcode::LtU64, Ty::Bool)
+            } else {
+                (Opcode::LtI64, Ty::Bool)
+            }
+        }
+        BinOp::Le => {
+            if is_u64 {
+                (Opcode::LeU64, Ty::Bool)
+            } else {
+                (Opcode::LeI64, Ty::Bool)
+            }
+        }
+        BinOp::Gt => {
+            if is_u64 {
+                (Opcode::GtU64, Ty::Bool)
+            } else {
+                (Opcode::GtI64, Ty::Bool)
+            }
+        }
+        BinOp::Ge => {
+            if is_u64 {
+                (Opcode::GeU64, Ty::Bool)
+            } else {
+                (Opcode::GeI64, Ty::Bool)
+            }
+        }
         BinOp::And => (Opcode::And, Ty::Bool),
         BinOp::Or => (Opcode::Or, Ty::Bool),
-        BinOp::BitXor => if is_u64 { (Opcode::XorU64, Ty::U64) } else { (Opcode::XorI64, Ty::I64) },
+        BinOp::BitXor => {
+            if is_u64 {
+                (Opcode::XorU64, Ty::U64)
+            } else {
+                (Opcode::XorI64, Ty::I64)
+            }
+        }
     }
 }
 
@@ -2242,7 +2373,9 @@ fn lower_stmt(ctx: &mut LowerCtx, stmt: &Stmt) {
         } => {
             let mut val = lower_expr(ctx, init);
             let span = init.span;
-            if let Some(AstType::Named { name: type_name, .. }) = ty
+            if let Some(AstType::Named {
+                name: type_name, ..
+            }) = ty
                 && type_name == "u64"
                 && ctx.inst_ty(val) != Ty::U64
             {
@@ -2272,8 +2405,13 @@ fn lower_stmt(ctx: &mut LowerCtx, stmt: &Stmt) {
                         } => {
                             ctx.inst_struct_type.insert(val, type_name.clone());
                             if type_name == "Vec"
-                                && let Some(AstType::Named { name: elem_name, .. }) = args.first()
-                                && !matches!(elem_name.as_str(), "i32" | "i64" | "u64" | "f32" | "f64" | "bool")
+                                && let Some(AstType::Named {
+                                    name: elem_name, ..
+                                }) = args.first()
+                                && !matches!(
+                                    elem_name.as_str(),
+                                    "i32" | "i64" | "u64" | "f32" | "f64" | "bool"
+                                )
                             {
                                 ctx.inst_vec_elem_type.insert(val, elem_name.clone());
                             }
@@ -2378,8 +2516,13 @@ pub fn lower_function(
             }
             AstType::Generic { name, args, .. } if name == "Vec" => {
                 ctx.inst_struct_type.insert(arg_id, "Vec".to_string());
-                if let Some(AstType::Named { name: elem_name, .. }) = args.first()
-                    && !matches!(elem_name.as_str(), "i32" | "i64" | "u64" | "f32" | "f64" | "bool")
+                if let Some(AstType::Named {
+                    name: elem_name, ..
+                }) = args.first()
+                    && !matches!(
+                        elem_name.as_str(),
+                        "i32" | "i64" | "u64" | "f32" | "f64" | "bool"
+                    )
                 {
                     ctx.inst_vec_elem_type.insert(arg_id, elem_name.clone());
                 }
@@ -2519,8 +2662,13 @@ pub fn lower_module(module: &AstModule, file: &str, string_exprs: &StringExprSet
                 .iter()
                 .map(|f| match &f.ty {
                     AstType::Generic { name, args, .. } if name == "Vec" => {
-                        if let Some(AstType::Named { name: elem_name, .. }) = args.first()
-                            && !matches!(elem_name.as_str(), "i32" | "i64" | "u64" | "f32" | "f64" | "bool")
+                        if let Some(AstType::Named {
+                            name: elem_name, ..
+                        }) = args.first()
+                            && !matches!(
+                                elem_name.as_str(),
+                                "i32" | "i64" | "u64" | "f32" | "f64" | "bool"
+                            )
                         {
                             return elem_name.clone();
                         }
@@ -3400,15 +3548,14 @@ mod tests {
             &HashMap::new(),
         );
 
-        let has_string_free = func
-            .blocks
-            .iter()
-            .flat_map(|b| b.insts.iter())
-            .any(|i| {
-                i.opcode == Opcode::Call
-                    && i.data == InstData::CallExtern("__vow_string_free".to_string())
-            });
-        assert!(has_string_free, "expected __vow_string_free for unused string");
+        let has_string_free = func.blocks.iter().flat_map(|b| b.insts.iter()).any(|i| {
+            i.opcode == Opcode::Call
+                && i.data == InstData::CallExtern("__vow_string_free".to_string())
+        });
+        assert!(
+            has_string_free,
+            "expected __vow_string_free for unused string"
+        );
     }
 
     #[test]
@@ -3436,7 +3583,10 @@ mod tests {
             .find(|i| i.opcode == Opcode::RegionFree)
             .map(|i| i.data.clone())
             .expect("expected RegionFree");
-        assert_eq!(alloc_data, free_data, "RegionFree size must match RegionAlloc size");
+        assert_eq!(
+            alloc_data, free_data,
+            "RegionFree size must match RegionAlloc size"
+        );
     }
 
     #[test]
@@ -3493,9 +3643,9 @@ mod tests {
     }
 
     #[test]
-    fn receiver_method_marks_escaped_no_free() {
+    fn receiver_method_does_not_prevent_free() {
         // fn f() -> i64 { let s = String::from("x"); s.len() }
-        // s.len() marks s as escaped (receiver) → no __vow_string_free
+        // s.len() is read-only — s must still be freed (#71)
         let body = Block {
             stmts: vec![let_stmt(
                 "s",
@@ -3537,19 +3687,13 @@ mod tests {
             &HashMap::new(),
         );
 
-        let has_string_free = func
-            .blocks
-            .iter()
-            .flat_map(|b| b.insts.iter())
-            .any(|i| {
-                i.opcode == Opcode::Call
-                    && i.data == InstData::CallExtern("__vow_string_free".to_string())
-            });
-        // Current behavior: receiver is marked escaped, so no free is emitted.
-        // This documents the known limitation (see GitHub issue: receiver-escape leak).
+        let has_string_free = func.blocks.iter().flat_map(|b| b.insts.iter()).any(|i| {
+            i.opcode == Opcode::Call
+                && i.data == InstData::CallExtern("__vow_string_free".to_string())
+        });
         assert!(
-            !has_string_free,
-            "method receiver is marked escaped — no free expected (known limitation)"
+            has_string_free,
+            "method call on receiver must not prevent deallocation (#71)"
         );
     }
 
@@ -3608,10 +3752,7 @@ mod tests {
         };
         let fn_def = make_fn(
             "f",
-            vec![
-                make_param("a", bool_ty.clone()),
-                make_param("b", bool_ty),
-            ],
+            vec![make_param("a", bool_ty.clone()), make_param("b", bool_ty)],
             pair_ty(),
             body,
             vec![],
@@ -3628,6 +3769,170 @@ mod tests {
             region_frees.is_empty(),
             "struct reachable through nested Phi chain should not be freed, found {} RegionFree(s)",
             region_frees.len()
+        );
+    }
+
+    #[test]
+    fn string_freed_after_method_call() {
+        // fn f() -> i64 { let s: String = String::from("hello"); s.len() }
+        // s.len() is read-only — s must still be freed
+        let string_from = Expr {
+            kind: ExprKind::EnumConstruct {
+                path: vec!["String".to_string(), "from".to_string()],
+                fields: vec![Expr {
+                    kind: ExprKind::Lit(Lit::String("hello".to_string())),
+                    span: sp(),
+                }],
+            },
+            span: sp(),
+        };
+        let method_call = Expr {
+            kind: ExprKind::MethodCall {
+                receiver: Box::new(ident_expr("s")),
+                method: "len".to_string(),
+                args: vec![],
+            },
+            span: sp(),
+        };
+        let body = Block {
+            stmts: vec![let_stmt(
+                "s",
+                Some(Type::Named {
+                    name: "String".to_string(),
+                    span: sp(),
+                }),
+                string_from,
+            )],
+            trailing_expr: Some(Box::new(method_call)),
+            span: sp(),
+        };
+        let fn_def = make_fn("f", vec![], i64_ty(), body, vec![]);
+        let (func, _, _) = lower_function(
+            &fn_def,
+            "",
+            &HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        let has_string_free = func.blocks.iter().flat_map(|b| b.insts.iter()).any(|i| {
+            i.opcode == Opcode::Call
+                && i.data == InstData::CallExtern("__vow_string_free".to_string())
+        });
+        assert!(
+            has_string_free,
+            "String used via .len() must still be freed at function exit"
+        );
+    }
+
+    #[test]
+    fn vec_freed_after_method_call() {
+        // fn f() -> i64 { let v: Vec<i64> = Vec::new(); v.len() }
+        // v.len() is read-only — v must still be freed
+        let vec_new = Expr {
+            kind: ExprKind::EnumConstruct {
+                path: vec!["Vec".to_string(), "new".to_string()],
+                fields: vec![],
+            },
+            span: sp(),
+        };
+        let method_call = Expr {
+            kind: ExprKind::MethodCall {
+                receiver: Box::new(ident_expr("v")),
+                method: "len".to_string(),
+                args: vec![],
+            },
+            span: sp(),
+        };
+        let body = Block {
+            stmts: vec![let_stmt(
+                "v",
+                Some(Type::Named {
+                    name: "Vec".to_string(),
+                    span: sp(),
+                }),
+                vec_new,
+            )],
+            trailing_expr: Some(Box::new(method_call)),
+            span: sp(),
+        };
+        let fn_def = make_fn("f", vec![], i64_ty(), body, vec![]);
+        let (func, _, _) = lower_function(
+            &fn_def,
+            "",
+            &HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        let has_vec_free = func.blocks.iter().flat_map(|b| b.insts.iter()).any(|i| {
+            i.opcode == Opcode::Call
+                && i.data == InstData::CallExtern("__vow_vec_free_val".to_string())
+        });
+        assert!(
+            has_vec_free,
+            "Vec used via .len() must still be freed at function exit"
+        );
+    }
+
+    #[test]
+    fn hashmap_freed_after_method_call() {
+        // fn f() -> i64 { let m: HashMap = HashMap::new(); m.len() }
+        // m.len() is read-only — m must still be freed
+        let map_new = Expr {
+            kind: ExprKind::EnumConstruct {
+                path: vec!["HashMap".to_string(), "new".to_string()],
+                fields: vec![],
+            },
+            span: sp(),
+        };
+        let method_call = Expr {
+            kind: ExprKind::MethodCall {
+                receiver: Box::new(ident_expr("m")),
+                method: "len".to_string(),
+                args: vec![],
+            },
+            span: sp(),
+        };
+        let body = Block {
+            stmts: vec![let_stmt(
+                "m",
+                Some(Type::Named {
+                    name: "HashMap".to_string(),
+                    span: sp(),
+                }),
+                map_new,
+            )],
+            trailing_expr: Some(Box::new(method_call)),
+            span: sp(),
+        };
+        let fn_def = make_fn("f", vec![], i64_ty(), body, vec![]);
+        let (func, _, _) = lower_function(
+            &fn_def,
+            "",
+            &HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        let has_map_free = func.blocks.iter().flat_map(|b| b.insts.iter()).any(|i| {
+            i.opcode == Opcode::Call && i.data == InstData::CallExtern("__vow_map_free".to_string())
+        });
+        assert!(
+            has_map_free,
+            "HashMap used via .len() must still be freed at function exit"
         );
     }
 }

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -2,10 +2,10 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::ffi::{c_char, CStr};
+use std::ffi::{CStr, c_char};
 use std::io::Write as _;
-use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 thread_local! {
     static LAST_STDOUT: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
@@ -378,11 +378,7 @@ pub unsafe extern "C" fn __vow_string_eq(a: *const u8, b: *const u8) -> i64 {
     }
     let sa = unsafe { std::slice::from_raw_parts(va.ptr, va.len) };
     let sb = unsafe { std::slice::from_raw_parts(vb.ptr, vb.len) };
-    if sa == sb {
-        1
-    } else {
-        0
-    }
+    if sa == sb { 1 } else { 0 }
 }
 
 #[unsafe(no_mangle)]
@@ -521,11 +517,7 @@ pub unsafe extern "C" fn __vow_string_starts_with(s: *const u8, prefix: *const u
     let vp = unsafe { &*(prefix as *const VowVec) };
     let ss = unsafe { std::slice::from_raw_parts(vs.ptr, vs.len) };
     let sp = unsafe { std::slice::from_raw_parts(vp.ptr, vp.len) };
-    if ss.starts_with(sp) {
-        1
-    } else {
-        0
-    }
+    if ss.starts_with(sp) { 1 } else { 0 }
 }
 
 #[unsafe(no_mangle)]
@@ -537,11 +529,7 @@ pub unsafe extern "C" fn __vow_string_ends_with(s: *const u8, suffix: *const u8)
     let vp = unsafe { &*(suffix as *const VowVec) };
     let ss = unsafe { std::slice::from_raw_parts(vs.ptr, vs.len) };
     let sp = unsafe { std::slice::from_raw_parts(vp.ptr, vp.len) };
-    if ss.ends_with(sp) {
-        1
-    } else {
-        0
-    }
+    if ss.ends_with(sp) { 1 } else { 0 }
 }
 
 #[unsafe(no_mangle)]

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -592,9 +592,7 @@ impl<'e> Checker<'e> {
                         }
                         Ty::Bool
                     }
-                    BinOp::BitXor => {
-                        self.check_same_numeric(lhs_ty, rhs_ty, expr.span)
-                    }
+                    BinOp::BitXor => self.check_same_numeric(lhs_ty, rhs_ty, expr.span),
                     BinOp::And | BinOp::Or => {
                         if lhs_ty != Ty::Bool && lhs_ty != Ty::Never {
                             self.emit_error_with_hints(
@@ -736,8 +734,15 @@ impl<'e> Checker<'e> {
                 );
                 let (known_methods, result_ty): (&[&str], Option<Ty>) = if is_str {
                     let methods: &[&str] = &[
-                        "len", "push_str", "eq", "contains", "byte_at", "push_byte",
-                        "substring", "parse_i64", "parse_u64",
+                        "len",
+                        "push_str",
+                        "eq",
+                        "contains",
+                        "byte_at",
+                        "push_byte",
+                        "substring",
+                        "parse_i64",
+                        "parse_u64",
                     ];
                     let ty = match method.as_str() {
                         "len" => Some(Ty::I64),
@@ -794,9 +799,7 @@ impl<'e> Checker<'e> {
                     if is_option_or_result {
                         let methods: &[&str] = &["unwrap"];
                         let ty = match method.as_str() {
-                            "unwrap" => Some(
-                                type_args.first().cloned().unwrap_or(Ty::Unit),
-                            ),
+                            "unwrap" => Some(type_args.first().cloned().unwrap_or(Ty::Unit)),
                             _ => None,
                         };
                         (methods, ty)
@@ -815,9 +818,11 @@ impl<'e> Checker<'e> {
                             "HashMap".to_string()
                         } else if is_vec {
                             "Vec".to_string()
-                        } else if matches!(&recv_ty, Ty::Applied(base, _) if matches!(base.as_ref(), Ty::Enum(n) if n == "Option")) {
+                        } else if matches!(&recv_ty, Ty::Applied(base, _) if matches!(base.as_ref(), Ty::Enum(n) if n == "Option"))
+                        {
                             "Option".to_string()
-                        } else if matches!(&recv_ty, Ty::Applied(base, _) if matches!(base.as_ref(), Ty::Enum(n) if n == "Result")) {
+                        } else if matches!(&recv_ty, Ty::Applied(base, _) if matches!(base.as_ref(), Ty::Enum(n) if n == "Result"))
+                        {
                             "Result".to_string()
                         } else {
                             format!("{recv_ty}")
@@ -828,16 +833,11 @@ impl<'e> Checker<'e> {
                         if let Some(s) = suggest_similar(method, &candidates, 3) {
                             hints.push(format!("did you mean `{s}`?"));
                         } else if !candidates.is_empty() {
-                            hints.push(format!(
-                                "available methods: {}",
-                                candidates.join(", ")
-                            ));
+                            hints.push(format!("available methods: {}", candidates.join(", ")));
                         }
                         self.emit_error_with_hints(
                             ErrorCode::UnknownMethod,
-                            format!(
-                                "unknown method `{method}` on type `{type_name}`"
-                            ),
+                            format!("unknown method `{method}` on type `{type_name}`"),
                             expr.span,
                             hints,
                         );
@@ -1025,9 +1025,7 @@ impl<'e> Checker<'e> {
                     _ => {
                         self.emit_error(
                             ErrorCode::TypeMismatch,
-                            format!(
-                                "for-each requires `Vec<T>` iterable, got `{iter_ty}`"
-                            ),
+                            format!("for-each requires `Vec<T>` iterable, got `{iter_ty}`"),
                             expr.span,
                         );
                         Ty::I64
@@ -2165,7 +2163,12 @@ mod tests {
             }),
         }));
         assert!(checker.has_errors());
-        assert!(emitter.0.iter().any(|d| d.message.contains("break type mismatch")));
+        assert!(
+            emitter
+                .0
+                .iter()
+                .any(|d| d.message.contains("break type mismatch"))
+        );
     }
 
     // --- Return ---

--- a/vow-types/src/effects.rs
+++ b/vow-types/src/effects.rs
@@ -69,9 +69,7 @@ fn collect_calls_in_expr<'a>(
             collect_calls_in_expr(condition, calls, panic_exprs);
             collect_calls_in_block(body, calls, panic_exprs);
         }
-        ExprKind::ForEach {
-            iterable, body, ..
-        } => {
+        ExprKind::ForEach { iterable, body, .. } => {
             collect_calls_in_expr(iterable, calls, panic_exprs);
             collect_calls_in_block(body, calls, panic_exprs);
         }
@@ -723,7 +721,10 @@ mod tests {
         check_fn_effects(&caller, &env, "test.vow", &mut emitter);
         assert_eq!(emitter.0.len(), 1);
         assert!(
-            emitter.0[0].hints.iter().any(|h| h.contains("Panic") || h.contains("?")),
+            emitter.0[0]
+                .hints
+                .iter()
+                .any(|h| h.contains("Panic") || h.contains("?")),
             "expected hint about adding Panic or using ?"
         );
     }

--- a/vow-types/src/linear.rs
+++ b/vow-types/src/linear.rs
@@ -188,9 +188,7 @@ fn check_expr(
             check_block(body, tracker, env, file, emitter);
             tracker.in_loop = was_in_loop;
         }
-        ExprKind::ForEach {
-            iterable, body, ..
-        } => {
+        ExprKind::ForEach { iterable, body, .. } => {
             check_expr(iterable, tracker, env, file, emitter, false);
             let was_in_loop = tracker.in_loop;
             tracker.in_loop = true;

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -125,8 +125,7 @@ fn collect_option_vars(func: &Function) -> HashSet<u32> {
         for inst in &block.insts {
             if inst.opcode == Opcode::Call
                 && let InstData::CallExtern(ref name) = inst.data
-                && (name == "__vow_string_parse_i64_opt"
-                    || name == "__vow_string_parse_u64_opt")
+                && (name == "__vow_string_parse_i64_opt" || name == "__vow_string_parse_u64_opt")
             {
                 vars.insert(inst.id.0);
             }

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1145,11 +1145,7 @@ fn compile_frontend(source: &Path) -> Result<FrontendResult, Box<BuildOutput>> {
         }));
     }
 
-    let module = vow_ir::lower_module(
-        &ast,
-        &source.to_string_lossy(),
-        &string_exprs,
-    );
+    let module = vow_ir::lower_module(&ast, &source.to_string_lossy(), &string_exprs);
     for w in &module.warnings {
         stderr_emit.emit(w);
     }
@@ -2137,8 +2133,14 @@ fn main() -> i32 [io] {
         assert!(json.contains("fs_read"), "missing fs_read builtin");
         assert!(json.contains("fs_write"), "missing fs_write builtin");
         assert!(json.contains("args"), "missing args builtin");
-        assert!(json.contains("eprintln_str"), "missing eprintln_str builtin");
-        assert!(json.contains("process_exit"), "missing process_exit builtin");
+        assert!(
+            json.contains("eprintln_str"),
+            "missing eprintln_str builtin"
+        );
+        assert!(
+            json.contains("process_exit"),
+            "missing process_exit builtin"
+        );
 
         // Must describe structural language features
         assert!(json.contains("\"structs\""), "missing structs section");
@@ -2152,10 +2154,7 @@ fn main() -> i32 [io] {
             json.contains("\"where_clauses\""),
             "missing where_clauses section"
         );
-        assert!(
-            json.contains("\"modules\""),
-            "missing modules section"
-        );
+        assert!(json.contains("\"modules\""), "missing modules section");
 
         // Now verify that a program an LLM would write from this description compiles and runs.
         // The LLM reads: function with requires/ensures, print_i64 builtin, [io] effect.


### PR DESCRIPTION
## Summary

- Remove the blanket `mark_escaped(recv_id)` in both the Rust lowerer (`vow-ir/src/lower/mod.rs`) and self-hosted lowerer (`compiler/lower.vow`)
- No method handler consumes the receiver — read-only methods just read it, mutating methods modify in-place — so the receiver stays locally owned and should be freed at function exit
- Add 3 new tests (`string_freed_after_method_call`, `vec_freed_after_method_call`, `hashmap_freed_after_method_call`) and update the existing `receiver_method_marks_escaped_no_free` test to assert the fixed behavior

Closes #71

## Test plan

- [x] All 65 `vow-ir` unit tests pass (including 4 updated/new deallocation tests)
- [x] `cargo clippy --all -- -D warnings` clean
- [x] Bootstrap produces a fixed-point binary (SHA-256 match)