### PR TITLE
fix: prevent orphaned ESBMC processes when parent dies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
 name = "vow-verify"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "tempfile",
  "vow-diag",
  "vow-ir",

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -1393,6 +1393,7 @@ fn scan_shift_needs_in_fns(fns: Vec<IrFunction>, start: i64, end: i64, target_op
 fn cemit_preamble(need_shl_i64: i64, need_shr_i64: i64, need_shl_u64: i64, need_shr_u64: i64) -> String {
     let out: String = String::from("");
     out.push_str(String::from("#include <stdint.h>\n"));
+    out.push_str(String::from("#include <stdlib.h>\n"));
     out.push_str(String::from("#include <stdbool.h>\n"));
     out.push_str(String::from("extern void __ESBMC_assume(_Bool);\n"));
     out.push_str(String::from("extern void __ESBMC_assert(_Bool, const char*);\n"));

--- a/vow-verify/Cargo.toml
+++ b/vow-verify/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 vow-ir = { path = "../vow-ir" }
 vow-diag = { path = "../vow-diag" }
 tempfile = "3"
+libc = "0.2"
 
 [dev-dependencies]
 vow-syntax = { path = "../vow-syntax" }

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -1279,7 +1279,7 @@ fn scan_shift_needs(funcs: &[&Function]) -> ShiftNeeds {
 
 fn emit_c_preamble(out: &mut String, shifts: &ShiftNeeds) {
     out.push_str("#include <stdint.h>\n");
-    out.push_str("#include <stddef.h>\n");
+    out.push_str("#include <stdlib.h>\n");
     out.push_str("#include <stdbool.h>\n");
     out.push_str("#include <stddef.h>\n");
     out.push_str("extern void __ESBMC_assume(_Bool);\n");

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -1281,7 +1281,6 @@ fn emit_c_preamble(out: &mut String, shifts: &ShiftNeeds) {
     out.push_str("#include <stdint.h>\n");
     out.push_str("#include <stdlib.h>\n");
     out.push_str("#include <stdbool.h>\n");
-    out.push_str("#include <stddef.h>\n");
     out.push_str("extern void __ESBMC_assume(_Bool);\n");
     out.push_str("extern void __ESBMC_assert(_Bool, const char*);\n");
     out.push_str("extern int __VERIFIER_nondet_int(void);\n");

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -308,9 +308,6 @@ fn verify_function_inner(
     run_esbmc_k_induction(&esbmc, &c_src, &func.name)
 }
 
-/// Default timeout for a single ESBMC invocation (5 minutes).
-const ESBMC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
-
 pub fn run_esbmc_with_unwind(
     esbmc: &std::path::Path,
     c_src: &str,
@@ -375,7 +372,8 @@ pub fn run_esbmc_with_max_k_step(
         .process_group(0);
 
     // SAFETY: pre_exec runs between fork() and exec() in the child.
-    // All operations inside must be async-signal-safe (no heap allocation).
+    // The error paths use last_os_error()/from_raw_os_error() which may
+    // allocate, but this only happens on failure just before the child aborts.
     #[cfg(target_os = "linux")]
     let parent_pid = std::process::id();
     unsafe {
@@ -420,38 +418,40 @@ pub fn run_esbmc_with_max_k_step(
         buf
     });
 
-    // Use the configured timeout if present, otherwise fall back to ESBMC_TIMEOUT.
-    let timeout = config
-        .timeout_secs
-        .map(|s| std::time::Duration::from_secs(s as u64))
-        .unwrap_or(ESBMC_TIMEOUT);
-    let deadline = std::time::Instant::now() + timeout;
-    let timed_out = loop {
-        match child.try_wait() {
-            Ok(Some(_)) => break false,
-            Ok(None) => {
-                if std::time::Instant::now() >= deadline {
-                    kill_process_group(&mut child);
-                    let _ = child.wait();
-                    break true;
+    // If a timeout is configured, poll with deadline; otherwise block on wait().
+    // PR_SET_PDEATHSIG handles orphan cleanup in both cases.
+    if let Some(timeout_secs) = config.timeout_secs {
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs as u64);
+        let timed_out = loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break false,
+                Ok(None) => {
+                    if std::time::Instant::now() >= deadline {
+                        kill_process_group(&mut child);
+                        let _ = child.wait();
+                        break true;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(50));
                 }
-                std::thread::sleep(std::time::Duration::from_millis(50));
+                Err(e) => {
+                    kill_process_group(&mut child);
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = stdout_thread.join();
+                    let _ = stderr_thread.join();
+                    return VerificationResult::ToolError(format!("wait error: {e}"));
+                }
             }
-            Err(e) => {
-                kill_process_group(&mut child);
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = stdout_thread.join();
-                let _ = stderr_thread.join();
-                return VerificationResult::ToolError(format!("wait error: {e}"));
-            }
+        };
+        if timed_out {
+            let _ = stdout_thread.join();
+            let _ = stderr_thread.join();
+            return VerificationResult::Timeout;
         }
-    };
-
-    if timed_out {
-        let _ = stdout_thread.join();
-        let _ = stderr_thread.join();
-        return VerificationResult::Timeout;
+    } else {
+        // No timeout: block until ESBMC finishes.
+        let _ = child.wait();
     }
 
     let stdout = stdout_thread.join().unwrap_or_default();

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::io::Write;
+#[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -308,16 +309,6 @@ fn verify_function_inner(
     run_esbmc_k_induction(&esbmc, &c_src, &func.name)
 }
 
-pub fn run_esbmc_with_unwind(
-    esbmc: &std::path::Path,
-    c_src: &str,
-    max_k_step: u32,
-    func_name: &str,
-    config: &SolverConfig,
-) -> VerificationResult {
-    run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, config)
-}
-
 pub fn run_esbmc_k_induction(
     esbmc: &std::path::Path,
     c_src: &str,
@@ -367,9 +358,9 @@ pub fn run_esbmc_with_max_k_step(
     }
 
     // Set up pipes and process-group isolation for orphan prevention.
-    cmd.stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .process_group(0);
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    #[cfg(unix)]
+    cmd.process_group(0);
 
     // SAFETY: pre_exec runs between fork() and exec() in the child.
     // The error paths use last_os_error()/from_raw_os_error() which may
@@ -424,14 +415,14 @@ pub fn run_esbmc_with_max_k_step(
                 Ok(Some(_)) => break false,
                 Ok(None) => {
                     if std::time::Instant::now() >= deadline {
-                        kill_process_group(&mut child);
+                        force_kill(&mut child);
                         let _ = child.wait();
                         break true;
                     }
                     std::thread::sleep(std::time::Duration::from_millis(50));
                 }
                 Err(e) => {
-                    kill_process_group(&mut child);
+                    force_kill(&mut child);
                     let _ = child.kill();
                     let _ = child.wait();
                     let _ = stdout_thread.join();
@@ -465,14 +456,19 @@ pub fn run_esbmc_with_max_k_step(
     }
 }
 
-/// Send SIGKILL to the entire process group of `child`.
-/// Falls back to killing just the child if the group kill fails.
-fn kill_process_group(child: &mut std::process::Child) {
-    let pid = child.id() as i32;
-    let ret = unsafe { libc::kill(-pid, libc::SIGKILL) };
-    if ret != 0 {
-        let _ = child.kill();
+/// Kill the ESBMC child process. On Unix, sends SIGKILL to the entire
+/// process group; falls back to killing just the child if that fails.
+/// On non-Unix, kills just the child directly.
+fn force_kill(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        let pid = child.id() as i32;
+        let ret = unsafe { libc::kill(-pid, libc::SIGKILL) };
+        if ret == 0 {
+            return;
+        }
     }
+    let _ = child.kill();
 }
 
 // ---------------------------------------------------------------------------

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -1,8 +1,8 @@
-use std::io::Write;
-use std::path::PathBuf;
-use std::process::Command;
-
 use std::collections::HashMap;
+use std::io::Write;
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
 
 use vow_ir::{FuncId, Function, Module, Ty};
 
@@ -308,6 +308,19 @@ fn verify_function_inner(
     run_esbmc_k_induction(&esbmc, &c_src, &func.name)
 }
 
+/// Default timeout for a single ESBMC invocation (5 minutes).
+const ESBMC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+pub fn run_esbmc_with_unwind(
+    esbmc: &std::path::Path,
+    c_src: &str,
+    max_k_step: u32,
+    func_name: &str,
+    config: &SolverConfig,
+) -> VerificationResult {
+    run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, config)
+}
+
 pub fn run_esbmc_k_induction(
     esbmc: &std::path::Path,
     c_src: &str,
@@ -342,6 +355,7 @@ pub fn run_esbmc_with_max_k_step(
 
     save_esbmc_debug(esbmc, c_src, func_name, max_k_step);
 
+    // Build the ESBMC command.
     let mut cmd = Command::new(esbmc);
     cmd.arg(tmp.path())
         .arg("--no-bounds-check")
@@ -355,50 +369,93 @@ pub fn run_esbmc_with_max_k_step(
         cmd.arg(arg);
     }
 
-    // If timeout is set, use spawn + thread-based timeout
-    if let Some(timeout_secs) = config.timeout_secs {
-        use std::process::Stdio;
-        use std::sync::mpsc;
-        use std::time::Duration;
+    // Set up pipes and process-group isolation for orphan prevention.
+    cmd.stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0);
 
-        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-        let child = match cmd.spawn() {
-            Ok(c) => c,
-            Err(e) => return VerificationResult::ToolError(e.to_string()),
-        };
-        let child_id = child.id();
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let _ = tx.send(child.wait_with_output());
-        });
-        match rx.recv_timeout(Duration::from_secs(timeout_secs as u64)) {
-            Ok(Ok(output)) => {
-                return parse_esbmc_result(&output);
-            }
-            Ok(Err(e)) => {
-                return VerificationResult::ToolError(e.to_string());
-            }
-            Err(_timeout) => {
-                let _ = Command::new("kill")
-                    .arg("-9")
-                    .arg(child_id.to_string())
-                    .output();
-                return VerificationResult::Timeout;
-            }
-        }
+    // SAFETY: pre_exec runs between fork() and exec() in the child.
+    // All operations inside must be async-signal-safe (no heap allocation).
+    #[cfg(target_os = "linux")]
+    let parent_pid = std::process::id();
+    unsafe {
+        cmd.pre_exec(
+            #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+            move || {
+                #[cfg(target_os = "linux")]
+                {
+                    let ret = libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
+                    if ret != 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    if libc::getppid() as u32 != parent_pid {
+                        return Err(std::io::Error::from_raw_os_error(libc::ESRCH));
+                    }
+                }
+                Ok(())
+            },
+        );
     }
 
-    let output = match cmd.output() {
-        Ok(o) => o,
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
         Err(e) => return VerificationResult::ToolError(e.to_string()),
     };
 
-    parse_esbmc_result(&output)
-}
+    // Drain stdout/stderr on background threads to prevent pipe buffer deadlock.
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+    let stdout_thread = std::thread::spawn(move || {
+        let mut buf = String::new();
+        if let Some(mut r) = stdout_handle {
+            let _ = std::io::Read::read_to_string(&mut r, &mut buf);
+        }
+        buf
+    });
+    let stderr_thread = std::thread::spawn(move || {
+        let mut buf = String::new();
+        if let Some(mut r) = stderr_handle {
+            let _ = std::io::Read::read_to_string(&mut r, &mut buf);
+        }
+        buf
+    });
 
-fn parse_esbmc_result(output: &std::process::Output) -> VerificationResult {
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Use the configured timeout if present, otherwise fall back to ESBMC_TIMEOUT.
+    let timeout = config
+        .timeout_secs
+        .map(|s| std::time::Duration::from_secs(s as u64))
+        .unwrap_or(ESBMC_TIMEOUT);
+    let deadline = std::time::Instant::now() + timeout;
+    let timed_out = loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break false,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    kill_process_group(&mut child);
+                    let _ = child.wait();
+                    break true;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(e) => {
+                kill_process_group(&mut child);
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stdout_thread.join();
+                let _ = stderr_thread.join();
+                return VerificationResult::ToolError(format!("wait error: {e}"));
+            }
+        }
+    };
+
+    if timed_out {
+        let _ = stdout_thread.join();
+        let _ = stderr_thread.join();
+        return VerificationResult::Timeout;
+    }
+
+    let stdout = stdout_thread.join().unwrap_or_default();
+    let stderr = stderr_thread.join().unwrap_or_default();
     let combined = format!("{stdout}{stderr}");
 
     if combined.contains("VERIFICATION SUCCESSFUL") {
@@ -409,6 +466,16 @@ fn parse_esbmc_result(output: &std::process::Output) -> VerificationResult {
         VerificationResult::Timeout
     } else {
         VerificationResult::ToolError(format!("unexpected esbmc output:\n{combined}"))
+    }
+}
+
+/// Send SIGKILL to the entire process group of `child`.
+/// Falls back to killing just the child if the group kill fails.
+fn kill_process_group(child: &mut std::process::Child) {
+    let pid = child.id() as i32;
+    let ret = unsafe { libc::kill(-pid, libc::SIGKILL) };
+    if ret != 0 {
+        let _ = child.kill();
     }
 }
 

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -375,24 +375,20 @@ pub fn run_esbmc_with_max_k_step(
     // The error paths use last_os_error()/from_raw_os_error() which may
     // allocate, but this only happens on failure just before the child aborts.
     #[cfg(target_os = "linux")]
-    let parent_pid = std::process::id();
-    unsafe {
-        cmd.pre_exec(
-            #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
-            move || {
-                #[cfg(target_os = "linux")]
-                {
-                    let ret = libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
-                    if ret != 0 {
-                        return Err(std::io::Error::last_os_error());
-                    }
-                    if libc::getppid() as u32 != parent_pid {
-                        return Err(std::io::Error::from_raw_os_error(libc::ESRCH));
-                    }
+    {
+        let parent_pid = std::process::id();
+        unsafe {
+            cmd.pre_exec(move || {
+                let ret = libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
+                if ret != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::getppid() as u32 != parent_pid {
+                    return Err(std::io::Error::from_raw_os_error(libc::ESRCH));
                 }
                 Ok(())
-            },
-        );
+            });
+        }
     }
 
     let mut child = match cmd.spawn() {

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -438,7 +438,11 @@ pub fn run_esbmc_with_max_k_step(
         }
     } else {
         // No timeout: block until ESBMC finishes.
-        let _ = child.wait();
+        if let Err(e) = child.wait() {
+            let _ = stdout_thread.join();
+            let _ = stderr_thread.join();
+            return VerificationResult::ToolError(format!("wait error: {e}"));
+        }
     }
 
     let stdout = stdout_thread.join().unwrap_or_default();
@@ -462,8 +466,8 @@ pub fn run_esbmc_with_max_k_step(
 fn force_kill(child: &mut std::process::Child) {
     #[cfg(unix)]
     {
-        let pid = child.id() as i32;
-        let ret = unsafe { libc::kill(-pid, libc::SIGKILL) };
+        let pgid = child.id() as i32;
+        let ret = unsafe { libc::kill(-pgid, libc::SIGKILL) };
         if ret == 0 {
             return;
         }

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -343,7 +343,6 @@ pub fn run_esbmc_with_max_k_step(
 
     save_esbmc_debug(esbmc, c_src, func_name, max_k_step);
 
-    // Build the ESBMC command.
     let mut cmd = Command::new(esbmc);
     cmd.arg(tmp.path())
         .arg("--no-bounds-check")
@@ -423,7 +422,6 @@ pub fn run_esbmc_with_max_k_step(
                 }
                 Err(e) => {
                     force_kill(&mut child);
-                    let _ = child.kill();
                     let _ = child.wait();
                     let _ = stdout_thread.join();
                     let _ = stderr_thread.join();


### PR DESCRIPTION
## Summary

- Switch `run_esbmc()` from blocking `.output()` to `.spawn()` with proper child lifecycle management
- Add `PR_SET_PDEATHSIG(SIGKILL)` via `pre_exec` so the kernel auto-kills ESBMC children when the parent `vow` process dies (any signal, crash, or normal exit)
- Add `.process_group(0)` + 5-minute timeout with `kill(-pgid, SIGKILL)` as a safety net for hung ESBMC runs
- Drain stdout/stderr on background threads to prevent pipe buffer deadlock

Fixes the issue where killing `vow build`/`vow verify` left ESBMC processes running indefinitely as orphans.

## Test plan

- [x] `cargo test --all` — 621 tests pass, 0 failures
- [x] `cargo clippy --all -- -D warnings` — zero warnings
- [x] End-to-end: `vow verify examples/divide.vow` → Verified
- [x] End-to-end: `vow build examples/divide.vow` → Verified
- [x] Confirmed `prctl(PR_SET_PDEATHSIG, SIGKILL) = 0` in ESBMC child via strace