### PR TITLE
Add mark-and-sweep GC library for Vow

### DIFF
--- a/examples/gc/gc.vow
+++ b/examples/gc/gc.vow
@@ -1,0 +1,212 @@
+module Gc
+
+// Mark-and-sweep garbage collector library.
+//
+// GcHeap manages a pool of i64 values with explicit root/reference tracking.
+// Allocation reuses free slots after collection. The mark phase uses an
+// iterative worklist to trace from roots through reference edges. The sweep
+// phase frees unmarked objects and prunes dead references.
+
+struct GcHeap {
+    values: Vec<i64>,
+    alive: Vec<i64>,
+    marks: Vec<i64>,
+    roots: Vec<i64>,
+    ref_from: Vec<i64>,
+    ref_to: Vec<i64>,
+    free_list: Vec<i64>,
+    count: i64,
+}
+
+fn gc_new() -> GcHeap {
+    GcHeap {
+        values: Vec::new(),
+        alive: Vec::new(),
+        marks: Vec::new(),
+        roots: Vec::new(),
+        ref_from: Vec::new(),
+        ref_to: Vec::new(),
+        free_list: Vec::new(),
+        count: 0,
+    }
+}
+
+fn gc_alloc(h: GcHeap, val: i64) -> i64 {
+    let fl: Vec<i64> = h.free_list;
+    if fl.len() > 0 {
+        let idx: i64 = fl.len() - 1;
+        let slot: i64 = fl[idx];
+        fl.pop();
+        let vals: Vec<i64> = h.values;
+        vals[slot] = val;
+        let alv: Vec<i64> = h.alive;
+        alv[slot] = 1;
+        h.count = h.count + 1;
+        slot
+    } else {
+        let vals: Vec<i64> = h.values;
+        let slot: i64 = vals.len();
+        vals.push(val);
+        let alv: Vec<i64> = h.alive;
+        alv.push(1);
+        let mrk: Vec<i64> = h.marks;
+        mrk.push(0);
+        h.count = h.count + 1;
+        slot
+    }
+}
+
+fn gc_add_root(h: GcHeap, slot: i64) vow {
+    requires: slot >= 0,
+    requires: slot < h.values.len()
+} {
+    let r: Vec<i64> = h.roots;
+    r.push(slot);
+}
+
+fn gc_remove_root(h: GcHeap, slot: i64) {
+    let r: Vec<i64> = h.roots;
+    let len: i64 = r.len();
+    let mut i: i64 = 0;
+    while i < len {
+        if r[i] == slot {
+            let last: i64 = r[len - 1];
+            r[i] = last;
+            r.pop();
+            return;
+        }
+        i = i + 1;
+    }
+}
+
+fn gc_add_ref(h: GcHeap, from: i64, to: i64) vow {
+    requires: from >= 0,
+    requires: from < h.values.len(),
+    requires: to >= 0,
+    requires: to < h.values.len()
+} {
+    let rf: Vec<i64> = h.ref_from;
+    let rt: Vec<i64> = h.ref_to;
+    rf.push(from);
+    rt.push(to);
+}
+
+fn gc_read(h: GcHeap, slot: i64) -> i64 vow {
+    requires: slot >= 0,
+    requires: slot < h.values.len()
+} {
+    let vals: Vec<i64> = h.values;
+    vals[slot]
+}
+
+fn gc_write(h: GcHeap, slot: i64, val: i64) vow {
+    requires: slot >= 0,
+    requires: slot < h.values.len()
+} {
+    let vals: Vec<i64> = h.values;
+    vals[slot] = val;
+}
+
+fn gc_is_alive(h: GcHeap, slot: i64) -> bool vow {
+    requires: slot >= 0,
+    requires: slot < h.values.len()
+} {
+    let alv: Vec<i64> = h.alive;
+    alv[slot] == 1
+}
+
+fn gc_count(h: GcHeap) -> i64 {
+    h.count
+}
+
+fn gc_collect(h: GcHeap) -> i64 {
+    let mrk: Vec<i64> = h.marks;
+    let alv: Vec<i64> = h.alive;
+    let vals: Vec<i64> = h.values;
+    let total: i64 = vals.len();
+
+    // Clear marks
+    let mut i: i64 = 0;
+    while i < total {
+        mrk[i] = 0;
+        i = i + 1;
+    }
+
+    // Build worklist from roots
+    let wl: Vec<i64> = Vec::new();
+    let r: Vec<i64> = h.roots;
+    let rlen: i64 = r.len();
+    i = 0;
+    while i < rlen {
+        let root: i64 = r[i];
+        if alv[root] == 1 && mrk[root] == 0 {
+            mrk[root] = 1;
+            wl.push(root);
+        }
+        i = i + 1;
+    }
+
+    // Mark phase: iterative worklist
+    let rf: Vec<i64> = h.ref_from;
+    let rt: Vec<i64> = h.ref_to;
+    let elen: i64 = rf.len();
+    while wl.len() > 0 {
+        let last_idx: i64 = wl.len() - 1;
+        let obj: i64 = wl[last_idx];
+        wl.pop();
+
+        let mut j: i64 = 0;
+        while j < elen {
+            if rf[j] == obj {
+                let target: i64 = rt[j];
+                if alv[target] == 1 && mrk[target] == 0 {
+                    mrk[target] = 1;
+                    wl.push(target);
+                }
+            }
+            j = j + 1;
+        }
+    }
+
+    // Sweep phase: free unmarked objects
+    let fl: Vec<i64> = h.free_list;
+    let mut freed: i64 = 0;
+    i = 0;
+    while i < total {
+        if alv[i] == 1 && mrk[i] == 0 {
+            alv[i] = 0;
+            vals[i] = 0;
+            fl.push(i);
+            freed = freed + 1;
+            h.count = h.count - 1;
+        }
+        i = i + 1;
+    }
+
+    // Prune dead references (edges where either endpoint was freed)
+    let new_rf: Vec<i64> = Vec::new();
+    let new_rt: Vec<i64> = Vec::new();
+    i = 0;
+    while i < elen {
+        let from_slot: i64 = rf[i];
+        let to_slot: i64 = rt[i];
+        if alv[from_slot] == 1 && alv[to_slot] == 1 {
+            new_rf.push(from_slot);
+            new_rt.push(to_slot);
+        }
+        i = i + 1;
+    }
+
+    // Replace edge lists
+    rf.clear();
+    rt.clear();
+    i = 0;
+    let new_len: i64 = new_rf.len();
+    while i < new_len {
+        rf.push(new_rf[i]);
+        rt.push(new_rt[i]);
+        i = i + 1;
+    }
+
+    freed
+}

--- a/examples/gc/gc.vow
+++ b/examples/gc/gc.vow
@@ -65,7 +65,10 @@ fn gc_add_root(h: GcHeap, slot: i64) vow {
     r.push(slot);
 }
 
-fn gc_remove_root(h: GcHeap, slot: i64) {
+fn gc_remove_root(h: GcHeap, slot: i64) vow {
+    requires: slot >= 0,
+    requires: slot < h.values.len()
+} {
     let r: Vec<i64> = h.roots;
     let len: i64 = r.len();
     let mut i: i64 = 0;

--- a/examples/gc/gc.vow
+++ b/examples/gc/gc.vow
@@ -58,7 +58,8 @@ fn gc_alloc(h: GcHeap, val: i64) -> i64 {
 
 fn gc_add_root(h: GcHeap, slot: i64) vow {
     requires: slot >= 0,
-    requires: slot < h.values.len()
+    requires: slot < h.values.len(),
+    requires: h.alive[slot] == 1
 } {
     let r: Vec<i64> = h.roots;
     r.push(slot);
@@ -83,7 +84,9 @@ fn gc_add_ref(h: GcHeap, from: i64, to: i64) vow {
     requires: from >= 0,
     requires: from < h.values.len(),
     requires: to >= 0,
-    requires: to < h.values.len()
+    requires: to < h.values.len(),
+    requires: h.alive[from] == 1,
+    requires: h.alive[to] == 1
 } {
     let rf: Vec<i64> = h.ref_from;
     let rt: Vec<i64> = h.ref_to;
@@ -93,7 +96,8 @@ fn gc_add_ref(h: GcHeap, from: i64, to: i64) vow {
 
 fn gc_read(h: GcHeap, slot: i64) -> i64 vow {
     requires: slot >= 0,
-    requires: slot < h.values.len()
+    requires: slot < h.values.len(),
+    requires: h.alive[slot] == 1
 } {
     let vals: Vec<i64> = h.values;
     vals[slot]
@@ -101,7 +105,8 @@ fn gc_read(h: GcHeap, slot: i64) -> i64 vow {
 
 fn gc_write(h: GcHeap, slot: i64, val: i64) vow {
     requires: slot >= 0,
-    requires: slot < h.values.len()
+    requires: slot < h.values.len(),
+    requires: h.alive[slot] == 1
 } {
     let vals: Vec<i64> = h.values;
     vals[slot] = val;

--- a/examples/gc/main.vow
+++ b/examples/gc/main.vow
@@ -1,4 +1,4 @@
-// TEST: stdout "PASS alloc\nPASS read\nPASS write\nPASS collect_frees_unreachable\nPASS roots_survive\nPASS ref_traversal\nPASS slot_reuse\nPASS count_tracking"
+// TEST: stdout "PASS alloc\nPASS read\nPASS write\nPASS collect_frees_unreachable\nPASS roots_survive\nPASS ref_traversal\nPASS slot_reuse\nPASS count_tracking\nPASS remove_root"
 module Main
 use gc
 
@@ -23,6 +23,7 @@ fn main() -> i32 [io] {
     test_ref_traversal();
     test_slot_reuse();
     test_count_tracking();
+    test_remove_root();
     0
 }
 
@@ -89,6 +90,17 @@ fn test_slot_reuse() [io] {
     // s0 was freed, slot 0 should be reused
     let s2: i64 = gc_alloc(h, 300);
     assert_true(String::from("slot_reuse"), s2 == s0 && gc_read(h, s2) == 300);
+}
+
+fn test_remove_root() [io] {
+    let h: GcHeap = gc_new();
+    let s0: i64 = gc_alloc(h, 10);
+    let s1: i64 = gc_alloc(h, 20);
+    gc_add_root(h, s0);
+    gc_add_root(h, s1);
+    gc_remove_root(h, s0);
+    let freed: i64 = gc_collect(h);
+    assert_true(String::from("remove_root"), freed == 1 && !gc_is_alive(h, s0) && gc_is_alive(h, s1));
 }
 
 fn test_count_tracking() [io] {

--- a/examples/gc/main.vow
+++ b/examples/gc/main.vow
@@ -1,0 +1,103 @@
+// TEST: stdout "PASS alloc\nPASS read\nPASS write\nPASS collect_frees_unreachable\nPASS roots_survive\nPASS ref_traversal\nPASS slot_reuse\nPASS count_tracking"
+module Main
+use gc
+
+fn assert_true(label: String, val: bool) [io] {
+    if val {
+        print_str(String::from("PASS "));
+        print_str(label);
+        print_str(String::from("\n"));
+    } else {
+        print_str(String::from("FAIL "));
+        print_str(label);
+        print_str(String::from("\n"));
+    }
+}
+
+fn main() -> i32 [io] {
+    test_alloc();
+    test_read();
+    test_write();
+    test_collect_frees_unreachable();
+    test_roots_survive();
+    test_ref_traversal();
+    test_slot_reuse();
+    test_count_tracking();
+    0
+}
+
+fn test_alloc() [io] {
+    let h: GcHeap = gc_new();
+    let s0: i64 = gc_alloc(h, 100);
+    let s1: i64 = gc_alloc(h, 200);
+    assert_true(String::from("alloc"), s0 == 0 && s1 == 1);
+}
+
+fn test_read() [io] {
+    let h: GcHeap = gc_new();
+    let s0: i64 = gc_alloc(h, 42);
+    let val: i64 = gc_read(h, s0);
+    assert_true(String::from("read"), val == 42);
+}
+
+fn test_write() [io] {
+    let h: GcHeap = gc_new();
+    let s0: i64 = gc_alloc(h, 10);
+    gc_write(h, s0, 99);
+    let val: i64 = gc_read(h, s0);
+    assert_true(String::from("write"), val == 99);
+}
+
+fn test_collect_frees_unreachable() [io] {
+    let h: GcHeap = gc_new();
+    let s0: i64 = gc_alloc(h, 100);
+    let s1: i64 = gc_alloc(h, 200);
+    // Neither is rooted, so both should be freed
+    let freed: i64 = gc_collect(h);
+    assert_true(String::from("collect_frees_unreachable"), freed == 2 && !gc_is_alive(h, s0) && !gc_is_alive(h, s1));
+}
+
+fn test_roots_survive() [io] {
+    let h: GcHeap = gc_new();
+    let s0: i64 = gc_alloc(h, 100);
+    let s1: i64 = gc_alloc(h, 200);
+    gc_add_root(h, s0);
+    let freed: i64 = gc_collect(h);
+    // s0 is rooted so survives; s1 is unreachable
+    assert_true(String::from("roots_survive"), freed == 1 && gc_is_alive(h, s0) && !gc_is_alive(h, s1) && gc_read(h, s0) == 100);
+}
+
+fn test_ref_traversal() [io] {
+    let h: GcHeap = gc_new();
+    let s0: i64 = gc_alloc(h, 10);
+    let s1: i64 = gc_alloc(h, 20);
+    let s2: i64 = gc_alloc(h, 30);
+    // Root s0, s0 -> s1, s1 -> s2 (chain keeps all alive)
+    gc_add_root(h, s0);
+    gc_add_ref(h, s0, s1);
+    gc_add_ref(h, s1, s2);
+    let freed: i64 = gc_collect(h);
+    assert_true(String::from("ref_traversal"), freed == 0 && gc_is_alive(h, s0) && gc_is_alive(h, s1) && gc_is_alive(h, s2));
+}
+
+fn test_slot_reuse() [io] {
+    let h: GcHeap = gc_new();
+    let s0: i64 = gc_alloc(h, 100);
+    let s1: i64 = gc_alloc(h, 200);
+    gc_add_root(h, s1);
+    gc_collect(h);
+    // s0 was freed, slot 0 should be reused
+    let s2: i64 = gc_alloc(h, 300);
+    assert_true(String::from("slot_reuse"), s2 == s0 && gc_read(h, s2) == 300);
+}
+
+fn test_count_tracking() [io] {
+    let h: GcHeap = gc_new();
+    gc_alloc(h, 1);
+    gc_alloc(h, 2);
+    gc_alloc(h, 3);
+    let c1: i64 = gc_count(h);
+    gc_collect(h);
+    let c2: i64 = gc_count(h);
+    assert_true(String::from("count_tracking"), c1 == 3 && c2 == 0);
+}

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -406,7 +406,7 @@ echo ""
 
 echo -e "${BOLD}--- Section 6: Multi-Module ---${RESET}"
 
-for multi in stack geometry bignum; do
+for multi in stack geometry bignum gc; do
     main_file="examples/${multi}/main.vow"
     printf "${BOLD}%s${RESET}\n" "$multi"
 


### PR DESCRIPTION
## Summary

- Adds `examples/gc/gc.vow`: mark-and-sweep GC library with GcHeap struct, allocation with free-slot reuse via free list, root/reference management, iterative worklist mark phase, sweep with dead reference pruning, and contracted read/write access
- Adds `examples/gc/main.vow`: 8-test multi-module test suite covering alloc, read, write, collect, reference traversal, slot reuse, and count tracking
- Registers `gc` in `scripts/full_test.sh` Section 6 multi-module loop

Both Rust and self-hosted compilers produce identical output — all 8 tests PASS. Contracts on `gc_read` and `gc_is_alive` verify as PROVEN; void-returning contracted functions hit a pre-existing ESBMC C model bug.

## Test plan

- [x] Both compilers build `examples/gc/main.vow` successfully
- [x] Runtime output matches expected: 8 PASS lines
- [x] `gc_read` and `gc_is_alive` contracts verified (PROVEN)
- [x] Registered in `full_test.sh` multi-module section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a garbage collection module with mark-and-sweep implementation and example usage demonstrating heap allocation and memory management.

* **Tests**
  * Added comprehensive test suite validating garbage collection operations including allocation, root tracking, reference traversal, and memory reclamation.

* **Chores**
  * Updated test automation to include garbage collection module verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->