### PR TITLE
test: add regression tests for Vec.truncate() and Vec.clear()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  ESBMC_VERSION: "8.1"
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -15,6 +18,19 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Cache ESBMC
+        id: cache-esbmc
+        uses: actions/cache@v4
+        with:
+          path: ~/esbmc
+          key: esbmc-${{ env.ESBMC_VERSION }}-ubuntu-24.04
+      - name: Install ESBMC
+        if: steps.cache-esbmc.outputs.cache-hit != 'true'
+        run: |
+          curl -sL -o /tmp/esbmc.zip "https://github.com/esbmc/esbmc/releases/download/v$ESBMC_VERSION/release-ubuntu-24.04--b.RelWithDebInfo.-e.OFF.zip"
+          unzip -q /tmp/esbmc.zip -d ~/esbmc
+          rm /tmp/esbmc.zip
+      - run: echo "$HOME/esbmc/bin" >> "$GITHUB_PATH"
       - run: cargo build --all
       - run: cargo llvm-cov --all --lcov --output-path lcov.info
       - run: cargo clippy --all -- -D warnings

--- a/tests/run/vec_clear.vow
+++ b/tests/run/vec_clear.vow
@@ -1,0 +1,33 @@
+// TEST: stdout "init:123clear:len0:push_after:45clear_empty:len0:done"
+module vec_clear
+
+fn main() -> i32 [io] {
+    let v: Vec<i64> = Vec::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+
+    print_str("init:");
+    print_i64(v[0]);
+    print_i64(v[1]);
+    print_i64(v[2]);
+
+    // clear non-empty vec
+    v.clear();
+    print_str("clear:len0:");
+
+    // push after clear
+    v.push(4);
+    v.push(5);
+    print_str("push_after:");
+    print_i64(v[0]);
+    print_i64(v[1]);
+
+    // clear empty vec (no-op)
+    v.clear();
+    v.clear();
+    print_str("clear_empty:len0:");
+
+    print_str("done");
+    0
+}

--- a/tests/run/vec_clear.vow
+++ b/tests/run/vec_clear.vow
@@ -12,21 +12,23 @@ fn main() -> i32 [io] {
     print_i64(v[1]);
     print_i64(v[2]);
 
-    // clear non-empty vec
     v.clear();
-    print_str("clear:len0:");
+    print_str("clear:len");
+    print_i64(v.len());
+    print_str(":");
 
-    // push after clear
     v.push(4);
     v.push(5);
     print_str("push_after:");
     print_i64(v[0]);
     print_i64(v[1]);
 
-    // clear empty vec (no-op)
+    // clear non-empty, then clear already-empty (no-op)
     v.clear();
     v.clear();
-    print_str("clear_empty:len0:");
+    print_str("clear_empty:len");
+    print_i64(v.len());
+    print_str(":");
 
     print_str("done");
     0

--- a/tests/run/vec_truncate.vow
+++ b/tests/run/vec_truncate.vow
@@ -1,4 +1,4 @@
-// TEST: stdout "init:12345trunc3:123trunc3_noop:123trunc5_noop:123trunc0:empty:push_after:67done"
+// TEST: stdout "init:12345trunc3:len3:123trunc3_noop:len3:123trunc5_noop:len3:123trunc0:len0:push_after:67done"
 module vec_truncate
 
 fn main() -> i32 [io] {
@@ -16,32 +16,37 @@ fn main() -> i32 [io] {
     print_i64(v[3]);
     print_i64(v[4]);
 
-    // truncate to smaller size
     v.truncate(3);
-    print_str("trunc3:");
+    print_str("trunc3:len");
+    print_i64(v.len());
+    print_str(":");
     print_i64(v[0]);
     print_i64(v[1]);
     print_i64(v[2]);
 
-    // truncate to same size (no-op)
+    // no-op: same size
     v.truncate(3);
-    print_str("trunc3_noop:");
+    print_str("trunc3_noop:len");
+    print_i64(v.len());
+    print_str(":");
     print_i64(v[0]);
     print_i64(v[1]);
     print_i64(v[2]);
 
-    // truncate to larger size (no-op)
+    // no-op: larger than current size
     v.truncate(5);
-    print_str("trunc5_noop:");
+    print_str("trunc5_noop:len");
+    print_i64(v.len());
+    print_str(":");
     print_i64(v[0]);
     print_i64(v[1]);
     print_i64(v[2]);
 
-    // truncate to 0
     v.truncate(0);
-    print_str("trunc0:empty:");
+    print_str("trunc0:len");
+    print_i64(v.len());
+    print_str(":");
 
-    // push after truncate
     v.push(6);
     v.push(7);
     print_str("push_after:");

--- a/tests/run/vec_truncate.vow
+++ b/tests/run/vec_truncate.vow
@@ -1,0 +1,53 @@
+// TEST: stdout "init:12345trunc3:123trunc3_noop:123trunc5_noop:123trunc0:empty:push_after:67done"
+module vec_truncate
+
+fn main() -> i32 [io] {
+    let v: Vec<i64> = Vec::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+
+    print_str("init:");
+    print_i64(v[0]);
+    print_i64(v[1]);
+    print_i64(v[2]);
+    print_i64(v[3]);
+    print_i64(v[4]);
+
+    // truncate to smaller size
+    v.truncate(3);
+    print_str("trunc3:");
+    print_i64(v[0]);
+    print_i64(v[1]);
+    print_i64(v[2]);
+
+    // truncate to same size (no-op)
+    v.truncate(3);
+    print_str("trunc3_noop:");
+    print_i64(v[0]);
+    print_i64(v[1]);
+    print_i64(v[2]);
+
+    // truncate to larger size (no-op)
+    v.truncate(5);
+    print_str("trunc5_noop:");
+    print_i64(v[0]);
+    print_i64(v[1]);
+    print_i64(v[2]);
+
+    // truncate to 0
+    v.truncate(0);
+    print_str("trunc0:empty:");
+
+    // push after truncate
+    v.push(6);
+    v.push(7);
+    print_str("push_after:");
+    print_i64(v[0]);
+    print_i64(v[1]);
+
+    print_str("done");
+    0
+}

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -242,10 +242,7 @@ impl LowerCtx {
     /// `live_out` contains InstIds that flow out of this scope (e.g. via Upsilon)
     /// and must not be freed.
     pub(super) fn pop_alloc_scope_frees(&mut self, live_out: &[InstId], span: Span) {
-        let scope = self
-            .alloc_scopes
-            .pop()
-            .expect("alloc_scopes underflow");
+        let scope = self.alloc_scopes.pop().expect("alloc_scopes underflow");
         for (id, tag) in &scope {
             if self.escaped_allocs.contains(id) || live_out.contains(id) {
                 continue;
@@ -2365,7 +2362,13 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 ),
                 (_, "truncate") => {
                     let len_id = args.first().map(|e| lower_expr(ctx, e)).unwrap_or_else(|| {
-                        ctx.emit(Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0), span)
+                        ctx.emit(
+                            Opcode::ConstI64,
+                            Ty::I64,
+                            vec![],
+                            InstData::ConstI64(0),
+                            span,
+                        )
                     });
                     ctx.emit(
                         Opcode::Call,

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -2,10 +2,10 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::ffi::{c_char, CStr};
+use std::ffi::{CStr, c_char};
 use std::io::Write as _;
-use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 thread_local! {
     static LAST_STDOUT: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
@@ -424,11 +424,7 @@ pub unsafe extern "C" fn __vow_string_eq(a: *const u8, b: *const u8) -> i64 {
     }
     let sa = unsafe { std::slice::from_raw_parts(va.ptr, va.len) };
     let sb = unsafe { std::slice::from_raw_parts(vb.ptr, vb.len) };
-    if sa == sb {
-        1
-    } else {
-        0
-    }
+    if sa == sb { 1 } else { 0 }
 }
 
 #[unsafe(no_mangle)]
@@ -567,11 +563,7 @@ pub unsafe extern "C" fn __vow_string_starts_with(s: *const u8, prefix: *const u
     let vp = unsafe { &*(prefix as *const VowVec) };
     let ss = unsafe { std::slice::from_raw_parts(vs.ptr, vs.len) };
     let sp = unsafe { std::slice::from_raw_parts(vp.ptr, vp.len) };
-    if ss.starts_with(sp) {
-        1
-    } else {
-        0
-    }
+    if ss.starts_with(sp) { 1 } else { 0 }
 }
 
 #[unsafe(no_mangle)]
@@ -583,11 +575,7 @@ pub unsafe extern "C" fn __vow_string_ends_with(s: *const u8, suffix: *const u8)
     let vp = unsafe { &*(suffix as *const VowVec) };
     let ss = unsafe { std::slice::from_raw_parts(vs.ptr, vs.len) };
     let sp = unsafe { std::slice::from_raw_parts(vp.ptr, vp.len) };
-    if ss.ends_with(sp) {
-        1
-    } else {
-        0
-    }
+    if ss.ends_with(sp) { 1 } else { 0 }
 }
 
 #[unsafe(no_mangle)]

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1483,11 +1483,7 @@ fn run_verify_only_inner(source: &Path, no_cache: bool) -> BuildOutput {
     };
 
     if find_esbmc().is_none() {
-        return verify_outcome_to_output(
-            VerifyOutcome::ToolNotFound,
-            frontend.diagnostics,
-            None,
-        );
+        return verify_outcome_to_output(VerifyOutcome::ToolNotFound, frontend.diagnostics, None);
     }
 
     let verify_cache = if no_cache { None } else { VerifyCache::new() };
@@ -1920,11 +1916,8 @@ fn run_contracts_command(source: &Path, verify: bool, no_cache: bool) {
 
     if verify {
         if find_esbmc().is_none() {
-            let output = verify_outcome_to_output(
-                VerifyOutcome::ToolNotFound,
-                frontend.diagnostics,
-                None,
-            );
+            let output =
+                verify_outcome_to_output(VerifyOutcome::ToolNotFound, frontend.diagnostics, None);
             output.emit_json();
             std::process::exit(1);
         }

--- a/vow/tests/contracts.rs
+++ b/vow/tests/contracts.rs
@@ -94,10 +94,12 @@ fn contracts_where_clause() {
     for c in contracts {
         assert_eq!(c["kind"], "requires");
         assert_eq!(c["blame"], "Caller");
-        assert!(c["description"]
-            .as_str()
-            .unwrap()
-            .contains("where on parameter"));
+        assert!(
+            c["description"]
+                .as_str()
+                .unwrap()
+                .contains("where on parameter")
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds dedicated regression tests for `Vec.truncate(n)` and `Vec.clear()`, which were already fully implemented but lacked test coverage
- `tests/run/vec_truncate.vow` — truncate to smaller, same size (no-op), larger (no-op), zero, and push-after-truncate
- `tests/run/vec_clear.vow` — clear non-empty, clear empty (no-op), push-after-clear

Closes #98

## Test plan
- [x] Both test files compile and produce expected stdout with build/vowc
- [x] Full test suite passes: 196 passed, 0 failed, 3 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for vector `clear()` operation
  * Added test coverage for vector `truncate()` operation, including edge cases

* **Chores**
  * Enhanced CI pipeline with ESBMC binary caching for improved build performance
  * Updated ESBMC to version 8.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->