### PR TITLE
fix: match-as-expression type check for enum payload destructuring

### DIFF
--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -411,7 +411,7 @@ fn enum_name_from_tid(ts: TyStore, tid: i64) -> String {
         let name_idx: i64 = ty_a(ts, tid);
         return ts.strs[name_idx];
     }
-    if tag == CTY_APPLIED() {
+    if tag == CTY_APPLIED() || tag == CTY_REF() {
         let base_tid: i64 = ty_a(ts, tid);
         return enum_name_from_tid(ts, base_tid);
     }
@@ -460,7 +460,7 @@ fn bind_arm_pattern(e: CheckEnv, m: Module, pid: i64, scrutinee_tid: i64) [io] {
         let n_inner: i64 = list_len(a, inner_lid);
         let n_path: i64 = list_len(a, path_lid);
         let variant_sid: i64 = if n_path >= 2 {
-            list_get(a, path_lid, 1)
+            list_get(a, path_lid, n_path - 1)
         } else if n_path == 1 {
             list_get(a, path_lid, 0)
         } else {
@@ -468,11 +468,12 @@ fn bind_arm_pattern(e: CheckEnv, m: Module, pid: i64, scrutinee_tid: i64) [io] {
         };
         let enum_name: String = enum_name_from_tid(e.ts, scrutinee_tid);
         let enum_idx: i64 = env_lookup_enum(e, enum_name);
+        let variant_name: String = if variant_sid != -1 { arena_str(a, variant_sid) } else { String::from("") };
         let mut i: i64 = 0;
         while i < n_inner {
             let ipid: i64 = list_get(a, inner_lid, i);
             let field_tid: i64 = if enum_idx != -1 && variant_sid != -1 {
-                lookup_variant_payload(e, enum_idx, arena_str(a, variant_sid), i)
+                lookup_variant_payload(e, enum_idx, variant_name, i)
             } else {
                 CTY_UNIT()
             };
@@ -887,6 +888,7 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
         let scrutinee_eid: i64 = expr_a(a, eid);
         let arms_lid: i64 = expr_b(a, eid);
         let scrutinee_tid: i64 = check_expr(e, m, scrutinee_eid);
+        let ts: TyStore = e.ts;
         let n_pairs: i64 = list_len(a, arms_lid);
         let n_arms: i64 = n_pairs / 2;
         let mut result_tid: i64 = CTY_NEVER();
@@ -900,6 +902,18 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
             env_pop_scope(e);
             if is_opaque(result_tid) {
                 result_tid = arm_tid;
+            } else if arm_tid != result_tid && !is_opaque(arm_tid) {
+                let arm_tag: i64 = ty_tag(ts, arm_tid);
+                let res_tag: i64 = ty_tag(ts, result_tid);
+                let coercible: bool = (arm_tag == CTY_I32() && ty_is_integer(ts, result_tid))
+                    || (res_tag == CTY_I32() && ty_is_integer(ts, arm_tid));
+                if coercible {
+                    if res_tag == CTY_I32() && ty_is_integer(ts, arm_tid) {
+                        result_tid = arm_tid;
+                    }
+                } else {
+                    env_emit_error(e, String::from("match arm type mismatch"), expr_span(a, body_eid));
+                }
             }
             i = i + 1;
         }

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -424,7 +424,8 @@ fn lookup_variant_payload(e: CheckEnv, enum_idx: i64, variant_name: String, fiel
     let mut i: i64 = 0;
     while i < nv {
         let vsid: i64 = ts_arg_get(e.ts, vname_lid, i);
-        let vname: String = e.ts.strs[vsid];
+        let ts: TyStore = e.ts;
+        let vname: String = ts.strs[vsid];
         if vname == variant_name {
             let vpayload_lid: i64 = e.edef_vpayload_lids[enum_idx];
             let fields_lid: i64 = ts_arg_get(e.ts, vpayload_lid, i);

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -276,15 +276,27 @@ fn register_enum(e: CheckEnv, m: Module, eid: i64) [io] {
     let name_s: i64 = edef_name_sid(a, eid);
     let name: String = arena_str(a, name_s);
     let variants_lid: i64 = edef_variants_lid(a, eid);
-    let n: i64 = list_len(a, variants_lid);
+    let n_pairs: i64 = list_len(a, variants_lid);
+    let n_variants: i64 = n_pairs / 2;
     let vnames: Vec<String> = Vec::new();
     let vpayloads: Vec<i64> = Vec::new();
     let mut i: i64 = 0;
-    while i < n {
-        let vsid: i64 = list_get(a, variants_lid, i);
+    while i < n_variants {
+        let vsid: i64 = list_get(a, variants_lid, i * 2);
+        let payload_lid: i64 = list_get(a, variants_lid, i * 2 + 1);
         let vname: String = arena_str(a, vsid);
         vnames.push(vname);
-        vpayloads.push(CTY_UNIT());
+        let n_fields: i64 = list_len(a, payload_lid);
+        let resolved_fields: Vec<i64> = Vec::new();
+        let mut fi: i64 = 0;
+        while fi < n_fields {
+            let ast_tid: i64 = list_get(a, payload_lid, fi);
+            let resolved: i64 = resolve_ast_ty(e, m, ast_tid);
+            resolved_fields.push(resolved);
+            fi = fi + 1;
+        }
+        let fields_lid: i64 = ts_add_args(e.ts, resolved_fields);
+        vpayloads.push(fields_lid);
         i = i + 1;
     }
     env_update_enum(e, name, vnames, vpayloads);
@@ -393,6 +405,40 @@ fn bind_pattern(e: CheckEnv, m: Module, pid: i64, tid: i64) [io] {
     }
 }
 
+fn enum_name_from_tid(ts: TyStore, tid: i64) -> String {
+    let tag: i64 = ty_tag(ts, tid);
+    if tag == CTY_ENUM() {
+        let name_idx: i64 = ty_a(ts, tid);
+        return ts.strs[name_idx];
+    }
+    if tag == CTY_APPLIED() {
+        let base_tid: i64 = ty_a(ts, tid);
+        return enum_name_from_tid(ts, base_tid);
+    }
+    String::from("")
+}
+
+fn lookup_variant_payload(e: CheckEnv, enum_idx: i64, variant_name: String, field_idx: i64) -> i64 {
+    let vname_lid: i64 = e.edef_vname_lids[enum_idx];
+    let nv: i64 = e.edef_variant_count[enum_idx];
+    let mut i: i64 = 0;
+    while i < nv {
+        let vsid: i64 = ts_arg_get(e.ts, vname_lid, i);
+        let vname: String = e.ts.strs[vsid];
+        if vname == variant_name {
+            let vpayload_lid: i64 = e.edef_vpayload_lids[enum_idx];
+            let fields_lid: i64 = ts_arg_get(e.ts, vpayload_lid, i);
+            let n_fields: i64 = ts_arg_len(e.ts, fields_lid);
+            if field_idx < n_fields {
+                return ts_arg_get(e.ts, fields_lid, field_idx);
+            }
+            return CTY_UNIT();
+        }
+        i = i + 1;
+    }
+    CTY_UNIT()
+}
+
 fn bind_arm_pattern(e: CheckEnv, m: Module, pid: i64, scrutinee_tid: i64) [io] {
     let a: AstArena = m.arena;
     let tag: i64 = pat_tag(a, pid);
@@ -409,12 +455,28 @@ fn bind_arm_pattern(e: CheckEnv, m: Module, pid: i64, scrutinee_tid: i64) [io] {
         return;
     }
     if tag == PAT_ENUM() {
+        let path_lid: i64 = pat_a(a, pid);
         let inner_lid: i64 = pat_b(a, pid);
         let n_inner: i64 = list_len(a, inner_lid);
+        let n_path: i64 = list_len(a, path_lid);
+        let variant_sid: i64 = if n_path >= 2 {
+            list_get(a, path_lid, 1)
+        } else if n_path == 1 {
+            list_get(a, path_lid, 0)
+        } else {
+            -1
+        };
+        let enum_name: String = enum_name_from_tid(e.ts, scrutinee_tid);
+        let enum_idx: i64 = env_lookup_enum(e, enum_name);
         let mut i: i64 = 0;
         while i < n_inner {
             let ipid: i64 = list_get(a, inner_lid, i);
-            bind_arm_pattern(e, m, ipid, CTY_UNIT());
+            let field_tid: i64 = if enum_idx != -1 && variant_sid != -1 {
+                lookup_variant_payload(e, enum_idx, arena_str(a, variant_sid), i)
+            } else {
+                CTY_UNIT()
+            };
+            bind_arm_pattern(e, m, ipid, field_tid);
             i = i + 1;
         }
         return;

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -3222,7 +3222,17 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>, file_path: String) -> IrModul
                 let vname_sid: i64 = list_get(a, variants_lid, vi * 2);
                 let vname: String = arena_str(a, vname_sid);
                 vnames.push(vname);
+                let payload_lid: i64 = list_get(a, variants_lid, vi * 2 + 1);
+                let n_payload: i64 = list_len(a, payload_lid);
                 let payload: Vec<IrFieldLayout> = Vec::new();
+                let mut pi: i64 = 0;
+                while pi < n_payload {
+                    let p_ast_tid: i64 = list_get(a, payload_lid, pi);
+                    let p_ir_ty: i64 = lower_ast_ty(a, p_ast_tid);
+                    let fl: IrFieldLayout = IrFieldLayout { name: String::from(""), ty: p_ir_ty };
+                    payload.push(fl);
+                    pi = pi + 1;
+                }
                 let vl: IrVariantLayout = IrVariantLayout { name: vname, tag: vi, payload: payload };
                 ir_variants.push(vl);
                 vi = vi + 1;

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -3213,12 +3213,13 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>, file_path: String) -> IrModul
             let ename_sid: i64 = edef_name_sid(a, iid);
             let ename: String = arena_str(a, ename_sid);
             let variants_lid: i64 = edef_variants_lid(a, iid);
-            let nv: i64 = list_len(a, variants_lid);
+            let n_pairs: i64 = list_len(a, variants_lid);
+            let nv: i64 = n_pairs / 2;
             let vnames: Vec<String> = Vec::new();
             let ir_variants: Vec<IrVariantLayout> = Vec::new();
             let mut vi: i64 = 0;
             while vi < nv {
-                let vname_sid: i64 = list_get(a, variants_lid, vi);
+                let vname_sid: i64 = list_get(a, variants_lid, vi * 2);
                 let vname: String = arena_str(a, vname_sid);
                 vnames.push(vname);
                 let payload: Vec<IrFieldLayout> = Vec::new();

--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -250,13 +250,17 @@ fn parse_enum_def(p: Parser) -> i64 {
         variant_items.push(vsid);
         if at(p, tok_lparen()) {
             let _lp: Token = advance(p);
+            let payload_types: Vec<i64> = Vec::new();
             while !at(p, tok_rparen()) && !at_end(p) {
-                let _tid: i64 = parse_type(p);
+                let tid: i64 = parse_type(p);
+                payload_types.push(tid);
                 if at(p, tok_comma()) {
                     let _c: Token = advance(p);
                 }
             }
             let _rp: bool = expect(p, tok_rparen());
+            let payload_lid: i64 = arena_add_list(p.arena, payload_types);
+            variant_items.push(payload_lid);
         } else if at(p, tok_lbrace()) {
             let _lb2: Token = advance(p);
             while !at(p, tok_rbrace()) && !at_end(p) {
@@ -268,6 +272,11 @@ fn parse_enum_def(p: Parser) -> i64 {
                 }
             }
             let _rb2: bool = expect(p, tok_rbrace());
+            let empty_lid: i64 = arena_add_list(p.arena, Vec::new());
+            variant_items.push(empty_lid);
+        } else {
+            let empty_lid: i64 = arena_add_list(p.arena, Vec::new());
+            variant_items.push(empty_lid);
         }
         if at(p, tok_comma()) {
             let _comma: Token = advance(p);

--- a/tests/run/match_enum_multi_payload.vow
+++ b/tests/run/match_enum_multi_payload.vow
@@ -1,0 +1,26 @@
+// TEST: stdout "3350"
+module match_enum_multi_payload
+
+enum Shape {
+    Circle(i64),
+    Rect(i64, i64),
+    Empty,
+}
+
+fn area(s: Shape) -> i64 {
+    match s {
+        Shape::Circle(r) => { r * r * 3 },
+        Shape::Rect(w, h) => { w * h },
+        Shape::Empty => { 0 },
+    }
+}
+
+fn main() -> i32 [io] {
+    let c: Shape = Shape::Circle(1);
+    let r: Shape = Shape::Rect(5, 7);
+    let e: Shape = Shape::Empty {};
+    print_i64(area(c));
+    print_i64(area(r));
+    print_i64(area(e));
+    0
+}

--- a/tests/run/match_enum_payload.vow
+++ b/tests/run/match_enum_payload.vow
@@ -1,0 +1,22 @@
+// TEST: stdout "420"
+module match_enum_payload
+
+enum E {
+    A(i64),
+    B,
+}
+
+fn extract(e: E) -> i64 {
+    match e {
+        E::A(n) => { n },
+        E::B => { 0 },
+    }
+}
+
+fn main() -> i32 [io] {
+    let a: E = E::A(42);
+    let b: E = E::B {};
+    print_i64(extract(a));
+    print_i64(extract(b));
+    0
+}

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -941,10 +941,7 @@ impl<'e> Checker<'e> {
                     self.env.pop_scope();
                     if i == 0 {
                         result_ty = arm_ty.clone();
-                    } else if arm_ty != result_ty
-                        && arm_ty != Ty::Never
-                        && result_ty != Ty::Never
-                    {
+                    } else if arm_ty != result_ty && arm_ty != Ty::Never && result_ty != Ty::Never {
                         let coercible = (arm_ty == Ty::I32 && result_ty.is_integer())
                             || (result_ty == Ty::I32 && arm_ty.is_integer());
                         if coercible {

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -940,15 +940,29 @@ impl<'e> Checker<'e> {
                     let arm_ty = self.check_expr(&arm.body);
                     self.env.pop_scope();
                     if i == 0 {
+                        result_ty = arm_ty.clone();
+                    } else if arm_ty != result_ty
+                        && arm_ty != Ty::Never
+                        && result_ty != Ty::Never
+                    {
+                        let coercible = (arm_ty == Ty::I32 && result_ty.is_integer())
+                            || (result_ty == Ty::I32 && arm_ty.is_integer());
+                        if coercible {
+                            if result_ty == Ty::I32 && arm_ty.is_integer() {
+                                result_ty = arm_ty.clone();
+                            }
+                        } else {
+                            self.emit_error(
+                                ErrorCode::TypeMismatch,
+                                format!(
+                                    "match arm has type `{arm_ty}` but previous arms have type `{result_ty}`"
+                                ),
+                                arm.span,
+                            );
+                        }
+                    }
+                    if result_ty == Ty::Never && arm_ty != Ty::Never {
                         result_ty = arm_ty;
-                    } else if arm_ty != result_ty && arm_ty != Ty::Never {
-                        self.emit_error(
-                            ErrorCode::TypeMismatch,
-                            format!(
-                                "match arm has type `{arm_ty}` but previous arms have type `{result_ty}`"
-                            ),
-                            arm.span,
-                        );
                     }
                 }
                 result_ty


### PR DESCRIPTION
## Summary

Fixes #103. Two bugs prevented `match` from working as a value-producing expression:

- **Rust compiler**: match arm type unification lacked i32-to-integer coercion (unlike if-else), so `E::A(n) => { n }` (i64) vs `E::B => { 0 }` (i32 literal) was rejected
- **Self-hosted compiler**: parser discarded enum variant payload types entirely, so destructured bindings like `n` in `E::A(n)` got `unit` type instead of `i64`, causing "function body type mismatch"

Changes:
- `vow-types/src/check.rs` — i32 coercion + `Never` widening in match arms
- `compiler/parser.vow` — store variant payload type lists in AST
- `compiler/checker.vow` — resolve payload types in `register_enum`, new `lookup_variant_payload` for per-field type lookup in `bind_arm_pattern`
- `compiler/lower.vow` — iterate variant pairs (stride 2) for new AST format

## Test plan

- [x] `tests/run/match_enum_payload.vow` — single-field enum destructuring (exact repro from issue)
- [x] `tests/run/match_enum_multi_payload.vow` — multi-field enum destructuring (`Shape::Rect(w, h)`)
- [x] Full test suite: 195 passed, 0 failed, 3 skipped
- [x] Bootstrap triple test passes (binary fixed point preserved)
- [x] Codex review passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enum pattern matching now correctly binds and handles variants with multiple payload fields.
  * Match expressions enforce stricter result-type reconciliation across arms, with sensible integer coercion to avoid false mismatches.

* **Tests**
  * Added tests covering single- and multi-payload enum variants and their pattern matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->