### PR TITLE
fix: reject break/continue outside loop in self-hosted checker

### DIFF
--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -937,6 +937,9 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
     }
 
     if tag == EXPR_BREAK() {
+        if e.loop_kind_stack.len() == 0 {
+            env_emit_error(e, String::from("`break` outside of a loop"), expr_span(a, eid));
+        }
         let val_eid: i64 = expr_a(a, eid);
         let mut val_tid: i64 = CTY_UNIT();
         if val_eid != -1 {
@@ -960,6 +963,9 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
     }
 
     if tag == EXPR_CONTINUE() {
+        if e.loop_kind_stack.len() == 0 {
+            env_emit_error(e, String::from("`continue` outside of a loop"), expr_span(a, eid));
+        }
         return CTY_NEVER();
     }
 

--- a/tests/error/break_outside_loop.vow
+++ b/tests/error/break_outside_loop.vow
@@ -1,0 +1,7 @@
+// TEST: stderr "outside of a loop"
+module BreakOutsideLoop
+
+fn main() -> i32 {
+    break;
+    0
+}

--- a/tests/error/continue_outside_loop.vow
+++ b/tests/error/continue_outside_loop.vow
@@ -1,0 +1,7 @@
+// TEST: stderr "outside of a loop"
+module ContinueOutsideLoop
+
+fn main() -> i32 {
+    continue;
+    0
+}


### PR DESCRIPTION
## Summary

- Add `loop_kind_stack.len() == 0` checks to `EXPR_BREAK` and `EXPR_CONTINUE` handlers in `compiler/checker.vow`, emitting `TypeMismatch` errors matching the Rust compiler behavior
- Add regression tests `tests/error/break_outside_loop.vow` and `tests/error/continue_outside_loop.vow`

Closes #142

## Test plan

- [x] Both compilers reject `continue` outside a loop with matching error messages
- [x] Both compilers reject `break` outside a loop with matching error messages
- [x] Bootstrap passes with SHA-256 fixed point match
- [x] All error tests pass (6/6)
- [x] `cargo test --all` passes
- [x] `cargo clippy --all -- -D warnings` clean