### PR TITLE
docs: document struct passing semantics

### DIFF
--- a/docs/skill/grammar.md
+++ b/docs/skill/grammar.md
@@ -405,6 +405,31 @@ let p: Point = Point { x: 1, y: 2 };
 p.x
 ```
 
+### Field Assignment
+
+```vow
+p.x = 10;
+```
+
+### Passing Semantics
+
+Structs are heap-allocated. A struct value is a pointer to a heap region, so passing a struct to a function passes the pointer — the function operates on the same heap data, not a copy. Field assignments inside the called function are visible to the caller:
+
+```vow
+fn shift_right(p: Point, dx: i64) {
+    p.x = p.x + dx;
+}
+
+fn main() -> i32 [io] {
+    let p: Point = Point { x: 0, y: 0 };
+    shift_right(p, 5);
+    print_i64(p.x);  // 5 — mutation visible to caller
+    0
+}
+```
+
+This enables in-place mutation patterns (e.g., make/unmake in search trees) without cloning. The same aliasing semantics apply when structs are stored in containers — see [Indexing](#indexing).
+
 ## Enum Definitions
 
 ```vow

--- a/docs/skill/grammar.md
+++ b/docs/skill/grammar.md
@@ -428,7 +428,9 @@ fn main() -> i32 [io] {
 }
 ```
 
-This enables in-place mutation patterns (e.g., make/unmake in search trees) without cloning. The same aliasing semantics apply when structs are stored in containers — see [Indexing](#indexing).
+This enables in-place mutation patterns (e.g., make/unmake in search trees) without cloning. The same aliasing semantics apply when structs are stored in containers — see [Indexing](#indexing). To avoid aliasing, construct a fresh struct literal with the desired field values.
+
+**Note:** For `linear struct` types, passing the value to a function consumes it — the caller cannot access it afterward. To observe mutations to a linear struct, return the updated value from the function.
 
 ## Enum Definitions
 


### PR DESCRIPTION
## Summary
- Add **Field Assignment** subsection documenting `p.x = 10;` syntax (was missing)
- Add **Passing Semantics** subsection explaining that structs are heap-allocated pointers — mutations in called functions are visible to callers
- Includes a verified code example and cross-reference to existing aliasing docs

Closes #128 — the reported issue (mutable references for in-place mutation) is already supported by Vow's existing semantics; this PR documents them explicitly.

## Test plan
- [x] Documentation example verified: compiles and outputs `5` as expected
- [x] `cargo test --all` passes (14 pre-existing link-time failures in worktree, unrelated)
- [x] `generate_help.py` and staleness check confirm no drift