### PR TITLE
add math utils library with arithmetic, number theory, and vector operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target/
 compiler/main
 /build/
+*.o
 compiler/*.o
 compiler/*.vow.c
 /.claude/*.local.json

--- a/lib/ROADMAP.md
+++ b/lib/ROADMAP.md
@@ -1,0 +1,214 @@
+# Vow Standard Library Roadmap
+
+This document outlines candidate libraries for the Vow standard library,
+prioritized by verification fitness, agent utility, and implementation
+feasibility. GC, bignum, and math are already in progress.
+
+## Tier 1 — High impact, low verifier cost
+
+### Byte Buffer (`lib/bytes`)
+Low-level `Vec<u8>` utilities for binary data manipulation.
+
+**Functions:** `bytes_get_u16_be`, `bytes_get_u32_be`, `bytes_get_u64_be`,
+`bytes_put_u16_be`, `bytes_put_u32_be`, `bytes_put_u64_be` (and `_le`
+variants), `bytes_copy`, `bytes_equal`, `bytes_fill`, `bytes_slice`.
+
+**Why now:** Bignum already needs byte-level manipulation. Crypto (hashing)
+needs it. Serialization needs it. Pure functions with tight bounds — contracts
+like `requires: offset + 4 <= v.len()` are trivially verifiable.
+
+**Verifier impact:** Near zero. All operations desugar to Vec indexing with
+offset arithmetic. Bounded by existing Vec limits (128 elements).
+
+**Depends on:** Nothing (uses existing `Vec<u8>` and `u64`).
+
+---
+
+### String Builder / Formatter (`lib/fmt`)
+Structured string construction from typed parts.
+
+**Functions:** `fmt_i64(n) -> String`, `fmt_u64(n) -> String`,
+`fmt_bool(b) -> String`, `fmt_pad_left(s, width, pad_byte) -> String`,
+`fmt_pad_right(s, width, pad_byte) -> String`, `fmt_hex_u64(n) -> String`,
+`fmt_join(parts: Vec<String>, sep: String) -> String`.
+
+**Why now:** Agents building output strings (diagnostics, logs, protocol
+messages) currently concatenate with `push_str` in ad-hoc ways. A small set
+of pure formatting functions eliminates a class of off-by-one and
+missing-separator bugs.
+
+**Verifier impact:** Minimal. String operations are already modeled.
+Formatting functions are pure and bounded.
+
+**Depends on:** Nothing (uses existing String builtins).
+
+---
+
+### JSON (`lib/json`)
+Parse and emit JSON. This is the lingua franca of agent communication — Vow's
+own diagnostics are JSON.
+
+**Types:** An enum-based `JsonValue` (Null, Bool, Number, Str, Array, Object).
+
+**Functions:** `json_parse(s: String) -> Result<JsonValue, String>`,
+`json_emit(v: JsonValue) -> String`, `json_get_field(obj, key) -> Option<JsonValue>`,
+`json_get_index(arr, i) -> Option<JsonValue>`.
+
+**Why now:** Any agent that consumes or produces structured data needs JSON.
+Without it, agents hand-roll parsers that are error-prone and unverifiable.
+A recursive-descent parser over `byte_at` is straightforward in Vow.
+
+**Verifier impact:** Moderate. Recursive parsing over bounded strings is
+tractable. The JsonValue enum exercises Vow's enum/match machinery well.
+
+**Depends on:** `lib/fmt` (for number-to-string in emission).
+
+---
+
+## Tier 2 — Solid utility, modest verifier cost
+
+### Sorting & Searching (`lib/sort`)
+Extend beyond the existing `vec_sort` builtin with verified variants.
+
+**Functions:** `insertion_sort(v: Vec<i64>) -> Vec<i64>` (with
+`ensures: vec_is_sorted(result)`), `binary_search(v: Vec<i64>, target: i64) -> i64`
+(with `requires: vec_is_sorted(v)`), `vec_partition(v, pivot) -> (Vec<i64>, Vec<i64>)`,
+`vec_merge(a: Vec<i64>, b: Vec<i64>) -> Vec<i64>` (both sorted).
+
+**Why now:** The benchmark suite already has sorting/searching tasks. Library
+versions with verified contracts would let agents compose rather than
+re-implement.
+
+**Verifier impact:** Low-moderate. Sorting invariants (`ensures: is_sorted(result),
+ensures: result.len() == v.len()`) are classic verification targets.
+
+**Depends on:** `lib/math/vec_math` (for `vec_is_sorted`).
+
+---
+
+### Bitwise Operations (`lib/bits`)
+Extend beyond the existing XOR operator.
+
+**Functions:** `bit_and(a, b) -> i64`, `bit_or(a, b) -> i64`,
+`bit_not(a) -> i64`, `shift_left(a, n) -> i64`, `shift_right(a, n) -> i64`,
+`bit_count(a) -> i64` (popcount), `bit_test(a, n) -> i64`,
+`bit_set(a, n) -> i64`, `bit_clear(a, n) -> i64`.
+
+**Why now:** Crypto (SHA-256, etc.) requires all of these. Currently only XOR
+exists as an operator. These would need to be wired as builtins through the
+runtime since Vow lacks bitwise AND/OR/shift operators.
+
+**Verifier impact:** Low. Bitwise ops are well-modeled in ESBMC's C backend.
+
+**Depends on:** Runtime additions (new `extern "C"` functions in `vow-runtime`).
+
+---
+
+### Crypto Hashes (`lib/crypto`)
+Pure hash functions over byte buffers.
+
+**Functions:** `sha256(data: Vec<u8>) -> Vec<u8>` (returns 32 bytes),
+`sha256_hex(data: Vec<u8>) -> String`, `hmac_sha256(key: Vec<u8>, data: Vec<u8>) -> Vec<u8>`.
+
+**Why now:** Agents dealing with authentication, integrity checks, or content
+addressing need hashing. SHA-256 is implementable as pure Vow code given
+bitwise ops and byte buffer support.
+
+**Verifier impact:** Moderate. The algorithm is fixed and deterministic.
+Contracts can verify output length (`ensures: result.len() == 32`) and
+known test vectors.
+
+**Depends on:** `lib/bits`, `lib/bytes`.
+
+---
+
+## Tier 3 — Useful but larger scope
+
+### Environment & Config (`lib/env`)
+Access to environment variables and simple config parsing.
+
+**Functions:** `env_get(key: String) -> Option<String>`,
+`env_get_or(key: String, default: String) -> String`.
+Possibly: `parse_ini(s: String) -> HashMap<String, String>`.
+
+**Why:** Agents need configuration. Currently the only external input is
+`args()` and `stdin_read`.
+
+**Verifier impact:** Minimal (env_get is a new `[read]` effect builtin).
+
+**Depends on:** Runtime addition for `getenv(3)`.
+
+---
+
+### CSV / TSV Parser (`lib/csv`)
+Line-oriented structured text parsing.
+
+**Functions:** `csv_parse_line(line: String, sep: String) -> Vec<String>`,
+`csv_parse(data: String, sep: String) -> Vec<Vec<String>>`,
+`csv_emit_line(fields: Vec<String>, sep: String) -> String`.
+
+**Why:** Common data interchange format. Implementable purely using
+`string_split` and `string_join`.
+
+**Verifier impact:** Low. Pure string manipulation.
+
+**Depends on:** Nothing.
+
+---
+
+### Ring Buffer (`lib/ring`)
+Fixed-capacity FIFO queue with contracts.
+
+**Types:** `Ring` struct with `data: Vec<i64>`, `head: i64`, `tail: i64`, `count: i64`, `cap: i64`.
+
+**Functions:** `ring_new(cap) -> Ring`, `ring_push(r, val) -> Ring`
+(with `requires: r.count < r.cap`), `ring_pop(r) -> Ring`
+(with `requires: r.count > 0`), `ring_peek(r) -> i64`,
+`ring_len(r) -> i64`, `ring_is_full(r) -> i64`.
+
+**Why:** Bounded data structure with natural contracts. Useful for streaming
+pipelines, rate limiting, sliding windows.
+
+**Verifier impact:** Low. Modular arithmetic on bounded indices is simple.
+
+**Depends on:** Nothing.
+
+---
+
+### Set (`lib/set`)
+Integer set backed by sorted vector.
+
+**Functions:** `set_new() -> Vec<i64>`, `set_insert(s, val) -> Vec<i64>`,
+`set_contains(s, val) -> i64`, `set_remove(s, val) -> Vec<i64>`,
+`set_union(a, b) -> Vec<i64>`, `set_intersection(a, b) -> Vec<i64>`,
+`set_difference(a, b) -> Vec<i64>`, `set_size(s) -> i64`.
+
+**Why:** Eliminates hand-rolled dedup/membership patterns. Sorted-vector
+backing means `set_contains` uses binary search, and set invariant
+(`ensures: vec_is_sorted(result)`) is verifiable.
+
+**Depends on:** `lib/sort` (binary search), `lib/math/vec_math` (`vec_is_sorted`).
+
+---
+
+## Recommended sequencing
+
+```
+Already done/in progress:
+  GC → Bignum → Math ✓
+
+Next batch (Tier 1):
+  Bytes → Fmt → JSON
+
+Then (Tier 2, can parallelize):
+  Bits → Crypto
+  Sort → Set
+
+Finally (Tier 3, as needed):
+  Env, CSV, Ring
+```
+
+The Tier 1 batch (bytes, fmt, json) is the highest-leverage next step because
+it enables agents to do structured I/O — which is the primary way agents
+communicate with the outside world. Each library is small (5-15 functions),
+pure, and verification-friendly.

--- a/lib/math/arithmetic.vow
+++ b/lib/math/arithmetic.vow
@@ -1,0 +1,182 @@
+module Arithmetic
+
+// --- Absolute value ---
+
+fn abs(x: i64) -> i64 vow {
+  requires: x > -9223372036854775807,
+  ensures: result >= 0
+} {
+  if x < 0 { 0 - x } else { x }
+}
+
+// --- Min / Max ---
+
+fn min(a: i64, b: i64) -> i64 vow {
+  ensures: result <= a,
+  ensures: result <= b
+} {
+  if a <= b { a } else { b }
+}
+
+fn max(a: i64, b: i64) -> i64 vow {
+  ensures: result >= a,
+  ensures: result >= b
+} {
+  if a >= b { a } else { b }
+}
+
+// --- Clamp ---
+
+fn clamp(val: i64, lo: i64, hi: i64) -> i64 vow {
+  requires: lo <= hi,
+  ensures: result >= lo,
+  ensures: result <= hi
+} {
+  if val < lo {
+    lo
+  } else {
+    if val > hi {
+      hi
+    } else {
+      val
+    }
+  }
+}
+
+// --- Sign ---
+
+fn sign(x: i64) -> i64 vow {
+  ensures: result >= -1,
+  ensures: result <= 1
+} {
+  if x > 0 {
+    1
+  } else {
+    if x < 0 {
+      -1
+    } else {
+      0
+    }
+  }
+}
+
+// --- Safe arithmetic with overflow preconditions ---
+
+fn safe_add(a: i64, b: i64) -> i64 vow {
+  requires: a >= 0,
+  requires: b >= 0,
+  requires: a <= 4611686018427387903,
+  requires: b <= 4611686018427387903,
+  ensures: result == a + b,
+  ensures: result >= 0
+} {
+  a + b
+}
+
+fn safe_sub(a: i64 where a >= 0, b: i64 where b >= 0) -> i64 vow {
+  requires: a >= b,
+  ensures: result == a - b,
+  ensures: result >= 0
+} {
+  a - b
+}
+
+fn safe_mul(a: i64, b: i64) -> i64 vow {
+  requires: a >= 0,
+  requires: b >= 0,
+  requires: a <= 3037000499,
+  requires: b <= 3037000499,
+  ensures: result == a * b,
+  ensures: result >= 0
+} {
+  a * b
+}
+
+fn safe_div(a: i64, b: i64) -> i64 vow {
+  requires: b != 0,
+  ensures: result == a / b
+} {
+  a / b
+}
+
+fn safe_mod(a: i64, m: i64) -> i64 vow {
+  requires: a >= 0,
+  requires: m > 0,
+  ensures: result >= 0,
+  ensures: result < m
+} {
+  a % m
+}
+
+// --- Integer power ---
+
+fn pow(base: i64, exp: i64) -> i64 vow {
+  requires: exp >= 0,
+  requires: exp <= 16,
+  requires: base >= -100,
+  requires: base <= 100,
+  ensures: result >= -9223372036854775807
+} {
+  if exp == 0 {
+    1
+  } else {
+    let mut r: i64 = 1;
+    let mut i: i64 = 0;
+    while i < exp vow {
+      invariant: i >= 0,
+      invariant: i <= exp
+    } {
+      r = r * base;
+      i = i + 1;
+    }
+    r
+  }
+}
+
+// --- Midpoint (overflow-safe average of two values) ---
+
+fn midpoint(a: i64, b: i64) -> i64 vow {
+  requires: a >= 0,
+  requires: b >= 0,
+  ensures: result >= 0
+} {
+  a / 2 + b / 2 + (a % 2 + b % 2) / 2
+}
+
+// --- Difference (absolute difference) ---
+
+fn diff(a: i64, b: i64) -> i64 vow {
+  requires: a > -4611686018427387903,
+  requires: b > -4611686018427387903,
+  requires: a < 4611686018427387903,
+  requires: b < 4611686018427387903,
+  ensures: result >= 0
+} {
+  if a >= b { a - b } else { b - a }
+}
+
+// --- Divides evenly ---
+
+fn divides(d: i64, n: i64) -> i64 vow {
+  requires: d != 0,
+  ensures: result >= 0,
+  ensures: result <= 1
+} {
+  if n % d == 0 { 1 } else { 0 }
+}
+
+// --- Is even / is odd ---
+
+fn is_even(x: i64) -> i64 vow {
+  ensures: result >= 0,
+  ensures: result <= 1
+} {
+  if x % 2 == 0 { 1 } else { 0 }
+}
+
+fn is_odd(x: i64) -> i64 vow {
+  ensures: result >= 0,
+  ensures: result <= 1
+} {
+  if x % 2 != 0 { 1 } else { 0 }
+}

--- a/lib/math/main.vow
+++ b/lib/math/main.vow
@@ -1,0 +1,166 @@
+module Main
+use arithmetic
+use number_theory
+use vec_math
+
+fn main() -> i32 [io] {
+    // --- Arithmetic ---
+    print_str(String::from("=== Arithmetic ==="));
+
+    print_str(String::from("abs(-42) = "));
+    print_i64(abs(-42));
+
+    print_str(String::from("min(3, 7) = "));
+    print_i64(min(3, 7));
+
+    print_str(String::from("max(3, 7) = "));
+    print_i64(max(3, 7));
+
+    print_str(String::from("clamp(50, 0, 10) = "));
+    print_i64(clamp(50, 0, 10));
+
+    print_str(String::from("sign(-5) = "));
+    print_i64(sign(-5));
+
+    print_str(String::from("sign(0) = "));
+    print_i64(sign(0));
+
+    print_str(String::from("sign(3) = "));
+    print_i64(sign(3));
+
+    print_str(String::from("safe_add(100, 200) = "));
+    print_i64(safe_add(100, 200));
+
+    print_str(String::from("safe_sub(200, 100) = "));
+    print_i64(safe_sub(200, 100));
+
+    print_str(String::from("safe_mul(12, 34) = "));
+    print_i64(safe_mul(12, 34));
+
+    print_str(String::from("safe_div(42, 5) = "));
+    print_i64(safe_div(42, 5));
+
+    print_str(String::from("safe_mod(17, 5) = "));
+    print_i64(safe_mod(17, 5));
+
+    print_str(String::from("pow(2, 10) = "));
+    print_i64(pow(2, 10));
+
+    print_str(String::from("midpoint(10, 20) = "));
+    print_i64(midpoint(10, 20));
+
+    print_str(String::from("diff(30, 10) = "));
+    print_i64(diff(30, 10));
+
+    print_str(String::from("diff(10, 30) = "));
+    print_i64(diff(10, 30));
+
+    print_str(String::from("divides(3, 9) = "));
+    print_i64(divides(3, 9));
+
+    print_str(String::from("divides(3, 10) = "));
+    print_i64(divides(3, 10));
+
+    print_str(String::from("is_even(4) = "));
+    print_i64(is_even(4));
+
+    print_str(String::from("is_odd(5) = "));
+    print_i64(is_odd(5));
+
+    // --- Number Theory ---
+    print_str(String::from("=== Number Theory ==="));
+
+    print_str(String::from("gcd(12, 8) = "));
+    print_i64(gcd(12, 8));
+
+    print_str(String::from("lcm(4, 6) = "));
+    print_i64(lcm(4, 6));
+
+    print_str(String::from("is_prime(7) = "));
+    print_i64(is_prime(7));
+
+    print_str(String::from("is_prime(9) = "));
+    print_i64(is_prime(9));
+
+    print_str(String::from("power_mod(2, 10, 100) = "));
+    print_i64(power_mod(2, 10, 100));
+
+    print_str(String::from("factorial(10) = "));
+    print_i64(factorial(10));
+
+    print_str(String::from("fibonacci(10) = "));
+    print_i64(fibonacci(10));
+
+    print_str(String::from("isqrt(49) = "));
+    print_i64(isqrt(49));
+
+    print_str(String::from("isqrt(50) = "));
+    print_i64(isqrt(50));
+
+    print_str(String::from("largest_divisor(12) = "));
+    print_i64(largest_divisor(12));
+
+    print_str(String::from("count_divisors(12) = "));
+    print_i64(count_divisors(12));
+
+    // --- Vec Math ---
+    print_str(String::from("=== Vec Math ==="));
+
+    let v: Vec<i64> = Vec::new();
+    v.push(10);
+    v.push(20);
+    v.push(30);
+    v.push(40);
+
+    print_str(String::from("vec_sum([10,20,30,40]) = "));
+    print_i64(vec_sum(v));
+
+    print_str(String::from("vec_min([10,20,30,40]) = "));
+    print_i64(vec_min(v));
+
+    print_str(String::from("vec_max([10,20,30,40]) = "));
+    print_i64(vec_max(v));
+
+    print_str(String::from("vec_mean([10,20,30,40]) = "));
+    print_i64(vec_mean(v));
+
+    print_str(String::from("vec_count([10,20,30,40], 20) = "));
+    print_i64(vec_count(v, 20));
+
+    print_str(String::from("vec_all_in_range([10,20,30,40], 0, 50) = "));
+    print_i64(vec_all_in_range(v, 0, 50));
+
+    print_str(String::from("vec_is_sorted([10,20,30,40]) = "));
+    print_i64(vec_is_sorted(v));
+
+    let a: Vec<i64> = Vec::new();
+    a.push(1);
+    a.push(2);
+    a.push(3);
+
+    let b: Vec<i64> = Vec::new();
+    b.push(4);
+    b.push(5);
+    b.push(6);
+
+    print_str(String::from("vec_dot([1,2,3],[4,5,6]) = "));
+    print_i64(vec_dot(a, b));
+
+    let ps: Vec<i64> = vec_prefix_sum(v);
+    print_str(String::from("vec_prefix_sum([10,20,30,40]) = "));
+    let mut pi: i64 = 0;
+    while pi < ps.len() {
+      print_i64(ps[pi]);
+      pi = pi + 1;
+    }
+
+    let rv: Vec<i64> = vec_reverse(v);
+    print_str(String::from("vec_reverse([10,20,30,40]) = "));
+    let mut ri: i64 = 0;
+    while ri < rv.len() {
+      print_i64(rv[ri]);
+      ri = ri + 1;
+    }
+
+    0
+}

--- a/lib/math/number_theory.vow
+++ b/lib/math/number_theory.vow
@@ -1,0 +1,232 @@
+module NumberTheory
+
+// --- Greatest common divisor (Euclidean algorithm) ---
+
+fn gcd(a: i64, b: i64) -> i64 vow {
+  requires: a >= 1,
+  requires: b >= 1,
+  requires: a <= 1000,
+  requires: b <= 1000,
+  ensures: result >= 1
+} {
+  let mut x: i64 = a;
+  let mut y: i64 = b;
+  while y > 0 vow {
+    invariant: x >= 1,
+    invariant: y >= 0,
+    invariant: x <= 1000,
+    invariant: y <= 1000
+  } {
+    let tmp: i64 = y;
+    y = x % y;
+    x = tmp;
+  }
+  x
+}
+
+// --- Least common multiple ---
+
+fn lcm(a: i64, b: i64) -> i64 vow {
+  requires: a >= 1,
+  requires: b >= 1,
+  requires: a <= 1000,
+  requires: b <= 1000,
+  ensures: result >= 1
+} {
+  let g: i64 = gcd(a, b);
+  (a / g) * b
+}
+
+// --- Primality test (trial division) ---
+
+fn is_prime(n: i64) -> i64 vow {
+  requires: n >= 0,
+  requires: n <= 1000,
+  ensures: result >= 0,
+  ensures: result <= 1
+} {
+  if n < 2 {
+    0
+  } else {
+    let mut d: i64 = 2;
+    let mut composite: i64 = 0;
+    while d * d <= n vow {
+      invariant: d >= 2,
+      invariant: composite >= 0,
+      invariant: composite <= 1
+    } {
+      if n % d == 0 {
+        composite = 1;
+      } else {
+        0;
+      }
+      d = d + 1;
+    }
+    if composite == 1 { 0 } else { 1 }
+  }
+}
+
+// --- Modular exponentiation: base^exp mod m ---
+
+fn power_mod(base: i64, exp: i64, m: i64) -> i64 vow {
+  requires: base >= 0,
+  requires: base <= 1000,
+  requires: exp >= 0,
+  requires: exp <= 30,
+  requires: m >= 2,
+  requires: m <= 1000,
+  ensures: result >= 0,
+  ensures: result < m
+} {
+  let mut r: i64 = 1;
+  let mut b: i64 = base % m;
+  let mut e: i64 = exp;
+  while e > 0 vow {
+    invariant: e >= 0,
+    invariant: r >= 0,
+    invariant: r < m,
+    invariant: b >= 0,
+    invariant: b < m
+  } {
+    if e % 2 == 1 {
+      r = (r * b) % m;
+    } else {
+      0;
+    }
+    b = (b * b) % m;
+    e = e / 2;
+  }
+  r
+}
+
+// --- Factorial ---
+
+fn factorial(n: i64) -> i64 vow {
+  requires: n >= 0,
+  requires: n <= 12,
+  ensures: result >= 1
+} {
+  let mut r: i64 = 1;
+  let mut i: i64 = 2;
+  while i <= n vow {
+    invariant: i >= 2,
+    invariant: i <= n + 1,
+    invariant: r >= 1
+  } {
+    r = r * i;
+    i = i + 1;
+  }
+  r
+}
+
+// --- Fibonacci ---
+
+fn fibonacci(n: i64) -> i64 vow {
+  requires: n >= 0,
+  requires: n <= 46,
+  ensures: result >= 0
+} {
+  if n <= 1 {
+    n
+  } else {
+    let mut a: i64 = 0;
+    let mut b: i64 = 1;
+    let mut i: i64 = 2;
+    while i <= n vow {
+      invariant: i >= 2,
+      invariant: i <= n + 1,
+      invariant: a >= 0,
+      invariant: b >= 0
+    } {
+      let tmp: i64 = a + b;
+      a = b;
+      b = tmp;
+      i = i + 1;
+    }
+    b
+  }
+}
+
+// --- Integer square root (floor) ---
+
+fn isqrt(n: i64) -> i64 vow {
+  requires: n >= 0,
+  requires: n <= 1000000,
+  ensures: result >= 0,
+  ensures: result * result <= n
+} {
+  if n == 0 {
+    0
+  } else {
+    let mut lo: i64 = 1;
+    let mut hi: i64 = n;
+    if hi > 1000 {
+      hi = 1000;
+    } else {
+      0;
+    }
+    let mut ans: i64 = 0;
+    while lo <= hi vow {
+      invariant: lo >= 1,
+      invariant: ans >= 0,
+      invariant: ans * ans <= n
+    } {
+      let mid: i64 = lo + (hi - lo) / 2;
+      if mid * mid <= n {
+        ans = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    ans
+  }
+}
+
+// --- Largest proper divisor ---
+
+fn largest_divisor(n: i64) -> i64 vow {
+  requires: n >= 2,
+  requires: n <= 1000,
+  ensures: result >= 1,
+  ensures: result < n,
+  ensures: n % result == 0
+} {
+  let mut d: i64 = n - 1;
+  while d >= 2 vow {
+    invariant: d >= 1,
+    invariant: d < n
+  } {
+    if n % d == 0 {
+      return d;
+    } else {
+      0;
+    }
+    d = d - 1;
+  }
+  1
+}
+
+// --- Count divisors ---
+
+fn count_divisors(n: i64) -> i64 vow {
+  requires: n >= 1,
+  requires: n <= 1000,
+  ensures: result >= 1
+} {
+  let mut count: i64 = 0;
+  let mut d: i64 = 1;
+  while d <= n vow {
+    invariant: d >= 1,
+    invariant: d <= n + 1,
+    invariant: count >= 0
+  } {
+    if n % d == 0 {
+      count = count + 1;
+    } else {
+      0;
+    }
+    d = d + 1;
+  }
+  count
+}

--- a/lib/math/vec_math.vow
+++ b/lib/math/vec_math.vow
@@ -1,0 +1,225 @@
+module VecMath
+
+// --- Sum of vector elements ---
+
+fn vec_sum(v: Vec<i64>) -> i64 vow {
+  requires: v.len() >= 0,
+  requires: v.len() <= 64
+} {
+  let mut total: i64 = 0;
+  let mut i: i64 = 0;
+  let n: i64 = v.len();
+  while i < n vow {
+    invariant: i >= 0,
+    invariant: i <= n
+  } {
+    total = total + v[i];
+    i = i + 1;
+  }
+  total
+}
+
+// --- Minimum element (requires non-empty vector) ---
+
+fn vec_min(v: Vec<i64>) -> i64 vow {
+  requires: v.len() >= 1,
+  requires: v.len() <= 64
+} {
+  let mut m: i64 = v[0];
+  let mut i: i64 = 1;
+  let n: i64 = v.len();
+  while i < n vow {
+    invariant: i >= 1,
+    invariant: i <= n
+  } {
+    if v[i] < m {
+      m = v[i];
+    } else {
+      0;
+    }
+    i = i + 1;
+  }
+  m
+}
+
+// --- Maximum element (requires non-empty vector) ---
+
+fn vec_max(v: Vec<i64>) -> i64 vow {
+  requires: v.len() >= 1,
+  requires: v.len() <= 64
+} {
+  let mut m: i64 = v[0];
+  let mut i: i64 = 1;
+  let n: i64 = v.len();
+  while i < n vow {
+    invariant: i >= 1,
+    invariant: i <= n
+  } {
+    if v[i] > m {
+      m = v[i];
+    } else {
+      0;
+    }
+    i = i + 1;
+  }
+  m
+}
+
+// --- Mean (integer division, requires non-empty) ---
+
+fn vec_mean(v: Vec<i64>) -> i64 vow {
+  requires: v.len() >= 1,
+  requires: v.len() <= 64
+} {
+  let total: i64 = vec_sum(v);
+  let n: i64 = v.len();
+  total / n
+}
+
+// --- Dot product of two equal-length vectors ---
+
+fn vec_dot(a: Vec<i64>, b: Vec<i64>) -> i64 vow {
+  requires: a.len() == b.len(),
+  requires: a.len() >= 0,
+  requires: a.len() <= 64
+} {
+  let mut total: i64 = 0;
+  let mut i: i64 = 0;
+  let n: i64 = a.len();
+  while i < n vow {
+    invariant: i >= 0,
+    invariant: i <= n
+  } {
+    total = total + a[i] * b[i];
+    i = i + 1;
+  }
+  total
+}
+
+// --- Count occurrences of a value ---
+
+fn vec_count(v: Vec<i64>, target: i64) -> i64 vow {
+  requires: v.len() >= 0,
+  requires: v.len() <= 64,
+  ensures: result >= 0,
+  ensures: result <= v.len()
+} {
+  let mut count: i64 = 0;
+  let mut i: i64 = 0;
+  let n: i64 = v.len();
+  while i < n vow {
+    invariant: i >= 0,
+    invariant: i <= n,
+    invariant: count >= 0,
+    invariant: count <= i
+  } {
+    if v[i] == target {
+      count = count + 1;
+    } else {
+      0;
+    }
+    i = i + 1;
+  }
+  count
+}
+
+// --- Check if all elements satisfy a bound ---
+
+fn vec_all_in_range(v: Vec<i64>, lo: i64, hi: i64) -> i64 vow {
+  requires: lo <= hi,
+  requires: v.len() >= 0,
+  requires: v.len() <= 64,
+  ensures: result >= 0,
+  ensures: result <= 1
+} {
+  let mut i: i64 = 0;
+  let n: i64 = v.len();
+  while i < n vow {
+    invariant: i >= 0,
+    invariant: i <= n
+  } {
+    if v[i] < lo {
+      return 0;
+    } else {
+      0;
+    }
+    if v[i] > hi {
+      return 0;
+    } else {
+      0;
+    }
+    i = i + 1;
+  }
+  1
+}
+
+// --- Check if vector is sorted (non-decreasing) ---
+
+fn vec_is_sorted(v: Vec<i64>) -> i64 vow {
+  requires: v.len() >= 0,
+  requires: v.len() <= 64,
+  ensures: result >= 0,
+  ensures: result <= 1
+} {
+  let n: i64 = v.len();
+  if n <= 1 {
+    1
+  } else {
+    let mut i: i64 = 1;
+    while i < n vow {
+      invariant: i >= 1,
+      invariant: i <= n
+    } {
+      if v[i] < v[i - 1] {
+        return 0;
+      } else {
+        0;
+      }
+      i = i + 1;
+    }
+    1
+  }
+}
+
+// --- Prefix sum (returns new vector of running totals) ---
+
+fn vec_prefix_sum(v: Vec<i64>) -> Vec<i64> vow {
+  requires: v.len() >= 0,
+  requires: v.len() <= 64,
+  ensures: result.len() == v.len()
+} {
+  let mut out: Vec<i64> = Vec::new();
+  let mut total: i64 = 0;
+  let mut i: i64 = 0;
+  let n: i64 = v.len();
+  while i < n vow {
+    invariant: i >= 0,
+    invariant: i <= n,
+    invariant: out.len() == i
+  } {
+    total = total + v[i];
+    out.push(total);
+    i = i + 1;
+  }
+  out
+}
+
+// --- Reverse a vector ---
+
+fn vec_reverse(v: Vec<i64>) -> Vec<i64> vow {
+  requires: v.len() >= 0,
+  requires: v.len() <= 64,
+  ensures: result.len() == v.len()
+} {
+  let mut out: Vec<i64> = Vec::new();
+  let n: i64 = v.len();
+  let mut i: i64 = n - 1;
+  while i >= 0 vow {
+    invariant: i >= -1,
+    invariant: i < n
+  } {
+    out.push(v[i]);
+    i = i - 1;
+  }
+  out
+}


### PR DESCRIPTION
Three verified modules in lib/math/:
- arithmetic: abs, min, max, clamp, sign, safe_add/sub/mul/div/mod, pow, midpoint, diff, divides, is_even, is_odd
- number_theory: gcd, lcm, is_prime, power_mod, factorial, fibonacci, isqrt, largest_divisor, count_divisors
- vec_math: vec_sum, vec_min, vec_max, vec_mean, vec_dot, vec_count, vec_all_in_range, vec_is_sorted, vec_prefix_sum, vec_reverse

All functions include contracts (requires/ensures/invariant) for verification.

https://claude.ai/code/session_01PRCg7uG6zAs2kg3XA8P7J8