### PR TITLE
feat: add debug_str/debug_i64/debug_u64 intrinsics for pure functions

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -166,7 +166,8 @@ fn is_modelable(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>, modelabl
                    || op == IOP_XOR_U64() || op == IOP_CONST_U64() || op == IOP_CAST_I64_TO_U64() || op == IOP_CAST_U64_TO_I64()
                    || op == IOP_VOW_REQ() || op == IOP_VOW_ENS() || op == IOP_VOW_INV()
                    || op == IOP_BRANCH() || op == IOP_JUMP() || op == IOP_RETURN() || op == IOP_UNREACHABLE()
-                   || op == IOP_PHI() || op == IOP_UPSILON() {
+                   || op == IOP_PHI() || op == IOP_UPSILON()
+                   || op == IOP_DEBUG_CALL() {
                     true
                 } else if op == IOP_CALL() {
                     if inst.dk == IDATA_CALL_EXTERN() {
@@ -680,6 +681,7 @@ fn emit_inst(out: String, inst: IrInst, vec_vars: Vec<i64>, string_vars: Vec<i64
 
     if op == IOP_PHI() { return; }
     if op == IOP_UPSILON() { return; }
+    if op == IOP_DEBUG_CALL() { return; }
 
     if op == IOP_CALL() {
         if inst.dk == IDATA_CALL_EXTERN() {

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -9,8 +9,9 @@ fn str2(a: String, b: String) -> String {
     r
 }
 
-fn collect_extern_syms(m: IrModule) -> Vec<String> {
+fn collect_extern_syms(m: IrModule, mode: i64) -> Vec<String> {
     let result: Vec<String> = Vec::new();
+    let has_debug: bool = mode == 1 || mode == 3;
     let fns: Vec<IrFunction> = m.functions;
     let mut fi: i64 = 0;
     while fi < fns.len() {
@@ -23,7 +24,8 @@ fn collect_extern_syms(m: IrModule) -> Vec<String> {
             let mut ii: i64 = 0;
             while ii < insts.len() {
                 let inst: IrInst = insts[ii];
-                if inst.dk == IDATA_CALL_EXTERN() {
+                let skip: bool = inst.op == IOP_DEBUG_CALL() && !has_debug;
+                if inst.dk == IDATA_CALL_EXTERN() && !skip {
                     let sym: String = inst.ds;
                     if !vec_contains_str(result, sym) {
                         result.push(sym);
@@ -148,7 +150,7 @@ fn clif_emit_module(m: IrModule, output_path: String, mode: i64, trace: i64) -> 
         si = si + 1;
     }
 
-    let extern_syms: Vec<String> = collect_extern_syms(m);
+    let extern_syms: Vec<String> = collect_extern_syms(m, mode);
     let mut ei: i64 = 0;
     while ei < extern_syms.len() {
         __vow_clif_declare_extern(ctx, extern_syms[ei]);

--- a/compiler/env.vow
+++ b/compiler/env.vow
@@ -170,6 +170,9 @@ fn env_new(dctx: DiagCtx, file: String) -> CheckEnv {
     env_define_fn(e, String::from("print_i64"), vec_of_1(i64_tid), unit_tid, eff_io);
     env_define_fn(e, String::from("print_u64"), vec_of_1(u64_tid), unit_tid, eff_io);
     env_define_fn(e, String::from("eprintln_str"), vec_of_1(str_tid), unit_tid, eff_io);
+    env_define_fn(e, String::from("debug_str"), vec_of_1(str_tid), unit_tid, 0);
+    env_define_fn(e, String::from("debug_i64"), vec_of_1(i64_tid), unit_tid, 0);
+    env_define_fn(e, String::from("debug_u64"), vec_of_1(u64_tid), unit_tid, 0);
     env_define_fn(e, String::from("fs_read"), vec_of_1(str_tid), str_tid, eff_read);
     let fs_write_p: Vec<i64> = Vec::new();
     fs_write_p.push(str_tid);

--- a/compiler/ir.vow
+++ b/compiler/ir.vow
@@ -121,6 +121,7 @@ fn IOP_XOR_U64() -> i64 vow { ensures: result >= 0 } { 101 }
 fn IOP_CONST_U64() -> i64 vow { ensures: result >= 0 } { 102 }
 fn IOP_CAST_I64_TO_U64() -> i64 vow { ensures: result >= 0 } { 103 }
 fn IOP_CAST_U64_TO_I64() -> i64 vow { ensures: result >= 0 } { 104 }
+fn IOP_DEBUG_CALL() -> i64 vow { ensures: result >= 0 } { 105 }
 
 fn iop_is_terminal(op: i64) -> bool vow {
     requires: op >= 0

--- a/compiler/ir_printer.vow
+++ b/compiler/ir_printer.vow
@@ -187,6 +187,7 @@ fn opcode_name(op: i64) -> String {
     if op == IOP_CONST_U64() { return String::from("ConstU64"); }
     if op == IOP_CAST_I64_TO_U64() { return String::from("CastI64ToU64"); }
     if op == IOP_CAST_U64_TO_I64() { return String::from("CastU64ToI64"); }
+    if op == IOP_DEBUG_CALL() { return String::from("DebugCall"); }
     String::from("???")
 }
 

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -653,6 +653,13 @@ fn binop_result_ty(op: i64, operand_ty: i64) -> i64 vow {
     ITY_I64()
 }
 
+fn debug_builtin_to_extern(name: String) -> String {
+    if name == String::from("debug_str") { return String::from("__vow_debug_str"); }
+    if name == String::from("debug_i64") { return String::from("__vow_debug_i64"); }
+    if name == String::from("debug_u64") { return String::from("__vow_debug_u64"); }
+    String::from("")
+}
+
 fn builtin_to_extern(name: String) -> String {
     if name == String::from("print_str") { return String::from("__vow_string_print"); }
     if name == String::from("print_i64") { return String::from("__vow_print_i64"); }
@@ -698,6 +705,13 @@ fn builtin_to_extern(name: String) -> String {
     if name == String::from("process_stdout_for") { return String::from("__vow_process_stdout_for"); }
     if name == String::from("process_stderr_for") { return String::from("__vow_process_stderr_for"); }
     String::from("")
+}
+
+fn debug_builtin_ret_ty(name: String) -> i64 {
+    if name == String::from("debug_str") { return ITY_UNIT(); }
+    if name == String::from("debug_i64") { return ITY_UNIT(); }
+    if name == String::from("debug_u64") { return ITY_UNIT(); }
+    -1
 }
 
 fn builtin_ret_ty(name: String) -> i64 {
@@ -1045,6 +1059,21 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         if callee_tag == EXPR_IDENT() {
             let name_sid: i64 = expr_a(a, callee_eid);
             fn_name = arena_str(a, name_sid);
+        }
+        let debug_ext: String = debug_builtin_to_extern(fn_name);
+        if debug_ext != String::from("") {
+            let ret_ty: i64 = debug_builtin_ret_ty(fn_name);
+            let call_args: Vec<i64> = Vec::new();
+            let nargs: i64 = list_len(a, args_lid);
+            let mut ai: i64 = 0;
+            while ai < nargs {
+                let arg_eid: i64 = list_get(a, args_lid, ai);
+                let arg_id: i64 = lower_expr(ctx, arg_eid);
+                lctx_mark_escaped(ctx, arg_id);
+                call_args.push(arg_id);
+                ai = ai + 1;
+            }
+            return lctx_emit(ctx, IOP_DEBUG_CALL(), ret_ty, call_args, IDATA_CALL_EXTERN(), 0, 0, debug_ext);
         }
         let ext: String = builtin_to_extern(fn_name);
         if ext != String::from("") {

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1069,7 +1069,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             while ai < nargs {
                 let arg_eid: i64 = list_get(a, args_lid, ai);
                 let arg_id: i64 = lower_expr(ctx, arg_eid);
-                lctx_mark_escaped(ctx, arg_id);
                 call_args.push(arg_id);
                 ai = ai + 1;
             }

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -631,6 +631,16 @@ Contract expressions (`requires`, `ensures`, `invariant`) must be pure — they 
 | `print_u64`      | `fn(v: u64) -> ()`                         | `[io]`     |
 | `eprintln_str`   | `fn(s: String) -> ()`                      | `[io]`     |
 
+#### Debug
+
+| Function         | Signature                                  | Effects    |
+|------------------|--------------------------------------------|------------|
+| `debug_str`      | `fn(s: String) -> ()`                      | `[]`       |
+| `debug_i64`      | `fn(v: i64) -> ()`                         | `[]`       |
+| `debug_u64`      | `fn(v: u64) -> ()`                         | `[]`       |
+
+**Debug print semantics:** Debug prints are effect-free and callable from pure functions. In debug and sanitize modes (`--mode debug`, `--mode sanitize`), they write to stderr. In release and profile modes, they are no-ops — zero runtime cost, no code emitted. They are also no-ops during verification. Use them to trace values inside pure kernel code without restructuring the effect hierarchy.
+
 #### Filesystem
 
 | Function         | Signature                                  | Effects    |

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -639,7 +639,7 @@ Contract expressions (`requires`, `ensures`, `invariant`) must be pure — they 
 | `debug_i64`      | `fn(v: i64) -> ()`                         | `[]`       |
 | `debug_u64`      | `fn(v: u64) -> ()`                         | `[]`       |
 
-**Debug print semantics:** Debug prints are effect-free and callable from pure functions. In debug and sanitize modes (`--mode debug`, `--mode sanitize`), they write to stderr. In release and profile modes, they are no-ops — zero runtime cost, no code emitted. They are also no-ops during verification. Use them to trace values inside pure kernel code without restructuring the effect hierarchy.
+**Debug print semantics:** Debug prints are effect-free and callable from pure functions. In debug and sanitize modes (`--mode debug`, `--mode sanitize`), they write to stderr. In release and profile modes, the debug call itself is not emitted — no function call occurs. However, argument expressions are still evaluated (e.g., `String::from("label")` still allocates). They are also no-ops during verification. Use them to trace values inside pure kernel code without restructuring the effect hierarchy.
 
 #### Filesystem
 

--- a/tests/debug/debug_print_pure.vow
+++ b/tests/debug/debug_print_pure.vow
@@ -1,0 +1,17 @@
+// TEST: exit 0
+// TEST: stdout "42"
+// TEST: stderr "tracing: 21"
+module DebugPrintPure
+
+fn pure_double(x: i64) -> i64 {
+    debug_str(String::from("tracing: "));
+    debug_i64(x);
+    debug_str(String::from("\n"));
+    x * 2
+}
+
+fn main() -> i32 [io] {
+    let v: i64 = pure_double(21);
+    print_i64(v);
+    0
+}

--- a/tests/run/debug_print_release.vow
+++ b/tests/run/debug_print_release.vow
@@ -1,0 +1,16 @@
+// TEST: exit 0
+// TEST: stdout "100"
+module DebugPrintRelease
+
+fn pure_square(x: i64) -> i64 {
+    debug_str(String::from("should not appear\n"));
+    debug_i64(x);
+    debug_u64(42 as u64);
+    x * x
+}
+
+fn main() -> i32 [io] {
+    let v: i64 = pure_square(10);
+    print_i64(v);
+    0
+}

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -194,6 +194,7 @@ const IOP_XOR_U64: i64 = 101;
 const IOP_CONST_U64: i64 = 102;
 const IOP_CAST_I64_TO_U64: i64 = 103;
 const IOP_CAST_U64_TO_I64: i64 = 104;
+const IOP_DEBUG_CALL: i64 = 105;
 
 // InstData kind constants (match compiler/ir.vow IDATA_*)
 #[allow(dead_code)]
@@ -1416,6 +1417,45 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
                     }
                 }
 
+                // Debug calls (only emitted in debug/sanitize mode)
+                IOP_DEBUG_CALL => {
+                    if (ctx.mode == 1 || ctx.mode == 3) && dk == IDATA_CALL_EXTERN {
+                        let sym = unsafe { read_vow_string(inst_ds_ptrs[ii]) };
+                        if let Some(&fr) = extern_func_refs.get(sym) {
+                            let sig_ref = builder.func.dfg.ext_funcs[fr].signature;
+                            let expected_types: Vec<types::Type> = builder.func.dfg.signatures
+                                [sig_ref]
+                                .params
+                                .iter()
+                                .map(|p| p.value_type)
+                                .collect();
+                            let call_args: Vec<Value> = (0..alen)
+                                .map(|i| {
+                                    let arg_id = all_args[aoff + i];
+                                    let v = *value_map.get(&arg_id).unwrap_or_else(|| {
+                                        panic!(
+                                            "clif shim: IOP_DEBUG_CALL value_map miss: inst_id={iid} arg_id={arg_id}"
+                                        )
+                                    });
+                                    if let Some(&expected_ty) = expected_types.get(i) {
+                                        let actual_ty = builder.func.dfg.value_type(v);
+                                        if actual_ty == types::I32 && expected_ty == types::I64 {
+                                            return builder.ins().sextend(types::I64, v);
+                                        }
+                                        if actual_ty == types::I8 && expected_ty == types::I64 {
+                                            return builder.ins().uextend(types::I64, v);
+                                        }
+                                    }
+                                    v
+                                })
+                                .collect();
+                            builder.ins().call(fr, &call_args);
+                        }
+                    }
+                    let unit = builder.ins().iconst(types::I32, 0);
+                    set_val!(iid, unit);
+                }
+
                 // Region / linear
                 IOP_REGION_ALLOC => {
                     let (size, align) = if dk == IDATA_ALLOC_SIZE {
@@ -1996,6 +2036,12 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.returns.push(AbiParam::new(types::I64));
         }
         "__vow_eprintln_str" => {
+            sig.params.push(AbiParam::new(types::I64));
+        }
+        "__vow_debug_str" => {
+            sig.params.push(AbiParam::new(types::I64));
+        }
+        "__vow_debug_i64" | "__vow_debug_u64" => {
             sig.params.push(AbiParam::new(types::I64));
         }
         "__vow_args" => {

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -700,6 +700,56 @@ fn lower_inst(
         }
 
         // ------------------------------------------------------------------
+        // Debug calls (only emitted in debug/sanitize mode)
+        // ------------------------------------------------------------------
+        Opcode::DebugCall => {
+            if ctx.mode.has_debug_checks() {
+                let InstData::CallExtern(ref sym) = inst.data else {
+                    return Err(CodegenError::UnsupportedOpcode(
+                        "DebugCall without CallExtern data".to_string(),
+                    ));
+                };
+                let Some(&func_ref) = ctx.extern_func_refs.get(sym.as_str()) else {
+                    return Err(CodegenError::UnsupportedOpcode(format!(
+                        "unknown debug extern symbol: {sym}"
+                    )));
+                };
+                let sig_ref = builder.func.dfg.ext_funcs[func_ref].signature;
+                let expected_types: Vec<types::Type> = builder.func.dfg.signatures[sig_ref]
+                    .params
+                    .iter()
+                    .map(|p| p.value_type)
+                    .collect();
+                let call_args: Vec<Value> = inst
+                    .args
+                    .iter()
+                    .enumerate()
+                    .map(|(i, id)| {
+                        let v = *ctx.value_map.get(id).unwrap_or_else(|| {
+                            panic!(
+                                "cranelift backend: DebugCall value_map miss for arg {id:?} in inst {:?}",
+                                inst.id
+                            )
+                        });
+                        if let Some(&expected_ty) = expected_types.get(i) {
+                            let actual_ty = builder.func.dfg.value_type(v);
+                            if actual_ty == types::I32 && expected_ty == types::I64 {
+                                return builder.ins().sextend(types::I64, v);
+                            }
+                            if actual_ty == types::I8 && expected_ty == types::I64 {
+                                return builder.ins().uextend(types::I64, v);
+                            }
+                        }
+                        v
+                    })
+                    .collect();
+                builder.ins().call(func_ref, &call_args);
+            }
+            let unit = builder.ins().iconst(types::I32, 0);
+            ctx.value_map.insert(inst.id, unit);
+        }
+
+        // ------------------------------------------------------------------
         // Function calls
         // ------------------------------------------------------------------
         Opcode::Call => {
@@ -1526,6 +1576,12 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_eprintln_str" => {
             sig.params.push(AbiParam::new(types::I64)); // C-string ptr
         }
+        "__vow_debug_str" => {
+            sig.params.push(AbiParam::new(types::I64)); // string ptr
+        }
+        "__vow_debug_i64" | "__vow_debug_u64" => {
+            sig.params.push(AbiParam::new(types::I64)); // value
+        }
         "__vow_args" => {
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<String>
         }
@@ -1713,6 +1769,9 @@ impl Backend for CraneliftBackend {
             for block in &func.blocks {
                 for inst in &block.insts {
                     if let InstData::CallExtern(sym) = &inst.data {
+                        if inst.opcode == Opcode::DebugCall && !mode.has_debug_checks() {
+                            continue;
+                        }
                         extern_syms.insert(sym.clone());
                     }
                 }

--- a/vow-ir/src/effects.rs
+++ b/vow-ir/src/effects.rs
@@ -91,6 +91,11 @@ pub fn inst_effects(opcode: &Opcode) -> Effects {
             e.writes.insert(AbstractHeap::Io);
             e
         }
+        Opcode::DebugCall => {
+            let mut e = Effects::pure();
+            e.writes.insert(AbstractHeap::Io);
+            e
+        }
         Opcode::Branch | Opcode::Jump | Opcode::Return | Opcode::Unreachable => {
             let mut e = Effects::pure();
             e.control = true;

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -844,9 +844,6 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     span,
                 )
             } else if let Some((sym, ret_ty)) = vow_debug_builtin_to_runtime(&callee_name) {
-                for &aid in &arg_ids {
-                    ctx.mark_escaped(aid);
-                }
                 ctx.emit(
                     Opcode::DebugCall,
                     ret_ty,

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -39,6 +39,15 @@ fn builtin_alloc_tag(sym: &str) -> &'static str {
     }
 }
 
+fn vow_debug_builtin_to_runtime(name: &str) -> Option<(&'static str, Ty)> {
+    match name {
+        "debug_str" => Some(("__vow_debug_str", Ty::Unit)),
+        "debug_i64" => Some(("__vow_debug_i64", Ty::Unit)),
+        "debug_u64" => Some(("__vow_debug_u64", Ty::Unit)),
+        _ => None,
+    }
+}
+
 fn vow_builtin_to_runtime(name: &str) -> Option<(&'static str, Ty)> {
     match name {
         "print_str" => Some(("__vow_string_print", Ty::Unit)),
@@ -832,6 +841,17 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     ret_ty,
                     arg_ids,
                     InstData::CallTarget(fid),
+                    span,
+                )
+            } else if let Some((sym, ret_ty)) = vow_debug_builtin_to_runtime(&callee_name) {
+                for &aid in &arg_ids {
+                    ctx.mark_escaped(aid);
+                }
+                ctx.emit(
+                    Opcode::DebugCall,
+                    ret_ty,
+                    arg_ids,
+                    InstData::CallExtern(sym.to_string()),
                     span,
                 )
             } else if let Some((sym, ret_ty)) = vow_builtin_to_runtime(&callee_name) {

--- a/vow-ir/src/printer.rs
+++ b/vow-ir/src/printer.rs
@@ -126,6 +126,7 @@ fn opcode_name(opcode: &Opcode) -> &'static str {
         Opcode::LinearBorrow => "LinearBorrow",
         Opcode::FieldGet => "FieldGet",
         Opcode::FieldSet => "FieldSet",
+        Opcode::DebugCall => "DebugCall",
     }
 }
 
@@ -535,6 +536,7 @@ mod tests {
             (Opcode::ConstU64, "ConstU64"),
             (Opcode::CastI64ToU64, "CastI64ToU64"),
             (Opcode::CastU64ToI64, "CastU64ToI64"),
+            (Opcode::DebugCall, "DebugCall"),
         ];
         for (op, expected) in pairs {
             assert_eq!(opcode_name(&op), expected);

--- a/vow-ir/src/types.rs
+++ b/vow-ir/src/types.rs
@@ -142,6 +142,8 @@ pub enum Opcode {
 
     FieldGet,
     FieldSet,
+
+    DebugCall,
 }
 
 impl Opcode {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -130,6 +130,27 @@ pub extern "C" fn __vow_print_u64(v: u64) {
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_debug_str(s: *const u8) {
+    sanitize_on_read(s as usize, 0);
+    let v = unsafe { &*(s as *const VowVec) };
+    let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
+    let _ = std::io::stderr().write_all(bytes);
+    let _ = std::io::stderr().flush();
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __vow_debug_i64(v: i64) {
+    let _ = write!(std::io::stderr(), "{v}");
+    let _ = std::io::stderr().flush();
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __vow_debug_u64(v: u64) {
+    let _ = write!(std::io::stderr(), "{v}");
+    let _ = std::io::stderr().flush();
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn __vow_arithmetic_overflow() {
     let json = r#"{"error":"ArithmeticOverflow"}"#;
     let _ = writeln!(std::io::stderr(), "{json}");

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -131,11 +131,13 @@ pub extern "C" fn __vow_print_u64(v: u64) {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_debug_str(s: *const u8) {
-    sanitize_on_read(s as usize, 0);
-    let v = unsafe { &*(s as *const VowVec) };
-    let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
-    let _ = std::io::stderr().write_all(bytes);
-    let _ = std::io::stderr().flush();
+    if !s.is_null() {
+        sanitize_on_read(s as usize, 0);
+        let v = unsafe { &*(s as *const VowVec) };
+        let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
+        let _ = std::io::stderr().write_all(bytes);
+        let _ = std::io::stderr().flush();
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/vow-types/src/env.rs
+++ b/vow-types/src/env.rs
@@ -92,6 +92,30 @@ impl TypeEnv {
             },
         );
         env.define_fn(
+            "debug_str",
+            FnSig {
+                params: vec![Ty::Str],
+                return_ty: Ty::Unit,
+                effects: BTreeSet::new(),
+            },
+        );
+        env.define_fn(
+            "debug_i64",
+            FnSig {
+                params: vec![Ty::I64],
+                return_ty: Ty::Unit,
+                effects: BTreeSet::new(),
+            },
+        );
+        env.define_fn(
+            "debug_u64",
+            FnSig {
+                params: vec![Ty::U64],
+                return_ty: Ty::Unit,
+                effects: BTreeSet::new(),
+            },
+        );
+        env.define_fn(
             "fs_read",
             FnSig {
                 params: vec![Ty::Str],

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -339,6 +339,8 @@ pub fn is_modelable(
                 | Opcode::LinearConsume
                 | Opcode::LinearBorrow
                 | Opcode::FieldSet => false,
+
+                Opcode::DebugCall => true,
             };
             if !ok {
                 return false;
@@ -940,6 +942,10 @@ fn emit_inst(
 
         Opcode::RemF32 | Opcode::RemF64 => {
             out.push_str(&format!("  /* float rem not modelled */ v{} = 0;\n", id));
+        }
+
+        Opcode::DebugCall => {
+            // Debug prints are no-ops for verification
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `debug_str`, `debug_i64`, `debug_u64` builtins with empty effects `[]`, callable from pure functions
- New `DebugCall` IR opcode (105) ensures codegen only emits calls in debug/sanitize mode — zero cost in release
- Output goes to stderr, avoiding interference with stdout-based protocols
- Verification (ESBMC) treats debug calls as no-ops
- Both Rust and self-hosted compilers updated; bootstrap passes with binary fixed point

Closes #96

## Test plan

- [ ] `tests/debug/debug_print_pure.vow` — debug prints in pure function produce stderr output in debug mode
- [ ] `tests/run/debug_print_release.vow` — debug prints are no-ops in release mode (no stderr output)
- [ ] `cargo test --all` passes (excluding pre-existing worktree-only failures)
- [ ] `cargo clippy --all -- -D warnings` clean
- [ ] `scripts/bootstrap.sh` produces binary fixed point
- [ ] `scripts/full_test.sh` passes