### PR TITLE
feat: add --mode profile for call-count profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
 name = "vow-runtime"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "serde_json",
  "vow-diag",
 ]

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -411,11 +411,9 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     };
     let mode_str: String = get_flag_arg(argv, String::from("--mode"));
     let mode: i64 = {
-        if mode_str == String::from("debug") {
-            1
-        } else {
-            0
-        }
+        if mode_str == String::from("debug") { 1 }
+        else if mode_str == String::from("profile") { 2 }
+        else { 0 }
     };
     let trace_str: String = get_flag_arg(argv, String::from("--debug-trace"));
     let trace: i64 = {
@@ -646,11 +644,9 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             let out: String = get_flag_arg(argv, String::from("-o"));
             let mode_str: String = get_flag_arg(argv, String::from("--mode"));
             let mode: i64 = {
-                if mode_str == String::from("debug") {
-                    1
-                } else {
-                    0
-                }
+                if mode_str == String::from("debug") { 1 }
+                else if mode_str == String::from("profile") { 2 }
+                else { 0 }
             };
             let trace_str: String = get_flag_arg(argv, String::from("--debug-trace"));
             let trace: i64 = {
@@ -697,7 +693,7 @@ fn skill_json() -> String {
     r.push_str(String::from("  \"legacy_usage\": \"vow [OPTIONS] <source.vow> (equivalent to vow build)\",\n"));
     r.push_str(String::from("  \"build_options\": {\n"));
     r.push_str(String::from("    \"-o, --output <path>\": \"Output executable path (default: source without .vow extension)\",\n"));
-    r.push_str(String::from("    \"--mode <debug|release>\": \"Build mode; debug inserts runtime vow checks (default: release)\",\n"));
+    r.push_str(String::from("    \"--mode <debug|release|profile>\": \"Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit (default: release)\",\n"));
     r.push_str(String::from("    \"--no-verify\": \"Skip ESBMC static verification\",\n"));
     r.push_str(String::from("    \"--dump-ir\": \"Print IR text to stdout and exit (no JSON output, no codegen)\",\n"));
     r.push_str(String::from("    \"--debug-trace <off|calls|full>\": \"Emit JSON trace lines to stderr at runtime (default: off)\",\n"));
@@ -919,7 +915,7 @@ fn skill_human() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("BUILD OPTIONS\n"));
     r.push_str(String::from("  -o, --output <path>     Output executable path (default: source without .vow extension)\n"));
-    r.push_str(String::from("  --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: release)\n"));
+    r.push_str(String::from("  --mode <debug|release|profile>  Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit (default: release)\n"));
     r.push_str(String::from("  --no-verify             Skip ESBMC static verification\n"));
     r.push_str(String::from("  --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)\n"));
     r.push_str(String::from("  --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)\n"));

--- a/docs/skill/cli.md
+++ b/docs/skill/cli.md
@@ -16,8 +16,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | Flag              | Default     | Description                                |
 |-------------------|-------------|--------------------------------------------|
 | `-o, --output`    | `build/<stem>` | Output executable path                  |
-| `--mode debug`    | `release`   | Insert runtime vow checks                 |
-| `--mode release`  | (default)   | Omit all vow checks for performance       |
+| `--mode <debug\|release\|profile>` | `release` | Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit |
 | `--no-verify`     | (off)       | Skip ESBMC static verification            |
 | `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |
 | `--debug-trace <off\|calls\|full>` | `off` | Emit JSON trace lines to stderr at runtime |
@@ -246,6 +245,24 @@ When `--debug-trace=calls` or `--debug-trace=full` is used, the compiled binary 
 {"event":"vow","fn":"divide","vow_id":0,"passed":true}
 {"event":"exit","fn":"divide"}
 ```
+
+## Profile Output (stderr, profile mode)
+
+When `--mode profile` is used, the compiled binary prints a call-count report to stderr on normal exit (via `atexit`). The report is not printed if the program is killed by a signal or calls `abort()`.
+
+```
+--- vow profile report ---
+function                                        calls       %
+-------------------------------------------------------------
+infer                                         4812399   48.2%
+is_def_eq_core                                3201882   32.1%
+whnf                                           984201    9.9%
+main                                                1    0.0%
+-------------------------------------------------------------
+total calls: 9998483, unique functions: 12
+```
+
+The report lists the top 20 most-called functions sorted by call count. No vow checks are emitted in profile mode.
 
 ## Runtime Error JSON (stderr, debug mode only)
 

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -362,6 +362,46 @@ for name in callee_blame clamp hello; do
 done
 echo ""
 
+# ─── Section 5b: Profile Mode ─────────────────────────────────────
+
+echo -e "${BOLD}--- Section 5b: Profile Mode ---${RESET}"
+
+# Build profile_mode.vow with both compilers
+$RUST build --mode profile --no-verify tests/run/profile_mode.vow -o "$TMPDIR/rust_profile_mode" >/dev/null 2>/dev/null
+run_self build --mode profile --no-verify tests/run/profile_mode.vow -o "$TMPDIR/self_profile_mode" >/dev/null 2>/dev/null
+
+# Run and capture stderr (profile report) and stdout (program output)
+rust_prof_out=$("$TMPDIR/rust_profile_mode" 2>"$TMPDIR/rust_prof_err") || true
+self_prof_out=$(run_self_bin "$TMPDIR/self_profile_mode" 2>"$TMPDIR/self_prof_err") || true
+
+errors=()
+# Verify stdout matches expected output
+if [ "$rust_prof_out" != "5" ]; then errors+=("rust stdout='$rust_prof_out', expected '5'"); fi
+if [ "$self_prof_out" != "5" ]; then errors+=("self stdout='$self_prof_out', expected '5'"); fi
+# Verify profile report structure in stderr
+for compiler in rust self; do
+    errfile="$TMPDIR/${compiler}_prof_err"
+    if ! grep -q "vow profile report" "$errfile"; then errors+=("${compiler} stderr missing 'vow profile report'"); fi
+    if ! grep -q "total calls: 5" "$errfile"; then errors+=("${compiler} stderr missing 'total calls: 5'"); fi
+    if ! grep -q "unique functions: 2" "$errfile"; then errors+=("${compiler} stderr missing 'unique functions: 2'"); fi
+    # helper called 4 times (4/5 = 80.0%)
+    if ! grep -qE "helper\s+4\s" "$errfile"; then errors+=("${compiler} stderr: helper not called 4 times"); fi
+    # main called 1 time
+    if ! grep -qE "main\s+1\s" "$errfile"; then errors+=("${compiler} stderr: main not called 1 time"); fi
+    # helper should appear before main (sorted by count descending)
+    helper_line=$(grep -n "helper" "$errfile" | head -1 | cut -d: -f1)
+    main_line=$(grep -n "main" "$errfile" | grep -v "vow_main" | tail -1 | cut -d: -f1)
+    if [ -n "$helper_line" ] && [ -n "$main_line" ] && [ "$helper_line" -gt "$main_line" ]; then
+        errors+=("${compiler} stderr: helper should appear before main (sorted by count)")
+    fi
+done
+if [ ${#errors[@]} -eq 0 ]; then
+    pass "profile_mode/profile"
+else
+    fail "profile_mode/profile" "$(IFS='; '; echo "${errors[*]}")"
+fi
+echo ""
+
 # ─── Section 6: Multi-Module ───────────────────────────────────────
 
 echo -e "${BOLD}--- Section 6: Multi-Module ---${RESET}"

--- a/tests/run/profile_mode.vow
+++ b/tests/run/profile_mode.vow
@@ -1,0 +1,14 @@
+// TEST: stdout "5"
+module ProfileMode
+
+fn helper(x: i64) -> i64 {
+  x + 1
+}
+
+fn main() -> i32 [io] {
+  let a: i64 = helper(1);
+  let b: i64 = helper(a);
+  let c: i64 = helper(b) + helper(0);
+  print_i64(c);
+  0
+}

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -237,7 +237,7 @@ struct ModuleContext {
     string_data_ids: Vec<DataId>,
     func_decls: Vec<FuncDecl>,
     extern_func_ids: HashMap<String, CraneliftFuncId>,
-    mode: i64,       // 0=release, 1=debug
+    mode: i64,       // 0=release, 1=debug, 2=profile
     trace_mode: i64, // 0=off, 1=calls, 2=full
 }
 
@@ -256,7 +256,7 @@ pub extern "C" fn __vow_clif_create(mode: i64, trace_mode: i64) -> i64 {
         eprintln!("clif_shim: error setting is_pic: {e}");
         return 0;
     }
-    if mode == 0
+    if (mode == 0 || mode == 2)
         && let Err(e) = flag_builder.set("opt_level", "speed")
     {
         eprintln!("clif_shim: error setting opt_level: {e}");
@@ -502,7 +502,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         .expect("declare arena_free");
 
     // Debug-only runtime functions
-    let vow_violation_id = if ctx.mode != 0 {
+    let vow_violation_id = if ctx.mode == 1 {
         let mut sig = ctx.obj_module.make_signature();
         sig.params.push(AbiParam::new(types::I32)); // vow_id
         sig.params.push(AbiParam::new(types::I8)); // blame
@@ -519,7 +519,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
     } else {
         None
     };
-    let overflow_id = if ctx.mode != 0 {
+    let overflow_id = if ctx.mode == 1 {
         let sig = ctx.obj_module.make_signature();
         Some(
             ctx.obj_module
@@ -553,7 +553,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
     } else {
         None
     };
-    let trace_vow_id = if ctx.trace_mode >= 2 && ctx.mode != 0 {
+    let trace_vow_id = if ctx.trace_mode >= 2 && ctx.mode == 1 {
         let mut sig = ctx.obj_module.make_signature();
         sig.params.push(AbiParam::new(types::I64));
         sig.params.push(AbiParam::new(types::I64));
@@ -562,6 +562,29 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
             ctx.obj_module
                 .declare_function("__vow_trace_vow", Linkage::Import, &sig)
                 .expect("declare trace_vow"),
+        )
+    } else {
+        None
+    };
+
+    // Profile runtime functions (mode=2)
+    let profile_enter_id = if ctx.mode == 2 {
+        let mut sig = ctx.obj_module.make_signature();
+        sig.params.push(AbiParam::new(types::I64));
+        Some(
+            ctx.obj_module
+                .declare_function("__vow_profile_enter", Linkage::Import, &sig)
+                .expect("declare profile_enter"),
+        )
+    } else {
+        None
+    };
+    let profile_init_id = if ctx.mode == 2 {
+        let sig = ctx.obj_module.make_signature();
+        Some(
+            ctx.obj_module
+                .declare_function("__vow_profile_init", Linkage::Import, &sig)
+                .expect("declare profile_init"),
         )
     } else {
         None
@@ -634,9 +657,13 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         trace_exit_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
     let trace_vow_ref =
         trace_vow_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
+    let profile_enter_ref =
+        profile_enter_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
+    let profile_init_ref =
+        profile_init_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
 
-    // Create function name data section for trace instrumentation
-    let fn_name_gv = if ctx.trace_mode != 0 {
+    // Create function name data section for trace/profile instrumentation
+    let fn_name_gv = if ctx.trace_mode != 0 || ctx.mode == 2 {
         let name = &ctx.func_decls[fi].name;
         let mut name_bytes = name.as_bytes().to_vec();
         name_bytes.push(0);
@@ -663,7 +690,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
     // Create vow description data sections (debug mode only)
     let mut vow_desc_gvs: HashMap<i64, GlobalValue> = HashMap::new();
     // We don't have file info from the self-hosted IR, so skip file/offset vow metadata
-    if ctx.mode != 0 {
+    if ctx.mode == 1 {
         for (vi, &vow_id) in vow_ids.iter().enumerate() {
             let desc_str = unsafe { read_vow_string(vow_desc_ptrs[vi]) };
             let mut bytes = desc_str.as_bytes().to_vec();
@@ -688,7 +715,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         inst_id: i64,
     }
     let mut vow_bindings: HashMap<i64, Vec<VowBindingInfo>> = HashMap::new();
-    if ctx.mode != 0 {
+    if ctx.mode == 1 {
         let mut bind_offset = 0usize;
         for (vi, &vow_id) in vow_ids.iter().enumerate() {
             let bc = binding_counts[vi] as usize;
@@ -787,6 +814,16 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         if let (Some(gv), Some(enter_ref)) = (fn_name_gv, trace_enter_ref) {
             let name_ptr = builder.ins().global_value(types::I64, gv);
             builder.ins().call(enter_ref, &[name_ptr]);
+        }
+        // Emit profile_init in main, profile_enter at all function entries
+        if ctx.func_decls[fi].is_main
+            && let Some(init_ref) = profile_init_ref
+        {
+            builder.ins().call(init_ref, &[]);
+        }
+        if let (Some(gv), Some(prof_ref)) = (fn_name_gv, profile_enter_ref) {
+            let name_ptr = builder.ins().global_value(types::I64, gv);
+            builder.ins().call(prof_ref, &[name_ptr]);
         }
     }
     // Emit blocks
@@ -1262,7 +1299,7 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
 
                 // Vow checks
                 IOP_VOW_REQ | IOP_VOW_ENS | IOP_VOW_INV => {
-                    if ctx.mode != 0 && alen > 0 {
+                    if ctx.mode == 1 && alen > 0 {
                         let pred_id = all_args[aoff];
                         if let Some(&pred) = value_map.get(&pred_id) {
                             let vow_id = if dk == IDATA_VOW_ID { dv } else { 0 };
@@ -2020,6 +2057,10 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
         }
+        "__vow_profile_enter" => {
+            sig.params.push(AbiParam::new(types::I64));
+        }
+        "__vow_profile_init" => {}
         "__vow_clif_create" => {
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -148,7 +148,7 @@ fn make_isa(mode: BuildMode) -> Result<Arc<dyn TargetIsa>, CodegenError> {
     flag_builder
         .set("is_pic", "true")
         .map_err(|e| CodegenError::IsaBuild(e.to_string()))?;
-    if mode == BuildMode::Release {
+    if mode == BuildMode::Release || mode == BuildMode::Profile {
         flag_builder
             .set("opt_level", "speed")
             .map_err(|e| CodegenError::IsaBuild(e.to_string()))?;
@@ -1058,6 +1058,8 @@ struct RuntimeIds {
     trace_enter_id: Option<CraneliftFuncId>,
     trace_exit_id: Option<CraneliftFuncId>,
     trace_vow_id: Option<CraneliftFuncId>,
+    profile_enter_id: Option<CraneliftFuncId>,
+    profile_init_id: Option<CraneliftFuncId>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1199,7 +1201,14 @@ fn compile_ir_function(
     let trace_vow_ref = runtime
         .trace_vow_id
         .map(|id| obj_module.declare_func_in_func(id, builder.func));
-    let fn_name_gv = if trace != TraceMode::Off {
+    let profile_enter_ref = runtime
+        .profile_enter_id
+        .map(|id| obj_module.declare_func_in_func(id, builder.func));
+    let profile_init_ref = runtime
+        .profile_init_id
+        .map(|id| obj_module.declare_func_in_func(id, builder.func));
+    let needs_fn_name = trace != TraceMode::Off || mode == BuildMode::Profile;
+    let fn_name_gv = if needs_fn_name {
         let mut name_bytes = ir_func.name.as_bytes().to_vec();
         name_bytes.push(0);
         let mut desc = DataDescription::new();
@@ -1233,6 +1242,15 @@ fn compile_ir_function(
         {
             let name_ptr = builder.ins().global_value(types::I64, gv);
             builder.ins().call(enter_ref, &[name_ptr]);
+        }
+        if ir_func.name == "main"
+            && let Some(init_ref) = profile_init_ref
+        {
+            builder.ins().call(init_ref, &[]);
+        }
+        if let (Some(prof_ref), Some(gv)) = (profile_enter_ref, fn_name_gv) {
+            let name_ptr = builder.ins().global_value(types::I64, gv);
+            builder.ins().call(prof_ref, &[name_ptr]);
         }
     }
 
@@ -1619,6 +1637,11 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // vow_id
             sig.params.push(AbiParam::new(types::I64)); // passed (0 or 1)
         }
+        // Profile instrumentation
+        "__vow_profile_enter" => {
+            sig.params.push(AbiParam::new(types::I64)); // fn_name C-string ptr
+        }
+        "__vow_profile_init" => {}
         _ => {}
     }
     sig
@@ -1762,6 +1785,21 @@ impl Backend for CraneliftBackend {
             (None, None, None)
         };
 
+        // Declare profile runtime functions
+        let (profile_enter_id, profile_init_id) = if mode == BuildMode::Profile {
+            let enter_sig = make_extern_sig("__vow_profile_enter", &obj_module);
+            let enter_id = obj_module
+                .declare_function("__vow_profile_enter", Linkage::Import, &enter_sig)
+                .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
+            let init_sig = make_extern_sig("__vow_profile_init", &obj_module);
+            let init_id = obj_module
+                .declare_function("__vow_profile_init", Linkage::Import, &init_sig)
+                .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
+            (Some(enter_id), Some(init_id))
+        } else {
+            (None, None)
+        };
+
         // Compile each function
         let mut builder_ctx = FunctionBuilderContext::new();
         for (ir_func, &(_, cl_id)) in module.functions.iter().zip(ir_to_cl.iter()) {
@@ -1785,6 +1823,8 @@ impl Backend for CraneliftBackend {
                     trace_enter_id,
                     trace_exit_id,
                     trace_vow_id,
+                    profile_enter_id,
+                    profile_init_id,
                 },
                 &string_data_ids,
                 &extern_func_ids,

--- a/vow-codegen/src/lib.rs
+++ b/vow-codegen/src/lib.rs
@@ -7,6 +7,7 @@ use vow_ir::Module;
 pub enum BuildMode {
     Debug,
     Release,
+    Profile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/vow-runtime/Cargo.toml
+++ b/vow-runtime/Cargo.toml
@@ -9,3 +9,4 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 vow-diag = { path = "../vow-diag" }
 serde_json = "1"
+libc = "0.2"

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -212,14 +212,17 @@ pub extern "C" fn __vow_profile_init() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
         extern "C" fn report() {
-            let guard = PROFILE_COUNTERS.lock().unwrap();
+            let guard = PROFILE_COUNTERS.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(counters) = guard.as_ref() {
                 if counters.is_empty() {
                     return;
                 }
-                let mut entries: Vec<(&&str, &u64)> = counters.iter().collect();
-                entries.sort_by(|a, b| b.1.cmp(a.1));
-                let total: u64 = entries.iter().map(|(_, c)| **c).sum();
+                let mut entries: Vec<_> = counters
+                    .iter()
+                    .map(|(name, count)| (*name, *count))
+                    .collect();
+                entries.sort_by_key(|k| std::cmp::Reverse(k.1));
+                let total: u64 = entries.iter().map(|item| item.1).sum();
                 let _ = writeln!(std::io::stderr(), "\n--- vow profile report ---");
                 let _ = writeln!(
                     std::io::stderr(),
@@ -230,7 +233,7 @@ pub extern "C" fn __vow_profile_init() {
                 );
                 let _ = writeln!(std::io::stderr(), "{}", "-".repeat(61));
                 let limit = entries.len().min(20);
-                for &(name, count) in &entries[..limit] {
+                for (name, count) in &entries[..limit] {
                     let pct = (*count as f64 / total as f64) * 100.0;
                     let _ = writeln!(
                         std::io::stderr(),

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -179,6 +179,88 @@ pub unsafe extern "C" fn __vow_trace_vow(fn_name_ptr: *const i8, vow_id: i64, pa
     );
 }
 
+// ---------------------------------------------------------------------------
+// Profile instrumentation
+// ---------------------------------------------------------------------------
+
+static PROFILE_COUNTERS: Mutex<Option<HashMap<&'static str, u64>>> = Mutex::new(None);
+
+fn profile_counters_init<'a>(
+    map: &'a mut Option<HashMap<&'static str, u64>>,
+) -> &'a mut HashMap<&'static str, u64> {
+    map.get_or_insert_with(HashMap::new)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_profile_enter(fn_name_ptr: *const i8) {
+    if fn_name_ptr.is_null() {
+        return;
+    }
+    // SAFETY: fn_name_ptr is a static C-string literal embedded in the binary.
+    // It lives for the duration of the program, so we can treat it as 'static.
+    let name: &'static str = unsafe { CStr::from_ptr(fn_name_ptr) }
+        .to_str()
+        .unwrap_or("?");
+    let mut guard = PROFILE_COUNTERS.lock().unwrap();
+    let counters = profile_counters_init(&mut guard);
+    *counters.entry(name).or_insert(0) += 1;
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __vow_profile_init() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        extern "C" fn report() {
+            let guard = PROFILE_COUNTERS.lock().unwrap();
+            if let Some(counters) = guard.as_ref() {
+                if counters.is_empty() {
+                    return;
+                }
+                let mut entries: Vec<(&&str, &u64)> = counters.iter().collect();
+                entries.sort_by(|a, b| b.1.cmp(a.1));
+                let total: u64 = entries.iter().map(|(_, c)| **c).sum();
+                let _ = writeln!(std::io::stderr(), "\n--- vow profile report ---");
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "{:<40} {:>12} {:>7}",
+                    "function",
+                    "calls",
+                    "%"
+                );
+                let _ = writeln!(std::io::stderr(), "{}", "-".repeat(61));
+                let limit = entries.len().min(20);
+                for &(name, count) in &entries[..limit] {
+                    let pct = (*count as f64 / total as f64) * 100.0;
+                    let _ = writeln!(
+                        std::io::stderr(),
+                        "{:<40} {:>12} {:>6.1}%",
+                        name,
+                        count,
+                        pct
+                    );
+                }
+                if entries.len() > limit {
+                    let _ = writeln!(
+                        std::io::stderr(),
+                        "  ... and {} more functions",
+                        entries.len() - limit
+                    );
+                }
+                let _ = writeln!(std::io::stderr(), "{}", "-".repeat(61));
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "total calls: {total}, unique functions: {}",
+                    entries.len()
+                );
+            }
+        }
+        unsafe {
+            libc::atexit(report);
+        }
+    });
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __vow_arena_alloc(size: usize, align: usize) -> *mut u8 {
     if size == 0 {

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -28,6 +28,7 @@ use cache::{CachedVerifyResult, VerifyCache};
 enum ModeArg {
     Debug,
     Release,
+    Profile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -172,7 +173,7 @@ fn skill_json() -> String {
   "legacy_usage": "vow [OPTIONS] <source.vow> (equivalent to vow build)",
   "build_options": {
     "-o, --output <path>": "Output executable path (default: source without .vow extension)",
-    "--mode <debug|release>": "Build mode; debug inserts runtime vow checks (default: release)",
+    "--mode <debug|release|profile>": "Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit (default: release)",
     "--no-verify": "Skip ESBMC static verification",
     "--dump-ir": "Print IR text to stdout and exit (no JSON output, no codegen)",
     "--debug-trace <off|calls|full>": "Emit JSON trace lines to stderr at runtime (default: off)",
@@ -394,7 +395,7 @@ USAGE
 
 BUILD OPTIONS
   -o, --output <path>     Output executable path (default: source without .vow extension)
-  --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: release)
+  --mode <debug|release|profile>  Build mode: debug inserts runtime vow checks, profile inserts call counters and prints report on normal exit (default: release)
   --no-verify             Skip ESBMC static verification
   --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)
   --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)
@@ -1962,6 +1963,7 @@ fn main() {
             let mode = match b.mode {
                 ModeArg::Debug => BuildMode::Debug,
                 ModeArg::Release => BuildMode::Release,
+                ModeArg::Profile => BuildMode::Profile,
             };
             let trace = match b.debug_trace {
                 TraceArg::Off => TraceMode::Off,
@@ -2065,6 +2067,7 @@ fn main() {
             let mode = match args.mode {
                 ModeArg::Debug => BuildMode::Debug,
                 ModeArg::Release => BuildMode::Release,
+                ModeArg::Profile => BuildMode::Profile,
             };
             let trace = match args.debug_trace {
                 TraceArg::Off => TraceMode::Off,


### PR DESCRIPTION
## Summary

- Adds `--mode profile` build mode that instruments every function entry with a call counter and prints a sorted top-20 report to stderr on normal exit
- Implemented in both the Rust compiler and self-hosted compiler (mode=2)
- Runtime uses `atexit` (guarded by `std::sync::Once`) with a global `Mutex<HashMap>` for thread-safe counter tracking

Closes #99

## Changes

- `vow-codegen/src/lib.rs`: Add `BuildMode::Profile`
- `vow-codegen/src/cranelift_backend.rs`: Declare and emit `__vow_profile_enter`/`__vow_profile_init` calls
- `vow-clif-shim/src/lib.rs`: Handle mode=2 (profile) in FFI shim
- `vow-runtime/src/lib.rs`: Implement profiling runtime functions with atexit report
- `vow/src/main.rs`: Add `ModeArg::Profile` and update help text
- `compiler/main.vow`: Parse `--mode profile` in self-hosted compiler
- `docs/skill/cli.md`: Document profile output format and atexit limitation
- `tests/run/profile_mode.vow` + `scripts/full_test.sh`: Regression test asserting exact call counts

## Test plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all -- -D warnings` clean
- [x] Bootstrap triple test passes (SHA-256 fixed point)
- [x] `scripts/full_test.sh`: 193 passed, 0 failed, 3 skipped
- [x] Profile mode tested with both Rust and self-hosted compilers
- [x] Codex review findings addressed (Once guard, tightened test, unified help, docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--mode profile` option to compiler build command for function call profiling
  * Profile mode generates a call-count report to stderr on normal exit, listing top functions by invocation count

* **Documentation**
  * Updated CLI documentation to include profile mode option and its behavior

* **Tests**
  * Added test coverage for profile mode functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->