### PR TITLE
docs: add EOF-safe stdin_read_line command-loop example

### DIFF
--- a/docs/skill/examples.md
+++ b/docs/skill/examples.md
@@ -1,6 +1,6 @@
 # Worked Examples
 
-Verification workflow examples. The first three demonstrate Counterexample-Guided Inductive Synthesis (CEGIS) cycles: write spec, build, read JSON, diagnose, fix, verify. The fourth shows break-with-value in loop expressions.
+Verification workflow examples. The first three demonstrate Counterexample-Guided Inductive Synthesis (CEGIS) cycles: write spec, build, read JSON, diagnose, fix, verify. The fourth shows break-with-value in loop expressions. The fifth shows an EOF-safe interactive command loop using `stdin_read_line()`.
 
 ## 1. Safe Division — Requires Pattern
 
@@ -253,3 +253,122 @@ $ vow build examples/search.vow
 - All `break` expressions in a `loop` must produce the same type (`i64` here)
 - `break <value>` is only allowed in `loop`, not in `while` (which always evaluates to `()`)
 - The result is bound with `let result: i64 = loop { ... };`
+
+---
+
+## 5. Command Loop — EOF-Safe `stdin_read_line`
+
+### Goal
+
+Write a line-oriented command interpreter that reads from stdin, dispatches commands, skips empty lines, and exits cleanly on EOF. This is the canonical pattern for CI-safe interactive programs.
+
+### Step 1: Write the program
+
+```vow
+module CmdLoop
+
+fn trim_newline(s: String) -> String {
+    let n: i64 = s.len();
+    if n == 0 { return s; }
+    let last: i64 = s.byte_at(n - 1);
+    if last == 10 {
+        if n >= 2 {
+            let prev: i64 = s.byte_at(n - 2);
+            if prev == 13 {
+                return s.substring(0, n - 2);
+            }
+        }
+        return s.substring(0, n - 1);
+    }
+    s
+}
+
+fn skip_spaces(s: String, start: i64) -> i64 {
+    let mut i: i64 = start;
+    let n: i64 = s.len();
+    while i < n {
+        if s.byte_at(i) != 32 { return i; }
+        i = i + 1;
+    }
+    i
+}
+
+fn main() -> i32 [read, io] {
+    let mut line: String = stdin_read_line();
+    while line.len() > 0 {
+        let cmd: String = trim_newline(line);
+
+        if cmd.len() > 0 {
+            if cmd.eq(String::from("quit")) {
+                return 0;
+            }
+
+            if cmd.eq(String::from("hello")) {
+                print_str(String::from("Hello, world!\n"));
+            } else {
+                if cmd.len() > 5 {
+                    let prefix: String = cmd.substring(0, 5);
+                    if prefix.eq(String::from("echo ")) {
+                        let start: i64 = skip_spaces(cmd, 5);
+                        let text: String = cmd.substring(start, cmd.len());
+                        print_str(text);
+                        print_str(String::from("\n"));
+                    } else {
+                        print_str(String::from("unknown: "));
+                        print_str(cmd);
+                        print_str(String::from("\n"));
+                    }
+                } else {
+                    print_str(String::from("unknown: "));
+                    print_str(cmd);
+                    print_str(String::from("\n"));
+                }
+            }
+        }
+
+        line = stdin_read_line();
+    }
+    0
+}
+```
+
+### Step 2: Build
+
+```
+$ vow build --no-verify examples/cmdloop.vow -o /tmp/cmdloop
+```
+
+```json
+{"status":"Unverified","executable":"/tmp/cmdloop","diagnostics":[],"counterexamples":[]}
+```
+
+No contracts here — this example focuses on the I/O pattern, not verification.
+
+### Step 3: Run with piped input
+
+```
+$ printf 'hello\necho Vow is great\n\nbogus\nquit\n' | /tmp/cmdloop
+Hello, world!
+Vow is great
+unknown: bogus
+```
+
+The `quit` command causes an early `return 0`. Empty lines are silently skipped.
+
+### Step 4: Run with EOF (no quit)
+
+```
+$ printf 'hello\necho test\n' | /tmp/cmdloop
+Hello, world!
+test
+```
+
+When stdin is exhausted, `stdin_read_line()` returns `""` (length 0), the `while` condition fails, and the program exits cleanly with code 0.
+
+### Key points
+
+- **EOF detection:** `stdin_read_line()` returns `""` at EOF. Check `.len() > 0` to exit the loop.
+- **Newline stripping:** `stdin_read_line()` includes the trailing `\n` (or `\r\n`). Strip it with `byte_at` + `substring` before comparing commands.
+- **Empty line handling:** After trimming, `cmd.len() == 0` means the line was blank — skip it.
+- **Effects:** `stdin_read_line()` requires `[read]`; `print_str()` requires `[io]`. The `main` function declares both.
+- **CI-safe:** No blocking reads, no prompts — the program processes whatever stdin provides and exits at EOF. Safe to run in pipelines and test harnesses.

--- a/docs/skill/examples.md
+++ b/docs/skill/examples.md
@@ -306,7 +306,7 @@ fn main() -> i32 [read, io] {
             if cmd.eq(String::from("hello")) {
                 print_str(String::from("Hello, world!\n"));
             } else {
-                if cmd.len() > 5 {
+                if cmd.len() >= 5 {
                     let prefix: String = cmd.substring(0, 5);
                     if prefix.eq(String::from("echo ")) {
                         let start: i64 = skip_spaces(cmd, 5);

--- a/examples/cmdloop.vow
+++ b/examples/cmdloop.vow
@@ -1,0 +1,90 @@
+module CmdLoop
+
+// Helper: strip trailing newline/carriage-return from a line
+fn trim_newline(s: String) -> String {
+    let n: i64 = s.len();
+    if n == 0 { return s; }
+    let last: i64 = s.byte_at(n - 1);
+    if last == 10 {
+        if n >= 2 {
+            let prev: i64 = s.byte_at(n - 2);
+            if prev == 13 {
+                return s.substring(0, n - 2);
+            }
+        }
+        return s.substring(0, n - 1);
+    }
+    s
+}
+
+// Helper: skip leading spaces (byte 32) and return substring from first non-space
+fn skip_spaces(s: String, start: i64) -> i64 {
+    let mut i: i64 = start;
+    let n: i64 = s.len();
+    while i < n {
+        if s.byte_at(i) != 32 { return i; }
+        i = i + 1;
+    }
+    i
+}
+
+// Helper: find the next space (byte 32) starting at pos, or return len
+fn find_space(s: String, start: i64) -> i64 {
+    let mut i: i64 = start;
+    let n: i64 = s.len();
+    while i < n {
+        if s.byte_at(i) == 32 { return i; }
+        i = i + 1;
+    }
+    n
+}
+
+fn main() -> i32 [read, io] {
+    let mut line: String = stdin_read_line();
+    while line.len() > 0 {
+        let cmd: String = trim_newline(line);
+
+        if cmd.len() > 0 {
+            if cmd.eq(String::from("quit")) {
+                return 0;
+            }
+
+            if cmd.eq(String::from("hello")) {
+                print_str(String::from("Hello, world!\n"));
+            } else {
+                // Check for "echo " prefix (5 bytes)
+                if cmd.len() > 5 {
+                    let prefix: String = cmd.substring(0, 5);
+                    if prefix.eq(String::from("echo ")) {
+                        let start: i64 = skip_spaces(cmd, 5);
+                        let text: String = cmd.substring(start, cmd.len());
+                        print_str(text);
+                        print_str(String::from("\n"));
+                    } else {
+                        print_str(String::from("unknown: "));
+                        print_str(cmd);
+                        print_str(String::from("\n"));
+                    }
+                } else {
+                    if cmd.len() == 4 {
+                        let prefix4: String = cmd.substring(0, 4);
+                        if prefix4.eq(String::from("echo")) {
+                            print_str(String::from("\n"));
+                        } else {
+                            print_str(String::from("unknown: "));
+                            print_str(cmd);
+                            print_str(String::from("\n"));
+                        }
+                    } else {
+                        print_str(String::from("unknown: "));
+                        print_str(cmd);
+                        print_str(String::from("\n"));
+                    }
+                }
+            }
+        }
+
+        line = stdin_read_line();
+    }
+    0
+}

--- a/examples/cmdloop.vow
+++ b/examples/cmdloop.vow
@@ -1,6 +1,5 @@
 module CmdLoop
 
-// Helper: strip trailing newline/carriage-return from a line
 fn trim_newline(s: String) -> String {
     let n: i64 = s.len();
     if n == 0 { return s; }
@@ -17,7 +16,6 @@ fn trim_newline(s: String) -> String {
     s
 }
 
-// Helper: skip leading spaces (byte 32) and return substring from first non-space
 fn skip_spaces(s: String, start: i64) -> i64 {
     let mut i: i64 = start;
     let n: i64 = s.len();
@@ -26,17 +24,6 @@ fn skip_spaces(s: String, start: i64) -> i64 {
         i = i + 1;
     }
     i
-}
-
-// Helper: find the next space (byte 32) starting at pos, or return len
-fn find_space(s: String, start: i64) -> i64 {
-    let mut i: i64 = start;
-    let n: i64 = s.len();
-    while i < n {
-        if s.byte_at(i) == 32 { return i; }
-        i = i + 1;
-    }
-    n
 }
 
 fn main() -> i32 [read, io] {
@@ -52,8 +39,7 @@ fn main() -> i32 [read, io] {
             if cmd.eq(String::from("hello")) {
                 print_str(String::from("Hello, world!\n"));
             } else {
-                // Check for "echo " prefix (5 bytes)
-                if cmd.len() > 5 {
+                if cmd.len() >= 5 {
                     let prefix: String = cmd.substring(0, 5);
                     if prefix.eq(String::from("echo ")) {
                         let start: i64 = skip_spaces(cmd, 5);
@@ -66,20 +52,9 @@ fn main() -> i32 [read, io] {
                         print_str(String::from("\n"));
                     }
                 } else {
-                    if cmd.len() == 4 {
-                        let prefix4: String = cmd.substring(0, 4);
-                        if prefix4.eq(String::from("echo")) {
-                            print_str(String::from("\n"));
-                        } else {
-                            print_str(String::from("unknown: "));
-                            print_str(cmd);
-                            print_str(String::from("\n"));
-                        }
-                    } else {
-                        print_str(String::from("unknown: "));
-                        print_str(cmd);
-                        print_str(String::from("\n"));
-                    }
+                    print_str(String::from("unknown: "));
+                    print_str(cmd);
+                    print_str(String::from("\n"));
                 }
             }
         }

--- a/tests/run/cmdloop.vow
+++ b/tests/run/cmdloop.vow
@@ -41,7 +41,7 @@ fn main() -> i32 [read, io] {
             if cmd.eq(String::from("hello")) {
                 print_str(String::from("Hello, world!\n"));
             } else {
-                if cmd.len() > 5 {
+                if cmd.len() >= 5 {
                     let prefix: String = cmd.substring(0, 5);
                     if prefix.eq(String::from("echo ")) {
                         let start: i64 = skip_spaces(cmd, 5);

--- a/tests/run/cmdloop.vow
+++ b/tests/run/cmdloop.vow
@@ -1,0 +1,67 @@
+// TEST: stdin "hello\necho Vow is great\n\nbogus\n"
+// TEST: stdout "Hello, world!\nVow is great\nunknown: bogus"
+module CmdLoop
+
+fn trim_newline(s: String) -> String {
+    let n: i64 = s.len();
+    if n == 0 { return s; }
+    let last: i64 = s.byte_at(n - 1);
+    if last == 10 {
+        if n >= 2 {
+            let prev: i64 = s.byte_at(n - 2);
+            if prev == 13 {
+                return s.substring(0, n - 2);
+            }
+        }
+        return s.substring(0, n - 1);
+    }
+    s
+}
+
+fn skip_spaces(s: String, start: i64) -> i64 {
+    let mut i: i64 = start;
+    let n: i64 = s.len();
+    while i < n {
+        if s.byte_at(i) != 32 { return i; }
+        i = i + 1;
+    }
+    i
+}
+
+fn main() -> i32 [read, io] {
+    let mut line: String = stdin_read_line();
+    while line.len() > 0 {
+        let cmd: String = trim_newline(line);
+
+        if cmd.len() > 0 {
+            if cmd.eq(String::from("quit")) {
+                return 0;
+            }
+
+            if cmd.eq(String::from("hello")) {
+                print_str(String::from("Hello, world!\n"));
+            } else {
+                if cmd.len() > 5 {
+                    let prefix: String = cmd.substring(0, 5);
+                    if prefix.eq(String::from("echo ")) {
+                        let start: i64 = skip_spaces(cmd, 5);
+                        let text: String = cmd.substring(start, cmd.len());
+                        print_str(text);
+                        print_str(String::from("\n"));
+                    } else {
+                        print_str(String::from("unknown: "));
+                        print_str(cmd);
+                        print_str(String::from("\n"));
+                    }
+                } else {
+                    print_str(String::from("unknown: "));
+                    print_str(cmd);
+                    print_str(String::from("\n"));
+                }
+            }
+        }
+
+        line = stdin_read_line();
+    }
+    0
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -97,6 +97,7 @@ parse_annotations() {
   TEST_CX_FN=""
   TEST_CX_BLAME=""
   TEST_SKIP=""
+  TEST_STDIN=""
 
   while IFS= read -r line; do
     if [[ "$line" =~ ^//\ TEST:\ exit\ ([0-9]+) ]]; then
@@ -115,6 +116,12 @@ parse_annotations() {
       TEST_CX_FN="${BASH_REMATCH[1]}"
     elif [[ "$line" =~ ^//\ TEST:\ counterexample-blame\ (.+) ]]; then
       TEST_CX_BLAME="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^//\ TEST:\ stdin\ \"(.*)\" ]]; then
+      TEST_STDIN="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^//\ TEST:\ stdin-file\ (.+) ]]; then
+      local stdin_file
+      stdin_file="$(dirname "$file")/${BASH_REMATCH[1]}"
+      TEST_STDIN="$(cat "$stdin_file")"
     elif [[ "$line" =~ ^//\ TEST:\ skip\ \"(.+)\" ]]; then
       TEST_SKIP="${BASH_REMATCH[1]}"
     elif [[ ! "$line" =~ ^// ]]; then
@@ -202,12 +209,13 @@ for f in "$SCRIPT_DIR"/run/*.vow; do
     continue
   fi
 
-  # Run
-  actual_stdout="$(run_bin "$out" 2>/dev/null)" || true
-  actual_exit=$?
-  # Re-run to capture exit code properly
+  # Run (pipe stdin if TEST_STDIN is set)
   set +e
-  actual_stdout="$(run_bin "$out" 2>/dev/null)"
+  if [[ -n "$TEST_STDIN" ]]; then
+    actual_stdout="$(echo -e "$TEST_STDIN" | run_bin "$out" 2>/dev/null)"
+  else
+    actual_stdout="$(run_bin "$out" 2>/dev/null)"
+  fi
   actual_exit=$?
   set -e
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -98,6 +98,7 @@ parse_annotations() {
   TEST_CX_BLAME=""
   TEST_SKIP=""
   TEST_STDIN=""
+  TEST_STDIN_FILE=""
 
   while IFS= read -r line; do
     if [[ "$line" =~ ^//\ TEST:\ exit\ ([0-9]+) ]]; then
@@ -119,9 +120,7 @@ parse_annotations() {
     elif [[ "$line" =~ ^//\ TEST:\ stdin\ \"(.*)\" ]]; then
       TEST_STDIN="${BASH_REMATCH[1]}"
     elif [[ "$line" =~ ^//\ TEST:\ stdin-file\ (.+) ]]; then
-      local stdin_file
-      stdin_file="$(dirname "$file")/${BASH_REMATCH[1]}"
-      TEST_STDIN="$(cat "$stdin_file")"
+      TEST_STDIN_FILE="$(dirname "$file")/${BASH_REMATCH[1]}"
     elif [[ "$line" =~ ^//\ TEST:\ skip\ \"(.+)\" ]]; then
       TEST_SKIP="${BASH_REMATCH[1]}"
     elif [[ ! "$line" =~ ^// ]]; then
@@ -211,8 +210,10 @@ for f in "$SCRIPT_DIR"/run/*.vow; do
 
   # Run (pipe stdin if TEST_STDIN is set)
   set +e
-  if [[ -n "$TEST_STDIN" ]]; then
-    actual_stdout="$(echo -e "$TEST_STDIN" | run_bin "$out" 2>/dev/null)"
+  if [[ -n "$TEST_STDIN_FILE" ]]; then
+    actual_stdout="$(run_bin "$out" < "$TEST_STDIN_FILE" 2>/dev/null)"
+  elif [[ -n "$TEST_STDIN" ]]; then
+    actual_stdout="$(printf '%b' "$TEST_STDIN" | run_bin "$out" 2>/dev/null)"
   else
     actual_stdout="$(run_bin "$out" 2>/dev/null)"
   fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -209,11 +209,13 @@ for f in "$SCRIPT_DIR"/run/*.vow; do
   fi
 
   # Run (pipe stdin if TEST_STDIN is set)
+  # Disable pipefail in the stdin subshell so we capture the binary's exit
+  # code, not printf's SIGPIPE (141) when the binary exits early.
   set +e
   if [[ -n "$TEST_STDIN_FILE" ]]; then
     actual_stdout="$(run_bin "$out" < "$TEST_STDIN_FILE" 2>/dev/null)"
   elif [[ -n "$TEST_STDIN" ]]; then
-    actual_stdout="$(printf '%b' "$TEST_STDIN" | run_bin "$out" 2>/dev/null)"
+    actual_stdout="$(set +o pipefail; printf '%b' "$TEST_STDIN" | run_bin "$out" 2>/dev/null)"
   else
     actual_stdout="$(run_bin "$out" 2>/dev/null)"
   fi


### PR DESCRIPTION
## Summary

Closes #104.

- Add `examples/cmdloop.vow` — canonical EOF-safe `stdin_read_line()` command loop with newline trimming, empty line skipping, and command dispatch
- Add worked Example 5 to `docs/skill/examples.md` with build/run walkthrough and key points
- Add `TEST: stdin` / `TEST: stdin-file` annotation support to `tests/run_tests.sh` for stdin-dependent regression tests
- Add `tests/run/cmdloop.vow` regression test

## Test plan

- [x] `cmdloop` test passes in run test suite (`tests/run_tests.sh --filter cmdloop`)
- [x] All other run tests remain green (45/45 passing; 2 pre-existing `u64_*` failures unrelated)
- [x] Example compiles with `vowc build --no-verify examples/cmdloop.vow`
- [x] Piped stdin produces expected output (`hello`, `echo`, unknown, EOF exit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a worked example showing an EOF-safe interactive command-loop with build and run scenarios.

* **New Features**
  * Added a command-loop example demonstrating quit/hello/echo behaviors and EOF termination.

* **Tests**
  * Added automated tests for the command-loop behavior and stdin-driven scenarios.
  * Test runner now supports stdin annotations and stdin-file annotations to feed input into tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->