### PR TITLE
fix: resolve loop-carried Phi bindings from header scope on continue

### DIFF
--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -32,6 +32,7 @@ struct LowerCtx {
     loop_continue_phi_names: Vec<Vec<String>>,
     loop_continue_phi_ids: Vec<Vec<i64>>,
     loop_continue_idx_phi: Vec<i64>,
+    loop_continue_scope_depth: Vec<i64>,
     loop_is_loop: Vec<i64>,
     loop_break_up_ids: Vec<i64>,
     loop_break_up_blocks: Vec<i64>,
@@ -87,6 +88,7 @@ fn lctx_new(name: String, return_ty: i64, effects: i64, arena: AstArena, str_eid
         loop_continue_phi_names: Vec::new(),
         loop_continue_phi_ids: Vec::new(),
         loop_continue_idx_phi: Vec::new(),
+        loop_continue_scope_depth: Vec::new(),
         loop_is_loop: Vec::new(),
         loop_break_up_ids: Vec::new(),
         loop_break_up_blocks: Vec::new(),
@@ -200,6 +202,17 @@ fn lctx_assign(ctx: LowerCtx, name: String, val: i64) {
 fn lctx_lookup(ctx: LowerCtx, name: String) -> i64 {
     let n: i64 = ctx.scope_vars.len();
     let mut i: i64 = n;
+    while i > 0 {
+        i = i - 1;
+        if ctx.scope_vars[i] == name {
+            return ctx.scope_vals[i];
+        }
+    }
+    -1
+}
+
+fn lctx_lookup_at_depth(ctx: LowerCtx, name: String, depth: i64) -> i64 {
+    let mut i: i64 = depth;
     while i > 0 {
         i = i - 1;
         if ctx.scope_vars[i] == name {
@@ -1364,12 +1377,14 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_continue_phi_names.push(cpn);
         ctx.loop_continue_phi_ids.push(cpi);
         ctx.loop_continue_idx_phi.push(-1);
+        ctx.loop_continue_scope_depth.push(ctx.scope_vars.len());
         ctx.loop_is_loop.push(0);
         ctx.loop_break_counts.push(0);
         lctx_push_alloc_scope(ctx);
         lower_block(ctx, body_bid);
         ctx.loop_break_counts.pop();
         ctx.loop_is_loop.pop();
+        ctx.loop_continue_scope_depth.pop();
         ctx.loop_continue_idx_phi.pop();
         ctx.loop_continue_phi_ids.pop();
         ctx.loop_continue_phi_names.pop();
@@ -1486,6 +1501,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_continue_phi_names.push(lcpn);
         ctx.loop_continue_phi_ids.push(lcpi);
         ctx.loop_continue_idx_phi.push(-1);
+        ctx.loop_continue_scope_depth.push(ctx.scope_vars.len());
         ctx.loop_is_loop.push(1);
         ctx.loop_break_counts.push(0);
         let break_start: i64 = ctx.loop_break_up_ids.len();
@@ -1494,6 +1510,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         let break_count: i64 = ctx.loop_break_counts[break_count_idx];
         ctx.loop_break_counts.pop();
         ctx.loop_is_loop.pop();
+        ctx.loop_continue_scope_depth.pop();
         ctx.loop_continue_idx_phi.pop();
         ctx.loop_continue_phi_ids.pop();
         ctx.loop_continue_phi_names.pop();
@@ -1641,6 +1658,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             lctx_tag(ctx, elem_id, elem_tag);
         }
 
+        let for_scope_depth: i64 = ctx.scope_vars.len();
         lctx_push_scope(ctx);
         lctx_define(ctx, binding_name, elem_id);
 
@@ -1657,12 +1675,14 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_continue_phi_names.push(fcpn);
         ctx.loop_continue_phi_ids.push(fcpi);
         ctx.loop_continue_idx_phi.push(idx_phi);
+        ctx.loop_continue_scope_depth.push(for_scope_depth);
         ctx.loop_is_loop.push(0);
         ctx.loop_break_counts.push(0);
         lctx_push_alloc_scope(ctx);
         lower_block(ctx, body_bid);
         ctx.loop_break_counts.pop();
         ctx.loop_is_loop.pop();
+        ctx.loop_continue_scope_depth.pop();
         ctx.loop_continue_idx_phi.pop();
         ctx.loop_continue_phi_ids.pop();
         ctx.loop_continue_phi_names.pop();
@@ -2566,11 +2586,12 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let hdr_block: i64 = ctx.loop_header_blocks[nlh - 1];
             let phi_names: Vec<String> = ctx.loop_continue_phi_names[nlh - 1];
             let phi_ids2: Vec<i64> = ctx.loop_continue_phi_ids[nlh - 1];
+            let scope_depth: i64 = ctx.loop_continue_scope_depth[nlh - 1];
             let nphis: i64 = phi_names.len();
             let mut pi: i64 = 0;
             while pi < nphis {
                 let vname: String = phi_names[pi];
-                let cur_val: i64 = lctx_lookup(ctx, vname);
+                let cur_val: i64 = lctx_lookup_at_depth(ctx, vname, scope_depth);
                 let val_ty: i64 = ITY_I64();
                 let up_args: Vec<i64> = Vec::new();
                 up_args.push(cur_val);

--- a/tests/run/continue_shadow.vow
+++ b/tests/run/continue_shadow.vow
@@ -1,0 +1,21 @@
+// TEST: stdout "5\n495\n"
+// Regression test for #143: shadowed variables must not corrupt loop-carried
+// Phi bindings on continue. The outer x (mutated) should flow to the Phi,
+// not the inner shadow.
+module ContinueShadow
+
+fn main() -> i32 [io] {
+    let mut x: i64 = 0;
+    let mut count: i64 = 0;
+    while x < 5 {
+        x = x + 1;
+        let x: i64 = 99;
+        count = count + x;
+        continue;
+    }
+    print_i64(x);
+    print_str("\n");
+    print_i64(count);
+    print_str("\n");
+    0
+}

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -154,6 +154,10 @@ pub struct LowerCtx {
     loop_continue_phis: Vec<Vec<(String, InstId)>>,
     // For for-each: the index Phi to increment on continue (None for while/loop)
     loop_continue_idx_phi: Vec<Option<InstId>>,
+    // Scope depth at loop header (before body scope push) for correct continue resolution.
+    // continue must resolve loop-carried vars from this depth, not the current scope, to
+    // avoid picking up shadowed bindings in inner blocks.
+    loop_continue_scope_depth: Vec<usize>,
     // Per-loop break-value Upsilon collector.  `Some(vec)` for `loop` (collects
     // (source_block, upsilon_id, value_ty)), `None` for `while`.
     loop_break_upsilons: Vec<Option<Vec<(BlockId, InstId, Ty)>>>,
@@ -227,6 +231,7 @@ impl LowerCtx {
             loop_header_blocks: Vec::new(),
             loop_continue_phis: Vec::new(),
             loop_continue_idx_phi: Vec::new(),
+            loop_continue_scope_depth: Vec::new(),
             loop_break_upsilons: Vec::new(),
             inst_vec_elem_type: HashMap::new(),
             struct_field_vec_elems,
@@ -399,6 +404,18 @@ impl LowerCtx {
 
     pub(super) fn lookup(&self, name: &str) -> Option<InstId> {
         for frame in self.scope.iter().rev() {
+            if let Some(&id) = frame.get(name) {
+                return Some(id);
+            }
+        }
+        None
+    }
+
+    /// Look up a variable considering only scope frames up to (exclusive) `depth`.
+    /// Used by `continue` to resolve loop-carried vars from the loop header scope,
+    /// skipping any inner-scope shadows introduced in the loop body.
+    pub(super) fn lookup_at_depth(&self, name: &str, depth: usize) -> Option<InstId> {
+        for frame in self.scope[..depth].iter().rev() {
             if let Some(&id) = frame.get(name) {
                 return Some(id);
             }
@@ -1220,10 +1237,12 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_header_blocks.push(header_block);
             ctx.loop_continue_phis.push(phi_ids.clone());
             ctx.loop_continue_idx_phi.push(None);
+            ctx.loop_continue_scope_depth.push(ctx.scope.len());
             ctx.loop_break_upsilons.push(None);
             ctx.push_alloc_scope();
             lower_block(ctx, body);
             ctx.loop_break_upsilons.pop();
+            ctx.loop_continue_scope_depth.pop();
             ctx.loop_continue_idx_phi.pop();
             ctx.loop_continue_phis.pop();
             ctx.loop_header_blocks.pop();
@@ -1400,6 +1419,12 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 ctx.inst_struct_type.insert(elem_id, elem_name);
             }
 
+            // Save scope depth before pushing the for-each binding scope.
+            // Loop-carried phis track outer mutation variables whose bindings
+            // live at this depth; the for-each binding is a new scope that must
+            // be excluded from continue's lookup to avoid resolving to it.
+            let for_scope_depth = ctx.scope.len();
+
             ctx.push_scope();
             ctx.define(binding.clone(), elem_id);
 
@@ -1407,7 +1432,9 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_header_blocks.push(header_block);
             ctx.loop_continue_phis.push(phi_ids.clone());
             ctx.loop_continue_idx_phi.push(Some(idx_phi));
+            ctx.loop_continue_scope_depth.push(for_scope_depth);
             lower_block(ctx, body);
+            ctx.loop_continue_scope_depth.pop();
             ctx.loop_continue_idx_phi.pop();
             ctx.loop_continue_phis.pop();
             ctx.loop_header_blocks.pop();
@@ -1523,10 +1550,12 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_header_blocks.push(header_block);
             ctx.loop_continue_phis.push(phi_ids.clone());
             ctx.loop_continue_idx_phi.push(None);
+            ctx.loop_continue_scope_depth.push(ctx.scope.len());
             ctx.loop_break_upsilons.push(Some(Vec::new()));
             ctx.push_alloc_scope();
             lower_block(ctx, body);
             let break_ups = ctx.loop_break_upsilons.pop().unwrap();
+            ctx.loop_continue_scope_depth.pop();
             ctx.loop_continue_idx_phi.pop();
             ctx.loop_continue_phis.pop();
             ctx.loop_header_blocks.pop();
@@ -1630,10 +1659,17 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .expect("continue outside of loop");
             let phis = ctx.loop_continue_phis.last().cloned().unwrap_or_default();
             let idx_phi = ctx.loop_continue_idx_phi.last().copied().flatten();
+            let scope_depth = ctx
+                .loop_continue_scope_depth
+                .last()
+                .copied()
+                .expect("continue outside of loop");
 
             // Emit back-edge Upsilons for mutation variables.
+            // Use lookup_at_depth to resolve from the loop header scope, not the
+            // current scope, so that shadowed bindings in inner blocks are skipped.
             for (name, phi_id) in &phis {
-                if let Some(cur_val) = ctx.lookup(name) {
+                if let Some(cur_val) = ctx.lookup_at_depth(name, scope_depth) {
                     ctx.emit(
                         Opcode::Upsilon,
                         ctx.inst_ty(cur_val),


### PR DESCRIPTION
## Summary

- Fix `continue` resolving loop-carried variables from the current (possibly shadowed) scope instead of the loop header scope, corrupting Phi bindings (#143)
- Add `loop_continue_scope_depth` tracking and `lookup_at_depth` to both Rust and self-hosted compilers, applied to while, loop, and for-each constructs
- Add regression test `tests/run/continue_shadow.vow`

## Test plan

- [x] Reproduction case confirms fix: exit code changes from 99 (1 iteration) to 239 (5 iterations)
- [x] Bootstrap succeeds with binary fixed point (SHA-256 match)
- [x] 66/66 vow-ir unit tests pass
- [x] All existing continue tests (`continue_while`, `continue_for`, `continue_loop`, `continue_nested`) produce correct output
- [x] Clippy clean, no warnings

Closes #143