### PR TITLE
fix: scope deallocation for branches, break/continue, and for-each

### DIFF
--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -2648,9 +2648,19 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 }
             }
             // Free loop body allocations before jumping to exit.
+            // Trace transitive sources of break value through Phi/Upsilon chains.
             let nlasd: i64 = ctx.loop_alloc_scope_depths.len();
             if nlasd > 0 {
                 let depth: i64 = ctx.loop_alloc_scope_depths[nlasd - 1];
+                if break_live_out.len() > 0 {
+                    let bv: i64 = break_live_out[0];
+                    let sources: Vec<i64> = lctx_collect_return_sources(ctx, bv);
+                    let mut si: i64 = 0;
+                    while si < sources.len() {
+                        break_live_out.push(sources[si]);
+                        si = si + 1;
+                    }
+                }
                 lctx_emit_alloc_frees_to_depth(ctx, depth, break_live_out);
             }
             let jmp_args: Vec<i64> = Vec::new();

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -46,6 +46,7 @@ struct LowerCtx {
     alloc_sizes: Vec<i64>,
     escaped_ids: Vec<i64>,
     alloc_scope_starts: Vec<i64>,
+    loop_alloc_scope_depths: Vec<i64>,
     file: String,
 }
 
@@ -102,6 +103,7 @@ fn lctx_new(name: String, return_ty: i64, effects: i64, arena: AstArena, str_eid
         alloc_sizes: Vec::new(),
         escaped_ids: Vec::new(),
         alloc_scope_starts: Vec::new(),
+        loop_alloc_scope_depths: Vec::new(),
         file: String::from(""),
     }
 }
@@ -332,6 +334,49 @@ fn lctx_discard_alloc_scope(ctx: LowerCtx) {
         ctx.alloc_ids.pop();
         ctx.alloc_tags.pop();
         ctx.alloc_sizes.pop();
+    }
+}
+
+fn lctx_emit_alloc_frees_to_depth(ctx: LowerCtx, target_depth: i64, live_out: Vec<i64>) {
+    let n: i64 = ctx.alloc_ids.len();
+    let mut i: i64 = target_depth;
+    while i < n {
+        let id: i64 = ctx.alloc_ids[i];
+        let tag: String = ctx.alloc_tags[i];
+        let mut skip: bool = lctx_is_escaped(ctx, id);
+        if !skip {
+            let mut li: i64 = 0;
+            while li < live_out.len() {
+                if live_out[li] == id {
+                    skip = true;
+                }
+                li = li + 1;
+            }
+        }
+        if !skip {
+            if lower_str_starts_with(tag, String::from("region:")) {
+                let size: i64 = ctx.alloc_sizes[i];
+                let free_args: Vec<i64> = Vec::new();
+                free_args.push(id);
+                lctx_emit(ctx, IOP_REGION_FREE(), ITY_UNIT(), free_args, IDATA_ALLOC_SIZE(), size, 8, String::from(""));
+            }
+            if tag == String::from("String") {
+                let free_args: Vec<i64> = Vec::new();
+                free_args.push(id);
+                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_free"));
+            }
+            if tag == String::from("Vec") {
+                let free_args: Vec<i64> = Vec::new();
+                free_args.push(id);
+                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_free_val"));
+            }
+            if tag == String::from("HashMap") {
+                let free_args: Vec<i64> = Vec::new();
+                free_args.push(id);
+                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_map_free"));
+            }
+        }
+        i = i + 1;
     }
 }
 
@@ -1385,7 +1430,9 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_is_loop.push(0);
         ctx.loop_break_counts.push(0);
         lctx_push_alloc_scope(ctx);
+        ctx.loop_alloc_scope_depths.push(ctx.alloc_ids.len());
         lower_block(ctx, body_bid);
+        ctx.loop_alloc_scope_depths.pop();
         ctx.loop_break_counts.pop();
         ctx.loop_is_loop.pop();
         ctx.loop_continue_scope_depth.pop();
@@ -1509,7 +1556,10 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_is_loop.push(1);
         ctx.loop_break_counts.push(0);
         let break_start: i64 = ctx.loop_break_up_ids.len();
+        lctx_push_alloc_scope(ctx);
+        ctx.loop_alloc_scope_depths.push(ctx.alloc_ids.len());
         lower_block(ctx, body_bid);
+        ctx.loop_alloc_scope_depths.pop();
         let break_count_idx: i64 = ctx.loop_break_counts.len() - 1;
         let break_count: i64 = ctx.loop_break_counts[break_count_idx];
         ctx.loop_break_counts.pop();
@@ -1520,6 +1570,22 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_continue_phi_names.pop();
         ctx.loop_header_blocks.pop();
         ctx.loop_exit_blocks.pop();
+
+        // Free loop-body temporaries before back-edge.
+        if !lctx_is_terminated(ctx) {
+            let loop_live_out2: Vec<i64> = Vec::new();
+            let mut lli: i64 = 0;
+            while lli < nassigned {
+                let vname: String = assigned[lli];
+                let cur: i64 = lctx_lookup(ctx, vname);
+                loop_live_out2.push(cur);
+                lli = lli + 1;
+            }
+            lctx_pop_alloc_scope_frees(ctx, loop_live_out2);
+        } else {
+            // Loop body terminated (by break/return) — break already freed.
+            lctx_discard_alloc_scope(ctx);
+        }
 
         if !lctx_is_terminated(ctx) {
             let mut ai3: i64 = 0;
@@ -1683,7 +1749,9 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_is_loop.push(0);
         ctx.loop_break_counts.push(0);
         lctx_push_alloc_scope(ctx);
+        ctx.loop_alloc_scope_depths.push(ctx.alloc_ids.len());
         lower_block(ctx, body_bid);
+        ctx.loop_alloc_scope_depths.pop();
         ctx.loop_break_counts.pop();
         ctx.loop_is_loop.pop();
         ctx.loop_continue_scope_depth.pop();
@@ -2559,8 +2627,10 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         if nle > 0 {
             let exit_block: i64 = ctx.loop_exit_blocks[nle - 1];
             let val_eid: i64 = expr_a(a, eid);
+            let break_live_out: Vec<i64> = Vec::new();
             if val_eid != -1 {
                 let val_id: i64 = lower_expr(ctx, val_eid);
+                break_live_out.push(val_id);
                 let is_loop_idx: i64 = ctx.loop_is_loop.len() - 1;
                 let is_loop: i64 = ctx.loop_is_loop[is_loop_idx];
                 if is_loop == 1 {
@@ -2577,6 +2647,12 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     ctx.loop_break_counts[cnt_idx] = old_cnt + 1;
                 }
             }
+            // Free loop body allocations before jumping to exit.
+            let nlasd: i64 = ctx.loop_alloc_scope_depths.len();
+            if nlasd > 0 {
+                let depth: i64 = ctx.loop_alloc_scope_depths[nlasd - 1];
+                lctx_emit_alloc_frees_to_depth(ctx, depth, break_live_out);
+            }
             let jmp_args: Vec<i64> = Vec::new();
             return lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args, IDATA_JUMP_TARGET(), exit_block, 0, String::from(""));
         }
@@ -2592,6 +2668,21 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let phi_ids2: Vec<i64> = ctx.loop_continue_phi_ids[nlh - 1];
             let scope_depth: i64 = ctx.loop_continue_scope_depth[nlh - 1];
             let nphis: i64 = phi_names.len();
+
+            // Free loop body allocations before jumping back to header.
+            let nlasd: i64 = ctx.loop_alloc_scope_depths.len();
+            if nlasd > 0 {
+                let depth: i64 = ctx.loop_alloc_scope_depths[nlasd - 1];
+                let cont_live_out: Vec<i64> = Vec::new();
+                let mut cli: i64 = 0;
+                while cli < nphis {
+                    let vname: String = phi_names[cli];
+                    cont_live_out.push(lctx_lookup(ctx, vname));
+                    cli = cli + 1;
+                }
+                lctx_emit_alloc_frees_to_depth(ctx, depth, cont_live_out);
+            }
+
             let mut pi: i64 = 0;
             while pi < nphis {
                 let vname: String = phi_names[pi];
@@ -3065,6 +3156,7 @@ fn lower_function_vow(ctx: LowerCtx, fid: i64) -> IrFunction {
     ctx.alloc_sizes = Vec::new();
     ctx.escaped_ids = Vec::new();
     ctx.alloc_scope_starts = Vec::new();
+    ctx.loop_alloc_scope_depths = Vec::new();
 
     if vow_lid != -1 {
         ctx.cur_vow_lid = vow_lid;

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1572,6 +1572,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_exit_blocks.pop();
 
         // Free loop-body temporaries before back-edge.
+        // Include transitive sources so Phi/Upsilon aliases aren't freed.
         if !lctx_is_terminated(ctx) {
             let loop_live_out2: Vec<i64> = Vec::new();
             let mut lli: i64 = 0;
@@ -1579,11 +1580,16 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 let vname: String = assigned[lli];
                 let cur: i64 = lctx_lookup(ctx, vname);
                 loop_live_out2.push(cur);
+                let sources: Vec<i64> = lctx_collect_return_sources(ctx, cur);
+                let mut si: i64 = 0;
+                while si < sources.len() {
+                    loop_live_out2.push(sources[si]);
+                    si = si + 1;
+                }
                 lli = lli + 1;
             }
             lctx_pop_alloc_scope_frees(ctx, loop_live_out2);
         } else {
-            // Loop body terminated (by break/return) — break already freed.
             lctx_discard_alloc_scope(ctx);
         }
 
@@ -2680,6 +2686,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let nphis: i64 = phi_names.len();
 
             // Free loop body allocations before jumping back to header.
+            // Include transitive sources so Phi/Upsilon aliases aren't freed.
             let nlasd: i64 = ctx.loop_alloc_scope_depths.len();
             if nlasd > 0 {
                 let depth: i64 = ctx.loop_alloc_scope_depths[nlasd - 1];
@@ -2687,7 +2694,14 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 let mut cli: i64 = 0;
                 while cli < nphis {
                     let vname: String = phi_names[cli];
-                    cont_live_out.push(lctx_lookup(ctx, vname));
+                    let cval: i64 = lctx_lookup(ctx, vname);
+                    cont_live_out.push(cval);
+                    let csources: Vec<i64> = lctx_collect_return_sources(ctx, cval);
+                    let mut csi: i64 = 0;
+                    while csi < csources.len() {
+                        cont_live_out.push(csources[csi]);
+                        csi = csi + 1;
+                    }
                     cli = cli + 1;
                 }
                 lctx_emit_alloc_frees_to_depth(ctx, depth, cont_live_out);

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1241,16 +1241,44 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         let then_terminated: bool = lctx_is_terminated(ctx);
         let then_exit_block: i64 = ctx.current_block;
 
-        // Discard branch alloc scope (branch temporaries freed at function exit).
-        lctx_discard_alloc_scope(ctx);
+        // Collect mutation values before freeing branch temporaries.
+        let then_mut_vals: Vec<i64> = Vec::new();
+        let mut tmi: i64 = 0;
+        while tmi < nmut {
+            then_mut_vals.push(lctx_lookup(ctx, mutations[tmi]));
+            tmi = tmi + 1;
+        }
+        // Free branch temporaries (keep result and transitive sources alive).
+        if !then_terminated {
+            let then_live_out: Vec<i64> = Vec::new();
+            let mut loi: i64 = 0;
+            while loi < then_mut_vals.len() {
+                then_live_out.push(then_mut_vals[loi]);
+                let srcs: Vec<i64> = lctx_collect_return_sources(ctx, then_mut_vals[loi]);
+                let mut si: i64 = 0;
+                while si < srcs.len() {
+                    then_live_out.push(srcs[si]);
+                    si = si + 1;
+                }
+                loi = loi + 1;
+            }
+            then_live_out.push(then_result);
+            let rsrcs: Vec<i64> = lctx_collect_return_sources(ctx, then_result);
+            let mut rsi: i64 = 0;
+            while rsi < rsrcs.len() {
+                then_live_out.push(rsrcs[rsi]);
+                rsi = rsi + 1;
+            }
+            lctx_pop_alloc_scope_frees(ctx, then_live_out);
+        } else {
+            lctx_discard_alloc_scope(ctx);
+        }
 
         let mut_up_then: Vec<i64> = Vec::new();
         let mut mi: i64 = 0;
         while mi < nmut {
-            let mname: String = mutations[mi];
-            let mval: i64 = lctx_lookup(ctx, mname);
             let up_args: Vec<i64> = Vec::new();
-            up_args.push(mval);
+            up_args.push(then_mut_vals[mi]);
             let up_id: i64 = lctx_emit(ctx, IOP_UPSILON(), ITY_UNIT(), up_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
             mut_up_then.push(up_id);
             mi = mi + 1;
@@ -1285,16 +1313,44 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         let else_terminated: bool = lctx_is_terminated(ctx);
         let else_exit_block: i64 = ctx.current_block;
 
-        // Discard branch alloc scope (branch temporaries freed at function exit).
-        lctx_discard_alloc_scope(ctx);
+        // Collect mutation values before freeing branch temporaries.
+        let else_mut_vals: Vec<i64> = Vec::new();
+        let mut emi: i64 = 0;
+        while emi < nmut {
+            else_mut_vals.push(lctx_lookup(ctx, mutations[emi]));
+            emi = emi + 1;
+        }
+        // Free branch temporaries (keep result and transitive sources alive).
+        if !else_terminated {
+            let else_live_out: Vec<i64> = Vec::new();
+            let mut eloi: i64 = 0;
+            while eloi < else_mut_vals.len() {
+                else_live_out.push(else_mut_vals[eloi]);
+                let esrcs: Vec<i64> = lctx_collect_return_sources(ctx, else_mut_vals[eloi]);
+                let mut esi: i64 = 0;
+                while esi < esrcs.len() {
+                    else_live_out.push(esrcs[esi]);
+                    esi = esi + 1;
+                }
+                eloi = eloi + 1;
+            }
+            else_live_out.push(else_result);
+            let ersrcs: Vec<i64> = lctx_collect_return_sources(ctx, else_result);
+            let mut ersi: i64 = 0;
+            while ersi < ersrcs.len() {
+                else_live_out.push(ersrcs[ersi]);
+                ersi = ersi + 1;
+            }
+            lctx_pop_alloc_scope_frees(ctx, else_live_out);
+        } else {
+            lctx_discard_alloc_scope(ctx);
+        }
 
         let mut_up_else: Vec<i64> = Vec::new();
         let mut mi2: i64 = 0;
         while mi2 < nmut {
-            let mname: String = mutations[mi2];
-            let mval: i64 = lctx_lookup(ctx, mname);
             let up_args: Vec<i64> = Vec::new();
-            up_args.push(mval);
+            up_args.push(else_mut_vals[mi2]);
             let up_id: i64 = lctx_emit(ctx, IOP_UPSILON(), ITY_UNIT(), up_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
             mut_up_else.push(up_id);
             mi2 = mi2 + 1;
@@ -2472,16 +2528,46 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 }
 
                 let arm_result: i64 = lower_expr(ctx, body_eid);
+                let arm_terminated: bool = lctx_is_terminated(ctx);
                 lctx_pop_scope(ctx);
 
-                // Discard match arm alloc scope.
-                lctx_discard_alloc_scope(ctx);
+                // Collect mutation values before freeing match arm temporaries.
+                let arm_mut_vals: Vec<i64> = Vec::new();
+                let mut ami: i64 = 0;
+                while ami < nmut {
+                    arm_mut_vals.push(lctx_lookup(ctx, match_muts[ami]));
+                    ami = ami + 1;
+                }
+                // Free match arm temporaries (keep result and transitive sources alive).
+                if !arm_terminated {
+                    let arm_live_out: Vec<i64> = Vec::new();
+                    let mut aloi: i64 = 0;
+                    while aloi < arm_mut_vals.len() {
+                        arm_live_out.push(arm_mut_vals[aloi]);
+                        let asrcs: Vec<i64> = lctx_collect_return_sources(ctx, arm_mut_vals[aloi]);
+                        let mut asi: i64 = 0;
+                        while asi < asrcs.len() {
+                            arm_live_out.push(asrcs[asi]);
+                            asi = asi + 1;
+                        }
+                        aloi = aloi + 1;
+                    }
+                    arm_live_out.push(arm_result);
+                    let arsrcs: Vec<i64> = lctx_collect_return_sources(ctx, arm_result);
+                    let mut arsi: i64 = 0;
+                    while arsi < arsrcs.len() {
+                        arm_live_out.push(arsrcs[arsi]);
+                        arsi = arsi + 1;
+                    }
+                    lctx_pop_alloc_scope_frees(ctx, arm_live_out);
+                } else {
+                    lctx_discard_alloc_scope(ctx);
+                }
 
                 let mut mci: i64 = 0;
                 while mci < nmut {
-                    let mv: i64 = lctx_lookup(ctx, match_muts[mci]);
                     let mu_args: Vec<i64> = Vec::new();
-                    mu_args.push(mv);
+                    mu_args.push(arm_mut_vals[mci]);
                     let mu_id: i64 = lctx_emit(ctx, IOP_UPSILON(), ITY_UNIT(), mu_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
                     arm_mut_ups.push(mu_id);
                     mci = mci + 1;
@@ -2515,16 +2601,46 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     lctx_define(ctx, pname, ptr_id);
                 }
                 let arm_result: i64 = lower_expr(ctx, body_eid);
+                let arm_terminated2: bool = lctx_is_terminated(ctx);
                 lctx_pop_scope(ctx);
 
-                // Discard match arm alloc scope.
-                lctx_discard_alloc_scope(ctx);
+                // Collect mutation values before freeing match arm temporaries.
+                let arm_mut_vals2: Vec<i64> = Vec::new();
+                let mut ami2: i64 = 0;
+                while ami2 < nmut {
+                    arm_mut_vals2.push(lctx_lookup(ctx, match_muts[ami2]));
+                    ami2 = ami2 + 1;
+                }
+                // Free match arm temporaries (keep result and transitive sources alive).
+                if !arm_terminated2 {
+                    let arm_live_out2: Vec<i64> = Vec::new();
+                    let mut aloi2: i64 = 0;
+                    while aloi2 < arm_mut_vals2.len() {
+                        arm_live_out2.push(arm_mut_vals2[aloi2]);
+                        let asrcs2: Vec<i64> = lctx_collect_return_sources(ctx, arm_mut_vals2[aloi2]);
+                        let mut asi2: i64 = 0;
+                        while asi2 < asrcs2.len() {
+                            arm_live_out2.push(asrcs2[asi2]);
+                            asi2 = asi2 + 1;
+                        }
+                        aloi2 = aloi2 + 1;
+                    }
+                    arm_live_out2.push(arm_result);
+                    let arsrcs2: Vec<i64> = lctx_collect_return_sources(ctx, arm_result);
+                    let mut arsi2: i64 = 0;
+                    while arsi2 < arsrcs2.len() {
+                        arm_live_out2.push(arsrcs2[arsi2]);
+                        arsi2 = arsi2 + 1;
+                    }
+                    lctx_pop_alloc_scope_frees(ctx, arm_live_out2);
+                } else {
+                    lctx_discard_alloc_scope(ctx);
+                }
 
                 let mut mci2: i64 = 0;
                 while mci2 < nmut {
-                    let mv2: i64 = lctx_lookup(ctx, match_muts[mci2]);
                     let mu2_args: Vec<i64> = Vec::new();
-                    mu2_args.push(mv2);
+                    mu2_args.push(arm_mut_vals2[mci2]);
                     let mu2_id: i64 = lctx_emit(ctx, IOP_UPSILON(), ITY_UNIT(), mu2_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
                     arm_mut_ups.push(mu2_id);
                     mci2 = mci2 + 1;
@@ -2708,7 +2824,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 let mut cli: i64 = 0;
                 while cli < nphis {
                     let vname: String = phi_names[cli];
-                    let cval: i64 = lctx_lookup(ctx, vname);
+                    let cval: i64 = lctx_lookup_at_depth(ctx, vname, scope_depth);
                     cont_live_out.push(cval);
                     let csources: Vec<i64> = lctx_collect_return_sources(ctx, cval);
                     let mut csi: i64 = 0;

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1443,6 +1443,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_exit_blocks.pop();
 
         // Free loop-body temporaries before back-edge.
+        // Include transitive sources so Phi/Upsilon aliases aren't freed.
         if !lctx_is_terminated(ctx) {
             let loop_live_out: Vec<i64> = Vec::new();
             let mut li: i64 = 0;
@@ -1450,6 +1451,12 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 let vname: String = assigned[li];
                 let cur: i64 = lctx_lookup(ctx, vname);
                 loop_live_out.push(cur);
+                let sources: Vec<i64> = lctx_collect_return_sources(ctx, cur);
+                let mut si: i64 = 0;
+                while si < sources.len() {
+                    loop_live_out.push(sources[si]);
+                    si = si + 1;
+                }
                 li = li + 1;
             }
             lctx_pop_alloc_scope_frees(ctx, loop_live_out);
@@ -1770,6 +1777,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         lctx_pop_scope(ctx);
 
         // Free loop-body temporaries before back-edge.
+        // Include transitive sources so Phi/Upsilon aliases aren't freed.
         if !lctx_is_terminated(ctx) {
             let loop_live_out: Vec<i64> = Vec::new();
             let mut li: i64 = 0;
@@ -1777,6 +1785,12 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 let vname: String = assigned[li];
                 let cur: i64 = lctx_lookup(ctx, vname);
                 loop_live_out.push(cur);
+                let sources: Vec<i64> = lctx_collect_return_sources(ctx, cur);
+                let mut si: i64 = 0;
+                while si < sources.len() {
+                    loop_live_out.push(sources[si]);
+                    si = si + 1;
+                }
                 li = li + 1;
             }
             lctx_pop_alloc_scope_frees(ctx, loop_live_out);

--- a/tests/run/dealloc_branch.vow
+++ b/tests/run/dealloc_branch.vow
@@ -1,0 +1,44 @@
+// TEST: stdout "branch_ok:12:for_ok:12"
+module DeallocBranch
+
+// Test that allocations inside if-else branches are freed,
+// not leaked. Before the fix, branch alloc scopes were discarded
+// without emitting free calls.
+fn branch_allocs(flag: bool) -> i64 {
+    let result: i64 = if flag {
+        let s: String = String::from("hello");
+        s.len()
+    } else {
+        let s: String = String::from("world!");
+        let v: Vec<i64> = Vec::new();
+        v.push(1);
+        s.len() + v.len()
+    };
+    result
+}
+
+// Test that allocations inside for-each loop bodies are freed
+// each iteration, not accumulated across iterations.
+fn for_each_allocs() -> i64 {
+    let items: Vec<i64> = Vec::new();
+    items.push(1);
+    items.push(2);
+    items.push(3);
+    let mut total: i64 = 0;
+    for item in items {
+        let s: String = String::from("ab");
+        total = total + item + s.len();
+    }
+    total
+}
+
+fn main() -> i32 [io] {
+    let a: i64 = branch_allocs(false);
+    let b: i64 = branch_allocs(true);
+    print_str(String::from("branch_ok:"));
+    print_i64(a + b);
+    print_str(String::from(":for_ok:"));
+    let c: i64 = for_each_allocs();
+    print_i64(c);
+    0
+}

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -1726,8 +1726,14 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             };
 
             // Free loop body allocations before jumping to exit.
+            // Use collect_return_sources to trace through Phi/Upsilon chains —
+            // break_val may alias multiple heap allocations (e.g., from if-else).
             if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
-                let live_out: Vec<InstId> = break_val.into_iter().collect();
+                let live_out: Vec<InstId> = if let Some(bv) = break_val {
+                    ctx.collect_return_sources(bv).into_iter().collect()
+                } else {
+                    vec![]
+                };
                 ctx.emit_alloc_frees_to_depth(depth, &live_out, span);
             }
 

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -992,6 +992,11 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 for src in ctx.collect_return_sources(then_val) {
                     live_out.push(src);
                 }
+                for mv in &then_mut_vals {
+                    for src in ctx.collect_return_sources(*mv) {
+                        live_out.push(src);
+                    }
+                }
                 ctx.pop_alloc_scope_frees(&live_out, span);
             } else {
                 ctx.alloc_scopes.pop();
@@ -1039,6 +1044,11 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 live_out.push(else_val);
                 for src in ctx.collect_return_sources(else_val) {
                     live_out.push(src);
+                }
+                for mv in &else_mut_vals {
+                    for src in ctx.collect_return_sources(*mv) {
+                        live_out.push(src);
+                    }
                 }
                 ctx.pop_alloc_scope_frees(&live_out, span);
             } else {
@@ -1777,7 +1787,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
                 let mut live_out: Vec<InstId> = Vec::new();
                 for (name, _) in &phis {
-                    if let Some(val) = ctx.lookup(name) {
+                    if let Some(val) = ctx.lookup_at_depth(name, scope_depth) {
                         for src in ctx.collect_return_sources(val) {
                             live_out.push(src);
                         }
@@ -2176,6 +2186,11 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                             for src in ctx.collect_return_sources(arm_result) {
                                 live_out.push(src);
                             }
+                            for mv in &arm_mut_vals {
+                                for src in ctx.collect_return_sources(*mv) {
+                                    live_out.push(src);
+                                }
+                            }
                             ctx.pop_alloc_scope_frees(&live_out, span);
                         } else {
                             ctx.alloc_scopes.pop();
@@ -2229,6 +2244,11 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                             live_out.push(arm_result);
                             for src in ctx.collect_return_sources(arm_result) {
                                 live_out.push(src);
+                            }
+                            for mv in &arm_mut_vals {
+                                for src in ctx.collect_return_sources(*mv) {
+                                    live_out.push(src);
+                                }
                             }
                             ctx.pop_alloc_scope_frees(&live_out, span);
                         } else {

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -170,6 +170,8 @@ pub struct LowerCtx {
     // Push on entering a branch/loop/match arm, pop (with frees) on exit.
     alloc_scopes: Vec<Vec<(InstId, String)>>,
     escaped_allocs: HashSet<InstId>,
+    // Alloc scope depth at each loop body entry (for break/continue frees).
+    loop_alloc_scope_depth: Vec<usize>,
 }
 
 impl LowerCtx {
@@ -238,6 +240,7 @@ impl LowerCtx {
             warnings: Vec::new(),
             alloc_scopes: vec![Vec::new()],
             escaped_allocs: HashSet::new(),
+            loop_alloc_scope_depth: Vec::new(),
         }
     }
 
@@ -286,6 +289,50 @@ impl LowerCtx {
                 Opcode::Call,
                 Ty::Unit,
                 vec![*id],
+                InstData::CallExtern(sym.to_string()),
+                span,
+            );
+        }
+    }
+
+    /// Emit frees for allocations from the innermost scope down to (and including)
+    /// the scope at `target_depth`. Does NOT pop any scopes.
+    /// Used by break/continue to free loop body temporaries before jumping.
+    pub(super) fn emit_alloc_frees_to_depth(
+        &mut self,
+        target_depth: usize,
+        live_out: &[InstId],
+        span: Span,
+    ) {
+        let allocs: Vec<(InstId, String)> = self.alloc_scopes[target_depth..]
+            .iter()
+            .flat_map(|scope| scope.iter().cloned())
+            .collect();
+        for (id, tag) in allocs {
+            if self.escaped_allocs.contains(&id) || live_out.contains(&id) {
+                continue;
+            }
+            if let Some(size_str) = tag.strip_prefix("region:") {
+                let size: u32 = size_str.parse().unwrap_or(0);
+                self.emit(
+                    Opcode::RegionFree,
+                    Ty::Unit,
+                    vec![id],
+                    InstData::AllocSize { size, align: 8 },
+                    span,
+                );
+                continue;
+            }
+            let sym = match tag.as_str() {
+                "String" => "__vow_string_free",
+                "Vec" => "__vow_vec_free_val",
+                "HashMap" => "__vow_map_free",
+                _ => continue,
+            };
+            self.emit(
+                Opcode::Call,
+                Ty::Unit,
+                vec![id],
                 InstData::CallExtern(sym.to_string()),
                 span,
             );
@@ -938,8 +985,16 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .iter()
                 .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                 .collect();
-            // Discard branch alloc scope (branch temporaries freed at function exit).
-            ctx.alloc_scopes.pop();
+            // Free branch temporaries (keep result and mutation values alive).
+            if !then_terminated {
+                let mut live_out: Vec<InstId> = then_mut_vals.clone();
+                live_out.push(then_val);
+                ctx.pop_alloc_scope_frees(&live_out, span);
+            } else {
+                // Terminated by return (which already freed via emit_return_frees)
+                // or break/continue (handled separately).
+                ctx.alloc_scopes.pop();
+            }
             let then_upsilon_id = if !then_terminated {
                 let u = ctx.emit(
                     Opcode::Upsilon,
@@ -977,8 +1032,14 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .iter()
                 .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                 .collect();
-            // Discard branch alloc scope (branch temporaries freed at function exit).
-            ctx.alloc_scopes.pop();
+            // Free branch temporaries (keep result and mutation values alive).
+            if !else_terminated {
+                let mut live_out: Vec<InstId> = else_mut_vals.clone();
+                live_out.push(else_val);
+                ctx.pop_alloc_scope_frees(&live_out, span);
+            } else {
+                ctx.alloc_scopes.pop();
+            }
             let else_upsilon_id = if !else_terminated {
                 let u = ctx.emit(
                     Opcode::Upsilon,
@@ -1240,7 +1301,9 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_continue_scope_depth.push(ctx.scope.len());
             ctx.loop_break_upsilons.push(None);
             ctx.push_alloc_scope();
+            ctx.loop_alloc_scope_depth.push(ctx.alloc_scopes.len() - 1);
             lower_block(ctx, body);
+            ctx.loop_alloc_scope_depth.pop();
             ctx.loop_break_upsilons.pop();
             ctx.loop_continue_scope_depth.pop();
             ctx.loop_continue_idx_phi.pop();
@@ -1433,7 +1496,10 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_continue_phis.push(phi_ids.clone());
             ctx.loop_continue_idx_phi.push(Some(idx_phi));
             ctx.loop_continue_scope_depth.push(for_scope_depth);
+            ctx.push_alloc_scope();
+            ctx.loop_alloc_scope_depth.push(ctx.alloc_scopes.len() - 1);
             lower_block(ctx, body);
+            ctx.loop_alloc_scope_depth.pop();
             ctx.loop_continue_scope_depth.pop();
             ctx.loop_continue_idx_phi.pop();
             ctx.loop_continue_phis.pop();
@@ -1441,6 +1507,17 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_exit_blocks.pop();
 
             ctx.pop_scope();
+
+            // Free loop-body temporaries before back-edge.
+            if !ctx.is_terminated() {
+                let loop_live_out: Vec<InstId> = phi_ids
+                    .iter()
+                    .filter_map(|(name, _)| ctx.lookup(name))
+                    .collect();
+                ctx.pop_alloc_scope_frees(&loop_live_out, span);
+            } else {
+                ctx.alloc_scopes.pop();
+            }
 
             // Increment index and emit back-edge
             if !ctx.is_terminated() {
@@ -1553,7 +1630,9 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_continue_scope_depth.push(ctx.scope.len());
             ctx.loop_break_upsilons.push(Some(Vec::new()));
             ctx.push_alloc_scope();
+            ctx.loop_alloc_scope_depth.push(ctx.alloc_scopes.len() - 1);
             lower_block(ctx, body);
+            ctx.loop_alloc_scope_depth.pop();
             let break_ups = ctx.loop_break_upsilons.pop().unwrap();
             ctx.loop_continue_scope_depth.pop();
             ctx.loop_continue_idx_phi.pop();
@@ -1623,7 +1702,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .copied()
                 .expect("break outside of loop");
 
-            if let Some(val_expr) = value {
+            let break_val = if let Some(val_expr) = value {
                 let val_id = lower_expr(ctx, val_expr);
                 // If inside a `loop` (Some), emit Upsilon for the break-value Phi.
                 let is_loop = matches!(ctx.loop_break_upsilons.last(), Some(Some(_)));
@@ -1641,6 +1720,15 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         ups.push((block, up_id, val_ty));
                     }
                 }
+                Some(val_id)
+            } else {
+                None
+            };
+
+            // Free loop body allocations before jumping to exit.
+            if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
+                let live_out: Vec<InstId> = break_val.into_iter().collect();
+                ctx.emit_alloc_frees_to_depth(depth, &live_out, span);
             }
 
             ctx.emit(
@@ -1664,6 +1752,15 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .last()
                 .copied()
                 .expect("continue outside of loop");
+
+            // Free loop body allocations before jumping back to header.
+            if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
+                let live_out: Vec<InstId> = phis
+                    .iter()
+                    .filter_map(|(name, _)| ctx.lookup(name))
+                    .collect();
+                ctx.emit_alloc_frees_to_depth(depth, &live_out, span);
+            }
 
             // Emit back-edge Upsilons for mutation variables.
             // Use lookup_at_depth to resolve from the loop header scope, not the
@@ -2040,6 +2137,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         }
                         let arm_result = lower_expr(ctx, &arm.body);
                         let arm_ty = ctx.inst_ty(arm_result);
+                        let arm_terminated = ctx.is_terminated();
                         ctx.pop_scope();
 
                         let arm_mut_vals: Vec<InstId> = mutations
@@ -2047,8 +2145,14 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                             .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                             .collect();
 
-                        // Discard match arm alloc scope.
-                        ctx.alloc_scopes.pop();
+                        // Free match arm temporaries.
+                        if !arm_terminated {
+                            let mut live_out: Vec<InstId> = arm_mut_vals.clone();
+                            live_out.push(arm_result);
+                            ctx.pop_alloc_scope_frees(&live_out, span);
+                        } else {
+                            ctx.alloc_scopes.pop();
+                        }
 
                         let up_id = ctx.emit(
                             Opcode::Upsilon,
@@ -2084,6 +2188,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         ctx.push_alloc_scope();
                         let arm_result = lower_expr(ctx, &arm.body);
                         let arm_ty = ctx.inst_ty(arm_result);
+                        let arm_terminated = ctx.is_terminated();
                         ctx.pop_scope();
 
                         let arm_mut_vals: Vec<InstId> = mutations
@@ -2091,8 +2196,14 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                             .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                             .collect();
 
-                        // Discard match arm alloc scope.
-                        ctx.alloc_scopes.pop();
+                        // Free match arm temporaries.
+                        if !arm_terminated {
+                            let mut live_out: Vec<InstId> = arm_mut_vals.clone();
+                            live_out.push(arm_result);
+                            ctx.pop_alloc_scope_frees(&live_out, span);
+                        } else {
+                            ctx.alloc_scopes.pop();
+                        }
 
                         let up_id = ctx.emit(
                             Opcode::Upsilon,

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -985,14 +985,15 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .iter()
                 .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                 .collect();
-            // Free branch temporaries (keep result and mutation values alive).
+            // Free branch temporaries (keep result and transitive sources alive).
             if !then_terminated {
                 let mut live_out: Vec<InstId> = then_mut_vals.clone();
                 live_out.push(then_val);
+                for src in ctx.collect_return_sources(then_val) {
+                    live_out.push(src);
+                }
                 ctx.pop_alloc_scope_frees(&live_out, span);
             } else {
-                // Terminated by return (which already freed via emit_return_frees)
-                // or break/continue (handled separately).
                 ctx.alloc_scopes.pop();
             }
             let then_upsilon_id = if !then_terminated {
@@ -1032,10 +1033,13 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .iter()
                 .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                 .collect();
-            // Free branch temporaries (keep result and mutation values alive).
+            // Free branch temporaries (keep result and transitive sources alive).
             if !else_terminated {
                 let mut live_out: Vec<InstId> = else_mut_vals.clone();
                 live_out.push(else_val);
+                for src in ctx.collect_return_sources(else_val) {
+                    live_out.push(src);
+                }
                 ctx.pop_alloc_scope_frees(&live_out, span);
             } else {
                 ctx.alloc_scopes.pop();
@@ -1760,11 +1764,16 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .expect("continue outside of loop");
 
             // Free loop body allocations before jumping back to header.
+            // Include transitive sources so Phi/Upsilon aliases aren't freed.
             if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
-                let live_out: Vec<InstId> = phis
-                    .iter()
-                    .filter_map(|(name, _)| ctx.lookup(name))
-                    .collect();
+                let mut live_out: Vec<InstId> = Vec::new();
+                for (name, _) in &phis {
+                    if let Some(val) = ctx.lookup(name) {
+                        for src in ctx.collect_return_sources(val) {
+                            live_out.push(src);
+                        }
+                    }
+                }
                 ctx.emit_alloc_frees_to_depth(depth, &live_out, span);
             }
 
@@ -2151,10 +2160,13 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                             .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                             .collect();
 
-                        // Free match arm temporaries.
+                        // Free match arm temporaries (keep transitive sources alive).
                         if !arm_terminated {
                             let mut live_out: Vec<InstId> = arm_mut_vals.clone();
                             live_out.push(arm_result);
+                            for src in ctx.collect_return_sources(arm_result) {
+                                live_out.push(src);
+                            }
                             ctx.pop_alloc_scope_frees(&live_out, span);
                         } else {
                             ctx.alloc_scopes.pop();
@@ -2202,10 +2214,13 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                             .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                             .collect();
 
-                        // Free match arm temporaries.
+                        // Free match arm temporaries (keep transitive sources alive).
                         if !arm_terminated {
                             let mut live_out: Vec<InstId> = arm_mut_vals.clone();
                             live_out.push(arm_result);
+                            for src in ctx.collect_return_sources(arm_result) {
+                                live_out.push(src);
+                            }
                             ctx.pop_alloc_scope_frees(&live_out, span);
                         } else {
                             ctx.alloc_scopes.pop();

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -1316,12 +1316,16 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_exit_blocks.pop();
 
             // Free loop-body temporaries before back-edge.
+            // Include transitive sources so Phi/Upsilon aliases aren't freed.
             if !ctx.is_terminated() {
-                // Mutation values flow back to header Phis — don't free them.
-                let loop_live_out: Vec<InstId> = phi_ids
-                    .iter()
-                    .filter_map(|(name, _)| ctx.lookup(name))
-                    .collect();
+                let mut loop_live_out: Vec<InstId> = Vec::new();
+                for (name, _) in &phi_ids {
+                    if let Some(val) = ctx.lookup(name) {
+                        for src in ctx.collect_return_sources(val) {
+                            loop_live_out.push(src);
+                        }
+                    }
+                }
                 ctx.pop_alloc_scope_frees(&loop_live_out, span);
             } else {
                 ctx.alloc_scopes.pop();
@@ -1513,11 +1517,16 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.pop_scope();
 
             // Free loop-body temporaries before back-edge.
+            // Include transitive sources so Phi/Upsilon aliases aren't freed.
             if !ctx.is_terminated() {
-                let loop_live_out: Vec<InstId> = phi_ids
-                    .iter()
-                    .filter_map(|(name, _)| ctx.lookup(name))
-                    .collect();
+                let mut loop_live_out: Vec<InstId> = Vec::new();
+                for (name, _) in &phi_ids {
+                    if let Some(val) = ctx.lookup(name) {
+                        for src in ctx.collect_return_sources(val) {
+                            loop_live_out.push(src);
+                        }
+                    }
+                }
                 ctx.pop_alloc_scope_frees(&loop_live_out, span);
             } else {
                 ctx.alloc_scopes.pop();

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -1280,6 +1280,7 @@ fn scan_shift_needs(funcs: &[&Function]) -> ShiftNeeds {
 fn emit_c_preamble(out: &mut String, shifts: &ShiftNeeds) {
     out.push_str("#include <stdint.h>\n");
     out.push_str("#include <stdbool.h>\n");
+    out.push_str("#include <stddef.h>\n");
     out.push_str("extern void __ESBMC_assume(_Bool);\n");
     out.push_str("extern void __ESBMC_assert(_Bool, const char*);\n");
     out.push_str("extern int __VERIFIER_nondet_int(void);\n");

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::esbmc::{VerificationResult, run_esbmc_with_unwind};
+use crate::esbmc::{run_esbmc_with_max_k_step, VerificationResult};
 
 // ---------------------------------------------------------------------------
 // Solver / Encoding / Config types
@@ -208,7 +208,7 @@ pub fn run_with_fallback(
     // If encoding is explicit (not Auto), run once — no fallback.
     if config.encoding != Encoding::Auto {
         let resolved = config.resolve();
-        let result = run_esbmc_with_unwind(esbmc, c_src, unwind, func_name, &resolved);
+        let result = run_esbmc_with_max_k_step(esbmc, c_src, unwind, func_name, &resolved);
         return (result, resolved);
     }
 
@@ -221,7 +221,7 @@ pub fn run_with_fallback(
     }
     .resolve();
 
-    let result = run_esbmc_with_unwind(esbmc, c_src, unwind, func_name, &bv_config);
+    let result = run_esbmc_with_max_k_step(esbmc, c_src, unwind, func_name, &bv_config);
 
     match result {
         VerificationResult::Timeout => {
@@ -237,7 +237,7 @@ pub fn run_with_fallback(
                 encoding: Encoding::Ir,
                 timeout_secs: Some(timeout),
             };
-            let ir_result = run_esbmc_with_unwind(esbmc, c_src, unwind, func_name, &ir_config);
+            let ir_result = run_esbmc_with_max_k_step(esbmc, c_src, unwind, func_name, &ir_config);
             match ir_result {
                 VerificationResult::Proven => (VerificationResult::ProvenIr, ir_config),
                 other => (other, ir_config),

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -254,7 +254,7 @@ pub fn run_with_fallback(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vow_ir::{BasicBlock, BlockId, FuncId, Inst, InstId, Ty, VowEntry};
+    use vow_ir::{BasicBlock, BlockId, FuncId, Inst, InstId, Ty};
     use vow_syntax::span::Span;
 
     fn inst(id: u32, opcode: Opcode, ty: Ty, args: Vec<u32>, data: InstData) -> Inst {

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::esbmc::{run_esbmc_with_max_k_step, VerificationResult};
+use crate::esbmc::{VerificationResult, run_esbmc_with_max_k_step};
 
 // ---------------------------------------------------------------------------
 // Solver / Encoding / Config types


### PR DESCRIPTION
## Summary

- Fix three memory management bugs in the scope deallocation system that caused unbounded memory growth in long-running programs (SIGABRT during cleanup)
- If-else/match branch alloc scopes now free temporaries instead of discarding them silently
- Break/continue now free loop body allocations before jumping, via new `emit_alloc_frees_to_depth()` / `lctx_emit_alloc_frees_to_depth()`
- Rust for-each loop now has proper alloc scope push/pop (self-hosted already had this)

Closes #136

## Test plan

- [x] All 66 `vow-ir` unit tests pass
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Bootstrap achieves binary fixed point (SHA-256 match)
- [x] New regression test `tests/run/dealloc_branch.vow` exercises branch and for-each deallocation
- [x] Existing deallocation, continue, break, and for-each tests pass