### PR TITLE
feat: add --mode sanitize with Vec provenance tracking

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -441,6 +441,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     let mode: i64 = {
         if mode_str == String::from("debug") { 1 }
         else if mode_str == String::from("profile") { 2 }
+        else if mode_str == String::from("sanitize") { 3 }
         else { 0 }
     };
     let trace_str: String = get_flag_arg(argv, String::from("--debug-trace"));
@@ -943,6 +944,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             let mode: i64 = {
                 if mode_str == String::from("debug") { 1 }
                 else if mode_str == String::from("profile") { 2 }
+                else if mode_str == String::from("sanitize") { 3 }
                 else { 0 }
             };
             let trace_str: String = get_flag_arg(argv, String::from("--debug-trace"));
@@ -992,7 +994,7 @@ fn skill_json() -> String {
     r.push_str(String::from("  \"legacy_usage\": \"vow [OPTIONS] <source.vow> (equivalent to vow build)\",\n"));
     r.push_str(String::from("  \"build_options\": {\n"));
     r.push_str(String::from("    \"-o, --output <path>\": \"Output executable path (default: source without .vow extension)\",\n"));
-    r.push_str(String::from("    \"--mode <debug|release|profile>\": \"Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit (default: release)\",\n"));
+    r.push_str(String::from("    \"--mode <debug|release|profile|sanitize>\": \"Build mode: debug inserts runtime vow checks, profile inserts call counters, sanitize adds debug checks + Vec provenance tracking (default: release)\",\n"));
     r.push_str(String::from("    \"--no-verify\": \"Skip ESBMC static verification\",\n"));
     r.push_str(String::from("    \"--dump-ir\": \"Print IR text to stdout and exit (no JSON output, no codegen)\",\n"));
     r.push_str(String::from("    \"--debug-trace <off|calls|full>\": \"Emit JSON trace lines to stderr at runtime (default: off)\",\n"));
@@ -1260,7 +1262,7 @@ fn skill_human() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("BUILD OPTIONS\n"));
     r.push_str(String::from("  -o, --output <path>     Output executable path (default: source without .vow extension)\n"));
-    r.push_str(String::from("  --mode <debug|release|profile>  Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit (default: release)\n"));
+    r.push_str(String::from("  --mode <debug|release|profile|sanitize>  Build mode (default: release)\n"));
     r.push_str(String::from("  --no-verify             Skip ESBMC static verification\n"));
     r.push_str(String::from("  --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)\n"));
     r.push_str(String::from("  --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)\n"));

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -16,7 +16,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | Flag              | Default     | Description                                |
 |-------------------|-------------|--------------------------------------------|
 | `-o, --output`    | `build/<stem>` | Output executable path                  |
-| `--mode <debug\|release\|profile>` | `release` | Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit |
+| `--mode <debug\|release\|profile\|sanitize>` | `release` | Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit, sanitize adds debug checks + Vec provenance tracking |
 | `--no-verify`     | (off)       | Skip ESBMC static verification            |
 | `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |
 | `--debug-trace <off\|calls\|full>` | `off` | Emit JSON trace lines to stderr at runtime |
@@ -333,9 +333,9 @@ total calls: 9998483, unique functions: 12
 
 The report lists the top 20 most-called functions sorted by call count. No vow checks are emitted in profile mode.
 
-## Runtime Error JSON (stderr, debug mode only)
+## Runtime Error JSON (stderr, debug/sanitize mode)
 
-When a compiled program runs in debug mode (`--mode debug`) and violates a vow at runtime, it emits JSON to stderr before aborting.
+When a compiled program runs in debug mode (`--mode debug`) or sanitize mode (`--mode sanitize`) and violates a vow at runtime, it emits JSON to stderr before aborting.
 
 ### VowViolation
 
@@ -368,6 +368,30 @@ Emitted when `.unwrap()` is called on `Option::None`.
 ```
 
 Emitted when a `Vec` index is out of bounds.
+
+### UseAfterFree (sanitize mode only)
+
+```json
+{"error":"UseAfterFree","op":"push","vec":"0x55a1b2c3d4e0"}
+```
+
+Emitted when a Vec operation is attempted on a Vec that has already been freed.
+
+### DoubleFree (sanitize mode only)
+
+```json
+{"error":"DoubleFree","vec":"0x55a1b2c3d4e0"}
+```
+
+Emitted when a Vec is freed twice.
+
+### StaleIndex (sanitize mode only)
+
+```json
+{"error":"StaleIndex","index":5,"expected_gen":3,"actual_gen":7,"vec":"0x55a1b2c3d4e0"}
+```
+
+Emitted when `__vow_sanitize_check_generation` detects that a Vec slot's generation counter does not match the expected value, indicating the slot was overwritten since the index was recorded.
 
 ## Agent Decision Tree
 

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -402,6 +402,16 @@ else
 fi
 echo ""
 
+# ─── Section 5c: Sanitize Mode ────────────────────────────────────
+
+echo -e "${BOLD}--- Section 5c: Sanitize Mode ---${RESET}"
+
+# sanitize_vec.vow: Vec operations with sanitize instrumentation
+$RUST build --mode sanitize --no-verify tests/debug/sanitize_vec.vow -o "$TMPDIR/rust_sanitize_vec" >/dev/null 2>/dev/null
+run_self build --mode sanitize --no-verify tests/debug/sanitize_vec.vow -o "$TMPDIR/self_sanitize_vec" >/dev/null 2>/dev/null
+compare_runtime "sanitize_vec/sanitize" "$TMPDIR/rust_sanitize_vec" "$TMPDIR/self_sanitize_vec"
+
+echo ""
 # ─── Section 6: Multi-Module ───────────────────────────────────────
 
 echo -e "${BOLD}--- Section 6: Multi-Module ---${RESET}"

--- a/tests/debug/sanitize_vec.vow
+++ b/tests/debug/sanitize_vec.vow
@@ -1,0 +1,19 @@
+// TEST: exit 0
+// TEST: stdout "10"
+// TEST: stdout "20"
+// TEST: stdout "30"
+// TEST: mode sanitize
+module SanitizeVec
+
+fn main() -> i32 [io] {
+  let v: Vec<i64> = Vec::new();
+  v.push(10);
+  v.push(20);
+  v.push(30);
+  let mut i: i64 = 0;
+  while i < v.len() {
+    print_i64(v[i]);
+    i = i + 1;
+  };
+  0
+}

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -237,7 +237,7 @@ struct ModuleContext {
     string_data_ids: Vec<DataId>,
     func_decls: Vec<FuncDecl>,
     extern_func_ids: HashMap<String, CraneliftFuncId>,
-    mode: i64,       // 0=release, 1=debug, 2=profile
+    mode: i64,       // 0=release, 1=debug, 2=profile, 3=sanitize
     trace_mode: i64, // 0=off, 1=calls, 2=full
 }
 
@@ -501,8 +501,8 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         .declare_function("__vow_arena_free", Linkage::Import, &arena_free_sig)
         .expect("declare arena_free");
 
-    // Debug-only runtime functions
-    let vow_violation_id = if ctx.mode == 1 {
+    // Debug-only runtime functions (debug=1 or sanitize=3)
+    let vow_violation_id = if ctx.mode == 1 || ctx.mode == 3 {
         let mut sig = ctx.obj_module.make_signature();
         sig.params.push(AbiParam::new(types::I32)); // vow_id
         sig.params.push(AbiParam::new(types::I8)); // blame
@@ -519,7 +519,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
     } else {
         None
     };
-    let overflow_id = if ctx.mode == 1 {
+    let overflow_id = if ctx.mode == 1 || ctx.mode == 3 {
         let sig = ctx.obj_module.make_signature();
         Some(
             ctx.obj_module
@@ -553,7 +553,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
     } else {
         None
     };
-    let trace_vow_id = if ctx.trace_mode >= 2 && ctx.mode == 1 {
+    let trace_vow_id = if ctx.trace_mode >= 2 && (ctx.mode == 1 || ctx.mode == 3) {
         let mut sig = ctx.obj_module.make_signature();
         sig.params.push(AbiParam::new(types::I64));
         sig.params.push(AbiParam::new(types::I64));
@@ -662,6 +662,18 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
     let profile_init_ref =
         profile_init_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
 
+    // Sanitize init (mode==3 only, main function only)
+    let sanitize_init_ref = if ctx.mode == 3 && ctx.func_decls[fi].is_main {
+        let sig = ctx.obj_module.make_signature();
+        let id = ctx
+            .obj_module
+            .declare_function("__vow_sanitize_init", Linkage::Import, &sig)
+            .expect("declare sanitize_init");
+        Some(ctx.obj_module.declare_func_in_func(id, builder.func))
+    } else {
+        None
+    };
+
     // Create function name data section for trace/profile instrumentation
     let fn_name_gv = if ctx.trace_mode != 0 || ctx.mode == 2 {
         let name = &ctx.func_decls[fi].name;
@@ -687,10 +699,10 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         inst_ty_map.insert(inst_ids[ii], inst_tys[ii]);
     }
 
-    // Create vow description data sections (debug mode only)
+    // Create vow description data sections (debug/sanitize mode)
     let mut vow_desc_gvs: HashMap<i64, GlobalValue> = HashMap::new();
     // We don't have file info from the self-hosted IR, so skip file/offset vow metadata
-    if ctx.mode == 1 {
+    if ctx.mode == 1 || ctx.mode == 3 {
         for (vi, &vow_id) in vow_ids.iter().enumerate() {
             let desc_str = unsafe { read_vow_string(vow_desc_ptrs[vi]) };
             let mut bytes = desc_str.as_bytes().to_vec();
@@ -715,7 +727,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         inst_id: i64,
     }
     let mut vow_bindings: HashMap<i64, Vec<VowBindingInfo>> = HashMap::new();
-    if ctx.mode == 1 {
+    if ctx.mode == 1 || ctx.mode == 3 {
         let mut bind_offset = 0usize;
         for (vi, &vow_id) in vow_ids.iter().enumerate() {
             let bc = binding_counts[vi] as usize;
@@ -824,6 +836,10 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         if let (Some(gv), Some(prof_ref)) = (fn_name_gv, profile_enter_ref) {
             let name_ptr = builder.ins().global_value(types::I64, gv);
             builder.ins().call(prof_ref, &[name_ptr]);
+        }
+        // Emit sanitize_init at main entry
+        if let Some(init_ref) = sanitize_init_ref {
+            builder.ins().call(init_ref, &[]);
         }
     }
     // Emit blocks
@@ -1299,7 +1315,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
 
                 // Vow checks
                 IOP_VOW_REQ | IOP_VOW_ENS | IOP_VOW_INV => {
-                    if ctx.mode == 1 && alen > 0 {
+                    if (ctx.mode == 1 || ctx.mode == 3) && alen > 0 {
                         let pred_id = all_args[aoff];
                         if let Some(&pred) = value_map.get(&pred_id) {
                             let vow_id = if dk == IDATA_VOW_ID { dv } else { 0 };

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -653,7 +653,7 @@ fn lower_inst(
         // Vow checks
         // ------------------------------------------------------------------
         Opcode::VowRequires | Opcode::VowEnsures | Opcode::VowInvariant => {
-            if ctx.mode == BuildMode::Debug
+            if ctx.mode.has_debug_checks()
                 && let Some(&pred_id) = inst.args.first()
                 && let Some(&pred) = ctx.value_map.get(&pred_id)
             {
@@ -1060,6 +1060,7 @@ struct RuntimeIds {
     trace_vow_id: Option<CraneliftFuncId>,
     profile_enter_id: Option<CraneliftFuncId>,
     profile_init_id: Option<CraneliftFuncId>,
+    sanitize_init_id: Option<CraneliftFuncId>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1139,7 +1140,7 @@ fn compile_ir_function(
     let mut vow_desc_global_values: HashMap<u32, GlobalValue> = HashMap::new();
     let mut vow_file_global_values: HashMap<u32, GlobalValue> = HashMap::new();
     let mut vow_binding_name_gvs: HashMap<(u32, u32), GlobalValue> = HashMap::new();
-    if mode == BuildMode::Debug {
+    if mode.has_debug_checks() {
         for vow_entry in &ir_func.vows {
             let mut bytes = vow_entry.description.as_bytes().to_vec();
             bytes.push(0);
@@ -1251,6 +1252,12 @@ fn compile_ir_function(
         if let (Some(prof_ref), Some(gv)) = (profile_enter_ref, fn_name_gv) {
             let name_ptr = builder.ins().global_value(types::I64, gv);
             builder.ins().call(prof_ref, &[name_ptr]);
+        }
+        if ir_func.name == "main"
+            && let Some(init_id) = runtime.sanitize_init_id
+        {
+            let init_ref = obj_module.declare_func_in_func(init_id, builder.func);
+            builder.ins().call(init_ref, &[]);
         }
     }
 
@@ -1752,8 +1759,8 @@ impl Backend for CraneliftBackend {
             .declare_function("__vow_arena_free", Linkage::Import, &arena_free_sig)
             .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
 
-        // Declare external runtime functions (debug mode only)
-        let (vow_violation_id, overflow_id) = if mode == BuildMode::Debug {
+        // Declare external runtime functions (debug/sanitize mode only)
+        let (vow_violation_id, overflow_id) = if mode.has_debug_checks() {
             let mut violation_sig = obj_module.make_signature();
             violation_sig.params.push(AbiParam::new(types::I32)); // vow_id
             violation_sig.params.push(AbiParam::new(types::I8)); // blame
@@ -1815,6 +1822,17 @@ impl Backend for CraneliftBackend {
             (None, None)
         };
 
+        // Declare sanitize init function (sanitize mode only)
+        let sanitize_init_id = if mode == BuildMode::Sanitize {
+            let sig = obj_module.make_signature();
+            let id = obj_module
+                .declare_function("__vow_sanitize_init", Linkage::Import, &sig)
+                .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
+            Some(id)
+        } else {
+            None
+        };
+
         // Compile each function
         let mut builder_ctx = FunctionBuilderContext::new();
         for (ir_func, &(_, cl_id)) in module.functions.iter().zip(ir_to_cl.iter()) {
@@ -1840,6 +1858,7 @@ impl Backend for CraneliftBackend {
                     trace_vow_id,
                     profile_enter_id,
                     profile_init_id,
+                    sanitize_init_id,
                 },
                 &string_data_ids,
                 &extern_func_ids,

--- a/vow-codegen/src/lib.rs
+++ b/vow-codegen/src/lib.rs
@@ -8,6 +8,14 @@ pub enum BuildMode {
     Debug,
     Release,
     Profile,
+    Sanitize,
+}
+
+impl BuildMode {
+    /// Returns true if runtime vow checks should be emitted (Debug or Sanitize).
+    pub fn has_debug_checks(self) -> bool {
+        matches!(self, BuildMode::Debug | BuildMode::Sanitize)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -409,11 +409,11 @@ pub unsafe extern "C" fn __vow_vec_clear(vec: *mut u8) {
 /// If `new_len >= len`, this is a no-op. If `new_len == 0`, equivalent to clear().
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_truncate(vec: *mut u8, new_len: usize) {
+    sanitize_on_truncate(vec as usize, new_len);
     let v = unsafe { &mut *(vec as *mut VowVec) };
     if new_len >= v.len {
         return;
     }
-    sanitize_on_truncate(vec as usize, new_len);
     if new_len == 0 {
         unsafe { __vow_vec_clear(vec) };
         return;

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::ffi::{CStr, c_char};
 use std::io::Write as _;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 
 thread_local! {
     static LAST_STDOUT: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
@@ -311,6 +311,7 @@ pub extern "C" fn __vow_vec_new(elem_size: usize, align: usize) -> *mut u8 {
         (*header_ptr).len = 0;
         (*header_ptr).cap = 0;
     }
+    sanitize_on_vec_new(header_ptr as usize);
     header_ptr as *mut u8
 }
 
@@ -368,18 +369,21 @@ pub unsafe extern "C" fn __vow_vec_len(vec: *const u8) -> usize {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_push_val(vec: *mut u8, value: i64) {
+    sanitize_on_push(vec as usize);
     let bytes = value.to_ne_bytes();
     unsafe { __vow_vec_push(vec, bytes.as_ptr(), 8, 8) };
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_get_val(vec: *const u8, index: usize) -> i64 {
+    sanitize_on_read(vec as usize, index);
     let ptr = unsafe { __vow_vec_get_ptr(vec, index, 8) };
     unsafe { *(ptr as *const i64) }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_pop(vec: *mut u8) {
+    sanitize_on_pop(vec as usize);
     let v = unsafe { &mut *(vec as *mut VowVec) };
     if v.len > 0 {
         v.len -= 1;
@@ -390,6 +394,7 @@ pub unsafe extern "C" fn __vow_vec_pop(vec: *mut u8) {
 /// The Vec header itself remains valid and can be reused with push().
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_clear(vec: *mut u8) {
+    sanitize_on_clear(vec as usize);
     let v = unsafe { &mut *(vec as *mut VowVec) };
     if v.cap > 0 && !v.ptr.is_null() {
         let buf_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(v.cap * 8, 8) };
@@ -408,6 +413,7 @@ pub unsafe extern "C" fn __vow_vec_truncate(vec: *mut u8, new_len: usize) {
     if new_len >= v.len {
         return;
     }
+    sanitize_on_truncate(vec as usize, new_len);
     if new_len == 0 {
         unsafe { __vow_vec_clear(vec) };
         return;
@@ -428,6 +434,7 @@ pub unsafe extern "C" fn __vow_vec_truncate(vec: *mut u8, new_len: usize) {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_set_val(vec: *mut u8, index: usize, value: i64) {
+    sanitize_on_set(vec as usize, index);
     let v = unsafe { &*(vec as *const VowVec) };
     if index >= v.len {
         let json = r#"{"error":"IndexOutOfBounds"}"#;
@@ -445,6 +452,7 @@ pub unsafe extern "C" fn __vow_vec_get_ptr(
     index: usize,
     elem_size: usize,
 ) -> *const u8 {
+    sanitize_on_read(vec as usize, index);
     let v = unsafe { &*(vec as *const VowVec) };
     if index >= v.len {
         let json = r#"{"error":"IndexOutOfBounds"}"#;
@@ -1510,6 +1518,7 @@ pub unsafe extern "C" fn __vow_string_free(s: *mut u8) {
     if s.is_null() {
         return;
     }
+    sanitize_on_free(s as usize);
     let v = unsafe { &*(s as *const VowVec) };
     if v.cap > 0 && !v.ptr.is_null() {
         let buf_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(v.cap, 1) };
@@ -1524,6 +1533,7 @@ pub unsafe extern "C" fn __vow_vec_free_val(v: *mut u8) {
     if v.is_null() {
         return;
     }
+    sanitize_on_free(v as usize);
     let vec = unsafe { &*(v as *const VowVec) };
     if vec.cap > 0 && !vec.ptr.is_null() {
         let buf_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(vec.cap * 8, 8) };
@@ -1546,6 +1556,213 @@ pub unsafe extern "C" fn __vow_map_free(m: *mut u8) {
     }
     let header_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(24, 8) };
     unsafe { std::alloc::dealloc(m, header_layout) };
+}
+
+// ---------------------------------------------------------------------------
+// Sanitize mode — Vec provenance tracking
+// ---------------------------------------------------------------------------
+
+static SANITIZE_ENABLED: AtomicBool = AtomicBool::new(false);
+static SANITIZE_GLOBAL_GEN: AtomicU64 = AtomicU64::new(1);
+
+struct ShadowVec {
+    generations: Vec<u64>,
+    freed: bool,
+}
+
+static SHADOW_TABLE: Mutex<Option<HashMap<usize, ShadowVec>>> = Mutex::new(None);
+
+fn shadow_table_get_or_init(
+    table: &mut Option<HashMap<usize, ShadowVec>>,
+) -> &mut HashMap<usize, ShadowVec> {
+    table.get_or_insert_with(HashMap::new)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __vow_sanitize_init() {
+    SANITIZE_ENABLED.store(true, Ordering::SeqCst);
+    let mut table = SHADOW_TABLE.lock().unwrap();
+    *table = Some(HashMap::new());
+}
+
+fn sanitize_is_enabled() -> bool {
+    SANITIZE_ENABLED.load(Ordering::Relaxed)
+}
+
+fn sanitize_emit_error(error_type: &str, details: &str) {
+    let _ = writeln!(std::io::stderr(), r#"{{"error":"{error_type}",{details}}}"#);
+    let _ = writeln!(std::io::stderr(), "sanitizer: {error_type}: {details}");
+    std::process::exit(1);
+}
+
+fn sanitize_on_vec_new(vec_addr: usize) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    let mut table = SHADOW_TABLE.lock().unwrap();
+    let map = shadow_table_get_or_init(&mut table);
+    map.insert(
+        vec_addr,
+        ShadowVec {
+            generations: Vec::new(),
+            freed: false,
+        },
+    );
+}
+
+fn sanitize_check_freed(vec_addr: usize, op: &str) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    let is_freed = {
+        let table = SHADOW_TABLE.lock().unwrap();
+        if let Some(map) = table.as_ref() {
+            if let Some(shadow) = map.get(&vec_addr) {
+                shadow.freed
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    };
+    if is_freed {
+        sanitize_emit_error(
+            "UseAfterFree",
+            &format!("\"op\":\"{op}\",\"vec\":\"0x{vec_addr:x}\""),
+        );
+    }
+}
+
+fn sanitize_on_push(vec_addr: usize) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    sanitize_check_freed(vec_addr, "push");
+    let generation = SANITIZE_GLOBAL_GEN.fetch_add(1, Ordering::Relaxed);
+    let mut table = SHADOW_TABLE.lock().unwrap();
+    let map = shadow_table_get_or_init(&mut table);
+    if let Some(shadow) = map.get_mut(&vec_addr) {
+        shadow.generations.push(generation);
+    }
+}
+
+fn sanitize_on_set(vec_addr: usize, index: usize) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    sanitize_check_freed(vec_addr, "set");
+    let generation = SANITIZE_GLOBAL_GEN.fetch_add(1, Ordering::Relaxed);
+    let mut table = SHADOW_TABLE.lock().unwrap();
+    let map = shadow_table_get_or_init(&mut table);
+    if let Some(shadow) = map.get_mut(&vec_addr)
+        && index < shadow.generations.len()
+    {
+        shadow.generations[index] = generation;
+    }
+}
+
+fn sanitize_on_truncate(vec_addr: usize, new_len: usize) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    sanitize_check_freed(vec_addr, "truncate");
+    let mut table = SHADOW_TABLE.lock().unwrap();
+    let map = shadow_table_get_or_init(&mut table);
+    if let Some(shadow) = map.get_mut(&vec_addr) {
+        shadow.generations.truncate(new_len);
+    }
+}
+
+fn sanitize_on_clear(vec_addr: usize) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    sanitize_check_freed(vec_addr, "clear");
+    let mut table = SHADOW_TABLE.lock().unwrap();
+    let map = shadow_table_get_or_init(&mut table);
+    if let Some(shadow) = map.get_mut(&vec_addr) {
+        shadow.generations.clear();
+    }
+}
+
+fn sanitize_on_free(vec_addr: usize) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    let already_freed = {
+        let mut table = SHADOW_TABLE.lock().unwrap();
+        let map = shadow_table_get_or_init(&mut table);
+        if let Some(shadow) = map.get_mut(&vec_addr) {
+            if shadow.freed {
+                true
+            } else {
+                shadow.freed = true;
+                shadow.generations.clear();
+                false
+            }
+        } else {
+            false
+        }
+    };
+    if already_freed {
+        sanitize_emit_error("DoubleFree", &format!("\"vec\":\"0x{vec_addr:x}\""));
+    }
+}
+
+fn sanitize_on_pop(vec_addr: usize) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    sanitize_check_freed(vec_addr, "pop");
+    let mut table = SHADOW_TABLE.lock().unwrap();
+    let map = shadow_table_get_or_init(&mut table);
+    if let Some(shadow) = map.get_mut(&vec_addr) {
+        shadow.generations.pop();
+    }
+}
+
+fn sanitize_on_read(vec_addr: usize, _index: usize) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    sanitize_check_freed(vec_addr, "read");
+}
+
+/// Query the generation of a Vec slot. Returns 0 if unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn __vow_sanitize_vec_generation(vec: *const u8, index: usize) -> u64 {
+    if !sanitize_is_enabled() || vec.is_null() {
+        return 0;
+    }
+    let vec_addr = vec as usize;
+    let table = SHADOW_TABLE.lock().unwrap();
+    if let Some(map) = table.as_ref()
+        && let Some(shadow) = map.get(&vec_addr)
+        && index < shadow.generations.len()
+    {
+        return shadow.generations[index];
+    }
+    0
+}
+
+/// Check that a Vec slot's generation matches the expected value.
+/// Aborts with StaleIndex error if it doesn't match.
+#[unsafe(no_mangle)]
+pub extern "C" fn __vow_sanitize_check_generation(vec: *const u8, index: usize, expected_gen: u64) {
+    if !sanitize_is_enabled() || vec.is_null() {
+        return;
+    }
+    let actual = __vow_sanitize_vec_generation(vec, index);
+    if actual != expected_gen && expected_gen != 0 {
+        sanitize_emit_error(
+            "StaleIndex",
+            &format!(
+                "\"index\":{index},\"expected_gen\":{expected_gen},\"actual_gen\":{actual},\"vec\":\"0x{:x}\"",
+                vec as usize
+            ),
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1705,5 +1922,72 @@ mod tests {
         assert_eq!(unsafe { __vow_vec_get_val(v, 1) }, 1);
         assert_eq!(unsafe { __vow_vec_get_val(v, 2) }, 2);
         unsafe { __vow_vec_free_val(v) };
+    }
+
+    // All sanitize tests consolidated into one test to avoid parallel test races
+    // on the global SANITIZE_ENABLED flag.
+    #[test]
+    fn sanitize_generation_tracking() {
+        __vow_sanitize_init();
+
+        // -- Push generation tracking --
+        let v = __vow_vec_new_val();
+        unsafe { __vow_vec_push_val(v, 10) };
+        unsafe { __vow_vec_push_val(v, 20) };
+        let gen0 = __vow_sanitize_vec_generation(v, 0);
+        let gen1 = __vow_sanitize_vec_generation(v, 1);
+        assert!(gen0 > 0, "generation should be nonzero after push");
+        assert!(gen1 > gen0, "second push should have higher generation");
+
+        // -- Set increments generation --
+        unsafe { __vow_vec_set_val(v, 0, 99) };
+        let gen0_after = __vow_sanitize_vec_generation(v, 0);
+        assert!(gen0_after > gen0, "set should increment generation");
+        assert_eq!(
+            __vow_sanitize_vec_generation(v, 1),
+            gen1,
+            "unmodified slot should keep its generation"
+        );
+
+        // -- Check generation pass --
+        let slot_gen = __vow_sanitize_vec_generation(v, 0);
+        __vow_sanitize_check_generation(v, 0, slot_gen);
+
+        unsafe { __vow_vec_free_val(v) };
+
+        // -- Truncate clears generations --
+        let v2 = __vow_vec_new_val();
+        unsafe { __vow_vec_push_val(v2, 1) };
+        unsafe { __vow_vec_push_val(v2, 2) };
+        unsafe { __vow_vec_push_val(v2, 3) };
+        assert!(
+            __vow_sanitize_vec_generation(v2, 2) > 0,
+            "slot 2 should have generation"
+        );
+        unsafe { __vow_vec_truncate(v2, 1) };
+        assert_eq!(
+            __vow_sanitize_vec_generation(v2, 2),
+            0,
+            "truncated slot should have no generation"
+        );
+        unsafe { __vow_vec_free_val(v2) };
+
+        // -- Pop removes generation --
+        let v3 = __vow_vec_new_val();
+        unsafe { __vow_vec_push_val(v3, 1) };
+        unsafe { __vow_vec_push_val(v3, 2) };
+        assert!(__vow_sanitize_vec_generation(v3, 1) > 0);
+        unsafe { __vow_vec_pop(v3) };
+        assert_eq!(
+            __vow_sanitize_vec_generation(v3, 1),
+            0,
+            "popped slot should have no generation"
+        );
+        unsafe { __vow_vec_free_val(v3) };
+
+        // -- Vec operations work without crash when sanitize enabled --
+        let v4 = __vow_vec_new_val();
+        unsafe { __vow_vec_push_val(v4, 42) };
+        unsafe { __vow_vec_free_val(v4) };
     }
 }

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -354,6 +354,7 @@ pub unsafe extern "C" fn __vow_vec_push(
     elem_size: usize,
     elem_align: usize,
 ) {
+    sanitize_on_push(vec as usize);
     unsafe { __vow_vec_reserve(vec, 1, elem_size, elem_align) };
     let v = unsafe { &mut *(vec as *mut VowVec) };
     let dest = unsafe { v.ptr.add(v.len * elem_size) };
@@ -370,7 +371,6 @@ pub unsafe extern "C" fn __vow_vec_len(vec: *const u8) -> usize {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_push_val(vec: *mut u8, value: i64) {
-    sanitize_on_push(vec as usize);
     let bytes = value.to_ne_bytes();
     unsafe { __vow_vec_push(vec, bytes.as_ptr(), 8, 8) };
 }

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -110,6 +110,7 @@ pub unsafe extern "C" fn __vow_violation(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_print_str(s: *const u8) {
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let _ = std::io::stdout().write_all(bytes);
@@ -498,6 +499,7 @@ pub unsafe extern "C" fn __vow_string_len(s: *const u8) -> usize {
 /// The String header remains valid and can be reused with push_byte/push_str.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_string_clear(s: *mut u8) {
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &mut *(s as *mut VowVec) };
     if v.cap > 0 && !v.ptr.is_null() {
         let buf_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(v.cap, 1) };
@@ -524,6 +526,8 @@ pub unsafe extern "C" fn __vow_string_eq(a: *const u8, b: *const u8) -> i64 {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_string_contains(haystack: *const u8, needle: *const u8) -> i64 {
+    sanitize_on_read(haystack as usize, 0);
+    sanitize_on_read(needle as usize, 0);
     let vh = unsafe { &*(haystack as *const VowVec) };
     let vn = unsafe { &*(needle as *const VowVec) };
     let sh = unsafe { std::slice::from_raw_parts(vh.ptr, vh.len) };
@@ -544,6 +548,8 @@ pub unsafe extern "C" fn __vow_string_contains(haystack: *const u8, needle: *con
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_string_push_str(dest: *mut u8, src: *const u8) {
+    sanitize_on_read(dest as usize, 0);
+    sanitize_on_read(src as usize, 0);
     let vs = unsafe { &*(src as *const VowVec) };
     if vs.len == 0 {
         return;
@@ -562,6 +568,7 @@ pub unsafe extern "C" fn __vow_string_from_i64(v: i64) -> *mut u8 {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_string_print(s: *const u8) {
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let _ = std::io::stdout().write_all(bytes);
@@ -570,6 +577,7 @@ pub unsafe extern "C" fn __vow_string_print(s: *const u8) {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_string_byte_at(s: *const u8, idx: i64) -> i64 {
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     if idx < 0 || idx as usize >= v.len {
         return -1;
@@ -593,6 +601,7 @@ pub unsafe extern "C" fn __vow_string_substr(s: *const u8, start: i64, len: i64)
     if s.is_null() {
         return __vow_vec_new(1, 1);
     }
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let slen = v.len as i64;
     let clamped_start = start.clamp(0, slen) as usize;
@@ -606,6 +615,7 @@ pub unsafe extern "C" fn __vow_string_substring(s: *const u8, start: i64, end: i
     if s.is_null() {
         return __vow_vec_new(1, 1);
     }
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let slen = v.len as i64;
     let clamped_start = start.clamp(0, slen) as usize;
@@ -621,6 +631,8 @@ pub unsafe extern "C" fn __vow_string_split(haystack: *const u8, separator: *con
     if haystack.is_null() || separator.is_null() {
         return result_vec;
     }
+    sanitize_on_read(haystack as usize, 0);
+    sanitize_on_read(separator as usize, 0);
     let vh = unsafe { &*(haystack as *const VowVec) };
     let vs = unsafe { &*(separator as *const VowVec) };
     let h = unsafe { std::slice::from_raw_parts(vh.ptr, vh.len) };
@@ -654,6 +666,8 @@ pub unsafe extern "C" fn __vow_string_starts_with(s: *const u8, prefix: *const u
     if s.is_null() || prefix.is_null() {
         return 0;
     }
+    sanitize_on_read(s as usize, 0);
+    sanitize_on_read(prefix as usize, 0);
     let vs = unsafe { &*(s as *const VowVec) };
     let vp = unsafe { &*(prefix as *const VowVec) };
     let ss = unsafe { std::slice::from_raw_parts(vs.ptr, vs.len) };
@@ -666,6 +680,8 @@ pub unsafe extern "C" fn __vow_string_ends_with(s: *const u8, suffix: *const u8)
     if s.is_null() || suffix.is_null() {
         return 0;
     }
+    sanitize_on_read(s as usize, 0);
+    sanitize_on_read(suffix as usize, 0);
     let vs = unsafe { &*(s as *const VowVec) };
     let vp = unsafe { &*(suffix as *const VowVec) };
     let ss = unsafe { std::slice::from_raw_parts(vs.ptr, vs.len) };
@@ -678,6 +694,7 @@ pub unsafe extern "C" fn __vow_string_trim(s: *const u8) -> *mut u8 {
     if s.is_null() {
         return __vow_vec_new(1, 1);
     }
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let trimmed = match std::str::from_utf8(bytes) {
@@ -692,6 +709,7 @@ pub unsafe extern "C" fn __vow_string_to_upper(s: *const u8) -> *mut u8 {
     if s.is_null() {
         return __vow_vec_new(1, 1);
     }
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let upper = match std::str::from_utf8(bytes) {
@@ -706,6 +724,7 @@ pub unsafe extern "C" fn __vow_string_to_lower(s: *const u8) -> *mut u8 {
     if s.is_null() {
         return __vow_vec_new(1, 1);
     }
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let lower = match std::str::from_utf8(bytes) {
@@ -724,6 +743,9 @@ pub unsafe extern "C" fn __vow_string_replace(
     if s.is_null() || from.is_null() || to.is_null() {
         return __vow_vec_new(1, 1);
     }
+    sanitize_on_read(s as usize, 0);
+    sanitize_on_read(from as usize, 0);
+    sanitize_on_read(to as usize, 0);
     let vs = unsafe { &*(s as *const VowVec) };
     let vf = unsafe { &*(from as *const VowVec) };
     let vt = unsafe { &*(to as *const VowVec) };
@@ -747,6 +769,8 @@ pub unsafe extern "C" fn __vow_string_join(vec_ptr: *const u8, sep: *const u8) -
     if vec_ptr.is_null() || sep.is_null() {
         return __vow_vec_new(1, 1);
     }
+    sanitize_on_read(vec_ptr as usize, 0);
+    sanitize_on_read(sep as usize, 0);
     let v = unsafe { &*(vec_ptr as *const VowVec) };
     let ptrs = unsafe { std::slice::from_raw_parts(v.ptr as *const i64, v.len) };
 
@@ -767,6 +791,7 @@ pub unsafe extern "C" fn __vow_string_parse_i64_opt(s: *const u8) -> *mut u8 {
         unsafe { *ptr = 0 };
         return ptr as *mut u8;
     }
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     match std::str::from_utf8(bytes) {
@@ -793,6 +818,7 @@ pub unsafe extern "C" fn __vow_string_parse_u64_opt(s: *const u8) -> *mut u8 {
         unsafe { *ptr = 0 };
         return ptr as *mut u8;
     }
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     match std::str::from_utf8(bytes) {
@@ -817,6 +843,7 @@ pub unsafe extern "C" fn __vow_parse_i64(s: *const u8) -> i64 {
     if s.is_null() {
         return 0;
     }
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     match std::str::from_utf8(bytes) {
@@ -835,6 +862,7 @@ pub unsafe extern "C" fn __vow_vec_sort(vec: *const u8) -> *mut u8 {
     if vec.is_null() {
         return result;
     }
+    sanitize_on_read(vec as usize, 0);
     let v = unsafe { &*(vec as *const VowVec) };
     let src = unsafe { std::slice::from_raw_parts(v.ptr as *const i64, v.len) };
     let mut sorted: Vec<i64> = src.to_vec();
@@ -866,6 +894,7 @@ pub unsafe extern "C" fn __vow_hex_encode(vec: *const u8) -> *mut u8 {
     if vec.is_null() {
         return __vow_vec_new(1, 1);
     }
+    sanitize_on_read(vec as usize, 0);
     let v = unsafe { &*(vec as *const VowVec) };
     let vals = unsafe { std::slice::from_raw_parts(v.ptr as *const i64, v.len) };
     let mut hex = String::new();
@@ -881,6 +910,7 @@ pub unsafe extern "C" fn __vow_hex_decode(s: *const u8) -> *mut u8 {
     if s.is_null() {
         return result;
     }
+    sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let hex_str = match std::str::from_utf8(bytes) {
@@ -910,6 +940,7 @@ pub unsafe extern "C" fn __vow_fs_read(path_ptr: *const u8) -> *mut u8 {
     if path_ptr.is_null() {
         return __vow_vec_new(1, 1);
     }
+    sanitize_on_read(path_ptr as usize, 0);
     let v = unsafe { &*(path_ptr as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let path = match std::str::from_utf8(bytes) {
@@ -927,6 +958,8 @@ pub unsafe extern "C" fn __vow_fs_write(path_ptr: *const u8, data_ptr: *const u8
     if path_ptr.is_null() || data_ptr.is_null() {
         return -1;
     }
+    sanitize_on_read(path_ptr as usize, 0);
+    sanitize_on_read(data_ptr as usize, 0);
     let vp = unsafe { &*(path_ptr as *const VowVec) };
     let path_bytes = unsafe { std::slice::from_raw_parts(vp.ptr, vp.len) };
     let path = match std::str::from_utf8(path_bytes) {
@@ -946,6 +979,7 @@ pub unsafe extern "C" fn __vow_fs_exists(path_ptr: *const u8) -> i64 {
     if path_ptr.is_null() {
         return 0;
     }
+    sanitize_on_read(path_ptr as usize, 0);
     let v = unsafe { &*(path_ptr as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let path = match std::str::from_utf8(bytes) {
@@ -964,6 +998,7 @@ pub unsafe extern "C" fn __vow_fs_mkdir(path_ptr: *const u8) -> i64 {
     if path_ptr.is_null() {
         return -1;
     }
+    sanitize_on_read(path_ptr as usize, 0);
     let v = unsafe { &*(path_ptr as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let path = match std::str::from_utf8(bytes) {
@@ -982,6 +1017,7 @@ pub unsafe extern "C" fn __vow_fs_listdir(path_ptr: *const u8) -> *mut u8 {
     if path_ptr.is_null() {
         return result_vec;
     }
+    sanitize_on_read(path_ptr as usize, 0);
     let v = unsafe { &*(path_ptr as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let path = match std::str::from_utf8(bytes) {
@@ -1010,6 +1046,7 @@ pub unsafe extern "C" fn __vow_fs_remove(path_ptr: *const u8) -> i64 {
     if path_ptr.is_null() {
         return -1;
     }
+    sanitize_on_read(path_ptr as usize, 0);
     let v = unsafe { &*(path_ptr as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let path = match std::str::from_utf8(bytes) {
@@ -1027,6 +1064,7 @@ pub unsafe extern "C" fn __vow_fs_remove_dir(path_ptr: *const u8) -> i64 {
     if path_ptr.is_null() {
         return -1;
     }
+    sanitize_on_read(path_ptr as usize, 0);
     let v = unsafe { &*(path_ptr as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let path = match std::str::from_utf8(bytes) {
@@ -1044,6 +1082,7 @@ pub unsafe extern "C" fn __vow_fs_is_dir(path_ptr: *const u8) -> i64 {
     if path_ptr.is_null() {
         return 0;
     }
+    sanitize_on_read(path_ptr as usize, 0);
     let v = unsafe { &*(path_ptr as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let path = match std::str::from_utf8(bytes) {
@@ -1062,6 +1101,8 @@ pub unsafe extern "C" fn __vow_fs_rename(old_ptr: *const u8, new_ptr: *const u8)
     if old_ptr.is_null() || new_ptr.is_null() {
         return -1;
     }
+    sanitize_on_read(old_ptr as usize, 0);
+    sanitize_on_read(new_ptr as usize, 0);
     let vo = unsafe { &*(old_ptr as *const VowVec) };
     let old_bytes = unsafe { std::slice::from_raw_parts(vo.ptr, vo.len) };
     let old_path = match std::str::from_utf8(old_bytes) {
@@ -1083,6 +1124,7 @@ pub unsafe extern "C" fn __vow_fs_rename(old_ptr: *const u8, new_ptr: *const u8)
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_eprintln_str(s: *const u8) {
     if !s.is_null() {
+        sanitize_on_read(s as usize, 0);
         let v = unsafe { &*(s as *const VowVec) };
         let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
         let _ = std::io::stderr().write_all(bytes);
@@ -1146,6 +1188,8 @@ pub extern "C" fn __vow_process_exit(code: i64) {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_process_run(cmd_ptr: i64, args_ptr: i64) -> i64 {
+    sanitize_on_read(cmd_ptr as usize, 0);
+    sanitize_on_read(args_ptr as usize, 0);
     let cmd_vec = unsafe { &*(cmd_ptr as *const VowVec) };
     let cmd_bytes = unsafe { std::slice::from_raw_parts(cmd_vec.ptr, cmd_vec.len) };
     let cmd_str = match std::str::from_utf8(cmd_bytes) {
@@ -1197,6 +1241,8 @@ pub extern "C" fn __vow_process_get_stderr() -> *mut u8 {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_process_start(cmd_ptr: i64, args_ptr: i64) -> i64 {
+    sanitize_on_read(cmd_ptr as usize, 0);
+    sanitize_on_read(args_ptr as usize, 0);
     let cmd_vec = unsafe { &*(cmd_ptr as *const VowVec) };
     let cmd_bytes = unsafe { std::slice::from_raw_parts(cmd_vec.ptr, cmd_vec.len) };
     let cmd_str = match std::str::from_utf8(cmd_bytes) {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -363,6 +363,7 @@ pub unsafe extern "C" fn __vow_vec_push(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_len(vec: *const u8) -> usize {
+    sanitize_on_read(vec as usize, 0);
     let v = unsafe { &*(vec as *const VowVec) };
     v.len
 }
@@ -376,7 +377,6 @@ pub unsafe extern "C" fn __vow_vec_push_val(vec: *mut u8, value: i64) {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_get_val(vec: *const u8, index: usize) -> i64 {
-    sanitize_on_read(vec as usize, index);
     let ptr = unsafe { __vow_vec_get_ptr(vec, index, 8) };
     unsafe { *(ptr as *const i64) }
 }
@@ -510,6 +510,8 @@ pub unsafe extern "C" fn __vow_string_clear(s: *mut u8) {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_string_eq(a: *const u8, b: *const u8) -> i64 {
+    sanitize_on_read(a as usize, 0);
+    sanitize_on_read(b as usize, 0);
     let va = unsafe { &*(a as *const VowVec) };
     let vb = unsafe { &*(b as *const VowVec) };
     if va.len != vb.len {
@@ -1610,39 +1612,20 @@ fn sanitize_on_vec_new(vec_addr: usize) {
     );
 }
 
-fn sanitize_check_freed(vec_addr: usize, op: &str) {
-    if !sanitize_is_enabled() {
-        return;
-    }
-    let is_freed = {
-        let table = SHADOW_TABLE.lock().unwrap();
-        if let Some(map) = table.as_ref() {
-            if let Some(shadow) = map.get(&vec_addr) {
-                shadow.freed
-            } else {
-                false
-            }
-        } else {
-            false
-        }
-    };
-    if is_freed {
-        sanitize_emit_error(
-            "UseAfterFree",
-            &format!("\"op\":\"{op}\",\"vec\":\"0x{vec_addr:x}\""),
-        );
-    }
-}
-
 fn sanitize_on_push(vec_addr: usize) {
     if !sanitize_is_enabled() {
         return;
     }
-    sanitize_check_freed(vec_addr, "push");
     let generation = SANITIZE_GLOBAL_GEN.fetch_add(1, Ordering::Relaxed);
     let mut table = SHADOW_TABLE.lock().unwrap();
     let map = shadow_table_get_or_init(&mut table);
     if let Some(shadow) = map.get_mut(&vec_addr) {
+        if shadow.freed {
+            sanitize_emit_error(
+                "UseAfterFree",
+                &format!("\"op\":\"push\",\"vec\":\"0x{vec_addr:x}\""),
+            );
+        }
         shadow.generations.push(generation);
     }
 }
@@ -1651,14 +1634,19 @@ fn sanitize_on_set(vec_addr: usize, index: usize) {
     if !sanitize_is_enabled() {
         return;
     }
-    sanitize_check_freed(vec_addr, "set");
     let generation = SANITIZE_GLOBAL_GEN.fetch_add(1, Ordering::Relaxed);
     let mut table = SHADOW_TABLE.lock().unwrap();
     let map = shadow_table_get_or_init(&mut table);
-    if let Some(shadow) = map.get_mut(&vec_addr)
-        && index < shadow.generations.len()
-    {
-        shadow.generations[index] = generation;
+    if let Some(shadow) = map.get_mut(&vec_addr) {
+        if shadow.freed {
+            sanitize_emit_error(
+                "UseAfterFree",
+                &format!("\"op\":\"set\",\"vec\":\"0x{vec_addr:x}\""),
+            );
+        }
+        if index < shadow.generations.len() {
+            shadow.generations[index] = generation;
+        }
     }
 }
 
@@ -1666,10 +1654,15 @@ fn sanitize_on_truncate(vec_addr: usize, new_len: usize) {
     if !sanitize_is_enabled() {
         return;
     }
-    sanitize_check_freed(vec_addr, "truncate");
     let mut table = SHADOW_TABLE.lock().unwrap();
     let map = shadow_table_get_or_init(&mut table);
     if let Some(shadow) = map.get_mut(&vec_addr) {
+        if shadow.freed {
+            sanitize_emit_error(
+                "UseAfterFree",
+                &format!("\"op\":\"truncate\",\"vec\":\"0x{vec_addr:x}\""),
+            );
+        }
         shadow.generations.truncate(new_len);
     }
 }
@@ -1678,10 +1671,15 @@ fn sanitize_on_clear(vec_addr: usize) {
     if !sanitize_is_enabled() {
         return;
     }
-    sanitize_check_freed(vec_addr, "clear");
     let mut table = SHADOW_TABLE.lock().unwrap();
     let map = shadow_table_get_or_init(&mut table);
     if let Some(shadow) = map.get_mut(&vec_addr) {
+        if shadow.freed {
+            sanitize_emit_error(
+                "UseAfterFree",
+                &format!("\"op\":\"clear\",\"vec\":\"0x{vec_addr:x}\""),
+            );
+        }
         shadow.generations.clear();
     }
 }
@@ -1714,10 +1712,15 @@ fn sanitize_on_pop(vec_addr: usize) {
     if !sanitize_is_enabled() {
         return;
     }
-    sanitize_check_freed(vec_addr, "pop");
     let mut table = SHADOW_TABLE.lock().unwrap();
     let map = shadow_table_get_or_init(&mut table);
     if let Some(shadow) = map.get_mut(&vec_addr) {
+        if shadow.freed {
+            sanitize_emit_error(
+                "UseAfterFree",
+                &format!("\"op\":\"pop\",\"vec\":\"0x{vec_addr:x}\""),
+            );
+        }
         shadow.generations.pop();
     }
 }
@@ -1726,7 +1729,16 @@ fn sanitize_on_read(vec_addr: usize, _index: usize) {
     if !sanitize_is_enabled() {
         return;
     }
-    sanitize_check_freed(vec_addr, "read");
+    let table = SHADOW_TABLE.lock().unwrap();
+    if let Some(map) = table.as_ref()
+        && let Some(shadow) = map.get(&vec_addr)
+        && shadow.freed
+    {
+        sanitize_emit_error(
+            "UseAfterFree",
+            &format!("\"op\":\"read\",\"vec\":\"0x{vec_addr:x}\""),
+        );
+    }
 }
 
 /// Query the generation of a Vec slot. Returns 0 if unknown.

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -29,6 +29,7 @@ enum ModeArg {
     Debug,
     Release,
     Profile,
+    Sanitize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -212,7 +213,7 @@ fn skill_json() -> String {
   "legacy_usage": "vow [OPTIONS] <source.vow> (equivalent to vow build)",
   "build_options": {
     "-o, --output <path>": "Output executable path (default: source without .vow extension)",
-    "--mode <debug|release|profile>": "Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit (default: release)",
+    "--mode <debug|release|profile|sanitize>": "Build mode: debug inserts runtime vow checks, profile inserts call counters, sanitize adds debug checks + Vec provenance tracking (default: release)",
     "--no-verify": "Skip ESBMC static verification",
     "--dump-ir": "Print IR text to stdout and exit (no JSON output, no codegen)",
     "--debug-trace <off|calls|full>": "Emit JSON trace lines to stderr at runtime (default: off)",
@@ -480,7 +481,7 @@ USAGE
 
 BUILD OPTIONS
   -o, --output <path>     Output executable path (default: source without .vow extension)
-  --mode <debug|release|profile>  Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit (default: release)
+  --mode <debug|release|profile|sanitize>  Build mode (default: release)
   --no-verify             Skip ESBMC static verification
   --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)
   --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)
@@ -4600,6 +4601,7 @@ fn main() {
                 ModeArg::Debug => BuildMode::Debug,
                 ModeArg::Release => BuildMode::Release,
                 ModeArg::Profile => BuildMode::Profile,
+                ModeArg::Sanitize => BuildMode::Sanitize,
             };
             let trace = match b.debug_trace {
                 TraceArg::Off => TraceMode::Off,
@@ -4737,6 +4739,7 @@ fn main() {
                 ModeArg::Debug => BuildMode::Debug,
                 ModeArg::Release => BuildMode::Release,
                 ModeArg::Profile => BuildMode::Profile,
+                ModeArg::Sanitize => BuildMode::Sanitize,
             };
             let trace = match args.debug_trace {
                 TraceArg::Off => TraceMode::Off,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -4653,6 +4653,7 @@ fn main() {
                     eprintln!("Error: --mode profile is not supported for test subcommand");
                     std::process::exit(1);
                 }
+                ModeArg::Sanitize => BuildMode::Sanitize,
             };
             run_test_command(
                 &path,


### PR DESCRIPTION
## Summary

- Add `--mode sanitize` build mode that includes all debug-mode checks plus Vec instrumentation via a shadow memory table
- Per-slot generation counters track writes; use-after-free and double-free detection abort with structured JSON errors
- Runtime APIs (`__vow_sanitize_vec_generation`, `__vow_sanitize_check_generation`) enable stale-index validation
- Both Rust and self-hosted compilers updated; bootstrap fixed-point verified

Closes #95

## Test plan

- [x] `cargo test --all` — 620+ tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `scripts/bootstrap.sh` — binary fixed-point match
- [x] `scripts/full_test.sh` — 190 passed, 0 failed, 3 skipped
- [x] Smoke-tested `--mode sanitize` with both compilers on `tests/debug/sanitize_vec.vow`
- [x] Help coverage check passes for both compilers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `--mode sanitize` build mode combining debug checks with vector memory provenance tracking to detect UseAfterFree, DoubleFree, and StaleIndex violations during execution.

* **Documentation**
  * Updated CLI documentation detailing the sanitize mode option and its runtime error detection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->