### PR TITLE
feat: extend investigate skill to support PR review workflow

### DIFF
--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -21,13 +21,32 @@ the skill detects whether it refers to an issue or a PR and follows the appropri
 
 ## Detection
 
-Run `gh pr view $ARGUMENTS --json number 2>/dev/null` to check if the number is a PR.
-- If it succeeds → follow the **PR Workflow** below.
-- If it fails → follow the **Issue Workflow** below.
+Determine whether the argument refers to a PR or an issue:
+
+```bash
+NUM="$ARGUMENTS"
+if gh pr view "$NUM" --json number >/dev/null 2>&1; then
+  # → follow the PR Workflow below
+elif gh issue view "$NUM" --json number >/dev/null 2>&1; then
+  # → follow the Issue Workflow below
+else
+  echo "Error: #$NUM is neither a PR nor an issue in this repo" >&2
+  exit 1
+fi
+```
+
+- If `gh pr view` succeeds → follow the **PR Workflow** below.
+- If `gh pr view` fails but `gh issue view` succeeds → follow the **Issue Workflow** below.
+- If both fail → stop and report the error (do not silently fall through).
 
 ---
 
 # PR Workflow
+
+Set the PR number from the argument at the start:
+```bash
+PR="$ARGUMENTS"
+```
 
 End-to-end review workflow for an open pull request. Checks CI, triages review comments,
 runs independent code reviews, and posts a consolidated Investigation Report.
@@ -36,7 +55,7 @@ runs independent code reviews, and posts a consolidated Investigation Report.
 
 Fetch PR details with:
 ```bash
-gh pr view $ARGUMENTS --json title,body,headRefName,baseRefName,state,labels,reviewRequests,reviews,statusCheckRollup,files
+gh pr view "$PR" --json title,body,headRefName,baseRefName,state,labels,reviewRequests,reviews,statusCheckRollup,files
 ```
 
 Extract:
@@ -48,7 +67,7 @@ Extract:
 
 Check out the PR branch locally:
 ```bash
-gh pr checkout $ARGUMENTS
+gh pr checkout "$PR"
 ```
 
 ## PR Phase 2 — Check CI
@@ -57,7 +76,7 @@ Examine the CI status from the PR data fetched in Phase 1.
 
 If checks are still running, poll with:
 ```bash
-gh pr checks $ARGUMENTS --watch
+gh pr checks "$PR" --watch
 ```
 
 - If CI **passes**: note this and proceed.
@@ -65,12 +84,17 @@ gh pr checks $ARGUMENTS --watch
   identify the failure, and include it prominently in the Investigation Report.
   Still proceed with the remaining phases — CI failure does not short-circuit the review.
 
+  **Finding the run ID:** In the `statusCheckRollup` array from Phase 1, find entries with
+  `conclusion: "FAILURE"`. The `detailsUrl` contains the run ID — e.g.,
+  `https://github.com/.../actions/runs/12345/job/...` → run ID is `12345`.
+  Alternatively: `gh run list --branch <headRefName> --status failure --limit 5 --json databaseId,name,conclusion`.
+
 ## PR Phase 3 — Triage Review Comments
 
-Fetch all review comments:
+Fetch all review comments (repo-relative paths — `gh api` infers the current repo):
 ```bash
-gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments --paginate
-gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/reviews --paginate
+gh api "pulls/$PR/comments" --paginate
+gh api "pulls/$PR/reviews" --paginate
 ```
 
 For each review comment:
@@ -81,6 +105,11 @@ For each review comment:
 3. **Ambiguous** (subjective suggestion, debatable design choice, unclear scope) →
    run `/codex-2nd-opinion` with the comment text and surrounding code context to get
    an independent judgment. Use the Codex verdict to classify as actionable or skip.
+
+**Getting code context for comments:** Each review comment from the API includes `path`
+(file), `line`/`original_line` (position), `start_line` (for multi-line comments), and
+`diff_hunk` (the surrounding diff context). Use `path` and line numbers to read the
+relevant source with the Read tool, and include `diff_hunk` as additional context.
 
 Produce a summary table of all comments with their classification and rationale.
 
@@ -112,7 +141,7 @@ Merge all findings from Phases 2–5 into a single consolidated comment on the P
 
 Post the comment with:
 ```bash
-gh pr comment $ARGUMENTS --body "<report>"
+gh pr comment "$PR" --body "<report>"
 ```
 
 The comment must follow this structure:
@@ -152,6 +181,11 @@ Do **not** start fixing anything automatically — wait for the user's decision.
 
 # Issue Workflow
 
+Set the issue number from the argument at the start:
+```bash
+ISSUE="$ARGUMENTS"
+```
+
 End-to-end workflow for reproducing, fixing, testing, and closing a Vow compiler bug
 reported as a GitHub issue. This workflow modifies **both** the Rust compiler and the
 self-hosted compiler, as required by the dual-compiler rule in CLAUDE.md.
@@ -160,7 +194,7 @@ self-hosted compiler, as required by the dual-compiler rule in CLAUDE.md.
 
 ### Phase 1 — Understand the Issue
 
-Fetch the issue with `gh issue view $ARGUMENTS --json title,body,labels,comments`.
+Fetch the issue with `gh issue view "$ISSUE" --json title,body,labels,comments`.
 
 Extract:
 - Reported bug behavior and symptoms
@@ -277,7 +311,7 @@ ulimit -v 2000000; scripts/full_test.sh
 ### Phase 8 — Commit and Push
 
 1. Stage all changed files (Rust sources, `compiler/*.vow`, and the new test file).
-2. Create a single commit with message format: `fix: <concise description> (#$ARGUMENTS)`
+2. Create a single commit with message format: `fix: <concise description> (#$ISSUE)`
    - Follow the existing commit style (see `git log --oneline`).
    - Never mention Claude or AI in the commit message.
 3. Push to the current branch.
@@ -287,7 +321,7 @@ ulimit -v 2000000; scripts/full_test.sh
 Post a comment on the issue using:
 
 ```bash
-gh issue comment $ARGUMENTS --body "<summary>"
+gh issue comment "$ISSUE" --body "<summary>"
 ```
 
 The comment must include:
@@ -300,7 +334,7 @@ The comment must include:
 After confirming the fix is pushed and the comment is posted, close the issue:
 
 ```bash
-gh issue close $ARGUMENTS
+gh issue close "$ISSUE"
 ```
 
 If the fix is partial or needs further review, skip this step and inform the user.

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -5,14 +5,152 @@ description: >-
   "investigate #<number>", "fix issue #<number>", "fix bug #<number>",
   "debug issue", "look into issue #<number>", "triage issue",
   "reproduce and fix GitHub issue", "close issue #<number>",
-  or invokes /investigate <number>. Runs the full end-to-end bug
-  investigation workflow: reproduce, fix both Rust and self-hosted
-  compilers, test, commit, push, and comment on the GitHub issue.
-args: issue_number
+  "investigate PR #<number>", "review PR #<number>", "check PR #<number>",
+  or invokes /investigate <number>. For issues: runs the full end-to-end bug
+  investigation workflow (reproduce, fix, test, commit, close). For PRs:
+  checks CI, triages review comments, runs code reviews, and posts an
+  Investigation Report.
+args: number
 user_invocable: true
 ---
 
-# Investigate GitHub Issue
+# Investigate GitHub Issue or Pull Request
+
+This skill handles both GitHub issues and pull requests. The argument is a number —
+the skill detects whether it refers to an issue or a PR and follows the appropriate workflow.
+
+## Detection
+
+Run `gh pr view $ARGUMENTS --json number 2>/dev/null` to check if the number is a PR.
+- If it succeeds → follow the **PR Workflow** below.
+- If it fails → follow the **Issue Workflow** below.
+
+---
+
+# PR Workflow
+
+End-to-end review workflow for an open pull request. Checks CI, triages review comments,
+runs independent code reviews, and posts a consolidated Investigation Report.
+
+## PR Phase 1 — Fetch the PR
+
+Fetch PR details with:
+```bash
+gh pr view $ARGUMENTS --json title,body,headRefName,baseRefName,state,labels,reviewRequests,reviews,statusCheckRollup,files
+```
+
+Extract:
+- PR title and description
+- Source and target branches
+- Changed files list
+- Current CI status
+- Existing reviews and their verdicts
+
+Check out the PR branch locally:
+```bash
+gh pr checkout $ARGUMENTS
+```
+
+## PR Phase 2 — Check CI
+
+Examine the CI status from the PR data fetched in Phase 1.
+
+If checks are still running, poll with:
+```bash
+gh pr checks $ARGUMENTS --watch
+```
+
+- If CI **passes**: note this and proceed.
+- If CI **fails**: fetch the failing check logs with `gh run view <run-id> --log-failed`,
+  identify the failure, and include it prominently in the Investigation Report.
+  Still proceed with the remaining phases — CI failure does not short-circuit the review.
+
+## PR Phase 3 — Triage Review Comments
+
+Fetch all review comments:
+```bash
+gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments --paginate
+gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/reviews --paginate
+```
+
+For each review comment:
+1. **Clearly actionable** (bug report, correctness issue, missing test, style violation
+   with project rule citation) → mark as **actionable**.
+2. **Clearly non-actionable** (praise, acknowledgement, "nit" with no substance,
+   already-addressed feedback) → mark as **skip**.
+3. **Ambiguous** (subjective suggestion, debatable design choice, unclear scope) →
+   run `/codex-2nd-opinion` with the comment text and surrounding code context to get
+   an independent judgment. Use the Codex verdict to classify as actionable or skip.
+
+Produce a summary table of all comments with their classification and rationale.
+
+## PR Phase 4 — Code Review
+
+Run the code-review skill on the PR's changes:
+
+```
+/code-review:code-review
+```
+
+This reviews the diff against project guidelines (CLAUDE.md) and coding standards.
+Capture the full output for inclusion in the Investigation Report.
+
+## PR Phase 5 — Codex Review
+
+Run the Codex review skill scoped to the PR branch:
+
+```
+/codex:review --background --scope branch
+```
+
+This provides an independent review from Codex. Capture the full output for inclusion
+in the Investigation Report.
+
+## PR Phase 6 — Investigation Report
+
+Merge all findings from Phases 2–5 into a single consolidated comment on the PR.
+
+Post the comment with:
+```bash
+gh pr comment $ARGUMENTS --body "<report>"
+```
+
+The comment must follow this structure:
+
+```markdown
+## Investigation Report
+
+### CI Status
+<pass/fail summary; if failed, include the failure reason and affected check>
+
+### Review Comment Triage
+<table of existing review comments: comment excerpt | classification | rationale>
+<count of actionable vs skipped comments>
+
+### Code Review Findings
+<summary of findings from /code-review:code-review>
+
+### Codex Review Findings
+<summary of findings from /codex:review>
+
+### Consolidated Action Items
+<numbered list of all actionable items from all sources, deduplicated>
+```
+
+## PR Phase 7 — Plan Mode Prompt
+
+After posting the Investigation Report, present the consolidated action items to the user
+and ask:
+
+> "Investigation Report posted. There are N action items. Would you like to enter plan mode
+> to address them?"
+
+If the user agrees, enter plan mode with the action items as the starting context.
+Do **not** start fixing anything automatically — wait for the user's decision.
+
+---
+
+# Issue Workflow
 
 End-to-end workflow for reproducing, fixing, testing, and closing a Vow compiler bug
 reported as a GitHub issue. This workflow modifies **both** the Rust compiler and the


### PR DESCRIPTION
## Summary
- Extends the `/investigate` skill to handle both GitHub issues and pull requests
- Adds automatic detection (tries `gh pr view` first) to route to the correct workflow
- PR workflow: 7 phases — check CI, triage review comments (with `/codex-2nd-opinion` for ambiguous ones), run `/code-review:code-review`, run `/codex:review --background --scope branch`, post consolidated Investigation Report as PR comment, prompt user for plan mode
- Issue workflow preserved unchanged under its own heading

## Test plan
- [ ] Run `/investigate <issue-number>` and verify the issue workflow still triggers
- [ ] Run `/investigate <pr-number>` and verify the PR workflow triggers
- [ ] Verify PR detection logic correctly distinguishes issues from PRs
- [ ] Verify Investigation Report comment structure matches the template