### PR TITLE
feat: make verification limits configurable and switch to incremental BMC

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -3,6 +3,10 @@ module CEmitter
 use ir
 use ir_printer
 
+fn VOW_VEC_MAX() -> i64 vow { ensures: result >= 0 } { 128 }
+fn VOW_STRING_MAX() -> i64 vow { ensures: result >= 0 } { 256 }
+fn VOW_HASHMAP_MAX() -> i64 vow { ensures: result >= 0 } { 64 }
+
 fn str3(a: String, b: String, c: String) -> String {
     let r: String = String::from("");
     r.push_str(a);
@@ -491,7 +495,8 @@ fn emit_cmp(out: String, id: i64, a: i64, b: i64, op: String) {
 }
 
 fn emit_inst(out: String, inst: IrInst, vec_vars: Vec<i64>, string_vars: Vec<i64>,
-             hashmap_vars: Vec<i64>, const_fn_indices: Vec<i64>, modelable_fi_set: Vec<i64>, m: IrModule) {
+             hashmap_vars: Vec<i64>, const_fn_indices: Vec<i64>, modelable_fi_set: Vec<i64>, m: IrModule,
+             vec_max: i64, string_max: i64, hashmap_max: i64) {
     let id: i64 = inst.id;
     let op: i64 = inst.op;
     let ty: i64 = inst.ty;
@@ -726,15 +731,15 @@ fn emit_inst(out: String, inst: IrInst, vec_vars: Vec<i64>, string_vars: Vec<i64
         if inst.dk == IDATA_CALL_EXTERN() {
             let ds: String = inst.ds;
             if str_starts_with(ds, String::from("__vow_vec_")) {
-                emit_vec_op(out, inst);
+                emit_vec_op(out, inst, vec_max);
                 return;
             }
             if str_starts_with(ds, String::from("__vow_string_")) {
-                emit_string_op(out, inst);
+                emit_string_op(out, inst, string_max);
                 return;
             }
             if str_starts_with(ds, String::from("__vow_map_")) {
-                emit_map_op(out, inst);
+                emit_map_op(out, inst, hashmap_max);
                 return;
             }
             emit_unmodelled(out, inst);
@@ -816,7 +821,7 @@ fn emit_inst(out: String, inst: IrInst, vec_vars: Vec<i64>, string_vars: Vec<i64
     emit_unmodelled(out, inst);
 }
 
-fn emit_vec_op(out: String, inst: IrInst) {
+fn emit_vec_op(out: String, inst: IrInst, vec_max: i64) {
     let id: i64 = inst.id;
     let ds: String = inst.ds;
     let iargs: Vec<i64> = inst.args;
@@ -832,9 +837,8 @@ fn emit_vec_op(out: String, inst: IrInst) {
         let val: i64 = iargs[1];
         let vs: String = i64_to_str(vec);
         let vas: String = i64_to_str(val);
-        out.push_str(str5(String::from("  v"), vs, String::from(".data = (int64_t*)realloc(v"), vs,
-            String::from(".data, sizeof(int64_t) * (size_t)(v")));
-        out.push_str(str2(vs, String::from(".len + 1));\n")));
+        out.push_str(str5(String::from("  __ESBMC_assert(v"), vs,
+            String::from(".len < "), i64_to_str(vec_max), String::from(", \"vec capacity\");\n")));
         out.push_str(str6(String::from("  v"), vs, String::from(".data[v"), vs,
             String::from(".len] = v"), str2(vas, String::from(";\n"))));
         out.push_str(str3(String::from("  v"), vs, String::from(".len++;\n")));
@@ -881,7 +885,7 @@ fn emit_vec_op(out: String, inst: IrInst) {
     emit_unmodelled(out, inst);
 }
 
-fn emit_string_op(out: String, inst: IrInst) {
+fn emit_string_op(out: String, inst: IrInst, string_max: i64) {
     let id: i64 = inst.id;
     let ds: String = inst.ds;
     let iargs: Vec<i64> = inst.args;
@@ -889,11 +893,9 @@ fn emit_string_op(out: String, inst: IrInst) {
     if ds == String::from("__vow_string_from_cstr") {
         let ids: String = i64_to_str(id);
         out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
-        out.push_str(str3(String::from("  __ESBMC_assume(v"), ids, String::from(".len >= 0 && v")));
-        out.push_str(str2(ids, String::from(".len < INT64_MAX);\n")));
-        out.push_str(str5(String::from("  v"), ids, String::from(".data = (v"), ids,
-            String::from(".len > 0) ? (int8_t*)malloc((size_t)v")));
-        out.push_str(str2(ids, String::from(".len) : (int8_t*)0;\n")));
+        out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
+            String::from(".len >= 0 && v"), ids,
+            str3(String::from(".len < "), i64_to_str(string_max), String::from(");\n"))));
         return;
     }
     if ds == String::from("__vow_string_len") {
@@ -913,9 +915,8 @@ fn emit_string_op(out: String, inst: IrInst) {
         let s: i64 = iargs[0];
         let byte: i64 = iargs[1];
         let ss: String = i64_to_str(s);
-        out.push_str(str5(String::from("  v"), ss, String::from(".data = (int8_t*)realloc(v"), ss,
-            String::from(".data, (size_t)(v")));
-        out.push_str(str2(ss, String::from(".len + 1));\n")));
+        out.push_str(str5(String::from("  __ESBMC_assert(v"), ss,
+            String::from(".len < "), i64_to_str(string_max), String::from(", \"string capacity\");\n")));
         out.push_str(str6(String::from("  v"), ss, String::from(".data[v"), ss,
             String::from(".len] = (int8_t)v"), str2(i64_to_str(byte), String::from(";\n"))));
         out.push_str(str3(String::from("  v"), ss, String::from(".len++;\n")));
@@ -987,7 +988,7 @@ fn emit_string_op(out: String, inst: IrInst) {
     emit_unmodelled(out, inst);
 }
 
-fn emit_map_op(out: String, inst: IrInst) {
+fn emit_map_op(out: String, inst: IrInst, hashmap_max: i64) {
     let id: i64 = inst.id;
     let ds: String = inst.ds;
     let iargs: Vec<i64> = inst.args;
@@ -1020,12 +1021,8 @@ fn emit_map_op(out: String, inst: IrInst) {
         out.push_str(str2(vs, String::from("; __found = 1; break; }\n")));
         out.push_str(String::from("    }\n"));
         out.push_str(String::from("    if (!__found) {\n"));
-        out.push_str(str5(String::from("      v"), ms, String::from(".keys = (int64_t*)realloc(v"), ms,
-            String::from(".keys, sizeof(int64_t) * (size_t)(v")));
-        out.push_str(str2(ms, String::from(".len + 1));\n")));
-        out.push_str(str5(String::from("      v"), ms, String::from(".vals = (int64_t*)realloc(v"), ms,
-            String::from(".vals, sizeof(int64_t) * (size_t)(v")));
-        out.push_str(str2(ms, String::from(".len + 1));\n")));
+        out.push_str(str5(String::from("      __ESBMC_assert(v"), ms,
+            String::from(".len < "), i64_to_str(hashmap_max), String::from(", \"hashmap capacity\");\n")));
         out.push_str(str6(String::from("      v"), ms, String::from(".keys[v"), ms,
             String::from(".len] = v"), str2(ks, String::from("; v"))));
         out.push_str(str5(ms, String::from(".vals[v"), ms,
@@ -1085,7 +1082,8 @@ fn emit_map_op(out: String, inst: IrInst) {
     emit_unmodelled(out, inst);
 }
 
-fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, modelable_fi_set: Vec<i64>, m: IrModule) {
+fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, modelable_fi_set: Vec<i64>, m: IrModule,
+                   vec_max: i64, string_max: i64, hashmap_max: i64) {
     let vec_vars: Vec<i64> = collect_vec_vars(f);
     let string_vars: Vec<i64> = collect_string_vars(f);
     let hashmap_vars: Vec<i64> = collect_hashmap_vars(f);
@@ -1326,7 +1324,7 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
         let mut ri: i64 = 0;
         while ri < regular.len() {
             let inst: IrInst = insts[regular[ri]];
-            emit_inst(out, inst, vec_vars, string_vars, hashmap_vars, const_fn_indices, modelable_fi_set, m);
+            emit_inst(out, inst, vec_vars, string_vars, hashmap_vars, const_fn_indices, modelable_fi_set, m, vec_max, string_max, hashmap_max);
             ri = ri + 1;
         }
 
@@ -1350,7 +1348,7 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
 
         if terminal_idx >= 0 {
             let term: IrInst = insts[terminal_idx];
-            emit_inst(out, term, vec_vars, string_vars, hashmap_vars, const_fn_indices, modelable_fi_set, m);
+            emit_inst(out, term, vec_vars, string_vars, hashmap_vars, const_fn_indices, modelable_fi_set, m, vec_max, string_max, hashmap_max);
         }
 
         bi = bi + 1;
@@ -1390,7 +1388,8 @@ fn scan_shift_needs_in_fns(fns: Vec<IrFunction>, start: i64, end: i64, target_op
     0
 }
 
-fn cemit_preamble(need_shl_i64: i64, need_shr_i64: i64, need_shl_u64: i64, need_shr_u64: i64) -> String {
+fn cemit_preamble_with_limits(need_shl_i64: i64, need_shr_i64: i64, need_shl_u64: i64, need_shr_u64: i64,
+                              vec_max: i64, string_max: i64, hashmap_max: i64) -> String {
     let out: String = String::from("");
     out.push_str(String::from("#include <stdint.h>\n"));
     out.push_str(String::from("#include <stdlib.h>\n"));
@@ -1402,9 +1401,23 @@ fn cemit_preamble(need_shl_i64: i64, need_shr_i64: i64, need_shl_u64: i64, need_
     out.push_str(String::from("extern float __VERIFIER_nondet_float(void);\n"));
     out.push_str(String::from("extern double __VERIFIER_nondet_double(void);\n"));
     out.push_str(String::from("extern _Bool __VERIFIER_nondet_bool(void);\n\n"));
-    out.push_str(String::from("typedef struct { int64_t len; int64_t* data; } __vow_vec_t;\n"));
-    out.push_str(String::from("typedef struct { int64_t len; int8_t* data; } __vow_string_t;\n"));
-    out.push_str(String::from("typedef struct { int64_t len; int64_t* keys; int64_t* vals; } __vow_hashmap_t;\n\n"));
+    out.push_str(str3(
+        String::from("typedef struct { int64_t len; int64_t data["),
+        i64_to_str(vec_max),
+        String::from("]; } __vow_vec_t;\n")
+    ));
+    out.push_str(str3(
+        String::from("typedef struct { int64_t len; int8_t data["),
+        i64_to_str(string_max),
+        String::from("]; } __vow_string_t;\n")
+    ));
+    out.push_str(str5(
+        String::from("typedef struct { int64_t len; int64_t keys["),
+        i64_to_str(hashmap_max),
+        String::from("]; int64_t vals["),
+        i64_to_str(hashmap_max),
+        String::from("]; } __vow_hashmap_t;\n\n")
+    ));
     if need_shl_i64 != 0 {
         out.push_str(String::from("static inline int64_t __vow_shl_i64(int64_t value, int64_t count) {\n"));
         out.push_str(String::from("  uint64_t shift = ((uint64_t)count) & 63ULL;\n"));
@@ -1434,6 +1447,10 @@ fn cemit_preamble(need_shl_i64: i64, need_shr_i64: i64, need_shl_u64: i64, need_
         out.push_byte(10);
     }
     out
+}
+
+fn cemit_preamble(need_shl_i64: i64, need_shr_i64: i64, need_shl_u64: i64, need_shr_u64: i64) -> String {
+    cemit_preamble_with_limits(need_shl_i64, need_shr_i64, need_shl_u64, need_shr_u64, VOW_VEC_MAX(), VOW_STRING_MAX(), VOW_HASHMAP_MAX())
 }
 
 fn emit_forward_declaration(out: String, f: IrFunction) {
@@ -1486,7 +1503,7 @@ fn emit_c_module(m: IrModule) -> String {
     let mut fi: i64 = 0;
     while fi < fns.len() {
         let f: IrFunction = fns[fi];
-        emit_c_function(out, f, const_fn_indices, empty_modelable, m);
+        emit_c_function(out, f, const_fn_indices, empty_modelable, m, VOW_VEC_MAX(), VOW_STRING_MAX(), VOW_HASHMAP_MAX());
         out.push_byte(10);
         fi = fi + 1;
     }
@@ -1514,13 +1531,14 @@ fn scan_shift_op_in_module_fns(fns: Vec<IrFunction>, target_fi: i64, callee_fis:
     0
 }
 
-fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>, modelable_fi_set: Vec<i64>) -> String {
+fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>, modelable_fi_set: Vec<i64>,
+                              vec_max: i64, string_max: i64, hashmap_max: i64) -> String {
     let fns: Vec<IrFunction> = m.functions;
     let need_shl_i64: i64 = scan_shift_op_in_module_fns(fns, target_fi, callee_fis, IOP_SHL_I64());
     let need_shr_i64: i64 = scan_shift_op_in_module_fns(fns, target_fi, callee_fis, IOP_SHR_I64());
     let need_shl_u64: i64 = scan_shift_op_in_module_fns(fns, target_fi, callee_fis, IOP_SHL_U64());
     let need_shr_u64: i64 = scan_shift_op_in_module_fns(fns, target_fi, callee_fis, IOP_SHR_U64());
-    let out: String = cemit_preamble(need_shl_i64, need_shr_i64, need_shl_u64, need_shr_u64);
+    let out: String = cemit_preamble_with_limits(need_shl_i64, need_shr_i64, need_shl_u64, need_shr_u64, vec_max, string_max, hashmap_max);
     let const_fn_indices: Vec<i64> = detect_const_fns(m);
 
     let mut ci: i64 = 0;
@@ -1548,7 +1566,7 @@ fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>,
         while fi < fns.len() {
             let callee: IrFunction = fns[fi];
             if callee.id == cfid {
-                emit_c_function(out, callee, const_fn_indices, modelable_fi_set, m);
+                emit_c_function(out, callee, const_fn_indices, modelable_fi_set, m, vec_max, string_max, hashmap_max);
                 out.push_byte(10);
                 fi = fns.len();
             }
@@ -1561,7 +1579,7 @@ fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>,
     while fi < fns.len() {
         let f: IrFunction = fns[fi];
         if f.id == target_fi {
-            emit_c_function(out, f, const_fn_indices, modelable_fi_set, m);
+            emit_c_function(out, f, const_fn_indices, modelable_fi_set, m, vec_max, string_max, hashmap_max);
             out.push_byte(10);
             fi = fns.len();
         }

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -1488,14 +1488,14 @@ fn emit_forward_declaration(out: String, f: IrFunction) {
     out.push_str(str5(ret_c, String::from(" "), f.name, String::from("("), str2(param_str, String::from(");\n"))));
 }
 
-fn emit_c_module(m: IrModule) -> String {
+fn emit_c_module(m: IrModule, vec_max: i64, string_max: i64, hashmap_max: i64) -> String {
     let fns: Vec<IrFunction> = m.functions;
     let n: i64 = fns.len();
     let need_shl_i64: i64 = scan_shift_needs_in_fns(fns, 0, n, IOP_SHL_I64());
     let need_shr_i64: i64 = scan_shift_needs_in_fns(fns, 0, n, IOP_SHR_I64());
     let need_shl_u64: i64 = scan_shift_needs_in_fns(fns, 0, n, IOP_SHL_U64());
     let need_shr_u64: i64 = scan_shift_needs_in_fns(fns, 0, n, IOP_SHR_U64());
-    let out: String = cemit_preamble(need_shl_i64, need_shr_i64, need_shl_u64, need_shr_u64);
+    let out: String = cemit_preamble_with_limits(need_shl_i64, need_shr_i64, need_shl_u64, need_shr_u64, vec_max, string_max, hashmap_max);
 
     let const_fn_indices: Vec<i64> = detect_const_fns(m);
     let empty_modelable: Vec<i64> = Vec::new();
@@ -1503,7 +1503,7 @@ fn emit_c_module(m: IrModule) -> String {
     let mut fi: i64 = 0;
     while fi < fns.len() {
         let f: IrFunction = fns[fi];
-        emit_c_function(out, f, const_fn_indices, empty_modelable, m, VOW_VEC_MAX(), VOW_STRING_MAX(), VOW_HASHMAP_MAX());
+        emit_c_function(out, f, const_fn_indices, empty_modelable, m, vec_max, string_max, hashmap_max);
         out.push_byte(10);
         fi = fi + 1;
     }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -552,6 +552,14 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
         else { 30000 }
     };
     let do_verify: bool = has_flag(argv, String::from("--verify"));
+    let t_mks_str: String = get_flag_arg(argv, String::from("--max-k-step"));
+    let t_max_k_step: String = { if t_mks_str.len() > 0 { t_mks_str } else { String::from("50") } };
+    let t_vm_str: String = get_flag_arg(argv, String::from("--vec-max"));
+    let t_vec_max: i64 = { if t_vm_str.len() > 0 { parse_i64(t_vm_str) } else { 128 } };
+    let t_sm_str: String = get_flag_arg(argv, String::from("--string-max"));
+    let t_string_max: i64 = { if t_sm_str.len() > 0 { parse_i64(t_sm_str) } else { 256 } };
+    let t_hm_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
+    let t_hashmap_max: i64 = { if t_hm_str.len() > 0 { parse_i64(t_hm_str) } else { 64 } };
 
     // Validate path exists
     if fs_exists(path) == 0 {
@@ -639,7 +647,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                     let vf: IrFunction = vfns[vfi];
                     let vows: Vec<IrVowEntry> = vf.vows;
                     if vows.len() > 0 {
-                        let vh: i64 = verify_start(vf, ir_mod, String::from("50"), vfi, false, String::from(""), String::from(""), VOW_VEC_MAX(), VOW_STRING_MAX(), VOW_HASHMAP_MAX());
+                        let vh: i64 = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max);
                         if vh != -1 && vh != -2 {
                             let vr: VerifyResult = verify_collect(vh, vf);
                             if vr.status == VERIFY_FAILED() {
@@ -821,7 +829,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             }
         } else if emit_c {
             emit_ir_warnings(ir_mod, dctx);
-            let c_code: String = emit_c_module(ir_mod);
+            let c_code: String = emit_c_module(ir_mod, VOW_VEC_MAX(), VOW_STRING_MAX(), VOW_HASHMAP_MAX());
             print_str(c_code);
         } else if has_output {
             let out: String = get_flag_arg(argv, String::from("-o"));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -40,7 +40,7 @@ fn get_source_path(argv: Vec<String>) -> String {
         if first_byte != 45 {
             if i > 1 {
                 let prev: String = argv[i - 1];
-                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") || prev == String::from("--solver") || prev == String::from("--encoding") {
+                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") || prev == String::from("--solver") || prev == String::from("--encoding") || prev == String::from("--vec-max") || prev == String::from("--string-max") || prev == String::from("--hashmap-max") {
                     i = i - 1;
                 } else {
                     return a;
@@ -63,7 +63,7 @@ fn get_source_path_sub(argv: Vec<String>) -> String {
         if first_byte != 45 {
             if i > 2 {
                 let prev: String = argv[i - 1];
-                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") || prev == String::from("--solver") || prev == String::from("--encoding") {
+                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") || prev == String::from("--solver") || prev == String::from("--encoding") || prev == String::from("--vec-max") || prev == String::from("--string-max") || prev == String::from("--hashmap-max") {
                     i = i - 1;
                 } else {
                     return a;
@@ -174,7 +174,8 @@ fn frontend_path_from_argv(argv: Vec<String>, sub: bool) -> String [io] {
     path
 }
 
-fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String) -> i64 [io] {
+fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String,
+                   vec_max: i64, string_max: i64, hashmap_max: i64) -> i64 [io] {
     let mut fi: i64 = 0;
     let mut all_proven: i64 = 1;
     while fi < fns.len() {
@@ -182,7 +183,7 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Ve
         let vows: Vec<IrVowEntry> = f.vows;
         if vows.len() > 0 {
             eprintln_str(str3(String::from("Verifying "), f.name, String::from("...")));
-            let vr: VerifyResult = verify_function_full(f, ir_mod, max_k_step, use_cache, solver, encoding);
+            let vr: VerifyResult = verify_function_full(f, ir_mod, max_k_step, use_cache, solver, encoding, vec_max, string_max, hashmap_max);
             let st: i64 = vr.status;
             if st == VERIFY_PROVEN() {
                 eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
@@ -259,11 +260,17 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
         diag_emit_verify_json(String::from("CompileFailed"), dctx, Vec::new());
         return 1;
     }
-    let mks_str: String = get_flag_arg(argv, String::from("--max-k-step"));
+    let max_k_step_str: String = get_flag_arg(argv, String::from("--max-k-step"));
     let max_k_step: String = {
-        if mks_str.len() > 0 { mks_str }
+        if max_k_step_str.len() > 0 { max_k_step_str }
         else { String::from("50") }
     };
+    let vec_max_str: String = get_flag_arg(argv, String::from("--vec-max"));
+    let vec_max: i64 = { if vec_max_str.len() > 0 { parse_i64(vec_max_str) } else { 128 } };
+    let string_max_str: String = get_flag_arg(argv, String::from("--string-max"));
+    let string_max: i64 = { if string_max_str.len() > 0 { parse_i64(string_max_str) } else { 256 } };
+    let hashmap_max_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
+    let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     let mut solver: String = get_flag_arg(argv, String::from("--solver"));
     let encoding: String = get_flag_arg(argv, String::from("--encoding"));
@@ -285,7 +292,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     emit_ir_warnings(ir_mod, dctx);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
-    let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache, solver, encoding);
+    let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, vec_max, string_max, hashmap_max);
     let status_str: String = {
         if all_proven == 1 {
             String::from("Verified")
@@ -344,9 +351,9 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         }
     }
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
-    let mks_str: String = get_flag_arg(argv, String::from("--max-k-step"));
+    let max_k_step_str: String = get_flag_arg(argv, String::from("--max-k-step"));
     let max_k_step: String = {
-        if mks_str.len() > 0 { mks_str }
+        if max_k_step_str.len() > 0 { max_k_step_str }
         else { String::from("50") }
     };
     let mut solver: String = get_flag_arg(argv, String::from("--solver"));
@@ -360,6 +367,12 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
             solver = String::from("z3");
         }
     }
+    let vec_max_str: String = get_flag_arg(argv, String::from("--vec-max"));
+    let vec_max: i64 = { if vec_max_str.len() > 0 { parse_i64(vec_max_str) } else { 128 } };
+    let string_max_str: String = get_flag_arg(argv, String::from("--string-max"));
+    let string_max: i64 = { if string_max_str.len() > 0 { parse_i64(string_max_str) } else { 256 } };
+    let hashmap_max_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
+    let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
     let fns: Vec<IrFunction> = ir_mod.functions;
     let handles: Vec<i64> = Vec::new();
     let vow_fn_indices: Vec<i64> = Vec::new();
@@ -370,7 +383,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
             let vows: Vec<IrVowEntry> = f.vows;
             if vows.len() > 0 {
                 eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
-                let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding);
+                let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, vec_max, string_max, hashmap_max);
                 handles.push(h);
                 vow_fn_indices.push(fi);
             }
@@ -411,7 +424,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
             if st == VERIFY_PROVEN() {
                 eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
                 if use_cache {
-                    let c_src2: String = emit_c_for_verify(f, ir_mod);
+                    let c_src2: String = emit_c_for_verify(f, ir_mod, vec_max, string_max, hashmap_max);
                     let ck2: String = verify_cache_key(c_src2, max_k_step, solver, encoding);
                     verify_cache_store(ck2, VERIFY_PROVEN());
                 }
@@ -626,7 +639,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                     let vf: IrFunction = vfns[vfi];
                     let vows: Vec<IrVowEntry> = vf.vows;
                     if vows.len() > 0 {
-                        let vh: i64 = verify_start(vf, ir_mod, String::from("10"), vfi, false, String::from(""), String::from(""));
+                        let vh: i64 = verify_start(vf, ir_mod, String::from("50"), vfi, false, String::from(""), String::from(""), VOW_VEC_MAX(), VOW_STRING_MAX(), VOW_HASHMAP_MAX());
                         if vh != -1 && vh != -2 {
                             let vr: VerifyResult = verify_collect(vh, vf);
                             if vr.status == VERIFY_FAILED() {
@@ -782,16 +795,19 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
                 diag_emit_verify_json(String::from("VerifyFailed"), dctx, Vec::new());
                 return 1;
             }
-            let mks_str: String = get_flag_arg(argv, String::from("--max-k-step"));
+            let max_k_step_str: String = get_flag_arg(argv, String::from("--max-k-step"));
             let max_k_step: String = {
-                if mks_str.len() > 0 { mks_str }
+                if max_k_step_str.len() > 0 { max_k_step_str }
                 else { String::from("50") }
             };
+            let vec_max_leg: i64 = { let s: String = get_flag_arg(argv, String::from("--vec-max")); if s.len() > 0 { parse_i64(s) } else { 128 } };
+            let string_max_leg: i64 = { let s: String = get_flag_arg(argv, String::from("--string-max")); if s.len() > 0 { parse_i64(s) } else { 256 } };
+            let hashmap_max_leg: i64 = { let s: String = get_flag_arg(argv, String::from("--hashmap-max")); if s.len() > 0 { parse_i64(s) } else { 64 } };
             emit_ir_warnings(ir_mod, dctx);
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
             let use_cache_leg: bool = !has_flag(argv, String::from("--no-cache"));
-            let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache_leg, String::from(""), String::from(""));
+            let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache_leg, String::from(""), String::from(""), vec_max_leg, string_max_leg, hashmap_max_leg);
             let status_str: String = {
                 if all_proven == 1 {
                     String::from("Verified")
@@ -995,6 +1011,30 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
     r.push_str(String::from("          \"default\": \"(none)\"\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max Vec capacity for verification model (default: 128)\",\n"));
+    r.push_str(String::from("          \"long\": \"--vec-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 128\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--string-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max String capacity for verification model (default: 256)\",\n"));
+    r.push_str(String::from("          \"long\": \"--string-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 256\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--hashmap-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
+    r.push_str(String::from("          \"long\": \"--hashmap-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 64\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1076,6 +1116,30 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
     r.push_str(String::from("          \"default\": \"(none)\"\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max Vec capacity for verification model (default: 128)\",\n"));
+    r.push_str(String::from("          \"long\": \"--vec-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 128\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--string-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max String capacity for verification model (default: 256)\",\n"));
+    r.push_str(String::from("          \"long\": \"--string-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 256\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--hashmap-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
+    r.push_str(String::from("          \"long\": \"--hashmap-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 64\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1244,6 +1308,30 @@ fn skill_json() -> String {
     r.push_str(String::from("            \"auto\"\n"));
     r.push_str(String::from("          ],\n"));
     r.push_str(String::from("          \"default\": \"auto\"\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max Vec capacity for verification model (default: 128)\",\n"));
+    r.push_str(String::from("          \"long\": \"--vec-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 128\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--string-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max String capacity for verification model (default: 256)\",\n"));
+    r.push_str(String::from("          \"long\": \"--string-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 256\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--hashmap-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
+    r.push_str(String::from("          \"long\": \"--hashmap-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 64\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1266,14 +1354,20 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
-    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds (default: (none))\"\n"));
+    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds (default: (none))\",\n"));
+    r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
+    r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
+    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"verify_options\": {\n"));
     r.push_str(String::from("    \"--no-cache\": \"Disable verification result caching\",\n"));
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
-    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds (default: (none))\"\n"));
+    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds (default: (none))\",\n"));
+    r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
+    r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
+    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"test_options\": {\n"));
     r.push_str(String::from("    \"--verify\": \"Run ESBMC verification on test files\",\n"));
@@ -1290,7 +1384,10 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--no-cache\": \"Disable verification result caching\",\n"));
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver (with --verify)\",\n"));
-    r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode (with --verify); ir requires z3 (default: auto)\"\n"));
+    r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode (with --verify); ir requires z3 (default: auto)\",\n"));
+    r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
+    r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
+    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"global_options\": {\n"));
     r.push_str(String::from("    \"--help\": \"Emit versioned JSON tool-help data\",\n"));
@@ -1605,7 +1702,10 @@ fn skill_json() -> String {
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"verification_defaults\": {\n"));
     r.push_str(String::from("    \"strategy\": \"k-induction-parallel\",\n"));
-    r.push_str(String::from("    \"max_k_step\": 50\n"));
+    r.push_str(String::from("    \"max_k_step\": 50,\n"));
+    r.push_str(String::from("    \"vec_max\": 128,\n"));
+    r.push_str(String::from("    \"string_max\": 256,\n"));
+    r.push_str(String::from("    \"hashmap_max\": 64\n"));
     r.push_str(String::from("  }\n"));
     r.push_str(String::from("}\n"));
     r
@@ -1636,6 +1736,9 @@ fn skill_human() -> String {
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
     r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds (default: (none))\n"));
+    r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
+    r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
+    r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("VERIFY OPTIONS\n"));
     r.push_str(String::from("  --no-cache              Disable verification result caching\n"));
@@ -1643,6 +1746,9 @@ fn skill_human() -> String {
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
     r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds (default: (none))\n"));
+    r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
+    r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
+    r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("TEST OPTIONS\n"));
     r.push_str(String::from("  --verify                Run ESBMC verification on test files\n"));
@@ -1657,6 +1763,9 @@ fn skill_human() -> String {
     r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver (with --verify)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode (with --verify); ir requires z3 (default: auto)\n"));
+    r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
+    r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
+    r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("DECL OPTIONS\n"));
     r.push_str(String::from("  -o, --output <path>     Output declaration file path (default: <source>.vow.d)\n"));
@@ -1712,7 +1821,9 @@ fn skill_human() -> String {
     r.push_str(String::from("VERIFICATION\n"));
     r.push_str(String::from("  Strategy      : k-induction-parallel (incremental BMC + k-induction)\n"));
     r.push_str(String::from("  Max k step    : 50 (default; override with --max-k-step)\n"));
-    r.push_str(String::from("  Containers    : unbounded (no artificial capacity limits)\n"));
+    r.push_str(String::from("  Vec<T>        : 128 max capacity (override with --vec-max)\n"));
+    r.push_str(String::from("  String        : 256 max capacity (override with --string-max)\n"));
+    r.push_str(String::from("  HashMap<K, V> : 64 max capacity (override with --hashmap-max)\n"));
     r
 }
 // GENERATE:SKILL_HUMAN:END
@@ -2590,6 +2701,9 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
     r.push_str(String::from("| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |\n"));
+    r.push_str(String::from("| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |\n"));
+    r.push_str(String::from("| `--string-max <N>` | `256`    | Max String capacity for verification model   |\n"));
+    r.push_str(String::from("| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow verify`\n"));
     r.push_str(String::from("\n"));
@@ -2608,6 +2722,9 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
     r.push_str(String::from("| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |\n"));
+    r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
+    r.push_str(String::from("| `--string-max <N>` | `256`     | Max String capacity for verification model |\n"));
+    r.push_str(String::from("| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow contracts`\n"));
     r.push_str(String::from("\n"));
@@ -2626,6 +2743,9 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |\n"));
+    r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
+    r.push_str(String::from("| `--string-max <N>` | `256`     | Max String capacity for verification model |\n"));
+    r.push_str(String::from("| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow skill`\n"));
     r.push_str(String::from("\n"));
@@ -4431,6 +4551,9 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
             solver = String::from("z3");
         }
     }
+    let vec_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--vec-max")); if s.len() > 0 { parse_i64(s) } else { 128 } };
+    let string_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--string-max")); if s.len() > 0 { parse_i64(s) } else { 256 } };
+    let hashmap_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--hashmap-max")); if s.len() > 0 { parse_i64(s) } else { 64 } };
 
     // Collect per-contract entries into parallel arrays
     let e_vow_ids: Vec<i64> = Vec::new();
@@ -4477,7 +4600,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
         while fi < nf {
             let func: IrFunction = ir_mod.functions[fi];
             if func.vows.len() > 0 {
-                let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache, solver, encoding);
+                let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache, solver, encoding, vec_max_c, string_max_c, hashmap_max_c);
                 let st: i64 = vr.status;
                 let mut ei: i64 = 0;
                 while ei < e_func_names.len() {

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -247,6 +247,13 @@ fn emit_ir_warnings(ir_mod: IrModule, dctx: DiagCtx) [io] {
     }
 }
 
+fn validate_limits(vec_max: i64, string_max: i64, hashmap_max: i64) [io] {
+    if vec_max <= 0 || string_max <= 0 || hashmap_max <= 0 {
+        eprintln_str(String::from("error: --vec-max, --string-max, and --hashmap-max must be >= 1"));
+        process_exit(1);
+    }
+}
+
 fn run_verify(argv: Vec<String>) -> i32 [io] {
     let path: String = frontend_path_from_argv(argv, true);
     let fr: LoweredFrontend = frontend_lower_path(path);
@@ -271,6 +278,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     let string_max: i64 = { if string_max_str.len() > 0 { parse_i64(string_max_str) } else { 256 } };
     let hashmap_max_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
     let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
+    validate_limits(vec_max, string_max, hashmap_max);
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     let mut solver: String = get_flag_arg(argv, String::from("--solver"));
     let encoding: String = get_flag_arg(argv, String::from("--encoding"));
@@ -373,6 +381,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     let string_max: i64 = { if string_max_str.len() > 0 { parse_i64(string_max_str) } else { 256 } };
     let hashmap_max_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
     let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
+    validate_limits(vec_max, string_max, hashmap_max);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let handles: Vec<i64> = Vec::new();
     let vow_fn_indices: Vec<i64> = Vec::new();
@@ -560,6 +569,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
     let t_string_max: i64 = { if t_sm_str.len() > 0 { parse_i64(t_sm_str) } else { 256 } };
     let t_hm_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
     let t_hashmap_max: i64 = { if t_hm_str.len() > 0 { parse_i64(t_hm_str) } else { 64 } };
+    validate_limits(t_vec_max, t_string_max, t_hashmap_max);
 
     // Validate path exists
     if fs_exists(path) == 0 {
@@ -811,6 +821,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             let vec_max_leg: i64 = { let s: String = get_flag_arg(argv, String::from("--vec-max")); if s.len() > 0 { parse_i64(s) } else { 128 } };
             let string_max_leg: i64 = { let s: String = get_flag_arg(argv, String::from("--string-max")); if s.len() > 0 { parse_i64(s) } else { 256 } };
             let hashmap_max_leg: i64 = { let s: String = get_flag_arg(argv, String::from("--hashmap-max")); if s.len() > 0 { parse_i64(s) } else { 64 } };
+            validate_limits(vec_max_leg, string_max_leg, hashmap_max_leg);
             emit_ir_warnings(ir_mod, dctx);
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
@@ -1215,6 +1226,30 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
     r.push_str(String::from("          \"default\": 50\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max Vec capacity for verification model (default: 128)\",\n"));
+    r.push_str(String::from("          \"long\": \"--vec-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 128\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--string-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max String capacity for verification model (default: 256)\",\n"));
+    r.push_str(String::from("          \"long\": \"--string-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 256\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--hashmap-max <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
+    r.push_str(String::from("          \"long\": \"--hashmap-max\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": 64\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1382,7 +1417,10 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--filter <pat>\": \"Only run tests whose name contains pat (default: (none))\",\n"));
     r.push_str(String::from("    \"--mode <debug|release>\": \"Build mode; debug inserts runtime vow checks (default: (default))\",\n"));
     r.push_str(String::from("    \"--timeout <ms>\": \"Per-test execution timeout in milliseconds (default: 30000)\",\n"));
-    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (with --verify)\"\n"));
+    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (with --verify)\",\n"));
+    r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
+    r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
+    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"decl_options\": {\n"));
     r.push_str(String::from("    \"-o, --output <path>\": \"Output declaration file path (default: <source>.vow.d)\"\n"));
@@ -1764,6 +1802,9 @@ fn skill_human() -> String {
     r.push_str(String::from("  --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: (default))\n"));
     r.push_str(String::from("  --timeout <ms>          Per-test execution timeout in milliseconds (default: 30000)\n"));
     r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (with --verify)\n"));
+    r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
+    r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
+    r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("CONTRACTS OPTIONS\n"));
     r.push_str(String::from("  --verify                Run ESBMC verification and report per-contract status\n"));
@@ -2731,8 +2772,8 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
     r.push_str(String::from("| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |\n"));
     r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
-    r.push_str(String::from("| `--string-max <N>` | `256`     | Max String capacity for verification model |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model |\n"));
+    r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
+    r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow contracts`\n"));
     r.push_str(String::from("\n"));
@@ -2752,8 +2793,8 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |\n"));
     r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
-    r.push_str(String::from("| `--string-max <N>` | `256`     | Max String capacity for verification model |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model |\n"));
+    r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
+    r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow skill`\n"));
     r.push_str(String::from("\n"));
@@ -2788,6 +2829,9 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--mode release`  | `debug`     | Omit all vow checks for performance       |\n"));
     r.push_str(String::from("| `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |\n"));
     r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC max k-induction step (with --verify) |\n"));
+    r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
+    r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
+    r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.\n"));
     r.push_str(String::from("\n"));
@@ -4562,6 +4606,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let vec_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--vec-max")); if s.len() > 0 { parse_i64(s) } else { 128 } };
     let string_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--string-max")); if s.len() > 0 { parse_i64(s) } else { 256 } };
     let hashmap_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--hashmap-max")); if s.len() > 0 { parse_i64(s) } else { 64 } };
+    validate_limits(vec_max_c, string_max_c, hashmap_max_c);
 
     // Collect per-contract entries into parallel arrays
     let e_vow_ids: Vec<i64> = Vec::new();

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -205,11 +205,12 @@ fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, 
             }
             emit_c_module_with_callees(m, f.id, callee_fis, modelable_fi_set, vec_max, string_max, hashmap_max)
         } else {
-            let preamble: String = cemit_preamble_with_limits(vec_max, string_max, hashmap_max,
+            let preamble: String = cemit_preamble_with_limits(
                 func_has_shift_op(f, IOP_SHL_I64()),
                 func_has_shift_op(f, IOP_SHR_I64()),
                 func_has_shift_op(f, IOP_SHL_U64()),
-                func_has_shift_op(f, IOP_SHR_U64())
+                func_has_shift_op(f, IOP_SHR_U64()),
+                vec_max, string_max, hashmap_max
             );
             let empty_modelable: Vec<i64> = Vec::new();
             emit_c_function(preamble, f, const_fn_indices, empty_modelable, m, vec_max, string_max, hashmap_max);

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -160,7 +160,7 @@ fn emit_harness(f: IrFunction) -> String {
     out
 }
 
-fn emit_c_preamble() -> String {
+fn emit_c_preamble(vec_max: i64, string_max: i64, hashmap_max: i64) -> String {
     let out: String = String::from("");
     out.push_str(String::from("#include <stdint.h>\n"));
     out.push_str(String::from("#include <stdbool.h>\n"));
@@ -171,13 +171,27 @@ fn emit_c_preamble() -> String {
     out.push_str(String::from("extern float __VERIFIER_nondet_float(void);\n"));
     out.push_str(String::from("extern double __VERIFIER_nondet_double(void);\n"));
     out.push_str(String::from("extern _Bool __VERIFIER_nondet_bool(void);\n\n"));
-    out.push_str(String::from("typedef struct { int64_t len; int64_t* data; } __vow_vec_t;\n"));
-    out.push_str(String::from("typedef struct { int64_t len; int8_t* data; } __vow_string_t;\n"));
-    out.push_str(String::from("typedef struct { int64_t len; int64_t* keys; int64_t* vals; } __vow_hashmap_t;\n\n"));
+    out.push_str(str3(
+        String::from("typedef struct { int64_t len; int64_t data["),
+        i64_to_str(vec_max),
+        String::from("]; } __vow_vec_t;\n")
+    ));
+    out.push_str(str3(
+        String::from("typedef struct { int64_t len; int8_t data["),
+        i64_to_str(string_max),
+        String::from("]; } __vow_string_t;\n")
+    ));
+    out.push_str(str5(
+        String::from("typedef struct { int64_t len; int64_t keys["),
+        i64_to_str(hashmap_max),
+        String::from("]; int64_t vals["),
+        i64_to_str(hashmap_max),
+        String::from("]; } __vow_hashmap_t;\n\n")
+    ));
     out
 }
 
-fn emit_c_for_verify(f: IrFunction, m: IrModule) -> String {
+fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, hashmap_max: i64) -> String {
     let const_fn_indices: Vec<i64> = detect_const_fns(m);
     let callee_fis: Vec<i64> = collect_modelable_callees(f, m, const_fn_indices);
 
@@ -189,16 +203,16 @@ fn emit_c_for_verify(f: IrFunction, m: IrModule) -> String {
                 modelable_fi_set.push(callee_fis[ci]);
                 ci = ci + 1;
             }
-            emit_c_module_with_callees(m, f.id, callee_fis, modelable_fi_set)
+            emit_c_module_with_callees(m, f.id, callee_fis, modelable_fi_set, vec_max, string_max, hashmap_max)
         } else {
-            let preamble: String = cemit_preamble(
+            let preamble: String = cemit_preamble_with_limits(vec_max, string_max, hashmap_max,
                 func_has_shift_op(f, IOP_SHL_I64()),
                 func_has_shift_op(f, IOP_SHR_I64()),
                 func_has_shift_op(f, IOP_SHL_U64()),
                 func_has_shift_op(f, IOP_SHR_U64())
             );
             let empty_modelable: Vec<i64> = Vec::new();
-            emit_c_function(preamble, f, const_fn_indices, empty_modelable, m);
+            emit_c_function(preamble, f, const_fn_indices, empty_modelable, m, vec_max, string_max, hashmap_max);
             preamble.push_byte(10);
             preamble
         }
@@ -231,7 +245,7 @@ fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func
     cmd.push_str(esbmc_path());
     cmd.push_str(String::from(" "));
     cmd.push_str(c_path);
-    cmd.push_str(String::from(" --no-bounds-check --no-pointer-check --k-induction-parallel --max-k-step "));
+    cmd.push_str(String::from(" --no-bounds-check --no-pointer-check --incremental-bmc --max-k-step "));
     cmd.push_str(max_k_step);
     cmd.push_str(String::from(" --64\n"));
     fs_write(cmd_path, cmd);
@@ -253,7 +267,7 @@ fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: 
     esbmc_args.push(tmp_path);
     esbmc_args.push(String::from("--no-bounds-check"));
     esbmc_args.push(String::from("--no-pointer-check"));
-    esbmc_args.push(String::from("--k-induction-parallel"));
+    esbmc_args.push(String::from("--incremental-bmc"));
     esbmc_args.push(String::from("--max-k-step"));
     esbmc_args.push(max_k_step);
     esbmc_args.push(String::from("--64"));
@@ -269,7 +283,7 @@ fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name
     esbmc_args.push(tmp_path);
     esbmc_args.push(String::from("--no-bounds-check"));
     esbmc_args.push(String::from("--no-pointer-check"));
-    esbmc_args.push(String::from("--k-induction-parallel"));
+    esbmc_args.push(String::from("--incremental-bmc"));
     esbmc_args.push(String::from("--max-k-step"));
     esbmc_args.push(max_k_step);
     esbmc_args.push(String::from("--64"));
@@ -541,7 +555,8 @@ fn verify_cache_store(key: String, status: i64) [io] {
     fs_write(path, content);
 }
 
-fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cache: bool, solver: String, encoding: String) -> VerifyResult [io] {
+fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cache: bool, solver: String, encoding: String,
+                        vec_max: i64, string_max: i64, hashmap_max: i64) -> VerifyResult [io] {
     let vows: Vec<IrVowEntry> = f.vows;
     if vows.len() == 0 {
         return VerifyResult {
@@ -553,7 +568,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
             raw_output: String::from(""),
         };
     }
-    let c_source: String = emit_c_for_verify(f, m);
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max);
     if use_cache {
         verify_cache_ensure_dir();
         let cache_key: String = verify_cache_key(c_source, max_k_step, solver, encoding);
@@ -623,12 +638,13 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
     }
 }
 
-fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_cache: bool, solver: String, encoding: String) -> i64 [io] {
+fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_cache: bool, solver: String, encoding: String,
+                vec_max: i64, string_max: i64, hashmap_max: i64) -> i64 [io] {
     let vows: Vec<IrVowEntry> = f.vows;
     if vows.len() == 0 {
         return -1;
     }
-    let c_source: String = emit_c_for_verify(f, m);
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max);
     if use_cache {
         verify_cache_ensure_dir();
         let cache_key: String = verify_cache_key(c_source, max_k_step, solver, encoding);

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -21,10 +21,13 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |
 | `--debug-trace <off\|calls\|full>` | `off` | Emit JSON trace lines to stderr at runtime |
 | `--no-cache`    | (off)       | Disable compile and verify caching           |
-| `--max-k-step <N>` | `50`     | ESBMC max k-induction step                   |
+| `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |
+| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
+| `--string-max <N>` | `256`    | Max String capacity for verification model   |
+| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
 
 ### `vow verify`
 
@@ -39,10 +42,13 @@ vow verify [OPTIONS] <source.vow>
 | Flag              | Default     | Description                                |
 |-------------------|-------------|--------------------------------------------|
 | `--no-cache`      | (off)       | Disable verification result caching        |
-| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
+| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |
+| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
+| `--string-max <N>`| `256`       | Max String capacity for verification model |
+| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
 
 ### `vow contracts`
 
@@ -58,9 +64,12 @@ vow contracts [OPTIONS] <source.vow>
 |-------------------|-------------|--------------------------------------------|
 | `--verify`        | (off)       | Run ESBMC verification and report per-contract status |
 | `--no-cache`      | (off)       | Disable verification result caching        |
-| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
+| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
+| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
+| `--string-max <N>`| `256`       | Max String capacity for verification model |
+| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
 
 ### `vow skill`
 
@@ -94,7 +103,10 @@ vow test [OPTIONS] [<path>]
 | `--mode debug`    | (default)   | Insert runtime vow checks                 |
 | `--mode release`  | `debug`     | Omit all vow checks for performance       |
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
-| `--max-k-step <N>` | `50`       | ESBMC max k-induction step (with --verify) |
+| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations (with --verify) |
+| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
+| `--string-max <N>`| `256`       | Max String capacity for verification model |
+| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.
 

--- a/docs/spec/contracts.md
+++ b/docs/spec/contracts.md
@@ -16,15 +16,21 @@ Contract clauses become IR opcodes. The C emitter translates `requires` to `__ES
 ### ESBMC Configuration
 
 - Verification strategy: **k-induction-parallel** (incremental BMC + k-induction proof)
-- Max k-induction step: **50** (default; override with `--max-k-step`)
+- Incremental BMC with `--max-k-step` (default: **50**) — loops are verified incrementally up to N iterations
 - Architecture: 64-bit
 - Array bounds / pointer checks disabled (Vow handles these in its own model)
 
 ### Collection Models for Verification
 
-Collections (`Vec<T>`, `String`, `HashMap<K, V>`) are modeled with unbounded, dynamically allocated storage — the same semantics as at runtime. There are no artificial capacity limits in the verification model. ESBMC reasons about container operations using k-induction to prove properties for all iterations.
+ESBMC uses bounded models for collection types. Defaults are shown below; override with `--vec-max`, `--string-max`, `--hashmap-max`:
 
-`String::from` produces a nondeterministic non-negative length in verification.
+| Type              | Default Max Capacity | CLI Flag | Supported Operations |
+|-------------------|---------------------|----------|----------------------------------------------|
+| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |
+| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `byte_at`        |
+| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|
+
+These support the same operations as the runtime but with bounded storage. `String::from` produces a nondeterministic length (0 to max-1) in verification.
 
 ## Blame Model
 
@@ -230,7 +236,7 @@ This is not inductive — `v.len() == n` is only true after the loop.
 
 ### Unbound Loop Iterations
 
-Without a bound on loop iterations, ESBMC may timeout (max-k-step is 50):
+Without a bound on loop iterations, ESBMC may timeout (default max-k-step is 50):
 
 ```vow
 fn fill(n: i64) -> Vec<i64> vow {

--- a/scripts/generate_help.py
+++ b/scripts/generate_help.py
@@ -293,10 +293,13 @@ def build_help_json(grammar: str, cli: str, _contracts: str) -> dict:
         contracts_options[key] = value
         contracts_option_entries.append(option)
 
-    # --- Verification defaults from contracts.md ---
+    # --- Verification defaults (configurable via CLI flags) ---
     verification_defaults: dict[str, str | int] = {
         "strategy": "k-induction-parallel",
         "max_k_step": DEFAULT_MAX_K_STEP,
+        "vec_max": 128,
+        "string_max": 256,
+        "hashmap_max": 64,
     }
 
     return {
@@ -727,10 +730,12 @@ def build_help_human(data: dict) -> str:
 
     vdefaults = data.get("verification_defaults", {})
     if vdefaults:
-        lines.append("VERIFICATION")
-        lines.append(f"  Strategy      : {vdefaults.get('strategy', 'k-induction-parallel')} (incremental BMC + k-induction)")
-        lines.append(f"  Max k step    : {vdefaults.get('max_k_step', DEFAULT_MAX_K_STEP)} (default; override with --max-k-step)")
-        lines.append("  Containers    : unbounded (no artificial capacity limits)")
+        lines.append("VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max)")
+        lines.append(f"  Strategy        : {vdefaults.get('strategy', 'k-induction-parallel')} (incremental BMC + k-induction)")
+        lines.append(f"  Max k step      : {vdefaults.get('max_k_step', DEFAULT_MAX_K_STEP)} max iterations (--max-k-step)")
+        lines.append(f"  Vec<T>          : {vdefaults.get('vec_max', 128)} max capacity")
+        lines.append(f"  String          : {vdefaults.get('string_max', 256)} max capacity")
+        lines.append(f"  HashMap<K, V>   : {vdefaults.get('hashmap_max', 64)} max capacity")
 
     return "\n".join(lines)
 

--- a/scripts/generate_help.py
+++ b/scripts/generate_help.py
@@ -146,7 +146,7 @@ def normalize_option(
         option["value_kind"] = "enum"
         option["values"] = ["off", "calls", "full"]
         option["default"] = default
-    elif normalized_flag == "--max-k-step <N>":
+    elif normalized_flag in ("--max-k-step <N>", "--vec-max <N>", "--string-max <N>", "--hashmap-max <N>"):
         option["default"] = int(default) if default.isdigit() else default
     elif output_default is not None:
         option["default"] = output_default

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -48,6 +48,29 @@ pub fn detect_constant_functions(module: &Module) -> HashMap<FuncId, ConstantVal
 }
 
 // ---------------------------------------------------------------------------
+// Verification limits for bounded model checking
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+pub struct VerifyLimits {
+    pub max_k_step: u32,
+    pub vec_max: usize,
+    pub string_max: usize,
+    pub hashmap_max: usize,
+}
+
+impl Default for VerifyLimits {
+    fn default() -> Self {
+        Self {
+            max_k_step: 50,
+            vec_max: 128,
+            string_max: 256,
+            hashmap_max: 64,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Type mapping
 // ---------------------------------------------------------------------------
 
@@ -417,6 +440,7 @@ fn emit_inst(
     const_fns: &HashMap<FuncId, ConstantValue>,
     modelable_fns: &HashSet<FuncId>,
     module: &Module,
+    limits: &VerifyLimits,
 ) {
     let id = inst.id.0;
     match inst.opcode {
@@ -680,9 +704,10 @@ fn emit_inst(
                     "__vow_vec_push_val" => {
                         let vec = inst.args[0].0;
                         let val = inst.args[1].0;
+                        let vec_max = limits.vec_max;
                         out.push_str(&format!(
-                            "  v{vec}.data = (int64_t*)realloc(v{vec}.data, sizeof(int64_t) * (size_t)(v{vec}.len + 1));\n\
-                             \x20 v{vec}.data[v{vec}.len] = v{val};\n  v{vec}.len++;\n"
+                            "  __ESBMC_assert(v{vec}.len < {vec_max}, \"vec capacity\");\n\
+                             \x20 v{vec}.data[v{vec}.len] = v{val};\n  v{vec}.len++;\n",
                         ));
                     }
                     "__vow_vec_get_val" => {
@@ -722,10 +747,10 @@ fn emit_inst(
             if let InstData::CallExtern(ref name) = inst.data {
                 match name.as_str() {
                     "__vow_string_from_cstr" => {
+                        let string_max = limits.string_max;
                         out.push_str(&format!(
                             "  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n\
-                             \x20 v{id}.data = (v{id}.len > 0) ? (int8_t*)malloc((size_t)v{id}.len) : (int8_t*)0;\n"
+                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {string_max});\n",
                         ));
                     }
                     "__vow_string_len" => {
@@ -740,9 +765,10 @@ fn emit_inst(
                     "__vow_string_push_byte" => {
                         let s = inst.args[0].0;
                         let byte = inst.args[1].0;
+                        let string_max = limits.string_max;
                         out.push_str(&format!(
-                            "  v{s}.data = (int8_t*)realloc(v{s}.data, (size_t)(v{s}.len + 1));\n\
-                             \x20 v{s}.data[v{s}.len] = (int8_t)v{byte};\n  v{s}.len++;\n"
+                            "  __ESBMC_assert(v{s}.len < {string_max}, \"string capacity\");\n\
+                             \x20 v{s}.data[v{s}.len] = (int8_t)v{byte};\n  v{s}.len++;\n",
                         ));
                     }
                     "__vow_string_byte_at" => {
@@ -787,14 +813,14 @@ fn emit_inst(
                         let s = inst.args[0].0;
                         let start = inst.args[1].0;
                         let end = inst.args[2].0;
+                        let string_max = limits.string_max;
                         out.push_str(&format!(
                             "  __ESBMC_assert(v{start} >= 0 && v{start} <= v{s}.len, \"substring start\");\n\
                              \x20 __ESBMC_assert(v{end} >= v{start} && v{end} <= v{s}.len, \"substring end\");\n\
                              \x20 v{id}.len = v{end} - v{start};\n\
-                             \x20 v{id}.data = (int8_t*)realloc((int8_t*)0, (size_t)(v{id}.len + 1));\n\
-                             \x20 for (int64_t __i = 0; __i < v{id}.len; __i++) {{\n\
+                             \x20 for (int64_t __i = 0; __i < v{id}.len && __i < {string_max}; __i++) {{\n\
                              \x20   v{id}.data[__i] = v{s}.data[v{start} + __i];\n\
-                             \x20 }}\n"
+                             \x20 }}\n",
                         ));
                     }
                     "__vow_string_parse_i64_opt" | "__vow_string_parse_u64_opt" => {
@@ -831,6 +857,7 @@ fn emit_inst(
                         let m = inst.args[0].0;
                         let k = inst.args[1].0;
                         let v = inst.args[2].0;
+                        let hashmap_max = limits.hashmap_max;
                         out.push_str(&format!(
                             "  {{\n\
                              \x20   _Bool __found = 0;\n\
@@ -838,8 +865,7 @@ fn emit_inst(
                              \x20     if (v{m}.keys[__i] == v{k}) {{ v{m}.vals[__i] = v{v}; __found = 1; break; }}\n\
                              \x20   }}\n\
                              \x20   if (!__found) {{\n\
-                             \x20     v{m}.keys = (int64_t*)realloc(v{m}.keys, sizeof(int64_t) * (size_t)(v{m}.len + 1));\n\
-                             \x20     v{m}.vals = (int64_t*)realloc(v{m}.vals, sizeof(int64_t) * (size_t)(v{m}.len + 1));\n\
+                             \x20     __ESBMC_assert(v{m}.len < {hashmap_max}, \"hashmap capacity\");\n\
                              \x20     v{m}.keys[v{m}.len] = v{k}; v{m}.vals[v{m}.len] = v{v}; v{m}.len++;\n\
                              \x20   }}\n\
                              \x20 }}\n"
@@ -1004,7 +1030,11 @@ fn c_nondet_suffix(ty: Ty) -> &'static str {
 // Function emission
 // ---------------------------------------------------------------------------
 
-pub fn emit_c_function(func: &Function, const_fns: &HashMap<FuncId, ConstantValue>) -> String {
+pub fn emit_c_function(
+    func: &Function,
+    const_fns: &HashMap<FuncId, ConstantValue>,
+    limits: &VerifyLimits,
+) -> String {
     emit_c_function_full(
         func,
         const_fns,
@@ -1017,6 +1047,7 @@ pub fn emit_c_function(func: &Function, const_fns: &HashMap<FuncId, ConstantValu
             enum_layouts: vec![],
             warnings: vec![],
         },
+        limits,
     )
 }
 
@@ -1025,6 +1056,7 @@ pub fn emit_c_function_full(
     const_fns: &HashMap<FuncId, ConstantValue>,
     modelable_fns: &HashSet<FuncId>,
     module: &Module,
+    limits: &VerifyLimits,
 ) -> String {
     let mut out = String::new();
     let vec_vars = collect_typed_vars(func, "__vow_vec_new", "__vow_vec_");
@@ -1221,6 +1253,7 @@ pub fn emit_c_function_full(
                 const_fns,
                 modelable_fns,
                 module,
+                limits,
             );
         }
         // Emit Upsilons: read all sources first, then write all targets.
@@ -1243,6 +1276,7 @@ pub fn emit_c_function_full(
                 const_fns,
                 modelable_fns,
                 module,
+                limits,
             );
         }
     }
@@ -1277,7 +1311,7 @@ fn scan_shift_needs(funcs: &[&Function]) -> ShiftNeeds {
     needs
 }
 
-fn emit_c_preamble(out: &mut String, shifts: &ShiftNeeds) {
+fn emit_c_preamble(out: &mut String, shifts: &ShiftNeeds, limits: &VerifyLimits) {
     out.push_str("#include <stdint.h>\n");
     out.push_str("#include <stdlib.h>\n");
     out.push_str("#include <stdbool.h>\n");
@@ -1288,11 +1322,18 @@ fn emit_c_preamble(out: &mut String, shifts: &ShiftNeeds) {
     out.push_str("extern float __VERIFIER_nondet_float(void);\n");
     out.push_str("extern double __VERIFIER_nondet_double(void);\n");
     out.push_str("extern _Bool __VERIFIER_nondet_bool(void);\n\n");
-    out.push_str("typedef struct { int64_t len; int64_t* data; } __vow_vec_t;\n");
-    out.push_str("typedef struct { int64_t len; int8_t* data; } __vow_string_t;\n");
-    out.push_str(
-        "typedef struct { int64_t len; int64_t* keys; int64_t* vals; } __vow_hashmap_t;\n",
-    );
+    let vec_max = limits.vec_max;
+    let string_max = limits.string_max;
+    let hashmap_max = limits.hashmap_max;
+    out.push_str(&format!(
+        "typedef struct {{ int64_t len; int64_t data[{vec_max}]; }} __vow_vec_t;\n",
+    ));
+    out.push_str(&format!(
+        "typedef struct {{ int64_t len; int8_t data[{string_max}]; }} __vow_string_t;\n",
+    ));
+    out.push_str(&format!(
+        "typedef struct {{ int64_t len; int64_t keys[{hashmap_max}]; int64_t vals[{hashmap_max}]; }} __vow_hashmap_t;\n",
+    ));
     out.push_str("typedef struct { int64_t tag; int64_t payload; } __vow_option_t;\n");
     if shifts.shl_i64 {
         out.push_str(
@@ -1359,12 +1400,16 @@ fn emit_forward_declaration(func: &Function, out: &mut String) {
     out.push_str(&format!("{} {}({});\n", ret_c, func.name, param_str));
 }
 
-pub fn emit_c_module(funcs: &[&Function], const_fns: &HashMap<FuncId, ConstantValue>) -> String {
+pub fn emit_c_module(
+    funcs: &[&Function],
+    const_fns: &HashMap<FuncId, ConstantValue>,
+    limits: &VerifyLimits,
+) -> String {
     let mut out = String::new();
     let shifts = scan_shift_needs(funcs);
-    emit_c_preamble(&mut out, &shifts);
+    emit_c_preamble(&mut out, &shifts, limits);
     for func in funcs {
-        out.push_str(&emit_c_function(func, const_fns));
+        out.push_str(&emit_c_function(func, const_fns, limits));
         out.push('\n');
     }
     out
@@ -1378,6 +1423,7 @@ pub fn emit_c_module_with_callees(
     const_fns: &HashMap<FuncId, ConstantValue>,
     callee_ids: &[FuncId],
     modelable_fns: &HashSet<FuncId>,
+    limits: &VerifyLimits,
 ) -> String {
     let mut out = String::new();
 
@@ -1389,7 +1435,7 @@ pub fn emit_c_module_with_callees(
         }
     }
     let shifts = scan_shift_needs(&all_funcs);
-    emit_c_preamble(&mut out, &shifts);
+    emit_c_preamble(&mut out, &shifts, limits);
 
     // Forward declarations for all callees
     for fid in callee_ids {
@@ -1409,6 +1455,7 @@ pub fn emit_c_module_with_callees(
                 const_fns,
                 modelable_fns,
                 module,
+                limits,
             ));
             out.push('\n');
         }
@@ -1420,6 +1467,7 @@ pub fn emit_c_module_with_callees(
         const_fns,
         modelable_fns,
         module,
+        limits,
     ));
     out.push('\n');
     out
@@ -1474,7 +1522,7 @@ mod tests {
             }],
             local_names: std::collections::HashMap::new(),
         };
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("int64_t add("), "signature: {c}");
         assert!(c.contains("v2 = v0 + v1"), "add: {c}");
         assert!(c.contains("return v2"), "return: {c}");
@@ -1524,7 +1572,7 @@ mod tests {
             }],
             local_names: std::collections::HashMap::new(),
         };
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("__ESBMC_assume(v3)"), "requires: {c}");
         assert!(!c.contains("__ESBMC_assert"), "no assert for requires: {c}");
     }
@@ -1611,7 +1659,7 @@ mod tests {
                 inst(7, Opcode::Return, Ty::Unit, vec![], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("int32_t v0;"), "ConstI32 decl: {c}");
         assert!(c.contains("v0 = 7;"), "ConstI32 assign: {c}");
         assert!(c.contains("float v1;"), "ConstF32 decl: {c}");
@@ -1703,7 +1751,7 @@ mod tests {
                 inst(11, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v0 - v1"), "sub: {c}");
         assert!(c.contains("v0 * v1"), "mul: {c}");
         assert!(c.contains("v0 / v1"), "div: {c}");
@@ -1732,7 +1780,7 @@ mod tests {
                 inst(12, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v0 + v1"), "fadd: {c}");
         assert!(c.contains("v0 - v1"), "fsub: {c}");
         assert!(c.contains("v0 * v1"), "fmul: {c}");
@@ -1765,7 +1813,7 @@ mod tests {
                 inst(14, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v0 == v1"), "eq: {c}");
         assert!(c.contains("v0 != v1"), "ne: {c}");
         assert!(c.contains("v0 < v1"), "lt: {c}");
@@ -1789,7 +1837,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("!v0"), "not: {c}");
         assert!(c.contains("v0 && v1"), "and: {c}");
         assert!(c.contains("v0 || v1"), "or: {c}");
@@ -1812,7 +1860,7 @@ mod tests {
                 inst(7, Opcode::Return, Ty::Unit, vec![6], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v0 & v1"), "bitand: {c}");
         assert!(c.contains("v0 | v1"), "bitor: {c}");
         assert!(c.contains("v0 ^ v1"), "xor: {c}");
@@ -1834,7 +1882,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![], InstData::None),
             ],
         );
-        let c = emit_c_module(&[&func], &HashMap::new());
+        let c = emit_c_module(&[&func], &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("static inline int64_t __vow_shl_i64"),
             "shl_i64 should be present: {c}"
@@ -1872,7 +1920,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
             ],
         );
-        let c = emit_c_module(&[&func], &HashMap::new());
+        let c = emit_c_module(&[&func], &HashMap::new(), &VerifyLimits::default());
         assert!(
             !c.contains("__vow_shl_i64"),
             "no shift helpers should be present: {c}"
@@ -1940,7 +1988,7 @@ mod tests {
             ],
             local_names: std::collections::HashMap::new(),
         };
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("if (v0) goto block1; else goto block2;"),
             "branch: {c}"
@@ -1977,7 +2025,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("int64_t v0;"), "phi declaration: {c}");
         assert!(c.contains("v0 = __ups_1;"), "upsilon assignment: {c}");
     }
@@ -2009,7 +2057,7 @@ mod tests {
                 inst(2, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("not modelled"), "not modelled comment: {c}");
         assert!(c.contains("__VERIFIER_nondet_long"), "nondet for I64: {c}");
     }
@@ -2040,7 +2088,7 @@ mod tests {
                 inst(2, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("__ESBMC_assert(v0, \"vow:2\")"),
             "invariant assert: {c}"
@@ -2055,7 +2103,7 @@ mod tests {
             Ty::Unit,
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("return 0;"), "void return: {c}");
     }
 
@@ -2076,7 +2124,7 @@ mod tests {
                 inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let out = emit_c_module(&[&f1, &f2], &HashMap::new());
+        let out = emit_c_module(&[&f1, &f2], &HashMap::new(), &VerifyLimits::default());
         assert!(out.contains("#include <stdint.h>"), "includes: {out}");
         assert!(out.contains("__ESBMC_assume"), "esbmc assume: {out}");
         assert!(out.contains("void f1(void)"), "f1 signature: {out}");
@@ -2123,7 +2171,7 @@ mod tests {
             }],
             local_names: std::collections::HashMap::new(),
         };
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("__ESBMC_assert(v0"), "ensures: {c}");
     }
 
@@ -2135,7 +2183,7 @@ mod tests {
             Ty::Unit,
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
-        let out = emit_c_module(&[&f], &HashMap::new());
+        let out = emit_c_module(&[&f], &HashMap::new(), &VerifyLimits::default());
         assert!(out.contains("__vow_vec_t"), "vec typedef: {out}");
         assert!(out.contains("int64_t len"), "vec len field: {out}");
         assert!(out.contains("int64_t* data"), "vec data ptr field: {out}");
@@ -2162,7 +2210,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("__vow_vec_t v2;"), "vec struct decl: {c}");
         assert!(c.contains("v2.len = 0;"), "vec len init: {c}");
         assert!(
@@ -2201,7 +2249,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             !c.contains("vec capacity"),
             "push must NOT have capacity assertion: {c}"
@@ -2239,7 +2287,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v3 = v2.len;"), "vec len: {c}");
     }
 
@@ -2273,7 +2321,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("__ESBMC_assert(v3 >= 0 && v3 < v2.len"),
             "bounds check: {c}"
@@ -2310,7 +2358,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v2.len--;"), "pop decrement: {c}");
     }
 
@@ -2345,7 +2393,7 @@ mod tests {
                 inst(6, Opcode::Return, Ty::Unit, vec![], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("__ESBMC_assert(v3 >= 0 && v3 < v2.len"),
             "bounds check: {c}"
@@ -2398,7 +2446,7 @@ mod tests {
             }],
             local_names: std::collections::HashMap::new(),
         };
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("__vow_vec_t v0;"), "phi uses vec type: {c}");
     }
 
@@ -2421,7 +2469,7 @@ mod tests {
                 inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("not modelled"), "non-vec call still nondet: {c}");
         assert!(
             c.contains("__VERIFIER_nondet_long"),
@@ -2437,7 +2485,7 @@ mod tests {
             Ty::Unit,
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
-        let out = emit_c_module(&[&f], &HashMap::new());
+        let out = emit_c_module(&[&f], &HashMap::new(), &VerifyLimits::default());
         assert!(out.contains("__vow_string_t"), "string typedef: {out}");
         assert!(out.contains("int8_t* data"), "string data ptr field: {out}");
     }
@@ -2462,7 +2510,7 @@ mod tests {
                 inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("__vow_string_t v1;"), "string struct decl: {c}");
         assert!(
             c.contains("v1.len = __VERIFIER_nondet_long()"),
@@ -2506,7 +2554,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v2 = v1.len;"), "string len: {c}");
     }
 
@@ -2539,7 +2587,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![1], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             !c.contains("string capacity"),
             "push_byte must NOT have capacity assertion: {c}"
@@ -2588,7 +2636,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![1], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v1.len += v3.len;"), "push_str: {c}");
     }
 
@@ -2621,7 +2669,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("__ESBMC_assert(v2 >= 0 && v2 < v1.len"),
             "bounds check: {c}"
@@ -2673,7 +2721,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("v4 = (v1.len == v3.len)"),
             "string eq length check: {c}"
@@ -2721,7 +2769,7 @@ mod tests {
                 inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v4 = 0;"), "contains init: {c}");
         assert!(
             c.contains("v1.data[__i + __j] != v3.data[__j]"),
@@ -2773,7 +2821,7 @@ mod tests {
             }],
             local_names: std::collections::HashMap::new(),
         };
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("__vow_string_t v0;"),
             "phi uses string type: {c}"
@@ -2808,7 +2856,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("string print not modelled"),
             "print not modelled: {c}"
@@ -2836,7 +2884,7 @@ mod tests {
                 inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("__vow_hashmap_t v0;"), "hashmap decl: {c}");
         assert!(c.contains("v0.len = 0;"), "hashmap len init: {c}");
         assert!(
@@ -2872,7 +2920,7 @@ mod tests {
                 inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v1 = v0.len;"), "hashmap len: {c}");
     }
 
@@ -2905,7 +2953,7 @@ mod tests {
                 inst(4, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v0.keys[__i] == v1"), "key search: {c}");
         assert!(c.contains("v0.vals[__i] = v2"), "update existing: {c}");
         assert!(
@@ -2945,7 +2993,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v2 = 0;"), "get default: {c}");
         assert!(c.contains("v0.keys[__i] == v1"), "get key search: {c}");
         assert!(c.contains("v2 = v0.vals[__i]"), "get reads value: {c}");
@@ -2979,7 +3027,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v2 = 0;"), "contains default: {c}");
         assert!(c.contains("v0.keys[__i] == v1"), "contains key search: {c}");
         assert!(c.contains("v2 = 1"), "contains sets true: {c}");
@@ -3013,7 +3061,7 @@ mod tests {
                 inst(3, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("v0.keys[__i] == v1"), "remove key search: {c}");
         assert!(c.contains("v0.len--"), "remove decrements len: {c}");
     }
@@ -3061,7 +3109,7 @@ mod tests {
             }],
             local_names: std::collections::HashMap::new(),
         };
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("__vow_hashmap_t v0;"),
             "phi uses hashmap type: {c}"
@@ -3076,7 +3124,7 @@ mod tests {
             Ty::Unit,
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
-        let c = emit_c_module(&[&func], &HashMap::new());
+        let c = emit_c_module(&[&func], &HashMap::new(), &VerifyLimits::default());
         assert!(
             c.contains("__vow_hashmap_t"),
             "hashmap typedef in header: {c}"
@@ -3131,7 +3179,7 @@ mod tests {
             ],
             local_names: std::collections::HashMap::new(),
         };
-        let c = emit_c_function(&func, &HashMap::new());
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("int __blk_0 = 0;"), "blk_0 decl: {c}");
         assert!(c.contains("int __blk_1 = 0;"), "blk_1 decl: {c}");
         assert!(c.contains("int __blk_2 = 0;"), "blk_2 decl: {c}");
@@ -3296,6 +3344,7 @@ mod tests {
             &const_fns,
             &HashSet::new(),
             &empty_module,
+            &VerifyLimits::default(),
         );
         assert!(out.contains("v5 = 42LL;"), "inlined constant: {out}");
     }
@@ -3329,6 +3378,7 @@ mod tests {
             &HashMap::new(),
             &HashSet::new(),
             &empty_module,
+            &VerifyLimits::default(),
         );
         assert!(
             out.contains("__VERIFIER_nondet_long()"),

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -699,7 +699,7 @@ fn emit_inst(
             if let InstData::CallExtern(ref name) = inst.data {
                 match name.as_str() {
                     "__vow_vec_new" => {
-                        out.push_str(&format!("  v{id}.len = 0;\n  v{id}.data = (int64_t*)0;\n"));
+                        out.push_str(&format!("  v{id}.len = 0;\n"));
                     }
                     "__vow_vec_push_val" => {
                         let vec = inst.args[0].0;
@@ -845,9 +845,7 @@ fn emit_inst(
             if let InstData::CallExtern(ref name) = inst.data {
                 match name.as_str() {
                     "__vow_map_new" => {
-                        out.push_str(&format!(
-                            "  v{id}.len = 0;\n  v{id}.keys = (int64_t*)0;\n  v{id}.vals = (int64_t*)0;\n"
-                        ));
+                        out.push_str(&format!("  v{id}.len = 0;\n"));
                     }
                     "__vow_map_len" => {
                         let m = inst.args[0].0;
@@ -2186,7 +2184,10 @@ mod tests {
         let out = emit_c_module(&[&f], &HashMap::new(), &VerifyLimits::default());
         assert!(out.contains("__vow_vec_t"), "vec typedef: {out}");
         assert!(out.contains("int64_t len"), "vec len field: {out}");
-        assert!(out.contains("int64_t* data"), "vec data ptr field: {out}");
+        assert!(
+            out.contains("int64_t data[128]"),
+            "vec data array field: {out}"
+        );
     }
 
     #[test]
@@ -2251,8 +2252,8 @@ mod tests {
         );
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
-            !c.contains("vec capacity"),
-            "push must NOT have capacity assertion: {c}"
+            c.contains("vec capacity"),
+            "push must have capacity assertion: {c}"
         );
         assert!(c.contains("v2.data[v2.len] = v3;"), "push store: {c}");
         assert!(c.contains("v2.len++;"), "push increment: {c}");
@@ -2487,7 +2488,10 @@ mod tests {
         );
         let out = emit_c_module(&[&f], &HashMap::new(), &VerifyLimits::default());
         assert!(out.contains("__vow_string_t"), "string typedef: {out}");
-        assert!(out.contains("int8_t* data"), "string data ptr field: {out}");
+        assert!(
+            out.contains("int8_t data[256]"),
+            "string data array field: {out}"
+        );
     }
 
     #[test]
@@ -2517,8 +2521,8 @@ mod tests {
             "nondet len: {c}"
         );
         assert!(
-            c.contains("__ESBMC_assume(v1.len >= 0 && v1.len < INT64_MAX)"),
-            "len bounded by type: {c}"
+            c.contains("__ESBMC_assume(v1.len >= 0 && v1.len < 256)"),
+            "len bounded by string_max: {c}"
         );
         assert!(
             c.contains("return 0; /* modelled type return */"),
@@ -2589,8 +2593,8 @@ mod tests {
         );
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
-            !c.contains("string capacity"),
-            "push_byte must NOT have capacity assertion: {c}"
+            c.contains("string capacity"),
+            "push_byte must have capacity assertion: {c}"
         );
         assert!(
             c.contains("v1.data[v1.len] = (int8_t)v2;"),
@@ -2957,8 +2961,8 @@ mod tests {
         assert!(c.contains("v0.keys[__i] == v1"), "key search: {c}");
         assert!(c.contains("v0.vals[__i] = v2"), "update existing: {c}");
         assert!(
-            !c.contains("hashmap capacity"),
-            "insert must NOT have capacity assertion: {c}"
+            c.contains("hashmap capacity"),
+            "insert must have capacity assertion: {c}"
         );
         assert!(c.contains("v0.keys[v0.len] = v1"), "insert new key: {c}");
         assert!(c.contains("v0.vals[v0.len] = v2"), "insert new val: {c}");
@@ -3129,8 +3133,8 @@ mod tests {
             c.contains("__vow_hashmap_t"),
             "hashmap typedef in header: {c}"
         );
-        assert!(c.contains("int64_t* keys"), "keys ptr in typedef: {c}");
-        assert!(c.contains("int64_t* vals"), "vals ptr in typedef: {c}");
+        assert!(c.contains("int64_t keys[64]"), "keys array in typedef: {c}");
+        assert!(c.contains("int64_t vals[64]"), "vals array in typedef: {c}");
     }
 
     #[test]

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -317,7 +317,13 @@ fn verify_function_inner(
     let mut c_src = emit_c_module(&[func], const_fns, limits);
     c_src.push_str(&emit_harness(func));
 
-    run_esbmc_k_induction(&esbmc, &c_src, &func.name)
+    run_esbmc_with_max_k_step(
+        &esbmc,
+        &c_src,
+        limits.max_k_step,
+        &func.name,
+        &SolverConfig::default_config(),
+    )
 }
 
 pub fn run_esbmc_k_induction(

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -10,8 +10,8 @@ use vow_ir::{FuncId, Function, Module, Ty};
 use crate::solver_strategy::SolverConfig;
 
 use crate::c_emitter::{
-    ConstantValue, collect_modelable_callees, detect_constant_functions, emit_c_module,
-    emit_c_module_with_callees,
+    ConstantValue, VerifyLimits, collect_modelable_callees, detect_constant_functions,
+    emit_c_module, emit_c_module_with_callees,
 };
 
 // ---------------------------------------------------------------------------
@@ -204,7 +204,7 @@ fn save_esbmc_debug(esbmc: &std::path::Path, c_src: &str, func_name: &str, max_k
     let _ = std::fs::write(debug_dir.join(&c_name), c_src);
 
     let cmd = format!(
-        "{} /tmp/vow-verify-debug/{} --no-bounds-check --no-pointer-check --k-induction-parallel --max-k-step {} --64\n",
+        "{} /tmp/vow-verify-debug/{} --no-bounds-check --no-pointer-check --incremental-bmc --max-k-step {} --64\n",
         esbmc.display(),
         c_name,
         max_k_step,
@@ -216,36 +216,42 @@ fn save_esbmc_debug(esbmc: &std::path::Path, c_src: &str, func_name: &str, max_k
 // Verification entry point
 // ---------------------------------------------------------------------------
 
-pub fn verify_function(func: &Function) -> VerificationResult {
+pub fn verify_function(func: &Function, limits: &VerifyLimits) -> VerificationResult {
     let empty: HashMap<FuncId, ConstantValue> = HashMap::new();
-    verify_function_inner(func, &empty)
+    verify_function_inner(func, &empty, limits)
 }
 
-pub fn verify_function_with_module(func: &Function, module: &Module) -> VerificationResult {
+pub fn verify_function_with_module(
+    func: &Function,
+    module: &Module,
+    limits: &VerifyLimits,
+) -> VerificationResult {
     let const_fns = detect_constant_functions(module);
-    verify_function_with_module_and_const_fns(func, module, &const_fns)
+    verify_function_with_module_and_const_fns(func, module, &const_fns, limits)
 }
 
 pub fn verify_function_with_const_fns(
     func: &Function,
     const_fns: &HashMap<FuncId, ConstantValue>,
+    limits: &VerifyLimits,
 ) -> VerificationResult {
-    verify_function_inner(func, const_fns)
+    verify_function_inner(func, const_fns, limits)
 }
 
 pub fn emit_verify_c_source(
     func: &Function,
     module: &Module,
     const_fns: &HashMap<FuncId, ConstantValue>,
+    limits: &VerifyLimits,
 ) -> String {
     let mut modelable_cache = HashMap::new();
     let callee_ids = collect_modelable_callees(func, module, const_fns, &mut modelable_cache);
 
     let mut c_src = if callee_ids.is_empty() {
-        emit_c_module(&[func], const_fns)
+        emit_c_module(&[func], const_fns, limits)
     } else {
         let modelable_fns: std::collections::HashSet<FuncId> = callee_ids.iter().copied().collect();
-        emit_c_module_with_callees(func, module, const_fns, &callee_ids, &modelable_fns)
+        emit_c_module_with_callees(func, module, const_fns, &callee_ids, &modelable_fns, limits)
     };
     c_src.push_str(&emit_harness(func));
     c_src
@@ -257,12 +263,14 @@ pub fn verify_function_with_module_and_const_fns(
     func: &Function,
     module: &Module,
     const_fns: &HashMap<FuncId, ConstantValue>,
+    limits: &VerifyLimits,
 ) -> VerificationResult {
     verify_function_with_module_and_const_fns_with_max_k_step(
         func,
         module,
         const_fns,
-        DEFAULT_MAX_K_STEP,
+        limits.max_k_step,
+        limits,
     )
 }
 
@@ -271,10 +279,11 @@ pub fn verify_function_with_module_and_const_fns_with_max_k_step(
     module: &Module,
     const_fns: &HashMap<FuncId, ConstantValue>,
     max_k_step: u32,
+    limits: &VerifyLimits,
 ) -> VerificationResult {
     let config = SolverConfig::default_config();
     verify_function_with_module_and_const_fns_configured(
-        func, module, const_fns, max_k_step, &config,
+        func, module, const_fns, max_k_step, &config, limits,
     )
 }
 
@@ -284,26 +293,28 @@ pub fn verify_function_with_module_and_const_fns_configured(
     const_fns: &HashMap<FuncId, ConstantValue>,
     max_k_step: u32,
     config: &SolverConfig,
+    limits: &VerifyLimits,
 ) -> VerificationResult {
     let esbmc = match find_esbmc() {
         Some(p) => p,
         None => return VerificationResult::ToolNotFound,
     };
 
-    let c_src = emit_verify_c_source(func, module, const_fns);
+    let c_src = emit_verify_c_source(func, module, const_fns, limits);
     run_esbmc_with_max_k_step(&esbmc, &c_src, max_k_step, &func.name, config)
 }
 
 fn verify_function_inner(
     func: &Function,
     const_fns: &HashMap<FuncId, ConstantValue>,
+    limits: &VerifyLimits,
 ) -> VerificationResult {
     let esbmc = match find_esbmc() {
         Some(p) => p,
         None => return VerificationResult::ToolNotFound,
     };
 
-    let mut c_src = emit_c_module(&[func], const_fns);
+    let mut c_src = emit_c_module(&[func], const_fns, limits);
     c_src.push_str(&emit_harness(func));
 
     run_esbmc_k_induction(&esbmc, &c_src, &func.name)
@@ -347,7 +358,7 @@ pub fn run_esbmc_with_max_k_step(
     cmd.arg(tmp.path())
         .arg("--no-bounds-check")
         .arg("--no-pointer-check")
-        .arg("--k-induction-parallel")
+        .arg("--incremental-bmc")
         .arg("--max-k-step")
         .arg(max_k_step.to_string())
         .arg("--64");
@@ -588,7 +599,7 @@ mod tests {
     #[test]
     fn verify_trivially_true_ensures() {
         let func = trivially_true_func();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Proven => {}
             VerificationResult::ToolNotFound => {
                 eprintln!("SKIP: esbmc not found");
@@ -600,7 +611,7 @@ mod tests {
     #[test]
     fn verify_trivially_false_ensures() {
         let func = trivially_false_func();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Failed(_) => {}
             VerificationResult::ToolNotFound => {
                 eprintln!("SKIP: esbmc not found");
@@ -653,7 +664,7 @@ mod tests {
             }],
             local_names: std::collections::HashMap::new(),
         };
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Proven | VerificationResult::ToolNotFound => {}
             other => panic!("expected Proven or ToolNotFound, got {other:?}"),
         }
@@ -662,7 +673,7 @@ mod tests {
     #[test]
     fn verify_trivially_false_has_structured_counterexample() {
         let func = trivially_false_func();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Failed(ce) => {
                 assert_eq!(ce.vow_id, Some(0), "vow_id should be 0");
                 assert!(!ce.raw_output.is_empty(), "raw_output should be non-empty");
@@ -965,7 +976,7 @@ VERIFICATION FAILED";
     #[test]
     fn verify_vec_push_ensures_len() {
         let func = vec_push_one_ensures_len_1();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Proven => {}
             VerificationResult::ToolNotFound => {
                 eprintln!("SKIP: esbmc not found");
@@ -977,7 +988,7 @@ VERIFICATION FAILED";
     #[test]
     fn verify_vec_violated_len_contract() {
         let func = vec_empty_ensures_len_1_violated();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Failed(ce) => {
                 assert_eq!(ce.vow_id, Some(0), "vow_id should be 0");
             }
@@ -1125,7 +1136,7 @@ VERIFICATION FAILED";
     #[test]
     fn verify_string_push_byte_ensures_len() {
         let func = string_push_byte_ensures_len_gt_0();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Proven => {}
             VerificationResult::ToolNotFound => {
                 eprintln!("SKIP: esbmc not found");
@@ -1137,7 +1148,7 @@ VERIFICATION FAILED";
     #[test]
     fn verify_string_violated_len_contract() {
         let func = string_empty_ensures_len_gt_0_violated();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Failed(ce) => {
                 assert_eq!(ce.vow_id, Some(0), "vow_id should be 0");
             }
@@ -1373,7 +1384,7 @@ VERIFICATION FAILED";
     #[test]
     fn verify_hashmap_insert_ensures_contains() {
         let func = hashmap_insert_ensures_contains();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Proven => {}
             VerificationResult::ToolNotFound => {
                 eprintln!("SKIP: esbmc not found");
@@ -1385,7 +1396,7 @@ VERIFICATION FAILED";
     #[test]
     fn verify_hashmap_insert_ensures_len() {
         let func = hashmap_insert_ensures_len_1();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Proven => {}
             VerificationResult::ToolNotFound => {
                 eprintln!("SKIP: esbmc not found");
@@ -1397,7 +1408,7 @@ VERIFICATION FAILED";
     #[test]
     fn verify_hashmap_violated_len_contract() {
         let func = hashmap_empty_ensures_len_1_violated();
-        match verify_function(&func) {
+        match verify_function(&func, &VerifyLimits::default()) {
             VerificationResult::Failed(ce) => {
                 assert_eq!(ce.vow_id, Some(0), "vow_id should be 0");
             }

--- a/vow-verify/src/lib.rs
+++ b/vow-verify/src/lib.rs
@@ -2,7 +2,7 @@ pub mod c_emitter;
 pub mod esbmc;
 pub mod solver_strategy;
 
-pub use c_emitter::detect_constant_functions;
+pub use c_emitter::{VerifyLimits, detect_constant_functions};
 pub use esbmc::{
     Counterexample, DEFAULT_MAX_K_STEP, VerificationResult, emit_verify_c_source, find_esbmc,
     parse_esbmc_output, run_esbmc_k_induction, run_esbmc_with_max_k_step, verify_function,

--- a/vow/src/cache.rs
+++ b/vow/src/cache.rs
@@ -53,11 +53,7 @@ impl CompileCache {
 
     pub fn lookup(&self, key: &str) -> Option<PathBuf> {
         let cached = self.dir.join(format!("{key}.o"));
-        if cached.exists() {
-            Some(cached)
-        } else {
-            None
-        }
+        if cached.exists() { Some(cached) } else { None }
     }
 
     pub fn store(&self, key: &str, obj: &Path) -> PathBuf {

--- a/vow/src/cache.rs
+++ b/vow/src/cache.rs
@@ -53,7 +53,11 @@ impl CompileCache {
 
     pub fn lookup(&self, key: &str) -> Option<PathBuf> {
         let cached = self.dir.join(format!("{key}.o"));
-        if cached.exists() { Some(cached) } else { None }
+        if cached.exists() {
+            Some(cached)
+        } else {
+            None
+        }
     }
 
     pub fn store(&self, key: &str, obj: &Path) -> PathBuf {

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1293,8 +1293,7 @@ METHODS   : Vec: Vec::new/push/pop/len/clear/truncate/v[i]/v[i] = val   String: 
 OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?
 
 VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max)
-  Strategy      : k-induction-parallel (incremental BMC + k-induction)
-  Max k step    : 50 (default; override with --max-k-step)
+  Incremental BMC : 50 max iterations (--max-k-step)
   Vec<T>        : 128 max capacity (--vec-max)
   String        : 256 max capacity (--string-max)
   HashMap<K, V> : 64 max capacity (--hashmap-max)"##
@@ -4737,8 +4736,13 @@ fn run_verification_sync(
                     Some(p) => p,
                     None => return VerifyOutcome::ToolNotFound,
                 };
-                let res =
-                    run_esbmc_with_max_k_step(&esbmc, &c_src, limits.max_k_step, &func.name, &func_config);
+                let res = run_esbmc_with_max_k_step(
+                    &esbmc,
+                    &c_src,
+                    limits.max_k_step,
+                    &func.name,
+                    &func_config,
+                );
                 match &res {
                     VerificationResult::Proven | VerificationResult::ProvenIr => {
                         vc.store(&key, &CachedVerifyResult::Proven);
@@ -4959,12 +4963,7 @@ fn verify_outcome_to_output(
 
 pub fn run_verify_only(source: &Path) -> BuildOutput {
     let limits = VerifyLimits::default();
-    run_verify_only_inner(
-        source,
-        false,
-        &limits,
-        &SolverConfig::default_config(),
-    )
+    run_verify_only_inner(source, false, &limits, &SolverConfig::default_config())
 }
 
 fn run_verify_only_inner(
@@ -5702,7 +5701,13 @@ fn update_contract_statuses(
                         continue;
                     }
                 };
-                let res = run_esbmc_with_max_k_step(&esbmc, &c_src, limits.max_k_step, &func.name, config);
+                let res = run_esbmc_with_max_k_step(
+                    &esbmc,
+                    &c_src,
+                    limits.max_k_step,
+                    &func.name,
+                    config,
+                );
                 match &res {
                     VerificationResult::Proven | VerificationResult::ProvenIr => {
                         vc.store(&key, &CachedVerifyResult::Proven);
@@ -5725,7 +5730,12 @@ fn update_contract_statuses(
             }
         } else {
             verify_function_with_module_and_const_fns_configured(
-                func, ir_module, &const_fns, limits.max_k_step, config, limits,
+                func,
+                ir_module,
+                &const_fns,
+                limits.max_k_step,
+                config,
+                limits,
             )
         };
 
@@ -5980,13 +5990,7 @@ fn main() {
             };
             validate_limits(&limits);
             let config = make_solver_config(c.solver, c.encoding, c.timeout);
-            run_contracts_command(
-                &source,
-                c.verify,
-                c.no_cache,
-                &limits,
-                &config,
-            );
+            run_contracts_command(&source, c.verify, c.no_cache, &limits, &config);
         }
         Some(Command::Skill(s)) => {
             if s.help {

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1174,9 +1174,9 @@ fn skill_json() -> String {
   "verification_defaults": {
     "strategy": "k-induction-parallel",
     "max_k_step": 50,
-    "Vec<T>": 128,
-    "String": 256,
-    "HashMap<K, V>": 64
+    "vec_max": 128,
+    "string_max": 256,
+    "hashmap_max": 64
   }
 }"##
     .to_string()
@@ -5543,6 +5543,13 @@ fn run_test_command(
 // Entry point
 // ---------------------------------------------------------------------------
 
+fn validate_limits(limits: &VerifyLimits) {
+    if limits.vec_max == 0 || limits.string_max == 0 || limits.hashmap_max == 0 {
+        eprintln!("error: --vec-max, --string-max, and --hashmap-max must be >= 1");
+        std::process::exit(1);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_build_command(
     source: &Path,
@@ -5856,6 +5863,7 @@ fn main() {
                 string_max: b.string_max,
                 hashmap_max: b.hashmap_max,
             };
+            validate_limits(&limits);
             let bconfig = make_solver_config(b.solver, b.encoding, b.timeout);
             run_build_command(
                 &source,
@@ -5891,6 +5899,7 @@ fn main() {
                 string_max: v.string_max,
                 hashmap_max: v.hashmap_max,
             };
+            validate_limits(&limits);
             let config = make_solver_config(v.solver, v.encoding, v.timeout);
             run_verify_command(&source, v.no_cache, &limits, &config);
         }
@@ -5919,6 +5928,7 @@ fn main() {
                 string_max: t.string_max,
                 hashmap_max: t.hashmap_max,
             };
+            validate_limits(&limits);
             run_test_command(
                 &path,
                 t.verify,
@@ -5968,6 +5978,7 @@ fn main() {
                 string_max: c.string_max,
                 hashmap_max: c.hashmap_max,
             };
+            validate_limits(&limits);
             let config = make_solver_config(c.solver, c.encoding, c.timeout);
             run_contracts_command(
                 &source,
@@ -6031,6 +6042,7 @@ fn main() {
                 string_max: args.string_max,
                 hashmap_max: args.hashmap_max,
             };
+            validate_limits(&limits);
             let config = make_solver_config(args.solver, args.encoding, args.timeout);
             run_build_command(
                 &source,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2191,8 +2191,8 @@ vow verify [OPTIONS] <source.vow>
 | `--no-cache`      | (off)       | Disable verification result caching        |
 | `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>` | `256`     | Max String capacity for verification model |
-| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model|
+| `--string-max <N>`| `256`       | Max String capacity for verification model |
+| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
 
 ### `vow contracts`
 
@@ -2210,8 +2210,8 @@ vow contracts [OPTIONS] <source.vow>
 | `--no-cache`      | (off)       | Disable verification result caching        |
 | `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>` | `256`     | Max String capacity for verification model |
-| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model|
+| `--string-max <N>`| `256`       | Max String capacity for verification model |
+| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
 
 ### `vow skill`
 
@@ -2247,8 +2247,8 @@ vow test [OPTIONS] [<path>]
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
 | `--max-k-step <N>` | `50`       | ESBMC max k-induction step (with --verify) |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>` | `256`     | Max String capacity for verification model |
-| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model|
+| `--string-max <N>`| `256`       | Max String capacity for verification model |
+| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -16,8 +16,8 @@ use vow_codegen::{Backend, BuildMode, TraceMode};
 use vow_diag::{Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
 use vow_verify::{
     Counterexample, DEFAULT_MAX_K_STEP, Encoding, Solver, SolverConfig, VerificationResult,
-    detect_constant_functions, emit_verify_c_source, find_esbmc, run_esbmc_with_max_k_step,
-    verify_function_with_module_and_const_fns_configured,
+    VerifyLimits, detect_constant_functions, emit_verify_c_source, find_esbmc,
+    run_esbmc_with_max_k_step, verify_function_with_module_and_const_fns_configured,
 };
 
 use cache::{CachedVerifyResult, VerifyCache};
@@ -111,6 +111,12 @@ struct Args {
     no_cache: bool,
     #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
     max_k_step: u32,
+    #[arg(long, default_value = "128")]
+    vec_max: usize,
+    #[arg(long, default_value = "256")]
+    string_max: usize,
+    #[arg(long, default_value = "64")]
+    hashmap_max: usize,
     #[arg(long, value_enum, default_value = "auto")]
     solver: SolverArg,
     #[arg(long, value_enum, default_value = "auto")]
@@ -157,6 +163,12 @@ struct BuildArgs {
     no_cache: bool,
     #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
     max_k_step: u32,
+    #[arg(long, default_value = "128")]
+    vec_max: usize,
+    #[arg(long, default_value = "256")]
+    string_max: usize,
+    #[arg(long, default_value = "64")]
+    hashmap_max: usize,
     #[arg(long, value_enum, default_value = "auto")]
     solver: SolverArg,
     #[arg(long, value_enum, default_value = "auto")]
@@ -181,6 +193,12 @@ struct VerifyArgs {
     no_cache: bool,
     #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
     max_k_step: u32,
+    #[arg(long, default_value = "128")]
+    vec_max: usize,
+    #[arg(long, default_value = "256")]
+    string_max: usize,
+    #[arg(long, default_value = "64")]
+    hashmap_max: usize,
     #[arg(long, value_enum, default_value = "auto")]
     solver: SolverArg,
     #[arg(long, value_enum, default_value = "auto")]
@@ -209,6 +227,12 @@ struct TestArgs {
     /// ESBMC max k-induction step (only with --verify)
     #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
     max_k_step: u32,
+    #[arg(long, default_value = "128")]
+    vec_max: usize,
+    #[arg(long, default_value = "256")]
+    string_max: usize,
+    #[arg(long, default_value = "64")]
+    hashmap_max: usize,
     #[arg(long)]
     help: bool,
     #[arg(long)]
@@ -237,6 +261,12 @@ struct ContractsArgs {
     no_cache: bool,
     #[arg(long)]
     max_k_step: Option<u32>,
+    #[arg(long, default_value = "128")]
+    vec_max: usize,
+    #[arg(long, default_value = "256")]
+    string_max: usize,
+    #[arg(long, default_value = "64")]
+    hashmap_max: usize,
     #[arg(long, value_enum, default_value = "auto")]
     solver: SolverArg,
     #[arg(long, value_enum, default_value = "auto")]
@@ -392,6 +422,30 @@ fn skill_json() -> String {
           "default": 50
         },
         {
+          "form": "--vec-max <N>",
+          "description": "Max Vec capacity for verification model (default: 128)",
+          "long": "--vec-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 128
+        },
+        {
+          "form": "--string-max <N>",
+          "description": "Max String capacity for verification model (default: 256)",
+          "long": "--string-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 256
+        },
+        {
+          "form": "--hashmap-max <N>",
+          "description": "Max HashMap capacity for verification model (default: 64)",
+          "long": "--hashmap-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 64
+        },
+        {
           "form": "--solver <boolector|z3|bitwuzla|auto>",
           "description": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
           "long": "--solver",
@@ -471,6 +525,30 @@ fn skill_json() -> String {
           "value_name": "N",
           "value_kind": "integer",
           "default": 50
+        },
+        {
+          "form": "--vec-max <N>",
+          "description": "Max Vec capacity for verification model (default: 128)",
+          "long": "--vec-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 128
+        },
+        {
+          "form": "--string-max <N>",
+          "description": "Max String capacity for verification model (default: 256)",
+          "long": "--string-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 256
+        },
+        {
+          "form": "--hashmap-max <N>",
+          "description": "Max HashMap capacity for verification model (default: 64)",
+          "long": "--hashmap-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 64
         },
         {
           "form": "--solver <boolector|z3|bitwuzla|auto>",
@@ -573,6 +651,30 @@ fn skill_json() -> String {
           "value_name": "N",
           "value_kind": "integer",
           "default": 50
+        },
+        {
+          "form": "--vec-max <N>",
+          "description": "Max Vec capacity for verification model (default: 128)",
+          "long": "--vec-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 128
+        },
+        {
+          "form": "--string-max <N>",
+          "description": "Max String capacity for verification model (default: 256)",
+          "long": "--string-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 256
+        },
+        {
+          "form": "--hashmap-max <N>",
+          "description": "Max HashMap capacity for verification model (default: 64)",
+          "long": "--hashmap-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 64
         }
       ],
       "stdout": {
@@ -649,6 +751,30 @@ fn skill_json() -> String {
           "default": 50
         },
         {
+          "form": "--vec-max <N>",
+          "description": "Max Vec capacity for verification model (default: 128)",
+          "long": "--vec-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 128
+        },
+        {
+          "form": "--string-max <N>",
+          "description": "Max String capacity for verification model (default: 256)",
+          "long": "--string-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 256
+        },
+        {
+          "form": "--hashmap-max <N>",
+          "description": "Max HashMap capacity for verification model (default: 64)",
+          "long": "--hashmap-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 64
+        },
+        {
           "form": "--solver <boolector|z3|bitwuzla|auto>",
           "description": "ESBMC SMT solver (with --verify)",
           "long": "--solver",
@@ -694,6 +820,9 @@ fn skill_json() -> String {
     "--debug-trace <off|calls|full>": "Emit JSON trace lines to stderr at runtime (default: off)",
     "--no-cache": "Disable compile and verify caching",
     "--max-k-step <N>": "ESBMC max k-induction step (default: 50)",
+    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
+    "--string-max <N>": "Max String capacity for verification model (default: 256)",
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
     "--timeout <N>": "ESBMC per-function timeout in seconds (default: (none))"
@@ -701,6 +830,9 @@ fn skill_json() -> String {
   "verify_options": {
     "--no-cache": "Disable verification result caching",
     "--max-k-step <N>": "ESBMC max k-induction step (default: 50)",
+    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
+    "--string-max <N>": "Max String capacity for verification model (default: 256)",
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
     "--timeout <N>": "ESBMC per-function timeout in seconds (default: (none))"
@@ -710,7 +842,10 @@ fn skill_json() -> String {
     "--filter <pat>": "Only run tests whose name contains pat (default: (none))",
     "--mode <debug|release>": "Build mode; debug inserts runtime vow checks (default: (default))",
     "--timeout <ms>": "Per-test execution timeout in milliseconds (default: 30000)",
-    "--max-k-step <N>": "ESBMC max k-induction step (with --verify)"
+    "--max-k-step <N>": "ESBMC max k-induction step (with --verify)",
+    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
+    "--string-max <N>": "Max String capacity for verification model (default: 256)",
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
   },
   "decl_options": {
     "-o, --output <path>": "Output declaration file path (default: <source>.vow.d)"
@@ -719,6 +854,9 @@ fn skill_json() -> String {
     "--verify": "Run ESBMC verification and report per-contract status",
     "--no-cache": "Disable verification result caching",
     "--max-k-step <N>": "ESBMC max k-induction step (default: 50)",
+    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
+    "--string-max <N>": "Max String capacity for verification model (default: 256)",
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver (with --verify)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode (with --verify); ir requires z3 (default: auto)"
   },
@@ -1035,7 +1173,10 @@ fn skill_json() -> String {
   },
   "verification_defaults": {
     "strategy": "k-induction-parallel",
-    "max_k_step": 50
+    "max_k_step": 50,
+    "Vec<T>": 128,
+    "String": 256,
+    "HashMap<K, V>": 64
   }
 }"##
     .to_string()
@@ -1063,6 +1204,9 @@ BUILD OPTIONS
   --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)
   --no-cache              Disable compile and verify caching
   --max-k-step <N>        ESBMC max k-induction step (default: 50)
+  --vec-max <N>           Max Vec capacity for verification model (default: 128)
+  --string-max <N>        Max String capacity for verification model (default: 256)
+  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
   --timeout <N>           ESBMC per-function timeout in seconds (default: (none))
@@ -1070,6 +1214,9 @@ BUILD OPTIONS
 VERIFY OPTIONS
   --no-cache              Disable verification result caching
   --max-k-step <N>        ESBMC max k-induction step (default: 50)
+  --vec-max <N>           Max Vec capacity for verification model (default: 128)
+  --string-max <N>        Max String capacity for verification model (default: 256)
+  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
   --timeout <N>           ESBMC per-function timeout in seconds (default: (none))
@@ -1080,11 +1227,17 @@ TEST OPTIONS
   --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: (default))
   --timeout <ms>          Per-test execution timeout in milliseconds (default: 30000)
   --max-k-step <N>        ESBMC max k-induction step (with --verify)
+  --vec-max <N>           Max Vec capacity for verification model (default: 128)
+  --string-max <N>        Max String capacity for verification model (default: 256)
+  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
 
 CONTRACTS OPTIONS
   --verify                Run ESBMC verification and report per-contract status
   --no-cache              Disable verification result caching
   --max-k-step <N>        ESBMC max k-induction step (default: 50)
+  --vec-max <N>           Max Vec capacity for verification model (default: 128)
+  --string-max <N>        Max String capacity for verification model (default: 256)
+  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver (with --verify)
   --encoding <bv|ir|auto>  ESBMC encoding mode (with --verify); ir requires z3 (default: auto)
 
@@ -1139,10 +1292,12 @@ METHODS   : Vec: Vec::new/push/pop/len/clear/truncate/v[i]/v[i] = val   String: 
             HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap
 OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?
 
-VERIFICATION
+VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max)
   Strategy      : k-induction-parallel (incremental BMC + k-induction)
   Max k step    : 50 (default; override with --max-k-step)
-  Containers    : unbounded (no artificial capacity limits)"##
+  Vec<T>        : 128 max capacity (--vec-max)
+  String        : 256 max capacity (--string-max)
+  HashMap<K, V> : 64 max capacity (--hashmap-max)"##
         .to_string()
 }
 // GENERATE:SKILL_HUMAN:END
@@ -2017,6 +2172,9 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--debug-trace <off\|calls\|full>` | `off` | Emit JSON trace lines to stderr at runtime |
 | `--no-cache`    | (off)       | Disable compile and verify caching           |
 | `--max-k-step <N>` | `50`     | ESBMC max k-induction step                   |
+| `--vec-max <N>` | `128`      | Max Vec capacity for verification model       |
+| `--string-max <N>` | `256`   | Max String capacity for verification model    |
+| `--hashmap-max <N>` | `64`   | Max HashMap capacity for verification model   |
 
 ### `vow verify`
 
@@ -2032,6 +2190,9 @@ vow verify [OPTIONS] <source.vow>
 |-------------------|-------------|--------------------------------------------|
 | `--no-cache`      | (off)       | Disable verification result caching        |
 | `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
+| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
+| `--string-max <N>` | `256`     | Max String capacity for verification model |
+| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model|
 
 ### `vow contracts`
 
@@ -2048,6 +2209,9 @@ vow contracts [OPTIONS] <source.vow>
 | `--verify`        | (off)       | Run ESBMC verification and report per-contract status |
 | `--no-cache`      | (off)       | Disable verification result caching        |
 | `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
+| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
+| `--string-max <N>` | `256`     | Max String capacity for verification model |
+| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model|
 
 ### `vow skill`
 
@@ -2082,6 +2246,9 @@ vow test [OPTIONS] [<path>]
 | `--mode release`  | `debug`     | Omit all vow checks for performance       |
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
 | `--max-k-step <N>` | `50`       | ESBMC max k-induction step (with --verify) |
+| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
+| `--string-max <N>` | `256`     | Max String capacity for verification model |
+| `--hashmap-max <N>` | `64`     | Max HashMap capacity for verification model|
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.
 
@@ -4527,7 +4694,7 @@ fn run_verification_sync(
     file: &str,
     call_site_index: &std::collections::HashMap<String, Vec<CallSiteInfo>>,
     verify_cache: Option<&VerifyCache>,
-    max_k_step: u32,
+    limits: &VerifyLimits,
     config: &SolverConfig,
 ) -> VerifyOutcome {
     let const_fns = detect_constant_functions(ir_module);
@@ -4550,10 +4717,10 @@ fn run_verification_sync(
         };
 
         let result = if let Some(vc) = verify_cache {
-            let c_src = emit_verify_c_source(func, ir_module, &const_fns);
+            let c_src = emit_verify_c_source(func, ir_module, &const_fns, limits);
             let key = VerifyCache::cache_key(
                 &c_src,
-                max_k_step,
+                limits.max_k_step,
                 func_config.solver_str(),
                 func_config.encoding_str(),
             );
@@ -4571,7 +4738,7 @@ fn run_verification_sync(
                     None => return VerifyOutcome::ToolNotFound,
                 };
                 let res =
-                    run_esbmc_with_max_k_step(&esbmc, &c_src, max_k_step, &func.name, &func_config);
+                    run_esbmc_with_max_k_step(&esbmc, &c_src, limits.max_k_step, &func.name, &func_config);
                 match &res {
                     VerificationResult::Proven | VerificationResult::ProvenIr => {
                         vc.store(&key, &CachedVerifyResult::Proven);
@@ -4597,8 +4764,9 @@ fn run_verification_sync(
                 func,
                 ir_module,
                 &const_fns,
-                max_k_step,
+                limits.max_k_step,
                 &func_config,
+                limits,
             )
         };
 
@@ -4790,10 +4958,11 @@ fn verify_outcome_to_output(
 // ---------------------------------------------------------------------------
 
 pub fn run_verify_only(source: &Path) -> BuildOutput {
+    let limits = VerifyLimits::default();
     run_verify_only_inner(
         source,
         false,
-        DEFAULT_MAX_K_STEP,
+        &limits,
         &SolverConfig::default_config(),
     )
 }
@@ -4801,7 +4970,7 @@ pub fn run_verify_only(source: &Path) -> BuildOutput {
 fn run_verify_only_inner(
     source: &Path,
     no_cache: bool,
-    max_k_step: u32,
+    limits: &VerifyLimits,
     config: &SolverConfig,
 ) -> BuildOutput {
     let frontend = match compile_frontend(source) {
@@ -4825,7 +4994,7 @@ fn run_verify_only_inner(
         &file,
         &call_site_index,
         verify_cache.as_ref(),
-        max_k_step,
+        limits,
         config,
     );
     verify_outcome_to_output(outcome, all_diagnostics, None)
@@ -4863,6 +5032,7 @@ pub fn run_pipeline(
     dump_ir: bool,
     trace: TraceMode,
 ) -> BuildOutput {
+    let limits = VerifyLimits::default();
     run_pipeline_inner(
         source,
         output,
@@ -4871,7 +5041,7 @@ pub fn run_pipeline(
         dump_ir,
         trace,
         false,
-        10,
+        &limits,
         &SolverConfig::default_config(),
     )
 }
@@ -4885,7 +5055,7 @@ fn run_pipeline_inner(
     dump_ir: bool,
     trace: TraceMode,
     no_cache: bool,
-    max_k_step: u32,
+    limits: &VerifyLimits,
     config: &SolverConfig,
 ) -> BuildOutput {
     let frontend = match compile_frontend(source) {
@@ -4894,7 +5064,7 @@ fn run_pipeline_inner(
     };
 
     run_pipeline_from_frontend(
-        frontend, source, output, mode, no_verify, dump_ir, trace, no_cache, max_k_step, config,
+        frontend, source, output, mode, no_verify, dump_ir, trace, no_cache, limits, config,
     )
 }
 
@@ -4908,7 +5078,7 @@ fn run_pipeline_from_frontend(
     dump_ir: bool,
     trace: TraceMode,
     no_cache: bool,
-    max_k_step: u32,
+    limits: &VerifyLimits,
     config: &SolverConfig,
 ) -> BuildOutput {
     let all_diagnostics = frontend.diagnostics().to_vec();
@@ -4943,6 +5113,7 @@ fn run_pipeline_from_frontend(
     } else {
         VerifyCache::new()
     };
+    let verify_limits = *limits;
     let verify_config = *config;
     let verify_handle = thread::spawn(move || -> VerifyOutcome {
         if no_verify {
@@ -4953,7 +5124,7 @@ fn run_pipeline_from_frontend(
             &file_for_verify,
             &call_site_index,
             verify_cache.as_ref(),
-            max_k_step,
+            &verify_limits,
             &verify_config,
         )
     });
@@ -5086,7 +5257,7 @@ fn run_test_command(
     filter: Option<&str>,
     mode: BuildMode,
     timeout_ms: u64,
-    max_k_step: u32,
+    limits: &VerifyLimits,
 ) {
     if !path.exists() {
         let result = TestResult {
@@ -5177,7 +5348,7 @@ fn run_test_command(
             false,
             TraceMode::Off,
             true,
-            max_k_step,
+            limits,
             &SolverConfig::default_config(),
         );
 
@@ -5381,11 +5552,11 @@ fn run_build_command(
     dump_ir: bool,
     trace: TraceMode,
     no_cache: bool,
-    max_k_step: u32,
+    limits: &VerifyLimits,
     config: &SolverConfig,
 ) {
     let result = run_pipeline_inner(
-        source, output, mode, no_verify, dump_ir, trace, no_cache, max_k_step, config,
+        source, output, mode, no_verify, dump_ir, trace, no_cache, limits, config,
     );
     if !dump_ir {
         result.emit_json();
@@ -5433,8 +5604,8 @@ fn run_decl_command(source: &Path, output: Option<&Path>) {
     eprintln!("wrote {}", out_path.display());
 }
 
-fn run_verify_command(source: &Path, no_cache: bool, max_k_step: u32, config: &SolverConfig) {
-    let result = run_verify_only_inner(source, no_cache, max_k_step, config);
+fn run_verify_command(source: &Path, no_cache: bool, limits: &VerifyLimits, config: &SolverConfig) {
+    let result = run_verify_only_inner(source, no_cache, limits, config);
     result.emit_json();
     if matches!(
         &result.status,
@@ -5487,7 +5658,7 @@ fn update_contract_statuses(
     entries: &mut [ContractEntryJson],
     ir_module: &vow_ir::Module,
     verify_cache: Option<&VerifyCache>,
-    max_k_step: u32,
+    limits: &VerifyLimits,
     config: &SolverConfig,
 ) {
     let const_fns = detect_constant_functions(ir_module);
@@ -5497,10 +5668,10 @@ fn update_contract_statuses(
         }
 
         let result = if let Some(vc) = verify_cache {
-            let c_src = emit_verify_c_source(func, ir_module, &const_fns);
+            let c_src = emit_verify_c_source(func, ir_module, &const_fns, limits);
             let key = VerifyCache::cache_key(
                 &c_src,
-                max_k_step,
+                limits.max_k_step,
                 config.solver_str(),
                 config.encoding_str(),
             );
@@ -5524,7 +5695,7 @@ fn update_contract_statuses(
                         continue;
                     }
                 };
-                let res = run_esbmc_with_max_k_step(&esbmc, &c_src, max_k_step, &func.name, config);
+                let res = run_esbmc_with_max_k_step(&esbmc, &c_src, limits.max_k_step, &func.name, config);
                 match &res {
                     VerificationResult::Proven | VerificationResult::ProvenIr => {
                         vc.store(&key, &CachedVerifyResult::Proven);
@@ -5547,7 +5718,7 @@ fn update_contract_statuses(
             }
         } else {
             verify_function_with_module_and_const_fns_configured(
-                func, ir_module, &const_fns, max_k_step, config,
+                func, ir_module, &const_fns, limits.max_k_step, config, limits,
             )
         };
 
@@ -5583,7 +5754,7 @@ fn run_contracts_command(
     source: &Path,
     verify: bool,
     no_cache: bool,
-    max_k_step: u32,
+    limits: &VerifyLimits,
     config: &SolverConfig,
 ) {
     let frontend = match compile_frontend(source) {
@@ -5634,7 +5805,7 @@ fn run_contracts_command(
             &mut entries,
             ir_module,
             verify_cache.as_ref(),
-            max_k_step,
+            limits,
             config,
         );
     }
@@ -5679,6 +5850,12 @@ fn main() {
                 TraceArg::Calls => TraceMode::Calls,
                 TraceArg::Full => TraceMode::Full,
             };
+            let limits = VerifyLimits {
+                max_k_step: b.max_k_step,
+                vec_max: b.vec_max,
+                string_max: b.string_max,
+                hashmap_max: b.hashmap_max,
+            };
             let bconfig = make_solver_config(b.solver, b.encoding, b.timeout);
             run_build_command(
                 &source,
@@ -5688,7 +5865,7 @@ fn main() {
                 b.dump_ir,
                 trace,
                 b.no_cache,
-                b.max_k_step,
+                &limits,
                 &bconfig,
             );
         }
@@ -5708,8 +5885,14 @@ fn main() {
                     std::process::exit(1);
                 }
             };
+            let limits = VerifyLimits {
+                max_k_step: v.max_k_step,
+                vec_max: v.vec_max,
+                string_max: v.string_max,
+                hashmap_max: v.hashmap_max,
+            };
             let config = make_solver_config(v.solver, v.encoding, v.timeout);
-            run_verify_command(&source, v.no_cache, v.max_k_step, &config);
+            run_verify_command(&source, v.no_cache, &limits, &config);
         }
         Some(Command::Test(t)) => {
             if t.help {
@@ -5730,13 +5913,19 @@ fn main() {
                 }
                 ModeArg::Sanitize => BuildMode::Sanitize,
             };
+            let limits = VerifyLimits {
+                max_k_step: t.max_k_step,
+                vec_max: t.vec_max,
+                string_max: t.string_max,
+                hashmap_max: t.hashmap_max,
+            };
             run_test_command(
                 &path,
                 t.verify,
                 t.filter.as_deref(),
                 mode,
                 t.timeout,
-                t.max_k_step,
+                &limits,
             );
         }
         Some(Command::Decl(d)) => {
@@ -5773,12 +5962,18 @@ fn main() {
                     std::process::exit(1);
                 }
             };
+            let limits = VerifyLimits {
+                max_k_step: c.max_k_step.unwrap_or(DEFAULT_MAX_K_STEP),
+                vec_max: c.vec_max,
+                string_max: c.string_max,
+                hashmap_max: c.hashmap_max,
+            };
             let config = make_solver_config(c.solver, c.encoding, c.timeout);
             run_contracts_command(
                 &source,
                 c.verify,
                 c.no_cache,
-                c.max_k_step.unwrap_or(DEFAULT_MAX_K_STEP),
+                &limits,
                 &config,
             );
         }
@@ -5830,6 +6025,12 @@ fn main() {
                 TraceArg::Full => TraceMode::Full,
             };
 
+            let limits = VerifyLimits {
+                max_k_step: args.max_k_step,
+                vec_max: args.vec_max,
+                string_max: args.string_max,
+                hashmap_max: args.hashmap_max,
+            };
             let config = make_solver_config(args.solver, args.encoding, args.timeout);
             run_build_command(
                 &source,
@@ -5839,7 +6040,7 @@ fn main() {
                 args.dump_ir,
                 trace,
                 args.no_cache,
-                args.max_k_step,
+                &limits,
                 &config,
             );
         }
@@ -8537,6 +8738,41 @@ fn main() -> i32 {
         assert_eq!(sce.branch_decisions[0].taken, "else");
         assert_eq!(sce.branch_decisions[0].condition_offset, 20);
         assert_eq!(sce.branch_decisions[0].condition_length, 8);
+    }
+
+    #[test]
+    fn verification_limits_are_configurable_in_help() {
+        let json = skill_json();
+        assert!(
+            json.contains("\"verification_defaults\""),
+            "JSON must contain verification_defaults"
+        );
+        assert!(
+            json.contains("\"--max-k-step\""),
+            "JSON must contain --max-k-step"
+        );
+        assert!(
+            !json.contains("\"--unwind\""),
+            "JSON must not contain --unwind"
+        );
+        assert!(
+            !json.contains("\"verification_limits\""),
+            "JSON must not contain verification_limits"
+        );
+
+        let human = skill_human();
+        assert!(
+            human.contains("VERIFICATION DEFAULTS"),
+            "Human help must contain VERIFICATION DEFAULTS"
+        );
+        assert!(
+            human.contains("--max-k-step"),
+            "Human help must contain --max-k-step"
+        );
+        assert!(
+            human.contains("Incremental BMC"),
+            "Human help must contain Incremental BMC"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Configurable verification limits**: Added `--max-k-step`, `--vec-max`, `--string-max`, `--hashmap-max` CLI flags to `build`, `verify`, `test`, and `contracts` subcommands in both the Rust and self-hosted compilers. Previously these were hardcoded constants with no override.
- **Incremental BMC**: Replaced ESBMC's fixed-depth `--unwind N` with `--incremental-bmc --max-k-step N`. Incremental BMC proves properties inductively across all loop depths instead of only checking up to a fixed bound, and finds counterexamples faster by starting from k=1.
- **`--unwind` was silently broken**: The old `--unwind` flag was accepted by the CLI parser but never passed to ESBMC — verification always used a hardcoded depth of 10.

Closes #140

## Test plan

- [x] `cargo test --all` passes (620+ tests, including new `verification_limits_are_configurable_in_help` test)
- [x] `cargo clippy --all -- -D warnings` clean
- [x] Bootstrap succeeds with binary fixed point (SHA-256 match stages 2/3)
- [x] Manual test: `vowc verify --max-k-step 20 --vec-max 32 examples/divide.vow` works on both compilers