### PR TITLE
feat: improve stack overflow diagnostics (#97)

### DIFF
--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -235,6 +235,24 @@ The `blame` field indicates who is at fault:
 
 **Fix:** Add a bounds check before indexing, or add contracts: `requires: i >= 0, requires: i < v.len()`.
 
+### StackOverflow
+
+**When:** The native call stack is exhausted, typically due to unbounded recursion.
+
+```json
+{"error":"StackOverflow"}
+```
+
+In debug or sanitize mode, the diagnostic includes call depth and the function that was executing when the overflow occurred:
+
+```json
+{"error":"StackOverflow","depth":10693,"function":"recurse"}
+```
+
+The signal handler is installed in **all** build modes. The `depth` and `function` fields are only available in debug/sanitize mode where call-depth instrumentation is emitted.
+
+**Fix:** Add a base case to recursive functions, or restructure the algorithm to use iteration instead of recursion.
+
 ## Warnings
 
 ### LoweringWarning

--- a/tests/run/stack_overflow.vow
+++ b/tests/run/stack_overflow.vow
@@ -1,4 +1,7 @@
 // TEST: exit 134
+// NOTE: On systems with `ulimit -s unlimited` (RLIM_INFINITY), stack bounds
+// cannot be determined and the handler falls back to SIG_DFL (exit 139).
+// CI enforces a finite stack limit so exit 134 is expected there.
 module StackOverflow
 
 fn recurse(n: i64) -> i64 {

--- a/tests/run/stack_overflow.vow
+++ b/tests/run/stack_overflow.vow
@@ -1,0 +1,11 @@
+// TEST: exit 134
+module StackOverflow
+
+fn recurse(n: i64) -> i64 {
+    recurse(n + 1)
+}
+
+fn main() -> i32 {
+    recurse(0);
+    0
+}

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -674,8 +674,43 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         None
     };
 
-    // Create function name data section for trace/profile instrumentation
-    let fn_name_gv = if ctx.trace_mode != 0 || ctx.mode == 2 {
+    // Stack guard init (always, main function only)
+    let stack_guard_init_ref = if ctx.func_decls[fi].is_main {
+        let sig = ctx.obj_module.make_signature();
+        let id = ctx
+            .obj_module
+            .declare_function("__vow_init_stack_guard", Linkage::Import, &sig)
+            .expect("declare stack_guard_init");
+        Some(ctx.obj_module.declare_func_in_func(id, builder.func))
+    } else {
+        None
+    };
+
+    // Stack depth tracking (debug/sanitize mode only)
+    let stack_enter_ref = if ctx.mode == 1 || ctx.mode == 3 {
+        let mut sig = ctx.obj_module.make_signature();
+        sig.params.push(AbiParam::new(types::I64));
+        let id = ctx
+            .obj_module
+            .declare_function("__vow_stack_enter", Linkage::Import, &sig)
+            .expect("declare stack_enter");
+        Some(ctx.obj_module.declare_func_in_func(id, builder.func))
+    } else {
+        None
+    };
+    let stack_exit_ref = if ctx.mode == 1 || ctx.mode == 3 {
+        let sig = ctx.obj_module.make_signature();
+        let id = ctx
+            .obj_module
+            .declare_function("__vow_stack_exit", Linkage::Import, &sig)
+            .expect("declare stack_exit");
+        Some(ctx.obj_module.declare_func_in_func(id, builder.func))
+    } else {
+        None
+    };
+
+    // Create function name data section for trace/profile/stack instrumentation
+    let fn_name_gv = if ctx.trace_mode != 0 || ctx.mode == 2 || ctx.mode == 1 || ctx.mode == 3 {
         let name = &ctx.func_decls[fi].name;
         let mut name_bytes = name.as_bytes().to_vec();
         name_bytes.push(0);
@@ -822,6 +857,10 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         for &slot in slot_map.values() {
             builder.ins().stack_store(zero, slot, 0);
         }
+        // Emit stack_guard_init at main entry (all modes)
+        if let Some(init_ref) = stack_guard_init_ref {
+            builder.ins().call(init_ref, &[]);
+        }
         // Emit trace_enter at function entry
         if let (Some(gv), Some(enter_ref)) = (fn_name_gv, trace_enter_ref) {
             let name_ptr = builder.ins().global_value(types::I64, gv);
@@ -836,6 +875,11 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
         if let (Some(gv), Some(prof_ref)) = (fn_name_gv, profile_enter_ref) {
             let name_ptr = builder.ins().global_value(types::I64, gv);
             builder.ins().call(prof_ref, &[name_ptr]);
+        }
+        // Emit stack_enter at function entry (debug/sanitize mode)
+        if let (Some(gv), Some(se_ref)) = (fn_name_gv, stack_enter_ref) {
+            let name_ptr = builder.ins().global_value(types::I64, gv);
+            builder.ins().call(se_ref, &[name_ptr]);
         }
         // Emit sanitize_init at main entry
         if let Some(init_ref) = sanitize_init_ref {
@@ -1272,6 +1316,9 @@ pub unsafe extern "C" fn __vow_clif_compile_function(
                     if let (Some(gv), Some(exit_ref)) = (fn_name_gv, trace_exit_ref) {
                         let name_ptr = builder.ins().global_value(types::I64, gv);
                         builder.ins().call(exit_ref, &[name_ptr]);
+                    }
+                    if let Some(se_ref) = stack_exit_ref {
+                        builder.ins().call(se_ref, &[]);
                     }
                     if ret_ty == ITY_UNIT {
                         builder.ins().return_(&[]);
@@ -2091,7 +2138,10 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_profile_enter" => {
             sig.params.push(AbiParam::new(types::I64));
         }
-        "__vow_profile_init" => {}
+        "__vow_profile_init" | "__vow_init_stack_guard" | "__vow_stack_exit" => {}
+        "__vow_stack_enter" => {
+            sig.params.push(AbiParam::new(types::I64));
+        }
         "__vow_clif_create" => {
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -223,6 +223,7 @@ struct LowerCtx<'a> {
     trace_exit_ref: Option<FuncRef>,
     trace_vow_ref: Option<FuncRef>,
     fn_name_gv: Option<GlobalValue>,
+    stack_exit_ref: Option<FuncRef>,
 }
 
 fn lower_inst(
@@ -621,6 +622,9 @@ fn lower_inst(
             {
                 let name_ptr = builder.ins().global_value(types::I64, gv);
                 builder.ins().call(exit_ref, &[name_ptr]);
+            }
+            if let Some(se_ref) = ctx.stack_exit_ref {
+                builder.ins().call(se_ref, &[]);
             }
             if ctx.return_ty == IrTy::Unit {
                 builder.ins().return_(&[]);
@@ -1061,6 +1065,9 @@ struct RuntimeIds {
     profile_enter_id: Option<CraneliftFuncId>,
     profile_init_id: Option<CraneliftFuncId>,
     sanitize_init_id: Option<CraneliftFuncId>,
+    stack_guard_init_id: CraneliftFuncId,
+    stack_enter_id: Option<CraneliftFuncId>,
+    stack_exit_id: Option<CraneliftFuncId>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1208,7 +1215,14 @@ fn compile_ir_function(
     let profile_init_ref = runtime
         .profile_init_id
         .map(|id| obj_module.declare_func_in_func(id, builder.func));
-    let needs_fn_name = trace != TraceMode::Off || mode == BuildMode::Profile;
+    let stack_enter_ref = runtime
+        .stack_enter_id
+        .map(|id| obj_module.declare_func_in_func(id, builder.func));
+    let stack_exit_ref = runtime
+        .stack_exit_id
+        .map(|id| obj_module.declare_func_in_func(id, builder.func));
+    let needs_fn_name =
+        trace != TraceMode::Off || mode == BuildMode::Profile || mode.has_debug_checks();
     let fn_name_gv = if needs_fn_name {
         let mut name_bytes = ir_func.name.as_bytes().to_vec();
         name_bytes.push(0);
@@ -1238,6 +1252,11 @@ fn compile_ir_function(
                 cl_idx += 1;
             }
         }
+        if ir_func.name == "main" {
+            let guard_ref =
+                obj_module.declare_func_in_func(runtime.stack_guard_init_id, builder.func);
+            builder.ins().call(guard_ref, &[]);
+        }
         if trace != TraceMode::Off
             && let (Some(enter_ref), Some(gv)) = (trace_enter_ref, fn_name_gv)
         {
@@ -1252,6 +1271,10 @@ fn compile_ir_function(
         if let (Some(prof_ref), Some(gv)) = (profile_enter_ref, fn_name_gv) {
             let name_ptr = builder.ins().global_value(types::I64, gv);
             builder.ins().call(prof_ref, &[name_ptr]);
+        }
+        if let (Some(se_ref), Some(gv)) = (stack_enter_ref, fn_name_gv) {
+            let name_ptr = builder.ins().global_value(types::I64, gv);
+            builder.ins().call(se_ref, &[name_ptr]);
         }
         if ir_func.name == "main"
             && let Some(init_id) = runtime.sanitize_init_id
@@ -1306,6 +1329,7 @@ fn compile_ir_function(
             trace_exit_ref,
             trace_vow_ref,
             fn_name_gv,
+            stack_exit_ref,
         };
 
         for inst in &ir_block.insts {
@@ -1663,7 +1687,10 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_profile_enter" => {
             sig.params.push(AbiParam::new(types::I64)); // fn_name C-string ptr
         }
-        "__vow_profile_init" => {}
+        "__vow_profile_init" | "__vow_init_stack_guard" | "__vow_stack_exit" => {}
+        "__vow_stack_enter" => {
+            sig.params.push(AbiParam::new(types::I64)); // fn_name C-string ptr
+        }
         _ => {}
     }
     sig
@@ -1833,6 +1860,29 @@ impl Backend for CraneliftBackend {
             None
         };
 
+        // Declare stack guard init (always — signal handler works in all modes)
+        let stack_guard_init_id = {
+            let sig = make_extern_sig("__vow_init_stack_guard", &obj_module);
+            obj_module
+                .declare_function("__vow_init_stack_guard", Linkage::Import, &sig)
+                .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?
+        };
+
+        // Declare stack depth tracking (debug/sanitize mode only)
+        let (stack_enter_id, stack_exit_id) = if mode.has_debug_checks() {
+            let enter_sig = make_extern_sig("__vow_stack_enter", &obj_module);
+            let enter_id = obj_module
+                .declare_function("__vow_stack_enter", Linkage::Import, &enter_sig)
+                .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
+            let exit_sig = make_extern_sig("__vow_stack_exit", &obj_module);
+            let exit_id = obj_module
+                .declare_function("__vow_stack_exit", Linkage::Import, &exit_sig)
+                .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
+            (Some(enter_id), Some(exit_id))
+        } else {
+            (None, None)
+        };
+
         // Compile each function
         let mut builder_ctx = FunctionBuilderContext::new();
         for (ir_func, &(_, cl_id)) in module.functions.iter().zip(ir_to_cl.iter()) {
@@ -1859,6 +1909,9 @@ impl Backend for CraneliftBackend {
                     profile_enter_id,
                     profile_init_id,
                     sanitize_init_id,
+                    stack_guard_init_id,
+                    stack_enter_id,
+                    stack_exit_id,
                 },
                 &string_data_ids,
                 &extern_func_ids,

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -324,9 +324,37 @@ pub extern "C" fn __vow_init_stack_guard() {
 
 unsafe extern "C" fn stack_overflow_handler(
     _sig: libc::c_int,
-    _info: *mut libc::siginfo_t,
+    info: *mut libc::siginfo_t,
     _ctx: *mut libc::c_void,
 ) {
+    // Distinguish stack overflow from other SIGSEGVs by checking whether the
+    // fault address is near the stack limit. If not, re-raise as default SIGSEGV
+    // so the OS produces a core dump for null-pointer or other segfaults.
+    if !info.is_null() {
+        let fault_addr = unsafe { (*info).si_addr() } as usize;
+        let mut rl: libc::rlimit = unsafe { std::mem::zeroed() };
+        if unsafe { libc::getrlimit(libc::RLIMIT_STACK, &mut rl) } == 0 {
+            let stack_size = rl.rlim_cur as usize;
+            // Use the current stack pointer as a reference. If the fault address
+            // is more than one stack size away, it's likely not a stack overflow.
+            let sp: usize;
+            unsafe {
+                std::arch::asm!("mov {}, rsp", out(reg) sp, options(nomem, nostack));
+            }
+            let stack_bottom = sp.saturating_sub(stack_size);
+            let stack_top = sp.saturating_add(stack_size);
+            if fault_addr < stack_bottom || fault_addr > stack_top {
+                // Not a stack overflow — restore default handler and re-raise.
+                let mut sa: libc::sigaction = unsafe { std::mem::zeroed() };
+                sa.sa_sigaction = libc::SIG_DFL;
+                unsafe {
+                    libc::sigaction(libc::SIGSEGV, &sa, std::ptr::null_mut());
+                }
+                return;
+            }
+        }
+    }
+
     // Read depth and function name (best-effort in signal context)
     let depth = STACK_DEPTH.load(Ordering::Relaxed);
     let fn_ptr = STACK_FN_NAME.load(Ordering::Relaxed) as *const i8;
@@ -356,7 +384,9 @@ unsafe extern "C" fn stack_overflow_handler(
         write_bytes!(b",\"function\":\"");
         let name = unsafe { CStr::from_ptr(fn_ptr) };
         let name_bytes = name.to_bytes();
-        let n = name_bytes.len().min(buf.len() - pos - 3);
+        let n = name_bytes
+            .len()
+            .min(buf.len().saturating_sub(pos).saturating_sub(3));
         buf[pos..pos + n].copy_from_slice(&name_bytes[..n]);
         pos += n;
         write_bytes!(b"\"");
@@ -394,7 +424,9 @@ unsafe extern "C" fn stack_overflow_handler(
         hwrite!(b" in ");
         let name = unsafe { CStr::from_ptr(fn_ptr) };
         let name_bytes = name.to_bytes();
-        let n = name_bytes.len().min(hbuf.len() - hpos - 1);
+        let n = name_bytes
+            .len()
+            .min(hbuf.len().saturating_sub(hpos).saturating_sub(1));
         hbuf[hpos..hpos + n].copy_from_slice(&name_bytes[..n]);
         hpos += n;
     }
@@ -417,7 +449,7 @@ fn format_i64_to_buf(mut val: i64, buf: &mut [u8; 20]) -> &[u8] {
     }
     let negative = val < 0;
     if negative {
-        val = val.wrapping_neg();
+        val = val.checked_neg().unwrap_or(i64::MAX);
     }
     let mut pos = 20;
     while val > 0 {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -413,6 +413,8 @@ unsafe extern "C" fn stack_overflow_handler(
 
     if !fn_ptr.is_null() {
         write_bytes!(b",\"function\":\"");
+        // SAFETY: fn_ptr points into .rodata (codegen-emitted function name
+        // global), so CStr::from_ptr is safe even in signal context.
         let name = unsafe { CStr::from_ptr(fn_ptr) };
         let name_bytes = name.to_bytes();
         let n = name_bytes
@@ -453,6 +455,7 @@ unsafe extern "C" fn stack_overflow_handler(
 
     if !fn_ptr.is_null() {
         hwrite!(b" in ");
+        // SAFETY: fn_ptr points into .rodata (see JSON branch above).
         let name = unsafe { CStr::from_ptr(fn_ptr) };
         let name_bytes = name.to_bytes();
         let n = name_bytes

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -265,6 +265,173 @@ pub extern "C" fn __vow_profile_init() {
     });
 }
 
+// ---------------------------------------------------------------------------
+// Stack overflow detection
+// ---------------------------------------------------------------------------
+
+static STACK_DEPTH: AtomicI64 = AtomicI64::new(0);
+static STACK_FN_NAME: AtomicU64 = AtomicU64::new(0);
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_stack_enter(fn_name_ptr: *const i8) {
+    STACK_DEPTH.fetch_add(1, Ordering::Relaxed);
+    STACK_FN_NAME.store(fn_name_ptr as u64, Ordering::Relaxed);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __vow_stack_exit() {
+    STACK_DEPTH.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __vow_init_stack_guard() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        unsafe {
+            // Allocate an alternate signal stack so the SIGSEGV handler can run
+            // even when the main stack is exhausted.
+            let stack_size = libc::SIGSTKSZ * 2;
+            let stack_mem = libc::mmap(
+                std::ptr::null_mut(),
+                stack_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            );
+            if stack_mem == libc::MAP_FAILED {
+                return;
+            }
+            let ss = libc::stack_t {
+                ss_sp: stack_mem,
+                ss_flags: 0,
+                ss_size: stack_size,
+            };
+            if libc::sigaltstack(&ss, std::ptr::null_mut()) != 0 {
+                return;
+            }
+
+            // Install SIGSEGV handler on the alternate stack.
+            let mut sa: libc::sigaction = std::mem::zeroed();
+            sa.sa_flags = libc::SA_ONSTACK | libc::SA_SIGINFO;
+            libc::sigemptyset(&mut sa.sa_mask);
+            sa.sa_sigaction = stack_overflow_handler as *const () as usize;
+            libc::sigaction(libc::SIGSEGV, &sa, std::ptr::null_mut());
+        }
+    });
+}
+
+unsafe extern "C" fn stack_overflow_handler(
+    _sig: libc::c_int,
+    _info: *mut libc::siginfo_t,
+    _ctx: *mut libc::c_void,
+) {
+    // Read depth and function name (best-effort in signal context)
+    let depth = STACK_DEPTH.load(Ordering::Relaxed);
+    let fn_ptr = STACK_FN_NAME.load(Ordering::Relaxed) as *const i8;
+
+    let mut buf = [0u8; 512];
+    let mut pos = 0;
+
+    macro_rules! write_bytes {
+        ($bytes:expr) => {
+            let src = $bytes;
+            let n = src.len().min(buf.len() - pos);
+            buf[pos..pos + n].copy_from_slice(&src[..n]);
+            pos += n;
+        };
+    }
+
+    write_bytes!(b"{\"error\":\"StackOverflow\"");
+
+    if depth > 0 {
+        write_bytes!(b",\"depth\":");
+        let mut num_buf = [0u8; 20];
+        let num_str = format_i64_to_buf(depth, &mut num_buf);
+        write_bytes!(num_str);
+    }
+
+    if !fn_ptr.is_null() {
+        write_bytes!(b",\"function\":\"");
+        let name = unsafe { CStr::from_ptr(fn_ptr) };
+        let name_bytes = name.to_bytes();
+        let n = name_bytes.len().min(buf.len() - pos - 3);
+        buf[pos..pos + n].copy_from_slice(&name_bytes[..n]);
+        pos += n;
+        write_bytes!(b"\"");
+    }
+
+    write_bytes!(b"}\n");
+
+    unsafe {
+        libc::write(2, buf.as_ptr() as *const libc::c_void, pos);
+    }
+
+    // Also write human-readable line
+    let mut hbuf = [0u8; 512];
+    let mut hpos = 0;
+
+    macro_rules! hwrite {
+        ($bytes:expr) => {
+            let src = $bytes;
+            let n = src.len().min(hbuf.len() - hpos);
+            hbuf[hpos..hpos + n].copy_from_slice(&src[..n]);
+            hpos += n;
+        };
+    }
+
+    hwrite!(b"stack overflow");
+
+    if depth > 0 {
+        hwrite!(b" at depth ");
+        let mut num_buf = [0u8; 20];
+        let num_str = format_i64_to_buf(depth, &mut num_buf);
+        hwrite!(num_str);
+    }
+
+    if !fn_ptr.is_null() {
+        hwrite!(b" in ");
+        let name = unsafe { CStr::from_ptr(fn_ptr) };
+        let name_bytes = name.to_bytes();
+        let n = name_bytes.len().min(hbuf.len() - hpos - 1);
+        hbuf[hpos..hpos + n].copy_from_slice(&name_bytes[..n]);
+        hpos += n;
+    }
+
+    hwrite!(b"\n");
+
+    unsafe {
+        libc::write(2, hbuf.as_ptr() as *const libc::c_void, hpos);
+    }
+
+    unsafe {
+        libc::_exit(134);
+    }
+}
+
+fn format_i64_to_buf(mut val: i64, buf: &mut [u8; 20]) -> &[u8] {
+    if val == 0 {
+        buf[0] = b'0';
+        return &buf[..1];
+    }
+    let negative = val < 0;
+    if negative {
+        val = val.wrapping_neg();
+    }
+    let mut pos = 20;
+    while val > 0 {
+        pos -= 1;
+        buf[pos] = b'0' + (val % 10) as u8;
+        val /= 10;
+    }
+    if negative {
+        pos -= 1;
+        buf[pos] = b'-';
+    }
+    &buf[pos..]
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __vow_arena_alloc(size: usize, align: usize) -> *mut u8 {
     if size == 0 {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -275,6 +275,11 @@ static STACK_FN_NAME: AtomicU64 = AtomicU64::new(0);
 static STACK_BOTTOM: AtomicU64 = AtomicU64::new(0);
 static STACK_TOP: AtomicU64 = AtomicU64::new(0);
 
+// STACK_FN_NAME tracks the most recently entered function, not the full call
+// chain. After a callee returns, the name may be stale (pointing to the callee
+// rather than the caller). This is intentional: the diagnostic reports the
+// "last known function" at overflow time, which is the deepest frame — exactly
+// the function whose entry pushed the stack past the limit.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_stack_enter(fn_name_ptr: *const i8) {
     STACK_DEPTH.fetch_add(1, Ordering::Relaxed);
@@ -300,7 +305,12 @@ pub extern "C" fn __vow_init_stack_guard() {
             && rl.rlim_cur != libc::RLIM_INFINITY
         {
             let stack_size = rl.rlim_cur as usize;
-            // Stack grows downward: bottom = SP - size, top = SP + guard margin.
+            // Stack grows downward. The guard page sits just below
+            // `initial_SP - stack_size`. sp_approx is already `delta` bytes
+            // below initial_SP (startup frames), so computed STACK_BOTTOM =
+            // sp_approx - stack_size is `delta` below the actual bottom.
+            // The guard page fault address lands inside [BOTTOM, TOP] as long
+            // as delta >= PAGE_SIZE (~4KB), which holds on any realistic binary.
             STACK_BOTTOM.store(
                 sp_approx.saturating_sub(stack_size) as u64,
                 Ordering::Relaxed,
@@ -349,23 +359,31 @@ unsafe extern "C" fn stack_overflow_handler(
 ) {
     // Distinguish stack overflow from other SIGSEGVs by checking whether the
     // fault address falls within the main stack region (saved at init time).
+    // If not a stack overflow, restore default handler and re-raise so the OS
+    // produces a core dump.
     let bottom = STACK_BOTTOM.load(Ordering::Relaxed);
     let top = STACK_TOP.load(Ordering::Relaxed);
-    if !info.is_null() {
-        let fault_addr = unsafe { (*info).si_addr() } as u64;
-        let is_stack_overflow = if bottom != 0 && top != 0 {
-            fault_addr >= bottom && fault_addr <= top
-        } else {
-            // Bounds unknown (e.g. RLIM_INFINITY or getrlimit failed).
-            // Cannot distinguish stack overflow from other SIGSEGVs.
-            false
-        };
-        if !is_stack_overflow {
-            unsafe {
-                libc::signal(libc::SIGSEGV, libc::SIG_DFL);
-            }
-            return;
+    if info.is_null() {
+        // SA_SIGINFO guarantees non-null on Linux, but handle defensively.
+        unsafe {
+            libc::signal(libc::SIGSEGV, libc::SIG_DFL);
+            libc::raise(libc::SIGSEGV);
         }
+        return;
+    }
+    let fault_addr = unsafe { (*info).si_addr() } as u64;
+    let is_stack_overflow = if bottom != 0 && top != 0 {
+        fault_addr >= bottom && fault_addr <= top
+    } else {
+        // Bounds unknown (e.g. RLIM_INFINITY or getrlimit failed).
+        false
+    };
+    if !is_stack_overflow {
+        unsafe {
+            libc::signal(libc::SIGSEGV, libc::SIG_DFL);
+            libc::raise(libc::SIGSEGV);
+        }
+        return;
     }
 
     // Read depth and function name (best-effort in signal context)

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -349,13 +349,18 @@ unsafe extern "C" fn stack_overflow_handler(
 ) {
     // Distinguish stack overflow from other SIGSEGVs by checking whether the
     // fault address falls within the main stack region (saved at init time).
-    // If boundaries were recorded and the fault is outside the stack region,
-    // restore the default handler so the OS produces a core dump.
     let bottom = STACK_BOTTOM.load(Ordering::Relaxed);
     let top = STACK_TOP.load(Ordering::Relaxed);
-    if bottom != 0 && top != 0 && !info.is_null() {
+    if !info.is_null() {
         let fault_addr = unsafe { (*info).si_addr() } as u64;
-        if fault_addr < bottom || fault_addr > top {
+        let is_stack_overflow = if bottom != 0 && top != 0 {
+            fault_addr >= bottom && fault_addr <= top
+        } else {
+            // Bounds unknown (e.g. RLIM_INFINITY or getrlimit failed).
+            // Cannot distinguish stack overflow from other SIGSEGVs.
+            false
+        };
+        if !is_stack_overflow {
             unsafe {
                 libc::signal(libc::SIGSEGV, libc::SIG_DFL);
             }

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -322,6 +322,7 @@ pub extern "C" fn __vow_init_stack_guard() {
             // Allocate an alternate signal stack so the SIGSEGV handler can run
             // even when the main stack is exhausted.
             let alt_stack_size = libc::SIGSTKSZ * 2;
+            // Allocated once at process startup; owned for process lifetime (freed by OS on exit).
             let stack_mem = libc::mmap(
                 std::ptr::null_mut(),
                 alt_stack_size,
@@ -396,7 +397,7 @@ unsafe extern "C" fn stack_overflow_handler(
     macro_rules! write_bytes {
         ($bytes:expr) => {
             let src = $bytes;
-            let n = src.len().min(buf.len() - pos);
+            let n = src.len().min(buf.len().saturating_sub(pos));
             buf[pos..pos + n].copy_from_slice(&src[..n]);
             pos += n;
         };
@@ -438,7 +439,7 @@ unsafe extern "C" fn stack_overflow_handler(
     macro_rules! hwrite {
         ($bytes:expr) => {
             let src = $bytes;
-            let n = src.len().min(hbuf.len() - hpos);
+            let n = src.len().min(hbuf.len().saturating_sub(hpos));
             hbuf[hpos..hpos + n].copy_from_slice(&src[..n]);
             hpos += n;
         };

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -271,6 +271,9 @@ pub extern "C" fn __vow_profile_init() {
 
 static STACK_DEPTH: AtomicI64 = AtomicI64::new(0);
 static STACK_FN_NAME: AtomicU64 = AtomicU64::new(0);
+// Stack boundary saved at init time (on the main stack, before any signal).
+static STACK_BOTTOM: AtomicU64 = AtomicU64::new(0);
+static STACK_TOP: AtomicU64 = AtomicU64::new(0);
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_stack_enter(fn_name_ptr: *const i8) {
@@ -288,13 +291,30 @@ pub extern "C" fn __vow_init_stack_guard() {
     use std::sync::Once;
     static INIT: Once = Once::new();
     INIT.call_once(|| {
+        // Record the main stack boundaries while we're on the main stack.
+        // Use address of a local variable as a portable SP approximation.
+        let local = 0u8;
+        let sp_approx = &local as *const u8 as usize;
+        let mut rl: libc::rlimit = unsafe { std::mem::zeroed() };
+        if unsafe { libc::getrlimit(libc::RLIMIT_STACK, &mut rl) } == 0
+            && rl.rlim_cur != libc::RLIM_INFINITY
+        {
+            let stack_size = rl.rlim_cur as usize;
+            // Stack grows downward: bottom = SP - size, top = SP + guard margin.
+            STACK_BOTTOM.store(
+                sp_approx.saturating_sub(stack_size) as u64,
+                Ordering::Relaxed,
+            );
+            STACK_TOP.store(sp_approx.saturating_add(4096) as u64, Ordering::Relaxed);
+        }
+
         unsafe {
             // Allocate an alternate signal stack so the SIGSEGV handler can run
             // even when the main stack is exhausted.
-            let stack_size = libc::SIGSTKSZ * 2;
+            let alt_stack_size = libc::SIGSTKSZ * 2;
             let stack_mem = libc::mmap(
                 std::ptr::null_mut(),
-                stack_size,
+                alt_stack_size,
                 libc::PROT_READ | libc::PROT_WRITE,
                 libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
                 -1,
@@ -306,7 +326,7 @@ pub extern "C" fn __vow_init_stack_guard() {
             let ss = libc::stack_t {
                 ss_sp: stack_mem,
                 ss_flags: 0,
-                ss_size: stack_size,
+                ss_size: alt_stack_size,
             };
             if libc::sigaltstack(&ss, std::ptr::null_mut()) != 0 {
                 return;
@@ -328,30 +348,18 @@ unsafe extern "C" fn stack_overflow_handler(
     _ctx: *mut libc::c_void,
 ) {
     // Distinguish stack overflow from other SIGSEGVs by checking whether the
-    // fault address is near the stack limit. If not, re-raise as default SIGSEGV
-    // so the OS produces a core dump for null-pointer or other segfaults.
-    if !info.is_null() {
-        let fault_addr = unsafe { (*info).si_addr() } as usize;
-        let mut rl: libc::rlimit = unsafe { std::mem::zeroed() };
-        if unsafe { libc::getrlimit(libc::RLIMIT_STACK, &mut rl) } == 0 {
-            let stack_size = rl.rlim_cur as usize;
-            // Use the current stack pointer as a reference. If the fault address
-            // is more than one stack size away, it's likely not a stack overflow.
-            let sp: usize;
+    // fault address falls within the main stack region (saved at init time).
+    // If boundaries were recorded and the fault is outside the stack region,
+    // restore the default handler so the OS produces a core dump.
+    let bottom = STACK_BOTTOM.load(Ordering::Relaxed);
+    let top = STACK_TOP.load(Ordering::Relaxed);
+    if bottom != 0 && top != 0 && !info.is_null() {
+        let fault_addr = unsafe { (*info).si_addr() } as u64;
+        if fault_addr < bottom || fault_addr > top {
             unsafe {
-                std::arch::asm!("mov {}, rsp", out(reg) sp, options(nomem, nostack));
+                libc::signal(libc::SIGSEGV, libc::SIG_DFL);
             }
-            let stack_bottom = sp.saturating_sub(stack_size);
-            let stack_top = sp.saturating_add(stack_size);
-            if fault_addr < stack_bottom || fault_addr > stack_top {
-                // Not a stack overflow — restore default handler and re-raise.
-                let mut sa: libc::sigaction = unsafe { std::mem::zeroed() };
-                sa.sa_sigaction = libc::SIG_DFL;
-                unsafe {
-                    libc::sigaction(libc::SIGSEGV, &sa, std::ptr::null_mut());
-                }
-                return;
-            }
+            return;
         }
     }
 

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -386,6 +386,12 @@ unsafe extern "C" fn stack_overflow_handler(
         }
         return;
     }
+    // Accepted heuristic limitation: [bottom, top] covers the entire main
+    // stack region, not just the guard page. A use-after-return dereference of
+    // a dead stack address could land in this window and be reported as
+    // StackOverflow. Do not "tighten" the range to exclude live-stack addresses
+    // without a precise guard-page boundary — doing so would silently break
+    // real-overflow detection.
 
     // Read depth and function name (best-effort in signal context)
     let depth = STACK_DEPTH.load(Ordering::Relaxed);


### PR DESCRIPTION
## Summary

- Install a SIGSEGV signal handler (via `sigaltstack`) in all Vow binaries so stack overflow produces a structured JSON diagnostic instead of a silent crash
- In debug mode, track call depth and current function name for richer output: `{"error":"StackOverflow","depth":10693,"function":"recurse"}`
- Applied to both Rust codegen and self-hosted compiler (vow-clif-shim)

Closes #97

## Test plan

- [x] `tests/run/stack_overflow.vow` regression test added (infinite recursion, expects exit 134)
- [x] Verified all 4 combinations: Rust compiler x self-hosted compiler x release/debug mode
- [x] Bootstrap passes with binary fixed point match
- [x] `cargo test --all` passes
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `scripts/full_test.sh` sections 1-6 pass (no new failures)