### PR TITLE
Enable position-independent code generation in Cranelift backend

### DIFF
--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -249,6 +249,7 @@ struct ModuleContext {
 pub extern "C" fn __vow_clif_create(mode: i64, trace_mode: i64) -> i64 {
     let mut flag_builder = settings::builder();
     let _ = flag_builder.set("use_colocated_libcalls", "false");
+    let _ = flag_builder.set("is_pic", "true");
     if mode == 0 {
         let _ = flag_builder.set("opt_level", "speed");
     }

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -248,10 +248,19 @@ struct ModuleContext {
 #[unsafe(no_mangle)]
 pub extern "C" fn __vow_clif_create(mode: i64, trace_mode: i64) -> i64 {
     let mut flag_builder = settings::builder();
-    let _ = flag_builder.set("use_colocated_libcalls", "false");
-    let _ = flag_builder.set("is_pic", "true");
-    if mode == 0 {
-        let _ = flag_builder.set("opt_level", "speed");
+    if let Err(e) = flag_builder.set("use_colocated_libcalls", "false") {
+        eprintln!("clif_shim: error setting use_colocated_libcalls: {e}");
+        return 0;
+    }
+    if let Err(e) = flag_builder.set("is_pic", "true") {
+        eprintln!("clif_shim: error setting is_pic: {e}");
+        return 0;
+    }
+    if mode == 0
+        && let Err(e) = flag_builder.set("opt_level", "speed")
+    {
+        eprintln!("clif_shim: error setting opt_level: {e}");
+        return 0;
     }
     let flags = settings::Flags::new(flag_builder);
     let isa = match cranelift_native::builder() {

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -145,6 +145,9 @@ fn make_isa(mode: BuildMode) -> Result<Arc<dyn TargetIsa>, CodegenError> {
     flag_builder
         .set("use_colocated_libcalls", "false")
         .map_err(|e| CodegenError::IsaBuild(e.to_string()))?;
+    flag_builder
+        .set("is_pic", "true")
+        .map_err(|e| CodegenError::IsaBuild(e.to_string()))?;
     if mode == BuildMode::Release {
         flag_builder
             .set("opt_level", "speed")


### PR DESCRIPTION
## Summary
Enable position-independent code (PIC) generation in both the Cranelift backend and the C FFI shim by setting the `is_pic` flag to `true` in the ISA configuration.

## Changes
- **vow-codegen/src/cranelift_backend.rs**: Added `is_pic` flag configuration in `make_isa()` function to enable PIC mode during ISA setup
- **vow-clif-shim/src/lib.rs**: Added `is_pic` flag configuration in `__vow_clif_create()` function to enable PIC mode in the C FFI interface

## Details
Both changes follow the same pattern as the existing `use_colocated_libcalls` flag configuration. The `is_pic` flag is set to `"true"` to generate position-independent code, which is necessary for creating shared libraries and improving security through address space layout randomization (ASLR) compatibility.

https://claude.ai/code/session_01Rc2m1RNNHDCCfx6XuwQoAb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for compiler configuration settings with error reporting.

* **Improvements**
  * Compiler now generates position-independent code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->