### PR TITLE
docs: improve investigate skill workflow

### DIFF
--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -59,8 +59,9 @@ Typical tasks:
 6. Implement equivalent fix in `compiler/*.vow`
 7. Rebuild self-hosted compiler and run `ulimit -v 2000000; scripts/full_test.sh`
 8. Verify reproduction case is fixed
-9. Add regression test to appropriate `tests/` category
-10. Commit, push, and comment on issue
+9. Run `/codex:review` and address feedback
+10. Add regression test to appropriate `tests/` category
+11. Commit, push, and comment on issue
 
 Set up dependency relationships between tasks.
 
@@ -107,7 +108,14 @@ After both compilers are fixed:
    ```
 5. If any step fails, iterate on the fix.
 
-### Phase 6 — Add Regression Test
+### Phase 6 — Codex Review
+
+After verifying the fix, request a Codex review of the changes by running `/codex:review`.
+
+Address all issues raised by the review before proceeding. Iterate until the review passes
+cleanly — re-run verification (Phase 5) after any changes made in response to review feedback.
+
+### Phase 7 — Add Regression Test
 
 Every bug fix **must** include a regression test. Move the reproduction `.vow` file from
 Phase 2 into the appropriate test category:
@@ -128,7 +136,7 @@ After adding the test, re-run the full test suite to confirm it's picked up:
 ulimit -v 2000000; scripts/full_test.sh
 ```
 
-### Phase 7 — Commit and Push
+### Phase 8 — Commit and Push
 
 1. Stage all changed files (Rust sources, `compiler/*.vow`, and the new test file).
 2. Create a single commit with message format: `fix: <concise description> (#$ARGUMENTS)`
@@ -136,7 +144,7 @@ ulimit -v 2000000; scripts/full_test.sh
    - Never mention Claude or AI in the commit message.
 3. Push to the current branch.
 
-### Phase 8 — Comment on the Issue
+### Phase 9 — Comment on the Issue
 
 Post a comment on the issue using:
 
@@ -149,7 +157,7 @@ The comment must include:
 - **Fix**: What was changed in both compilers and why.
 - **Testing**: What regression test was added and what test suites passed.
 
-### Phase 9 — Close the Issue
+### Phase 10 — Close the Issue
 
 After confirming the fix is pushed and the comment is posted, close the issue:
 
@@ -166,6 +174,7 @@ If the fix is partial or needs further review, skip this step and inform the use
 - **Task tracking**: Convert plans to task lists (TaskCreate) before execution.
 - **Bootstrap rebuild**: After changing `compiler/*.vow`, rebuild with `scripts/bootstrap.sh --skip-cargo`.
 - **Sequential workflow**: Fix Rust compiler first, then self-hosted. Do not use parallel sub-agents.
+- **Codex review**: Run `/codex:review` after implementation, address all feedback before committing.
 - **Regression tests**: Every bug fix must add a test to the appropriate `tests/` category.
 
 ## Crate-to-Module Mapping

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -77,7 +77,7 @@ sub-agents; work incrementally and directly.
 - Run `cargo clippy --all -- -D warnings` to ensure no lint warnings
 - Run `cargo fmt --all` to ensure formatting is clean
 
-**Step 2 — Self-Hosted Compiler Fix:**
+**Step 2 — Self-Hosted Compiler Fix (if applicable):**
 - Identify the corresponding code in `compiler/*.vow` modules (see Crate-to-Module Mapping below)
 - Implement the equivalent fix
 - Rebuild: `scripts/bootstrap.sh --skip-cargo`

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -169,7 +169,7 @@ If the fix is partial or needs further review, skip this step and inform the use
 
 ## Key Project Rules
 
-- **Dual-compiler rule**: Every change to the Rust compiler must have a corresponding change in the self-hosted compiler (`compiler/*.vow`).
+- **Dual-compiler rule**: Every change to the Rust compiler must have a corresponding change in the self-hosted compiler (`compiler/*.vow`), except for `vow-runtime` which has no self-hosted equivalent.
 - **Memory safety**: Always use `ulimit -v 2000000` when running `build/vowc` or any binary it produces.
 - **Task tracking**: Convert plans to task lists (TaskCreate) before execution.
 - **Bootstrap rebuild**: After changing `compiler/*.vow`, rebuild with `scripts/bootstrap.sh --skip-cargo`.

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -38,11 +38,13 @@ Write a minimal `.vow` file that triggers the reported bug. Compile and run with
 ulimit -v 2000000; build/vowc build <test-file>.vow
 ```
 
-- For verification bugs, use `build/vowc verify`.
-- For runtime bugs, use `--mode debug`.
+- For verification bugs, use `ulimit -v 2000000; build/vowc verify <test-file>.vow`.
+- For runtime bugs, use `ulimit -v 2000000; build/vowc build --mode debug <test-file>.vow`.
 - Confirm the bug manifests before proceeding.
 
-Keep the reproduction file for fix validation in Phase 5.
+**Critical:** Always use `ulimit -v 2000000` when running `build/vowc` or any binary it produces.
+
+Keep the reproduction file for fix validation and regression testing in later phases.
 
 ### Phase 3 — Create Task List
 
@@ -52,41 +54,39 @@ Typical tasks:
 1. Reproduce the bug (Phase 2 output)
 2. Identify root cause in Rust compiler
 3. Implement fix in Rust compiler
-4. Run `cargo test --all` until green
+4. Run `cargo test --all` and `cargo clippy --all -- -D warnings` until green
 5. Identify corresponding code in self-hosted compiler
 6. Implement equivalent fix in `compiler/*.vow`
-7. Rebuild self-hosted compiler and run `scripts/full_test.sh`
+7. Rebuild self-hosted compiler and run `ulimit -v 2000000; scripts/full_test.sh`
 8. Verify reproduction case is fixed
-9. Commit, push, and comment on issue
+9. Add regression test to appropriate `tests/` category
+10. Commit, push, and comment on issue
 
 Set up dependency relationships between tasks.
 
 ### Phase 4 — Fix Both Compilers
 
-Spawn **two sub-agents in parallel** using the Agent tool. Each agent works on
-independent files (Rust `.rs` files vs self-hosted `.vow` files), so there are no
-conflicts. If sub-agents encounter issues (stale worktrees, integration mismatches),
-fall back to sequential execution: fix Rust first, then self-hosted.
+Fix the compilers **sequentially** — Rust first, then self-hosted. Do not use parallel
+sub-agents; work incrementally and directly.
 
-**Agent 1 — Rust Compiler Fix:**
+**Step 1 — Rust Compiler Fix:**
 - Identify the root cause in the relevant crate (vow-syntax, vow-types, vow-ir, vow-codegen, vow-verify, vow-clif-shim, vow-runtime, vow-diag, or vow)
 - Implement the fix
 - Iterate: run `cargo test --all` until all tests pass
 - Run `cargo clippy --all -- -D warnings` to ensure no lint warnings
-- Report back: files changed, root cause summary, test results
+- Run `cargo fmt --all --check` to ensure formatting is clean
 
-**Agent 2 — Self-Hosted Compiler Fix:**
+**Step 2 — Self-Hosted Compiler Fix:**
 - Identify the corresponding code in `compiler/*.vow` modules (see Crate-to-Module Mapping below)
 - Implement the equivalent fix
-- Rebuild: `scripts/bootstrap.sh --no-verify --skip-cargo`
+- Rebuild: `scripts/bootstrap.sh --skip-cargo`
 - Iterate: run `ulimit -v 2000000; scripts/full_test.sh` until all tests pass
-- Report back: files changed, root cause summary, test results
 
-**Critical:** Both agents MUST use `ulimit -v 2000000` when running any self-compiled binary.
+**Critical:** Always use `ulimit -v 2000000` when running any self-compiled binary.
 
 ### Phase 5 — Verify the Fix
 
-After both agents complete:
+After both compilers are fixed:
 
 1. Re-run the Phase 2 reproduction `.vow` file to confirm the bug is fixed:
    ```bash
@@ -96,21 +96,47 @@ After both agents complete:
    ```bash
    cargo test --all
    ```
-3. Run the full self-hosted test suite:
+3. Run clippy and check formatting:
+   ```bash
+   cargo clippy --all -- -D warnings
+   cargo fmt --all --check
+   ```
+4. Run the full self-hosted test suite:
    ```bash
    ulimit -v 2000000; scripts/full_test.sh
    ```
-4. If either fails, iterate on the fix.
+5. If any step fails, iterate on the fix.
 
-### Phase 6 — Commit and Push
+### Phase 6 — Add Regression Test
 
-1. Stage all changed files (both Rust and `compiler/*.vow` changes).
+Every bug fix **must** include a regression test. Move the reproduction `.vow` file from
+Phase 2 into the appropriate test category:
+
+| Test Category | Directory | When to Use |
+|---|---|---|
+| Runtime tests | `tests/run/` | Bug produced wrong runtime output or crash |
+| Error tests | `tests/error/` | Bug was a missing or wrong compile-time error |
+| Verify tests | `tests/verify/` | Bug caused verification to incorrectly fail |
+| Verify-fail tests | `tests/verify-fail/` | Bug caused verification to incorrectly pass |
+| Debug tests | `tests/debug/` | Bug related to `--mode debug` behavior |
+| Multi-module tests | `tests/multi/` | Bug related to multi-module compilation |
+
+Name the test file descriptively (e.g., `tests/run/vec_index_oob.vow`).
+
+After adding the test, re-run the full test suite to confirm it's picked up:
+```bash
+ulimit -v 2000000; scripts/full_test.sh
+```
+
+### Phase 7 — Commit and Push
+
+1. Stage all changed files (Rust sources, `compiler/*.vow`, and the new test file).
 2. Create a single commit with message format: `fix: <concise description> (#$ARGUMENTS)`
    - Follow the existing commit style (see `git log --oneline`).
    - Never mention Claude or AI in the commit message.
 3. Push to the current branch.
 
-### Phase 7 — Comment on the Issue
+### Phase 8 — Comment on the Issue
 
 Post a comment on the issue using:
 
@@ -121,9 +147,9 @@ gh issue comment $ARGUMENTS --body "<summary>"
 The comment must include:
 - **Root cause**: What caused the bug and where in the codebase.
 - **Fix**: What was changed in both compilers and why.
-- **Testing**: What tests were run to validate the fix.
+- **Testing**: What regression test was added and what test suites passed.
 
-### Phase 8 — Close the Issue
+### Phase 9 — Close the Issue
 
 After confirming the fix is pushed and the comment is posted, close the issue:
 
@@ -138,7 +164,9 @@ If the fix is partial or needs further review, skip this step and inform the use
 - **Dual-compiler rule**: Every change to the Rust compiler must have a corresponding change in the self-hosted compiler (`compiler/*.vow`).
 - **Memory safety**: Always use `ulimit -v 2000000` when running `build/vowc` or any binary it produces.
 - **Task tracking**: Convert plans to task lists (TaskCreate) before execution.
-- **Bootstrap rebuild**: After changing `compiler/*.vow`, rebuild with `scripts/bootstrap.sh --no-verify --skip-cargo`.
+- **Bootstrap rebuild**: After changing `compiler/*.vow`, rebuild with `scripts/bootstrap.sh --skip-cargo`.
+- **Sequential workflow**: Fix Rust compiler first, then self-hosted. Do not use parallel sub-agents.
+- **Regression tests**: Every bug fix must add a test to the appropriate `tests/` category.
 
 ## Crate-to-Module Mapping
 
@@ -153,5 +181,7 @@ Use this to find the self-hosted equivalent of a Rust crate:
 | vow-ir | compiler/ir.vow, ir_printer.vow |
 | vow-ir (lowering) | compiler/lower.vow |
 | vow-codegen | compiler/clif.vow |
-| vow (CLI driver) | compiler/main.vow |
+| vow-clif-shim | (FFI shims consumed by compiler/clif.vow) |
+| vow-runtime | (linked runtime; no self-hosted equivalent) |
 | vow-diag | (integrated in main.vow/checker.vow) |
+| vow (CLI driver) | compiler/main.vow |

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -75,7 +75,7 @@ sub-agents; work incrementally and directly.
 - Implement the fix
 - Iterate: run `cargo test --all` until all tests pass
 - Run `cargo clippy --all -- -D warnings` to ensure no lint warnings
-- Run `cargo fmt --all --check` to ensure formatting is clean
+- Run `cargo fmt --all` to ensure formatting is clean
 
 **Step 2 — Self-Hosted Compiler Fix:**
 - Identify the corresponding code in `compiler/*.vow` modules (see Crate-to-Module Mapping below)


### PR DESCRIPTION
## Summary
- Replace parallel sub-agents with sequential workflow (Rust first, then self-hosted) to match established practice
- Add mandatory `/codex:review` phase (Phase 6) after verification — all feedback must be addressed before committing
- Add regression test phase (Phase 7) with test category guide (`tests/run/`, `tests/error/`, etc.)
- Fix stale `--no-verify` bootstrap flag, add `ulimit -v 2000000` consistently, include `cargo clippy`/`cargo fmt` checks
- Complete crate-to-module mapping with `vow-clif-shim` and `vow-runtime`

## Test plan
- [ ] Verify skill loads correctly in Claude Code
- [ ] Run `/investigate` on a test issue to confirm workflow executes end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated developer workflow and investigation docs: mandatory memory limits for build/test runs, stricter Rust linting/format checks, revised sequential repair & verification phases, replaced parallel sub-agent steps with a two-step flow, introduced Codex review and mandated regression-test creation with naming/location guidance, and improved testing reports to include added regression tests and suite results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->