### PR TITLE
feat: UCI benchmark harness for interactive examples (#107)

### DIFF
--- a/examples/chess_uci.vow
+++ b/examples/chess_uci.vow
@@ -1278,7 +1278,7 @@ fn movetime_to_depth(ms: i64) -> i64 {
     5
 }
 
-fn parse_go_depth(tokens: Vec<String>) -> i64 {
+fn parse_go_depth(tokens: Vec<String>, side: i64) -> i64 {
     let mut i: i64 = 1;
     while i + 1 < tokens.len() {
         let key: String = tokens[i];
@@ -1300,6 +1300,23 @@ fn parse_go_depth(tokens: Vec<String>) -> i64 {
             let value2: String = tokens[i + 1];
             let ms: i64 = parse_i64_or(value2, 100);
             return movetime_to_depth(ms);
+        }
+        i = i + 1;
+    }
+
+    let time_key: String = if side == 1 {
+        String::from("wtime")
+    } else {
+        String::from("btime")
+    };
+    i = 1;
+    while i + 1 < tokens.len() {
+        let key3: String = tokens[i];
+        if key3.eq(time_key) {
+            let remaining: i64 = parse_i64_or(tokens[i + 1], 0);
+            if remaining > 0 {
+                return movetime_to_depth(remaining / 30);
+            }
         }
         i = i + 1;
     }
@@ -1526,7 +1543,7 @@ fn dispatch_command(us: UciState, line: String) [io, read] {
                     us.board = handle_position(tokens, us.board);
                 } else {
                     if cmd.eq(String::from("go")) {
-                        let depth: i64 = parse_go_depth(tokens);
+                        let depth: i64 = parse_go_depth(tokens, us.board.side);
                         let ss: SearchState = SearchState { stopped: 0, nodes: 0, pending: Vec::new() };
                         let best: ChessMove = search_best_move(us.board, depth, ss);
                         let out: String = String::from("bestmove ");

--- a/examples/chess_uci.vow
+++ b/examples/chess_uci.vow
@@ -1338,6 +1338,136 @@ fn apply_uci_moves(b: Board, tokens: Vec<String>, start_idx: i64) -> Board [io] 
     b
 }
 
+fn fen_char_to_piece(ch: i64) -> i64 {
+    if ch == 80 { return PAWN; }
+    if ch == 78 { return KNIGHT; }
+    if ch == 66 { return BISHOP; }
+    if ch == 82 { return ROOK; }
+    if ch == 81 { return QUEEN; }
+    if ch == 75 { return KING; }
+    if ch == 112 { return -PAWN; }
+    if ch == 110 { return -KNIGHT; }
+    if ch == 98 { return -BISHOP; }
+    if ch == 114 { return -ROOK; }
+    if ch == 113 { return -QUEEN; }
+    if ch == 107 { return -KING; }
+    0
+}
+
+fn parse_fen_board(placement: String) -> Vec<i64> {
+    let sqs: Vec<i64> = Vec::new();
+    let mut i: i64 = 0;
+    while i < 64 {
+        sqs.push(EMPTY);
+        i = i + 1;
+    }
+
+    let mut rank: i64 = 7;
+    let mut file: i64 = 0;
+    let mut idx: i64 = 0;
+    let n: i64 = placement.len();
+    while idx < n {
+        let ch: i64 = placement.byte_at(idx);
+        if ch == 47 {
+            rank = rank - 1;
+            file = 0;
+        } else {
+            if ch >= 49 && ch <= 56 {
+                file = file + (ch - 48);
+            } else {
+                let piece: i64 = fen_char_to_piece(ch);
+                if piece != 0 && file < 8 && rank >= 0 {
+                    sqs[rank * 8 + file] = piece;
+                }
+                file = file + 1;
+            }
+        }
+        idx = idx + 1;
+    }
+    sqs
+}
+
+fn parse_fen_castling(s: String) -> Vec<i64> {
+    let rights: Vec<i64> = Vec::new();
+    let mut wk: i64 = 0;
+    let mut wq: i64 = 0;
+    let mut bk: i64 = 0;
+    let mut bq: i64 = 0;
+    let mut i: i64 = 0;
+    while i < s.len() {
+        let ch: i64 = s.byte_at(i);
+        if ch == 75 { wk = 1; }
+        if ch == 81 { wq = 1; }
+        if ch == 107 { bk = 1; }
+        if ch == 113 { bq = 1; }
+        i = i + 1;
+    }
+    rights.push(wk);
+    rights.push(wq);
+    rights.push(bk);
+    rights.push(bq);
+    rights
+}
+
+fn parse_fen_ep(s: String) -> i64 {
+    if s.len() < 2 {
+        return -1;
+    }
+    let file_ch: i64 = s.byte_at(0);
+    let rank_ch: i64 = s.byte_at(1);
+    if file_ch < 97 || file_ch > 104 {
+        return -1;
+    }
+    if rank_ch < 49 || rank_ch > 56 {
+        return -1;
+    }
+    let file: i64 = file_ch - 97;
+    let rank: i64 = rank_ch - 49;
+    rank * 8 + file
+}
+
+fn parse_fen(tokens: Vec<String>, start_idx: i64) -> Board {
+    let placement: String = tokens[start_idx];
+    let sqs: Vec<i64> = parse_fen_board(placement);
+
+    let mut side: i64 = WHITE;
+    if start_idx + 1 < tokens.len() {
+        let color_str: String = tokens[start_idx + 1];
+        if color_str.eq(String::from("b")) {
+            side = BLACK;
+        }
+    }
+
+    let mut wk: i64 = 0;
+    let mut wq: i64 = 0;
+    let mut bk: i64 = 0;
+    let mut bq: i64 = 0;
+    if start_idx + 2 < tokens.len() {
+        let castle_str: String = tokens[start_idx + 2];
+        let rights: Vec<i64> = parse_fen_castling(castle_str);
+        wk = rights[0];
+        wq = rights[1];
+        bk = rights[2];
+        bq = rights[3];
+    }
+
+    let mut ep: i64 = -1;
+    if start_idx + 3 < tokens.len() {
+        let ep_str: String = tokens[start_idx + 3];
+        ep = parse_fen_ep(ep_str);
+    }
+
+    Board {
+        squares: sqs,
+        side: side,
+        ep: ep,
+        wk: wk,
+        wq: wq,
+        bk: bk,
+        bq: bq,
+    }
+}
+
 fn handle_position(tokens: Vec<String>, current: Board) -> Board [io] {
     if tokens.len() < 2 {
         return current;
@@ -1351,6 +1481,22 @@ fn handle_position(tokens: Vec<String>, current: Board) -> Board [io] {
             if next.eq(String::from("moves")) {
                 return apply_uci_moves(board, tokens, 3);
             }
+        }
+        return board;
+    }
+
+    if mode.eq(String::from("fen")) {
+        if tokens.len() < 3 {
+            return current;
+        }
+        let board: Board = parse_fen(tokens, 2);
+        let mut moves_idx: i64 = 2;
+        while moves_idx < tokens.len() {
+            let tok: String = tokens[moves_idx];
+            if tok.eq(String::from("moves")) {
+                return apply_uci_moves(board, tokens, moves_idx + 1);
+            }
+            moves_idx = moves_idx + 1;
         }
         return board;
     }
@@ -1394,8 +1540,11 @@ fn dispatch_command(us: UciState, line: String) [io, read] {
                     } else {
                         if cmd.eq(String::from("stop")) {
                         } else {
-                            if cmd.eq(String::from("quit")) {
-                                us.running = 0;
+                            if cmd.eq(String::from("setoption")) {
+                            } else {
+                                if cmd.eq(String::from("quit")) {
+                                    us.running = 0;
+                                }
                             }
                         }
                     }

--- a/scripts/play_uci_match.py
+++ b/scripts/play_uci_match.py
@@ -1,4 +1,25 @@
 #!/usr/bin/env python3
+"""Play N games between two UCI engines with optional color alternation,
+UCI option passthrough, validator-based evaluation, and match scoring.
+
+Example usage:
+
+  # 10 games, alternating colors, Stockfish limited to ~1350 Elo
+  python scripts/play_uci_match.py \
+      --white ./build/chess_uci \
+      --black stockfish \
+      --black-option "UCI_LimitStrength=true" \
+      --black-option "UCI_Elo=1350" \
+      --games 10 --alternate-colors \
+      --plies 200 \
+      --validator stockfish \
+      --log match.log
+
+  # Quick single game (backwards-compatible with the old interface)
+  python scripts/play_uci_match.py --white ./build/chess_uci --black stockfish
+"""
+from __future__ import annotations
+
 import argparse
 import re
 import select
@@ -9,7 +30,12 @@ from pathlib import Path
 
 
 MOVE_RE = re.compile(r"^[a-h][1-8][a-h][1-8][nbrq]?$")
+SCORE_RE = re.compile(r"score (cp (-?\d+)|mate (-?\d+))")
 
+
+# ---------------------------------------------------------------------------
+# Engine wrapper
+# ---------------------------------------------------------------------------
 
 class Engine:
     def __init__(self, cmd: list[str], cwd: Path):
@@ -38,7 +64,9 @@ class Engine:
         while True:
             line = self.proc.stdout.readline()
             if line == "":
-                raise RuntimeError(f"{self.name}: EOF while waiting for {token!r}; partial={out!r}")
+                raise RuntimeError(
+                    f"{self.name}: EOF while waiting for {token!r}; partial={out!r}"
+                )
             text = line.rstrip("\n")
             out.append(text)
             if text == token:
@@ -51,7 +79,9 @@ class Engine:
         while True:
             line = self.proc.stdout.readline()
             if line == "":
-                raise RuntimeError(f"{self.name}: EOF while waiting for bestmove; partial={out!r}")
+                raise RuntimeError(
+                    f"{self.name}: EOF while waiting for bestmove; partial={out!r}"
+                )
             text = line.rstrip("\n")
             out.append(text)
             if text.startswith("bestmove "):
@@ -84,12 +114,24 @@ class Engine:
             self.proc.wait(timeout=3)
 
 
-def init_engine(engine: Engine) -> None:
+# ---------------------------------------------------------------------------
+# Engine lifecycle helpers
+# ---------------------------------------------------------------------------
+
+def init_engine(engine: Engine, options: list[str] | None = None) -> None:
     engine.send("uci")
     engine.read_until("uciok")
+    if options:
+        for opt in options:
+            engine.send(f"setoption {opt}")
     engine.send("isready")
     engine.read_until("readyok")
+
+
+def new_game(engine: Engine) -> None:
     engine.send("ucinewgame")
+    engine.send("isready")
+    engine.read_until("readyok")
 
 
 def position_command(moves: list[str]) -> str:
@@ -97,6 +139,10 @@ def position_command(moves: list[str]) -> str:
         return "position startpos"
     return "position startpos moves " + " ".join(moves)
 
+
+# ---------------------------------------------------------------------------
+# Validator helpers
+# ---------------------------------------------------------------------------
 
 def fen_for_moves(engine: Engine, moves: list[str], timeout: float = 5.0) -> str:
     engine.send(position_command(moves))
@@ -112,88 +158,320 @@ def fen_for_moves(engine: Engine, moves: list[str], timeout: float = 5.0) -> str
             return text[5:]
 
 
+def eval_position(engine: Engine, moves: list[str], movetime: int = 200) -> float:
+    """Use the validator to evaluate a position. Returns score in pawns from
+    white's perspective. Mate scores are mapped to +/-100."""
+    engine.send(position_command(moves))
+    engine.send(f"go movetime {movetime}")
+    _, lines = engine.read_bestmove()
+    cp = 0.0
+    for line in reversed(lines):
+        m = SCORE_RE.search(line)
+        if m:
+            if m.group(2) is not None:
+                cp = int(m.group(2)) / 100.0
+            elif m.group(3) is not None:
+                mate_in = int(m.group(3))
+                cp = 100.0 if mate_in > 0 else -100.0
+            break
+    return cp
+
+
+# ---------------------------------------------------------------------------
+# Game result
+# ---------------------------------------------------------------------------
+
+class GameResult:
+    def __init__(
+        self,
+        game_num: int,
+        white_name: str,
+        black_name: str,
+        moves: list[str],
+        outcome: str,
+        eval_score: float | None,
+        final_fen: str | None,
+    ):
+        self.game_num = game_num
+        self.white_name = white_name
+        self.black_name = black_name
+        self.moves = moves
+        self.outcome = outcome  # "1-0", "0-1", "1/2-1/2", "unfinished"
+        self.eval_score = eval_score
+        self.final_fen = final_fen
+
+    def white_score(self) -> float:
+        if self.outcome == "1-0":
+            return 1.0
+        if self.outcome == "0-1":
+            return 0.0
+        if self.outcome == "1/2-1/2":
+            return 0.5
+        # Unfinished: use eval if available
+        if self.eval_score is not None:
+            if self.eval_score > 1.0:
+                return 1.0
+            if self.eval_score < -1.0:
+                return 0.0
+            return 0.5
+        return 0.5
+
+
+# ---------------------------------------------------------------------------
+# Play one game
+# ---------------------------------------------------------------------------
+
+def play_game(
+    game_num: int,
+    white: Engine,
+    black: Engine,
+    white_go: str,
+    black_go: str,
+    max_plies: int,
+    validator: Engine | None,
+) -> GameResult:
+    new_game(white)
+    new_game(black)
+    if validator is not None:
+        new_game(validator)
+
+    moves: list[str] = []
+    prev_fen = fen_for_moves(validator, moves) if validator is not None else ""
+    outcome = "unfinished"
+
+    for ply in range(max_plies):
+        if ply % 2 == 0:
+            engine = white
+            go_cmd = white_go
+        else:
+            engine = black
+            go_cmd = black_go
+
+        engine.send(position_command(moves))
+        engine.send(go_cmd)
+        move, _ = engine.read_bestmove()
+
+        if move in {"(none)", "0000"}:
+            # No legal move — the side to move lost (checkmate) or it's stalemate.
+            # Heuristic: treat as loss for the side with no move.
+            outcome = "0-1" if ply % 2 == 0 else "1-0"
+            break
+        if MOVE_RE.match(move) is None:
+            raise RuntimeError(
+                f"game {game_num}: malformed bestmove {move!r} at ply {ply + 1}"
+            )
+
+        next_moves = moves + [move]
+        if validator is not None:
+            next_fen = fen_for_moves(validator, next_moves)
+            if next_fen == prev_fen:
+                raise RuntimeError(
+                    f"game {game_num}: move {move!r} did not change position at ply {ply + 1}"
+                )
+            prev_fen = next_fen
+
+        moves = next_moves
+
+    eval_score = None
+    final_fen = None
+    if validator is not None:
+        final_fen = fen_for_moves(validator, moves)
+        if outcome == "unfinished":
+            eval_score = eval_position(validator, moves)
+
+    return GameResult(
+        game_num=game_num,
+        white_name=white.name,
+        black_name=black.name,
+        moves=moves,
+        outcome=outcome,
+        eval_score=eval_score,
+        final_fen=final_fen,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Printing
+# ---------------------------------------------------------------------------
+
+def print_game_summary(result: GameResult) -> None:
+    plies = len(result.moves)
+    score_str = result.outcome
+    if result.outcome == "unfinished" and result.eval_score is not None:
+        score_str = f"unfinished (eval {result.eval_score:+.2f})"
+    print(f"  game {result.game_num:3d}: {result.white_name} vs {result.black_name}"
+          f"  {score_str}  ({plies} plies)")
+
+
+def print_match_summary(
+    results: list[GameResult],
+    engine_a_name: str,
+    engine_b_name: str,
+) -> None:
+    a_score = 0.0
+    b_score = 0.0
+    wins_a = draws = wins_b = 0
+
+    for r in results:
+        ws = r.white_score()
+        if r.white_name == engine_a_name:
+            a_score += ws
+            b_score += (1.0 - ws)
+        else:
+            b_score += ws
+            a_score += (1.0 - ws)
+
+        if ws == 1.0:
+            if r.white_name == engine_a_name:
+                wins_a += 1
+            else:
+                wins_b += 1
+        elif ws == 0.0:
+            if r.white_name == engine_a_name:
+                wins_b += 1
+            else:
+                wins_a += 1
+        else:
+            draws += 1
+
+    total = len(results)
+    print()
+    print("=" * 60)
+    print(f"Match result: {engine_a_name} vs {engine_b_name}")
+    print(f"  Games:  {total}")
+    print(f"  Score:  {engine_a_name} {a_score:.1f} - {b_score:.1f} {engine_b_name}")
+    print(f"  W/D/L:  +{wins_a} ={draws} -{wins_b} (from {engine_a_name}'s perspective)")
+    if total > 0:
+        pct = (a_score / total) * 100
+        print(f"  Win %%:  {pct:.1f}%")
+    print("=" * 60)
+
+
+def write_log(path: Path, results: list[GameResult]) -> None:
+    with open(path, "w") as f:
+        for r in results:
+            f.write(f"[Game {r.game_num}]\n")
+            f.write(f"White: {r.white_name}\n")
+            f.write(f"Black: {r.black_name}\n")
+            f.write(f"Result: {r.outcome}\n")
+            if r.eval_score is not None:
+                f.write(f"Eval: {r.eval_score:+.2f}\n")
+            if r.final_fen is not None:
+                f.write(f"FinalFEN: {r.final_fen}\n")
+            f.write(f"Moves: {' '.join(r.moves)}\n")
+            f.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+
 def split_cmd(text: str) -> list[str]:
     return shlex.split(text)
 
 
+def parse_options(raw: list[str] | None) -> list[str]:
+    """Convert ['UCI_LimitStrength=true', 'UCI_Elo=1350'] to
+    ['name UCI_LimitStrength value true', 'name UCI_Elo value 1350']."""
+    if not raw:
+        return []
+    result = []
+    for item in raw:
+        if "=" in item:
+            name, value = item.split("=", 1)
+            result.append(f"name {name} value {value}")
+        else:
+            result.append(f"name {item}")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Play a short game between two UCI engines.")
+    parser = argparse.ArgumentParser(
+        description="Play N games between two UCI engines and report match results.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
     parser.add_argument("--white", required=True, help="White engine command")
     parser.add_argument("--black", required=True, help="Black engine command")
     parser.add_argument(
         "--validator",
-        help="Optional validator engine command (must support the Stockfish-specific 'd' command) used to confirm that each move changes the position",
+        help="Optional validator engine command (must support the Stockfish-specific 'd' command; confirms moves change position, evaluates unfinished games)",
     )
-    parser.add_argument("--white-go", default="go movetime 100", help="UCI go command for White")
-    parser.add_argument("--black-go", default="go movetime 100", help="UCI go command for Black")
-    parser.add_argument("--plies", type=int, default=20, help="Maximum plies to play")
-    parser.add_argument(
-        "--cwd",
-        default=".",
-        help="Working directory used to launch engine binaries",
-    )
+    parser.add_argument("--white-go", default="go movetime 100",
+                        help="UCI go command for White (default: go movetime 100)")
+    parser.add_argument("--black-go", default="go movetime 100",
+                        help="UCI go command for Black (default: go movetime 100)")
+    parser.add_argument("--plies", type=int, default=200,
+                        help="Maximum plies per game (default: 200)")
+    parser.add_argument("--games", type=int, default=1,
+                        help="Number of games to play (default: 1)")
+    parser.add_argument("--alternate-colors", action="store_true",
+                        help="Swap engine colors each game")
+    parser.add_argument("--white-option", action="append", dest="white_options",
+                        help="UCI option for White engine (e.g. UCI_Elo=1350). Repeatable.")
+    parser.add_argument("--black-option", action="append", dest="black_options",
+                        help="UCI option for Black engine (e.g. UCI_LimitStrength=true). Repeatable.")
+    parser.add_argument("--validator-option", action="append", dest="validator_options",
+                        help="UCI option for validator engine. Repeatable.")
+    parser.add_argument("--log", type=Path,
+                        help="Write per-game move log to this file")
+    parser.add_argument("--cwd", default=".",
+                        help="Working directory for launching engine binaries")
     args = parser.parse_args()
 
     cwd = Path(args.cwd).resolve()
-    white: Engine | None = None
-    black: Engine | None = None
-    validator: Engine | None = None
+    white_opts = parse_options(args.white_options)
+    black_opts = parse_options(args.black_options)
+    validator_opts = parse_options(args.validator_options)
+
+    # Launch engines once; reuse across games.
+    engine_a = Engine(split_cmd(args.white), cwd)
+    engine_b = Engine(split_cmd(args.black), cwd)
+    validator = Engine(split_cmd(args.validator), cwd) if args.validator else None
+
+    engine_a_name = engine_a.name
+    engine_b_name = engine_b.name
 
     try:
-        white = Engine(split_cmd(args.white), cwd)
-        black = Engine(split_cmd(args.black), cwd)
-        if args.validator:
-            validator = Engine(split_cmd(args.validator), cwd)
-
-        init_engine(white)
-        init_engine(black)
+        init_engine(engine_a, white_opts)
+        init_engine(engine_b, black_opts)
         if validator is not None:
-            init_engine(validator)
+            init_engine(validator, validator_opts)
 
-        moves: list[str] = []
-        prev_fen = fen_for_moves(validator, moves) if validator is not None else ""
-
-        for ply in range(args.plies):
-            if ply % 2 == 0:
-                side = "white"
-                engine = white
-                go_cmd = args.white_go
+        results: list[GameResult] = []
+        for g in range(args.games):
+            swap = args.alternate_colors and g % 2 == 1
+            if swap:
+                white, black = engine_b, engine_a
             else:
-                side = "black"
-                engine = black
-                go_cmd = args.black_go
+                white, black = engine_a, engine_b
 
-            engine.send(position_command(moves))
-            engine.send(go_cmd)
-            move, _ = engine.read_bestmove()
+            result = play_game(
+                game_num=g + 1,
+                white=white,
+                black=black,
+                white_go=args.white_go,
+                black_go=args.black_go,
+                max_plies=args.plies,
+                validator=validator,
+            )
+            results.append(result)
+            print_game_summary(result)
 
-            if move in {"(none)", "0000"}:
-                print(f"{side} has no move after {' '.join(moves)}")
-                break
-            if MOVE_RE.match(move) is None:
-                raise RuntimeError(f"{side}: malformed bestmove {move!r}")
+        print_match_summary(results, engine_a_name, engine_b_name)
 
-            next_moves = moves + [move]
-            if validator is not None:
-                next_fen = fen_for_moves(validator, next_moves)
-                if next_fen == prev_fen:
-                    raise RuntimeError(
-                        f"{side}: move {move!r} did not change validator position after {' '.join(moves)!r}"
-                    )
-                prev_fen = next_fen
+        if args.log:
+            write_log(args.log, results)
+            print(f"\nGame log written to {args.log}")
 
-            print(f"{ply + 1:02d}. {side} {move}")
-            moves = next_moves
-
-        if validator is not None:
-            print(f"final_fen {prev_fen}")
-        print("moves", " ".join(moves))
         return 0
     finally:
-        if white is not None:
-            white.quit()
-        if black is not None:
-            black.quit()
+        engine_a.quit()
+        engine_b.quit()
         if validator is not None:
             validator.quit()
 

--- a/scripts/play_uci_match.py
+++ b/scripts/play_uci_match.py
@@ -38,9 +38,10 @@ SCORE_RE = re.compile(r"score (cp (-?\d+)|mate (-?\d+))")
 # ---------------------------------------------------------------------------
 
 class Engine:
-    def __init__(self, cmd: list[str], cwd: Path):
+    def __init__(self, cmd: list[str], cwd: Path, engine_id: str = ""):
         self.cmd = cmd
         self.name = cmd[0]
+        self.engine_id = engine_id
         self.proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -202,6 +203,7 @@ class GameResult:
         game_num: int,
         white_name: str,
         black_name: str,
+        white_is_a: bool,
         moves: list[str],
         outcome: str,
         eval_score: float | None,
@@ -210,6 +212,7 @@ class GameResult:
         self.game_num = game_num
         self.white_name = white_name
         self.black_name = black_name
+        self.white_is_a = white_is_a
         self.moves = moves
         self.outcome = outcome  # "1-0", "0-1", "1/2-1/2", "unfinished"
         self.eval_score = eval_score
@@ -307,6 +310,7 @@ def play_game(
         game_num=game_num,
         white_name=white.name,
         black_name=black.name,
+        white_is_a=white.engine_id == "A",
         moves=moves,
         outcome=outcome,
         eval_score=eval_score,
@@ -338,7 +342,7 @@ def print_match_summary(
 
     for r in results:
         ws = r.white_score()
-        if r.white_name == engine_a_name:
+        if r.white_is_a:
             a_score += ws
             b_score += (1.0 - ws)
         else:
@@ -346,12 +350,12 @@ def print_match_summary(
             a_score += (1.0 - ws)
 
         if ws == 1.0:
-            if r.white_name == engine_a_name:
+            if r.white_is_a:
                 wins_a += 1
             else:
                 wins_b += 1
         elif ws == 0.0:
-            if r.white_name == engine_a_name:
+            if r.white_is_a:
                 wins_b += 1
             else:
                 wins_a += 1
@@ -453,8 +457,8 @@ def main() -> int:
     validator_opts = parse_options(args.validator_options)
 
     # Launch engines once; reuse across games.
-    engine_a = Engine(split_cmd(args.white), cwd)
-    engine_b = Engine(split_cmd(args.black), cwd)
+    engine_a = Engine(split_cmd(args.white), cwd, engine_id="A")
+    engine_b = Engine(split_cmd(args.black), cwd, engine_id="B")
     validator = Engine(split_cmd(args.validator), cwd) if args.validator else None
 
     engine_a_name = engine_a.name

--- a/scripts/play_uci_match.py
+++ b/scripts/play_uci_match.py
@@ -145,8 +145,14 @@ def position_command(moves: list[str]) -> str:
 # ---------------------------------------------------------------------------
 
 def fen_for_moves(engine: Engine, moves: list[str], timeout: float = 5.0) -> str:
+    """Extract the FEN for a position using the Stockfish ``d`` command.
+
+    The ``d`` (display) command is a Stockfish extension -- it is **not** part
+    of the UCI standard.  The ``--validator`` engine must therefore be Stockfish
+    or another engine that implements ``d``."""
     engine.send(position_command(moves))
     engine.send("d")
+    fen: str | None = None
     while True:
         text = engine.read_line_timeout(timeout)
         if text is None:
@@ -155,7 +161,13 @@ def fen_for_moves(engine: Engine, moves: list[str], timeout: float = 5.0) -> str
                 f"(does this engine support the Stockfish-specific 'd' command?)"
             )
         if text.startswith("Fen: "):
-            return text[5:]
+            fen = text[5:]
+            break
+    # Drain remaining ``d`` output via the standard UCI sync barrier.
+    engine.send("isready")
+    engine.read_until("readyok")
+    assert fen is not None
+    return fen
 
 
 def eval_position(engine: Engine, moves: list[str], movetime: int = 200) -> float:
@@ -174,6 +186,9 @@ def eval_position(engine: Engine, moves: list[str], movetime: int = 200) -> floa
                 mate_in = int(m.group(3))
                 cp = 100.0 if mate_in > 0 else -100.0
             break
+    # UCI scores are relative to the side to move; negate for Black's turn.
+    if len(moves) % 2 == 1:
+        cp = -cp
     return cp
 
 
@@ -252,9 +267,18 @@ def play_game(
         move, _ = engine.read_bestmove()
 
         if move in {"(none)", "0000"}:
-            # No legal move — the side to move lost (checkmate) or it's stalemate.
-            # Heuristic: treat as loss for the side with no move.
-            outcome = "0-1" if ply % 2 == 0 else "1-0"
+            # No legal move: checkmate (loss) or stalemate (draw).
+            # When a validator is available, use its eval to distinguish:
+            # a large score means likely checkmate; near-zero means stalemate.
+            if validator is not None:
+                ev = eval_position(validator, moves)
+                if abs(ev) < 2.0:
+                    outcome = "1/2-1/2"
+                else:
+                    outcome = "0-1" if ply % 2 == 0 else "1-0"
+            else:
+                # Without a validator we cannot distinguish; default to loss.
+                outcome = "0-1" if ply % 2 == 0 else "1-0"
             break
         if MOVE_RE.match(move) is None:
             raise RuntimeError(
@@ -399,7 +423,7 @@ def main() -> int:
     parser.add_argument("--black", required=True, help="Black engine command")
     parser.add_argument(
         "--validator",
-        help="Optional validator engine command (must support the Stockfish-specific 'd' command; confirms moves change position, evaluates unfinished games)",
+        help="Optional Stockfish-compatible validator (must support the 'd' command; confirms moves change position, evaluates unfinished games)",
     )
     parser.add_argument("--white-go", default="go movetime 100",
                         help="UCI go command for White (default: go movetime 100)")


### PR DESCRIPTION
## Summary

- Adds `examples/chess_uci.vow` — a UCI chess engine written in Vow
- Extends `scripts/play_uci_match.py` into a full multi-game benchmark harness with `--games`, `--alternate-colors`, `--white-option`/`--black-option`/`--validator-option`, `--log`, and validator-based position evaluation for scoring unfinished games

## New flags

| Flag | Purpose |
|------|---------|
| `--games N` | Play N games (default 1, backwards-compatible) |
| `--alternate-colors` | Swap engine colors each game |
| `--white-option` / `--black-option` | UCI `setoption` passthrough (e.g. `UCI_Elo=1350`) |
| `--validator-option` | UCI options for the validator engine |
| `--log <file>` | Per-game log with FEN, moves, eval, result |

## Test plan

- [x] Smoke-tested 2-game match with Stockfish vs Stockfish (limited Elo), alternating colors, validator evaluation, and log output
- [x] Verified single-game backwards compatibility
- [ ] Test with `examples/chess_uci.vow` compiled binary against Stockfish at various Elo levels

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone chess engine with UCI support: legal move generation, position evaluation, tactical search, and UCI command handling to compute and return best moves.
  * Added a match orchestration tool to run configurable UCI engine games, aggregate per-game and match summaries, optionally validate moves, and produce match logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->