### PR TITLE
fix: decouple verification from runtime container bounds

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -891,6 +891,9 @@ fn emit_string_op(out: String, inst: IrInst) {
         out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
         out.push_str(str3(String::from("  __ESBMC_assume(v"), ids, String::from(".len >= 0 && v")));
         out.push_str(str2(ids, String::from(".len < INT64_MAX);\n")));
+        out.push_str(str5(String::from("  v"), ids, String::from(".data = (v"), ids,
+            String::from(".len > 0) ? (int8_t*)malloc((size_t)v")));
+        out.push_str(str2(ids, String::from(".len) : (int8_t*)0;\n")));
         return;
     }
     if ds == String::from("__vow_string_len") {

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -824,7 +824,7 @@ fn emit_vec_op(out: String, inst: IrInst) {
     if ds == String::from("__vow_vec_new") {
         let ids: String = i64_to_str(id);
         out.push_str(str3(String::from("  v"), ids, String::from(".len = 0;\n")));
-        out.push_str(str3(String::from("  v"), ids, String::from(".data = (int64_t*)malloc(sizeof(int64_t));\n")));
+        out.push_str(str3(String::from("  v"), ids, String::from(".data = (int64_t*)0;\n")));
         return;
     }
     if ds == String::from("__vow_vec_push_val") {
@@ -832,6 +832,9 @@ fn emit_vec_op(out: String, inst: IrInst) {
         let val: i64 = iargs[1];
         let vs: String = i64_to_str(vec);
         let vas: String = i64_to_str(val);
+        out.push_str(str5(String::from("  v"), vs, String::from(".data = (int64_t*)realloc(v"), vs,
+            String::from(".data, sizeof(int64_t) * (size_t)(v")));
+        out.push_str(str2(vs, String::from(".len + 1));\n")));
         out.push_str(str6(String::from("  v"), vs, String::from(".data[v"), vs,
             String::from(".len] = v"), str2(vas, String::from(";\n"))));
         out.push_str(str3(String::from("  v"), vs, String::from(".len++;\n")));
@@ -888,8 +891,6 @@ fn emit_string_op(out: String, inst: IrInst) {
         out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
         out.push_str(str3(String::from("  __ESBMC_assume(v"), ids, String::from(".len >= 0 && v")));
         out.push_str(str2(ids, String::from(".len < INT64_MAX);\n")));
-        out.push_str(str3(String::from("  v"), i64_to_str(id), String::from(".data = (int8_t*)malloc((size_t)v")));
-        out.push_str(str2(i64_to_str(id), String::from(".len + 1);\n")));
         return;
     }
     if ds == String::from("__vow_string_len") {
@@ -909,6 +910,9 @@ fn emit_string_op(out: String, inst: IrInst) {
         let s: i64 = iargs[0];
         let byte: i64 = iargs[1];
         let ss: String = i64_to_str(s);
+        out.push_str(str5(String::from("  v"), ss, String::from(".data = (int8_t*)realloc(v"), ss,
+            String::from(".data, (size_t)(v")));
+        out.push_str(str2(ss, String::from(".len + 1));\n")));
         out.push_str(str6(String::from("  v"), ss, String::from(".data[v"), ss,
             String::from(".len] = (int8_t)v"), str2(i64_to_str(byte), String::from(";\n"))));
         out.push_str(str3(String::from("  v"), ss, String::from(".len++;\n")));
@@ -988,8 +992,8 @@ fn emit_map_op(out: String, inst: IrInst) {
     if ds == String::from("__vow_map_new") {
         let ids: String = i64_to_str(id);
         out.push_str(str3(String::from("  v"), ids, String::from(".len = 0;\n")));
-        out.push_str(str3(String::from("  v"), ids, String::from(".keys = (int64_t*)malloc(sizeof(int64_t));\n")));
-        out.push_str(str3(String::from("  v"), ids, String::from(".vals = (int64_t*)malloc(sizeof(int64_t));\n")));
+        out.push_str(str3(String::from("  v"), ids, String::from(".keys = (int64_t*)0;\n")));
+        out.push_str(str3(String::from("  v"), ids, String::from(".vals = (int64_t*)0;\n")));
         return;
     }
     if ds == String::from("__vow_map_len") {
@@ -1013,6 +1017,12 @@ fn emit_map_op(out: String, inst: IrInst) {
         out.push_str(str2(vs, String::from("; __found = 1; break; }\n")));
         out.push_str(String::from("    }\n"));
         out.push_str(String::from("    if (!__found) {\n"));
+        out.push_str(str5(String::from("      v"), ms, String::from(".keys = (int64_t*)realloc(v"), ms,
+            String::from(".keys, sizeof(int64_t) * (size_t)(v")));
+        out.push_str(str2(ms, String::from(".len + 1));\n")));
+        out.push_str(str5(String::from("      v"), ms, String::from(".vals = (int64_t*)realloc(v"), ms,
+            String::from(".vals, sizeof(int64_t) * (size_t)(v")));
+        out.push_str(str2(ms, String::from(".len + 1));\n")));
         out.push_str(str6(String::from("      v"), ms, String::from(".keys[v"), ms,
             String::from(".len] = v"), str2(ks, String::from("; v"))));
         out.push_str(str5(ms, String::from(".vals[v"), ms,

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -3,10 +3,6 @@ module CEmitter
 use ir
 use ir_printer
 
-fn VOW_VEC_MAX() -> i64 vow { ensures: result >= 0 } { 128 }
-fn VOW_STRING_MAX() -> i64 vow { ensures: result >= 0 } { 256 }
-fn VOW_HASHMAP_MAX() -> i64 vow { ensures: result >= 0 } { 64 }
-
 fn str3(a: String, b: String, c: String) -> String {
     let r: String = String::from("");
     r.push_str(a);
@@ -826,7 +822,9 @@ fn emit_vec_op(out: String, inst: IrInst) {
     let iargs: Vec<i64> = inst.args;
 
     if ds == String::from("__vow_vec_new") {
-        out.push_str(str3(String::from("  v"), i64_to_str(id), String::from(".len = 0;\n")));
+        let ids: String = i64_to_str(id);
+        out.push_str(str3(String::from("  v"), ids, String::from(".len = 0;\n")));
+        out.push_str(str3(String::from("  v"), ids, String::from(".data = (int64_t*)malloc(sizeof(int64_t));\n")));
         return;
     }
     if ds == String::from("__vow_vec_push_val") {
@@ -834,8 +832,6 @@ fn emit_vec_op(out: String, inst: IrInst) {
         let val: i64 = iargs[1];
         let vs: String = i64_to_str(vec);
         let vas: String = i64_to_str(val);
-        out.push_str(str5(String::from("  __ESBMC_assert(v"), vs,
-            String::from(".len < "), i64_to_str(VOW_VEC_MAX()), String::from(", \"vec capacity\");\n")));
         out.push_str(str6(String::from("  v"), vs, String::from(".data[v"), vs,
             String::from(".len] = v"), str2(vas, String::from(";\n"))));
         out.push_str(str3(String::from("  v"), vs, String::from(".len++;\n")));
@@ -890,9 +886,10 @@ fn emit_string_op(out: String, inst: IrInst) {
     if ds == String::from("__vow_string_from_cstr") {
         let ids: String = i64_to_str(id);
         out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
-        out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
-            String::from(".len >= 0 && v"), ids,
-            str3(String::from(".len < "), i64_to_str(VOW_STRING_MAX()), String::from(");\n"))));
+        out.push_str(str3(String::from("  __ESBMC_assume(v"), ids, String::from(".len >= 0 && v")));
+        out.push_str(str2(ids, String::from(".len < INT64_MAX);\n")));
+        out.push_str(str3(String::from("  v"), i64_to_str(id), String::from(".data = (int8_t*)malloc((size_t)v")));
+        out.push_str(str2(i64_to_str(id), String::from(".len + 1);\n")));
         return;
     }
     if ds == String::from("__vow_string_len") {
@@ -912,8 +909,6 @@ fn emit_string_op(out: String, inst: IrInst) {
         let s: i64 = iargs[0];
         let byte: i64 = iargs[1];
         let ss: String = i64_to_str(s);
-        out.push_str(str5(String::from("  __ESBMC_assert(v"), ss,
-            String::from(".len < "), i64_to_str(VOW_STRING_MAX()), String::from(", \"string capacity\");\n")));
         out.push_str(str6(String::from("  v"), ss, String::from(".data[v"), ss,
             String::from(".len] = (int8_t)v"), str2(i64_to_str(byte), String::from(";\n"))));
         out.push_str(str3(String::from("  v"), ss, String::from(".len++;\n")));
@@ -993,6 +988,8 @@ fn emit_map_op(out: String, inst: IrInst) {
     if ds == String::from("__vow_map_new") {
         let ids: String = i64_to_str(id);
         out.push_str(str3(String::from("  v"), ids, String::from(".len = 0;\n")));
+        out.push_str(str3(String::from("  v"), ids, String::from(".keys = (int64_t*)malloc(sizeof(int64_t));\n")));
+        out.push_str(str3(String::from("  v"), ids, String::from(".vals = (int64_t*)malloc(sizeof(int64_t));\n")));
         return;
     }
     if ds == String::from("__vow_map_len") {
@@ -1016,8 +1013,6 @@ fn emit_map_op(out: String, inst: IrInst) {
         out.push_str(str2(vs, String::from("; __found = 1; break; }\n")));
         out.push_str(String::from("    }\n"));
         out.push_str(String::from("    if (!__found) {\n"));
-        out.push_str(str5(String::from("      __ESBMC_assert(v"), ms,
-            String::from(".len < "), i64_to_str(VOW_HASHMAP_MAX()), String::from(", \"hashmap capacity\");\n")));
         out.push_str(str6(String::from("      v"), ms, String::from(".keys[v"), ms,
             String::from(".len] = v"), str2(ks, String::from("; v"))));
         out.push_str(str5(ms, String::from(".vals[v"), ms,
@@ -1334,6 +1329,7 @@ fn cemit_preamble() -> String {
     let out: String = String::from("");
     out.push_str(String::from("#include <stdint.h>\n"));
     out.push_str(String::from("#include <stdbool.h>\n"));
+    out.push_str(String::from("#include <stdlib.h>\n"));
     out.push_str(String::from("extern void __ESBMC_assume(_Bool);\n"));
     out.push_str(String::from("extern void __ESBMC_assert(_Bool, const char*);\n"));
     out.push_str(String::from("extern int __VERIFIER_nondet_int(void);\n"));
@@ -1341,23 +1337,9 @@ fn cemit_preamble() -> String {
     out.push_str(String::from("extern float __VERIFIER_nondet_float(void);\n"));
     out.push_str(String::from("extern double __VERIFIER_nondet_double(void);\n"));
     out.push_str(String::from("extern _Bool __VERIFIER_nondet_bool(void);\n\n"));
-    out.push_str(str3(
-        String::from("typedef struct { int64_t len; int64_t data["),
-        i64_to_str(VOW_VEC_MAX()),
-        String::from("]; } __vow_vec_t;\n")
-    ));
-    out.push_str(str3(
-        String::from("typedef struct { int64_t len; int8_t data["),
-        i64_to_str(VOW_STRING_MAX()),
-        String::from("]; } __vow_string_t;\n")
-    ));
-    out.push_str(str5(
-        String::from("typedef struct { int64_t len; int64_t keys["),
-        i64_to_str(VOW_HASHMAP_MAX()),
-        String::from("]; int64_t vals["),
-        i64_to_str(VOW_HASHMAP_MAX()),
-        String::from("]; } __vow_hashmap_t;\n\n")
-    ));
+    out.push_str(String::from("typedef struct { int64_t len; int64_t* data; } __vow_vec_t;\n"));
+    out.push_str(String::from("typedef struct { int64_t len; int8_t* data; } __vow_string_t;\n"));
+    out.push_str(String::from("typedef struct { int64_t len; int64_t* keys; int64_t* vals; } __vow_hashmap_t;\n\n"));
     out.push_str(String::from("static inline int64_t __vow_shl_i64(int64_t value, int64_t count) {\n"));
     out.push_str(String::from("  uint64_t shift = ((uint64_t)count) & 63ULL;\n"));
     out.push_str(String::from("  return (int64_t)(((uint64_t)value) << shift);\n"));

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -1153,14 +1153,35 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
                 }
                 if found_cl >= 0 {
                     if vec_contains_i64(vec_vars, iid) {
-                        out.push_str(str4(String::from("  __vow_vec_t v"), i64_to_str(iid),
-                            String::from(";\n  v"), str2(i64_to_str(iid), String::from(".len = 0;\n"))));
+                        let ids: String = i64_to_str(iid);
+                        out.push_str(str3(String::from("  __vow_vec_t v"), ids, String::from(";\n")));
+                        out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
+                        out.push_str(str3(String::from("  __ESBMC_assume(v"), ids, String::from(".len >= 0 && v")));
+                        out.push_str(str2(ids, String::from(".len < INT64_MAX);\n")));
+                        out.push_str(str5(String::from("  v"), ids, String::from(".data = (v"), ids,
+                            String::from(".len > 0) ? (int64_t*)malloc(sizeof(int64_t) * (size_t)v")));
+                        out.push_str(str2(ids, String::from(".len) : (int64_t*)0;\n")));
                     } else if vec_contains_i64(string_vars, iid) {
-                        out.push_str(str4(String::from("  __vow_string_t v"), i64_to_str(iid),
-                            String::from(";\n  v"), str2(i64_to_str(iid), String::from(".len = 0;\n"))));
+                        let ids: String = i64_to_str(iid);
+                        out.push_str(str3(String::from("  __vow_string_t v"), ids, String::from(";\n")));
+                        out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
+                        out.push_str(str3(String::from("  __ESBMC_assume(v"), ids, String::from(".len >= 0 && v")));
+                        out.push_str(str2(ids, String::from(".len < INT64_MAX);\n")));
+                        out.push_str(str5(String::from("  v"), ids, String::from(".data = (v"), ids,
+                            String::from(".len > 0) ? (int8_t*)malloc((size_t)v")));
+                        out.push_str(str2(ids, String::from(".len) : (int8_t*)0;\n")));
                     } else if vec_contains_i64(hashmap_vars, iid) {
-                        out.push_str(str4(String::from("  __vow_hashmap_t v"), i64_to_str(iid),
-                            String::from(";\n  v"), str2(i64_to_str(iid), String::from(".len = 0;\n"))));
+                        let ids: String = i64_to_str(iid);
+                        out.push_str(str3(String::from("  __vow_hashmap_t v"), ids, String::from(";\n")));
+                        out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
+                        out.push_str(str3(String::from("  __ESBMC_assume(v"), ids, String::from(".len >= 0 && v")));
+                        out.push_str(str2(ids, String::from(".len < INT64_MAX);\n")));
+                        out.push_str(str5(String::from("  v"), ids, String::from(".keys = (v"), ids,
+                            String::from(".len > 0) ? (int64_t*)malloc(sizeof(int64_t) * (size_t)v")));
+                        out.push_str(str2(ids, String::from(".len) : (int64_t*)0;\n")));
+                        out.push_str(str5(String::from("  v"), ids, String::from(".vals = (v"), ids,
+                            String::from(".len > 0) ? (int64_t*)malloc(sizeof(int64_t) * (size_t)v")));
+                        out.push_str(str2(ids, String::from(".len) : (int64_t*)0;\n")));
                     } else {
                         let c_ty: String = {
                             if inst.ty == ITY_PTR() || inst.ty == ITY_LPTR() {

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -47,7 +47,7 @@ fn get_source_path(argv: Vec<String>) -> String {
         if first_byte != 45 {
             if i > 1 {
                 let prev: String = argv[i - 1];
-                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--unwind") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") {
+                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") {
                     i = i - 1;
                 } else {
                     return a;
@@ -70,7 +70,7 @@ fn get_source_path_sub(argv: Vec<String>) -> String {
         if first_byte != 45 {
             if i > 2 {
                 let prev: String = argv[i - 1];
-                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--unwind") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") {
+                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") {
                     i = i - 1;
                 } else {
                     return a;
@@ -300,7 +300,7 @@ fn run_frontend(argv: Vec<String>, sub: bool) -> FrontendResult [io] {
     run_frontend_for_path(path)
 }
 
-fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, unwind: String, use_cache: bool) -> i64 [io] {
+fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool) -> i64 [io] {
     let mut fi: i64 = 0;
     let mut all_proven: i64 = 1;
     while fi < fns.len() {
@@ -308,7 +308,7 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Ve
         let vows: Vec<IrVowEntry> = f.vows;
         if vows.len() > 0 {
             eprintln_str(str3(String::from("Verifying "), f.name, String::from("...")));
-            let vr: VerifyResult = verify_function_full(f, ir_mod, unwind, use_cache);
+            let vr: VerifyResult = verify_function_full(f, ir_mod, max_k_step, use_cache);
             let st: i64 = vr.status;
             if st == VERIFY_PROVEN() {
                 eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
@@ -386,10 +386,10 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
         diag_emit_verify_json(String::from("CompileFailed"), dctx, Vec::new());
         return 1;
     }
-    let unwind_str: String = get_flag_arg(argv, String::from("--unwind"));
-    let unwind: String = {
-        if unwind_str.len() > 0 { unwind_str }
-        else { String::from("10") }
+    let mks_str: String = get_flag_arg(argv, String::from("--max-k-step"));
+    let max_k_step: String = {
+        if mks_str.len() > 0 { mks_str }
+        else { String::from("50") }
     };
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     if !esbmc_exists() {
@@ -401,7 +401,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     emit_ir_warnings(ir_mod, dctx);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
-    let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, unwind, use_cache);
+    let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache);
     let status_str: String = {
         if all_proven == 1 {
             String::from("Verified")
@@ -461,10 +461,10 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         }
     }
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
-    let unwind_str: String = get_flag_arg(argv, String::from("--unwind"));
-    let unwind: String = {
-        if unwind_str.len() > 0 { unwind_str }
-        else { String::from("10") }
+    let mks_str: String = get_flag_arg(argv, String::from("--max-k-step"));
+    let max_k_step: String = {
+        if mks_str.len() > 0 { mks_str }
+        else { String::from("50") }
     };
     let fns: Vec<IrFunction> = ir_mod.functions;
     let handles: Vec<i64> = Vec::new();
@@ -476,7 +476,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
             let vows: Vec<IrVowEntry> = f.vows;
             if vows.len() > 0 {
                 eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
-                let h: i64 = verify_start(f, ir_mod, unwind, fi, use_cache);
+                let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache);
                 handles.push(h);
                 vow_fn_indices.push(fi);
             }
@@ -518,7 +518,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
                 eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
                 if use_cache {
                     let c_src2: String = emit_c_for_verify(f, ir_mod);
-                    let ck2: String = verify_cache_key(c_src2, unwind);
+                    let ck2: String = verify_cache_key(c_src2, max_k_step);
                     verify_cache_store(ck2, VERIFY_PROVEN());
                 }
             } else if st == VERIFY_FAILED() {
@@ -909,10 +909,10 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
                 diag_emit_verify_json(String::from("VerifyFailed"), dctx, Vec::new());
                 return 1;
             }
-            let unwind_str: String = get_flag_arg(argv, String::from("--unwind"));
-            let unwind: String = {
-                if unwind_str.len() > 0 { unwind_str }
-                else { String::from("10") }
+            let mks_str: String = get_flag_arg(argv, String::from("--max-k-step"));
+            let max_k_step: String = {
+                if mks_str.len() > 0 { mks_str }
+                else { String::from("50") }
             };
             let str_eids: Vec<i64> = e.expr_str_eids;
             let ir_mod: IrModule = lower_module_vow(merged, str_eids, path);
@@ -920,7 +920,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
             let use_cache_leg: bool = !has_flag(argv, String::from("--no-cache"));
-            let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, unwind, use_cache_leg);
+            let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache_leg);
             let status_str: String = {
                 if all_proven == 1 {
                     String::from("Verified")
@@ -1089,12 +1089,12 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_kind\": \"flag\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--unwind <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC loop unwind bound (default: 10)\",\n"));
-    r.push_str(String::from("          \"long\": \"--unwind\",\n"));
+    r.push_str(String::from("          \"form\": \"--max-k-step <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC max k-induction step (default: 50)\",\n"));
+    r.push_str(String::from("          \"long\": \"--max-k-step\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 10\n"));
+    r.push_str(String::from("          \"default\": 50\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1135,12 +1135,12 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_kind\": \"flag\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--unwind <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC loop unwind bound (default: 10)\",\n"));
-    r.push_str(String::from("          \"long\": \"--unwind\",\n"));
+    r.push_str(String::from("          \"form\": \"--max-k-step <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC max k-induction step (default: 50)\",\n"));
+    r.push_str(String::from("          \"long\": \"--max-k-step\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 10\n"));
+    r.push_str(String::from("          \"default\": 50\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1202,12 +1202,12 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"default\": \"30000\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--unwind <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC loop unwind bound (with --verify)\",\n"));
-    r.push_str(String::from("          \"long\": \"--unwind\",\n"));
+    r.push_str(String::from("          \"form\": \"--max-k-step <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC max k-induction step (with --verify)\",\n"));
+    r.push_str(String::from("          \"long\": \"--max-k-step\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 10\n"));
+    r.push_str(String::from("          \"default\": 50\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1276,12 +1276,12 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_kind\": \"flag\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--unwind <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC loop unwind bound (default: 10)\",\n"));
-    r.push_str(String::from("          \"long\": \"--unwind\",\n"));
+    r.push_str(String::from("          \"form\": \"--max-k-step <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC max k-induction step (default: 50)\",\n"));
+    r.push_str(String::from("          \"long\": \"--max-k-step\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 10\n"));
+    r.push_str(String::from("          \"default\": 50\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1301,18 +1301,18 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--dump-ir\": \"Print IR text to stdout and exit (no JSON output, no codegen)\",\n"));
     r.push_str(String::from("    \"--debug-trace <off|calls|full>\": \"Emit JSON trace lines to stderr at runtime (default: off)\",\n"));
     r.push_str(String::from("    \"--no-cache\": \"Disable compile and verify caching\",\n"));
-    r.push_str(String::from("    \"--unwind <N>\": \"ESBMC loop unwind bound (default: 10)\"\n"));
+    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (default: 50)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"verify_options\": {\n"));
     r.push_str(String::from("    \"--no-cache\": \"Disable verification result caching\",\n"));
-    r.push_str(String::from("    \"--unwind <N>\": \"ESBMC loop unwind bound (default: 10)\"\n"));
+    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (default: 50)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"test_options\": {\n"));
     r.push_str(String::from("    \"--verify\": \"Run ESBMC verification on test files\",\n"));
     r.push_str(String::from("    \"--filter <pat>\": \"Only run tests whose name contains pat (default: (none))\",\n"));
     r.push_str(String::from("    \"--mode <debug|release>\": \"Build mode; debug inserts runtime vow checks (default: (default))\",\n"));
     r.push_str(String::from("    \"--timeout <ms>\": \"Per-test execution timeout in milliseconds (default: 30000)\",\n"));
-    r.push_str(String::from("    \"--unwind <N>\": \"ESBMC loop unwind bound (with --verify)\"\n"));
+    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (with --verify)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"decl_options\": {\n"));
     r.push_str(String::from("    \"-o, --output <path>\": \"Output declaration file path (default: <source>.vow.d)\"\n"));
@@ -1320,7 +1320,7 @@ fn skill_json() -> String {
     r.push_str(String::from("  \"contracts_options\": {\n"));
     r.push_str(String::from("    \"--verify\": \"Run ESBMC verification and report per-contract status\",\n"));
     r.push_str(String::from("    \"--no-cache\": \"Disable verification result caching\",\n"));
-    r.push_str(String::from("    \"--unwind <N>\": \"ESBMC loop unwind bound (default: 10)\"\n"));
+    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (default: 50)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"global_options\": {\n"));
     r.push_str(String::from("    \"--help\": \"Emit versioned JSON tool-help data\",\n"));
@@ -1432,6 +1432,9 @@ fn skill_json() -> String {
     r.push_str(String::from("      \"print_i64\": \"fn(v: i64) -> () [io]\",\n"));
     r.push_str(String::from("      \"print_u64\": \"fn(v: u64) -> () [io]\",\n"));
     r.push_str(String::from("      \"eprintln_str\": \"fn(s: String) -> () [io]\",\n"));
+    r.push_str(String::from("      \"debug_str\": \"fn(s: String) -> () []\",\n"));
+    r.push_str(String::from("      \"debug_i64\": \"fn(v: i64) -> () []\",\n"));
+    r.push_str(String::from("      \"debug_u64\": \"fn(v: u64) -> () []\",\n"));
     r.push_str(String::from("      \"fs_read\": \"fn(path: String) -> String [read]\",\n"));
     r.push_str(String::from("      \"fs_write\": \"fn(path: String, data: String) -> i64 [write]\",\n"));
     r.push_str(String::from("      \"fs_exists\": \"fn(path: String) -> i64 [read]\",\n"));
@@ -1630,11 +1633,9 @@ fn skill_json() -> String {
     r.push_str(String::from("      ]\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  },\n"));
-    r.push_str(String::from("  \"verification_limits\": {\n"));
-    r.push_str(String::from("    \"loop_unwind\": 10,\n"));
-    r.push_str(String::from("    \"Vec<T>\": 128,\n"));
-    r.push_str(String::from("    \"String\": 256,\n"));
-    r.push_str(String::from("    \"HashMap<K, V>\": 64\n"));
+    r.push_str(String::from("  \"verification_defaults\": {\n"));
+    r.push_str(String::from("    \"strategy\": \"k-induction-parallel\",\n"));
+    r.push_str(String::from("    \"max_k_step\": 50\n"));
     r.push_str(String::from("  }\n"));
     r.push_str(String::from("}\n"));
     r
@@ -1661,23 +1662,23 @@ fn skill_human() -> String {
     r.push_str(String::from("  --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)\n"));
     r.push_str(String::from("  --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)\n"));
     r.push_str(String::from("  --no-cache              Disable compile and verify caching\n"));
-    r.push_str(String::from("  --unwind <N>            ESBMC loop unwind bound (default: 10)\n"));
+    r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (default: 50)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("VERIFY OPTIONS\n"));
     r.push_str(String::from("  --no-cache              Disable verification result caching\n"));
-    r.push_str(String::from("  --unwind <N>            ESBMC loop unwind bound (default: 10)\n"));
+    r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (default: 50)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("TEST OPTIONS\n"));
     r.push_str(String::from("  --verify                Run ESBMC verification on test files\n"));
     r.push_str(String::from("  --filter <pat>          Only run tests whose name contains pat (default: (none))\n"));
     r.push_str(String::from("  --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: (default))\n"));
     r.push_str(String::from("  --timeout <ms>          Per-test execution timeout in milliseconds (default: 30000)\n"));
-    r.push_str(String::from("  --unwind <N>            ESBMC loop unwind bound (with --verify)\n"));
+    r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (with --verify)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("CONTRACTS OPTIONS\n"));
     r.push_str(String::from("  --verify                Run ESBMC verification and report per-contract status\n"));
     r.push_str(String::from("  --no-cache              Disable verification result caching\n"));
-    r.push_str(String::from("  --unwind <N>            ESBMC loop unwind bound (default: 10)\n"));
+    r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (default: 50)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("DECL OPTIONS\n"));
     r.push_str(String::from("  -o, --output <path>     Output declaration file path (default: <source>.vow.d)\n"));
@@ -1725,16 +1726,15 @@ fn skill_human() -> String {
     r.push_str(String::from("TYPES     : i32  i64  u8  u64  f32  f64  bool  ()  !  Vec<T>  Option<T>  Result<T, E>  String  HashMap<K, V>\n"));
     r.push_str(String::from("EFFECTS   : io  read  write  panic  unsafe\n"));
     r.push_str(String::from("BUILTINS  : print_str: fn(s: String) -> () [io]   print_i64: fn(v: i64) -> () [io]   print_u64: fn(v: u64) -> () [io]\n"));
-    r.push_str(String::from("            eprintln_str: fn(s: String) -> () [io]   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]\n"));
+    r.push_str(String::from("            eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]\n"));
     r.push_str(String::from("METHODS   : Vec: Vec::new/push/pop/len/clear/truncate/v[i]/v[i] = val   String: String::from/String::new/len/byte_at/push_byte/push_str/clear/contains/eq/substring/parse_i64/parse_u64\n"));
     r.push_str(String::from("            HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap\n"));
     r.push_str(String::from("OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("VERIFICATION LIMITS\n"));
-    r.push_str(String::from("  Loop unwind  : 10 iterations\n"));
-    r.push_str(String::from("  Vec<T>        : 128 max capacity\n"));
-    r.push_str(String::from("  String        : 256 max capacity\n"));
-    r.push_str(String::from("  HashMap<K, V> : 64 max capacity\n"));
+    r.push_str(String::from("VERIFICATION\n"));
+    r.push_str(String::from("  Strategy      : k-induction-parallel (incremental BMC + k-induction)\n"));
+    r.push_str(String::from("  Max k step    : 50 (default; override with --max-k-step)\n"));
+    r.push_str(String::from("  Containers    : unbounded (no artificial capacity limits)\n"));
     r
 }
 // GENERATE:SKILL_HUMAN:END
@@ -2453,6 +2453,16 @@ fn skill_full() -> String {
     r.push_str(String::from("| `print_u64`      | `fn(v: u64) -> ()`                         | `[io]`     |\n"));
     r.push_str(String::from("| `eprintln_str`   | `fn(s: String) -> ()`                      | `[io]`     |\n"));
     r.push_str(String::from("\n"));
+    r.push_str(String::from("#### Debug\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("| Function         | Signature                                  | Effects    |\n"));
+    r.push_str(String::from("|------------------|--------------------------------------------|------------|\n"));
+    r.push_str(String::from("| `debug_str`      | `fn(s: String) -> ()`                      | `[]`       |\n"));
+    r.push_str(String::from("| `debug_i64`      | `fn(v: i64) -> ()`                         | `[]`       |\n"));
+    r.push_str(String::from("| `debug_u64`      | `fn(v: u64) -> ()`                         | `[]`       |\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Debug print semantics:** Debug prints are effect-free and callable from pure functions. In debug and sanitize modes (`--mode debug`, `--mode sanitize`), they write to stderr. In release and profile modes, the debug call itself is not emitted -- no function call occurs. However, argument expressions are still evaluated (e.g., `String::from(\"label\")` still allocates). They are also no-ops during verification. Use them to trace values inside pure kernel code without restructuring the effect hierarchy.\n"));
+    r.push_str(String::from("\n"));
     r.push_str(String::from("#### Filesystem\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("| Function         | Signature                                  | Effects    |\n"));
@@ -2598,7 +2608,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |\n"));
     r.push_str(String::from("| `--debug-trace <off\\|calls\\|full>` | `off` | Emit JSON trace lines to stderr at runtime |\n"));
     r.push_str(String::from("| `--no-cache`    | (off)       | Disable compile and verify caching           |\n"));
-    r.push_str(String::from("| `--unwind <N>`  | `10`        | ESBMC loop unwind bound                      |\n"));
+    r.push_str(String::from("| `--max-k-step <N>` | `50`     | ESBMC max k-induction step                   |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow verify`\n"));
     r.push_str(String::from("\n"));
@@ -2613,7 +2623,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| Flag              | Default     | Description                                |\n"));
     r.push_str(String::from("|-------------------|-------------|--------------------------------------------|\n"));
     r.push_str(String::from("| `--no-cache`      | (off)       | Disable verification result caching        |\n"));
-    r.push_str(String::from("| `--unwind <N>`    | `10`        | ESBMC loop unwind bound                   |\n"));
+    r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow contracts`\n"));
     r.push_str(String::from("\n"));
@@ -2629,7 +2639,7 @@ fn skill_full() -> String {
     r.push_str(String::from("|-------------------|-------------|--------------------------------------------|\n"));
     r.push_str(String::from("| `--verify`        | (off)       | Run ESBMC verification and report per-contract status |\n"));
     r.push_str(String::from("| `--no-cache`      | (off)       | Disable verification result caching        |\n"));
-    r.push_str(String::from("| `--unwind <N>`    | `10`        | ESBMC loop unwind bound                   |\n"));
+    r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow skill`\n"));
     r.push_str(String::from("\n"));
@@ -2663,7 +2673,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--mode debug`    | (default)   | Insert runtime vow checks                 |\n"));
     r.push_str(String::from("| `--mode release`  | `debug`     | Omit all vow checks for performance       |\n"));
     r.push_str(String::from("| `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |\n"));
-    r.push_str(String::from("| `--unwind <N>`    | `10`        | ESBMC loop unwind bound (with --verify)    |\n"));
+    r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC max k-induction step (with --verify) |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.\n"));
     r.push_str(String::from("\n"));
@@ -3025,21 +3035,16 @@ fn skill_full() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("### ESBMC Configuration\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("- Loop unwind bound: **10** -- loops are checked for up to 10 iterations\n"));
+    r.push_str(String::from("- Verification strategy: **k-induction-parallel** (incremental BMC + k-induction proof)\n"));
+    r.push_str(String::from("- Max k-induction step: **50** (default; override with `--max-k-step`)\n"));
     r.push_str(String::from("- Architecture: 64-bit\n"));
     r.push_str(String::from("- Array bounds / pointer checks disabled (Vow handles these in its own model)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Collection Models for Verification\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("ESBMC uses bounded models for collection types:\n"));
+    r.push_str(String::from("Collections (`Vec<T>`, `String`, `HashMap<K, V>`) are modeled with unbounded, dynamically allocated storage -- the same semantics as at runtime. There are no artificial capacity limits in the verification model. ESBMC reasons about container operations using k-induction to prove properties for all iterations.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("| Type              | Max Capacity | Supported Operations |\n"));
-    r.push_str(String::from("|-------------------|-------------|----------------------------------------------|\n"));
-    r.push_str(String::from("| `Vec<T>`          | 128         | `new`, `push`, `pop`, `len`, `get`, `set`    |\n"));
-    r.push_str(String::from("| `String`          | 256         | `from`, `len`, `push_byte`, `byte_at`        |\n"));
-    r.push_str(String::from("| `HashMap<K, V>`   | 64          | `new`, `insert`, `get`, `contains_key`, `len`|\n"));
-    r.push_str(String::from("\n"));
-    r.push_str(String::from("These support the same operations as the runtime but with bounded storage. `String::from` produces a nondeterministic length (0 to 255) in verification.\n"));
+    r.push_str(String::from("`String::from` produces a nondeterministic non-negative length in verification.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Blame Model\n"));
     r.push_str(String::from("\n"));
@@ -3245,7 +3250,7 @@ fn skill_full() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Unbound Loop Iterations\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("Without a bound on loop iterations, ESBMC may timeout (unwind bound is 10):\n"));
+    r.push_str(String::from("Without a bound on loop iterations, ESBMC may timeout (max-k-step is 50):\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("```vow\n"));
     r.push_str(String::from("fn fill(n: i64) -> Vec<i64> vow {\n"));
@@ -3782,7 +3787,7 @@ fn skill_full() -> String {
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("**Key points:**\n"));
-    r.push_str(String::from("- `requires: n <= 8` keeps iterations within ESBMC's unwind bound (10)\n"));
+    r.push_str(String::from("- `requires: n <= 8` keeps iterations tractable for verification\n"));
     r.push_str(String::from("- `invariant: i >= 0, invariant: i <= n` is inductive: true on entry, preserved by the loop body\n"));
     r.push_str(String::from("- The Vec model tracks `len`, so ESBMC can reason about `result.len() == n`\n"));
     r.push_str(String::from("\n"));
@@ -4425,10 +4430,10 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
 
     let do_verify: bool = has_flag(argv, String::from("--verify"));
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
-    let unwind_str: String = get_flag_arg(argv, String::from("--unwind"));
-    let unwind: String = {
-        if unwind_str.len() > 0 { unwind_str }
-        else { String::from("10") }
+    let mks_str: String = get_flag_arg(argv, String::from("--max-k-step"));
+    let max_k_step: String = {
+        if mks_str.len() > 0 { mks_str }
+        else { String::from("50") }
     };
 
     // Collect per-contract entries into parallel arrays
@@ -4476,7 +4481,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
         while fi < nf {
             let func: IrFunction = ir_mod.functions[fi];
             if func.vows.len() > 0 {
-                let vr: VerifyResult = verify_function_full(func, ir_mod, unwind, use_cache);
+                let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache);
                 let st: i64 = vr.status;
                 let mut ei: i64 = 0;
                 while ei < e_func_names.len() {

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -164,6 +164,7 @@ fn emit_c_preamble() -> String {
     let out: String = String::from("");
     out.push_str(String::from("#include <stdint.h>\n"));
     out.push_str(String::from("#include <stdbool.h>\n"));
+    out.push_str(String::from("#include <stdlib.h>\n"));
     out.push_str(String::from("extern void __ESBMC_assume(_Bool);\n"));
     out.push_str(String::from("extern void __ESBMC_assert(_Bool, const char*);\n"));
     out.push_str(String::from("extern int __VERIFIER_nondet_int(void);\n"));
@@ -171,23 +172,9 @@ fn emit_c_preamble() -> String {
     out.push_str(String::from("extern float __VERIFIER_nondet_float(void);\n"));
     out.push_str(String::from("extern double __VERIFIER_nondet_double(void);\n"));
     out.push_str(String::from("extern _Bool __VERIFIER_nondet_bool(void);\n\n"));
-    out.push_str(str3(
-        String::from("typedef struct { int64_t len; int64_t data["),
-        i64_to_str(VOW_VEC_MAX()),
-        String::from("]; } __vow_vec_t;\n")
-    ));
-    out.push_str(str3(
-        String::from("typedef struct { int64_t len; int8_t data["),
-        i64_to_str(VOW_STRING_MAX()),
-        String::from("]; } __vow_string_t;\n")
-    ));
-    out.push_str(str5(
-        String::from("typedef struct { int64_t len; int64_t keys["),
-        i64_to_str(VOW_HASHMAP_MAX()),
-        String::from("]; int64_t vals["),
-        i64_to_str(VOW_HASHMAP_MAX()),
-        String::from("]; } __vow_hashmap_t;\n\n")
-    ));
+    out.push_str(String::from("typedef struct { int64_t len; int64_t* data; } __vow_vec_t;\n"));
+    out.push_str(String::from("typedef struct { int64_t len; int8_t* data; } __vow_string_t;\n"));
+    out.push_str(String::from("typedef struct { int64_t len; int64_t* keys; int64_t* vals; } __vow_hashmap_t;\n\n"));
     out
 }
 
@@ -224,7 +211,7 @@ fn esbmc_exists() -> bool [io] {
     fs_exists(esbmc_path()) != 0
 }
 
-fn save_esbmc_debug(c_source: String, tmp_path: String, unwind: String, func_name: String, debug: bool) [io] {
+fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func_name: String, debug: bool) [io] {
     if !debug {
         return;
     }
@@ -240,35 +227,37 @@ fn save_esbmc_debug(c_source: String, tmp_path: String, unwind: String, func_nam
     cmd.push_str(esbmc_path());
     cmd.push_str(String::from(" "));
     cmd.push_str(c_path);
-    cmd.push_str(String::from(" --no-bounds-check --no-pointer-check --unwind "));
-    cmd.push_str(unwind);
+    cmd.push_str(String::from(" --no-bounds-check --no-pointer-check --k-induction-parallel --max-k-step "));
+    cmd.push_str(max_k_step);
     cmd.push_str(String::from(" --64\n"));
     fs_write(cmd_path, cmd);
 }
 
-fn run_esbmc(c_source: String, unwind: String, tmp_path: String, func_name: String) -> i64 [io] {
+fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: String) -> i64 [io] {
     fs_write(tmp_path, c_source);
-    save_esbmc_debug(c_source, tmp_path, unwind, func_name, false);
+    save_esbmc_debug(c_source, tmp_path, max_k_step, func_name, false);
     let esbmc_args: Vec<String> = Vec::new();
     esbmc_args.push(tmp_path);
     esbmc_args.push(String::from("--no-bounds-check"));
     esbmc_args.push(String::from("--no-pointer-check"));
-    esbmc_args.push(String::from("--unwind"));
-    esbmc_args.push(unwind);
+    esbmc_args.push(String::from("--k-induction-parallel"));
+    esbmc_args.push(String::from("--max-k-step"));
+    esbmc_args.push(max_k_step);
     esbmc_args.push(String::from("--64"));
     let exit_code: i64 = process_run(esbmc_path(), esbmc_args);
     exit_code
 }
 
-fn start_esbmc(c_source: String, unwind: String, tmp_path: String, func_name: String) -> i64 [io] {
+fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: String) -> i64 [io] {
     fs_write(tmp_path, c_source);
-    save_esbmc_debug(c_source, tmp_path, unwind, func_name, false);
+    save_esbmc_debug(c_source, tmp_path, max_k_step, func_name, false);
     let esbmc_args: Vec<String> = Vec::new();
     esbmc_args.push(tmp_path);
     esbmc_args.push(String::from("--no-bounds-check"));
     esbmc_args.push(String::from("--no-pointer-check"));
-    esbmc_args.push(String::from("--unwind"));
-    esbmc_args.push(unwind);
+    esbmc_args.push(String::from("--k-induction-parallel"));
+    esbmc_args.push(String::from("--max-k-step"));
+    esbmc_args.push(max_k_step);
     esbmc_args.push(String::from("--64"));
     let handle: i64 = process_start(esbmc_path(), esbmc_args);
     handle
@@ -494,9 +483,9 @@ fn vow_hash_string(s: String) -> i64 {
     h
 }
 
-fn verify_cache_key(c_source: String, unwind: String) -> String {
+fn verify_cache_key(c_source: String, max_k_step: String) -> String {
     let h: i64 = vow_hash_string(c_source);
-    let h2: i64 = h * 33 + vow_hash_string(unwind);
+    let h2: i64 = h * 33 + vow_hash_string(max_k_step);
     let abs_h: i64 = { if h2 < 0 { 0 - h2 } else { h2 } };
     i64_to_str(abs_h)
 }
@@ -535,7 +524,7 @@ fn verify_cache_store(key: String, status: i64) [io] {
     fs_write(path, content);
 }
 
-fn verify_function_full(f: IrFunction, m: IrModule, unwind: String, use_cache: bool) -> VerifyResult [io] {
+fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cache: bool) -> VerifyResult [io] {
     let vows: Vec<IrVowEntry> = f.vows;
     if vows.len() == 0 {
         return VerifyResult {
@@ -550,7 +539,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, unwind: String, use_cache: b
     let c_source: String = emit_c_for_verify(f, m);
     if use_cache {
         verify_cache_ensure_dir();
-        let cache_key: String = verify_cache_key(c_source, unwind);
+        let cache_key: String = verify_cache_key(c_source, max_k_step);
         let cached: i64 = verify_cache_lookup(cache_key);
         if cached == VERIFY_PROVEN() {
             return VerifyResult {
@@ -564,7 +553,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, unwind: String, use_cache: b
         }
     }
     let fn_name: String = f.name;
-    let exit_code: i64 = run_esbmc(c_source, unwind, String::from("/tmp/__vow_verify.c"), fn_name);
+    let exit_code: i64 = run_esbmc(c_source, max_k_step, String::from("/tmp/__vow_verify.c"), fn_name);
     if exit_code == -1 {
         return VerifyResult {
             status: VERIFY_NOT_FOUND(),
@@ -583,7 +572,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, unwind: String, use_cache: b
     let status: i64 = parse_verify_status(combined);
     if use_cache {
         if status == VERIFY_PROVEN() || status == VERIFY_FAILED() {
-            let cache_key2: String = verify_cache_key(c_source, unwind);
+            let cache_key2: String = verify_cache_key(c_source, max_k_step);
             verify_cache_store(cache_key2, status);
         }
     }
@@ -617,7 +606,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, unwind: String, use_cache: b
     }
 }
 
-fn verify_start(f: IrFunction, m: IrModule, unwind: String, idx: i64, use_cache: bool) -> i64 [io] {
+fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_cache: bool) -> i64 [io] {
     let vows: Vec<IrVowEntry> = f.vows;
     if vows.len() == 0 {
         return -1;
@@ -625,7 +614,7 @@ fn verify_start(f: IrFunction, m: IrModule, unwind: String, idx: i64, use_cache:
     let c_source: String = emit_c_for_verify(f, m);
     if use_cache {
         verify_cache_ensure_dir();
-        let cache_key: String = verify_cache_key(c_source, unwind);
+        let cache_key: String = verify_cache_key(c_source, max_k_step);
         let cached: i64 = verify_cache_lookup(cache_key);
         if cached == VERIFY_PROVEN() {
             return -2;
@@ -635,7 +624,7 @@ fn verify_start(f: IrFunction, m: IrModule, unwind: String, idx: i64, use_cache:
     tmp_path.push_str(i64_to_str(idx));
     tmp_path.push_str(String::from(".c"));
     let fn_name: String = f.name;
-    let handle: i64 = start_esbmc(c_source, unwind, tmp_path, fn_name);
+    let handle: i64 = start_esbmc(c_source, max_k_step, tmp_path, fn_name);
     handle
 }
 

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -21,7 +21,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |
 | `--debug-trace <off\|calls\|full>` | `off` | Emit JSON trace lines to stderr at runtime |
 | `--no-cache`    | (off)       | Disable compile and verify caching           |
-| `--unwind <N>`  | `10`        | ESBMC loop unwind bound                      |
+| `--max-k-step <N>` | `50`     | ESBMC max k-induction step                   |
 
 ### `vow verify`
 
@@ -36,7 +36,7 @@ vow verify [OPTIONS] <source.vow>
 | Flag              | Default     | Description                                |
 |-------------------|-------------|--------------------------------------------|
 | `--no-cache`      | (off)       | Disable verification result caching        |
-| `--unwind <N>`    | `10`        | ESBMC loop unwind bound                   |
+| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
 
 ### `vow contracts`
 
@@ -52,7 +52,7 @@ vow contracts [OPTIONS] <source.vow>
 |-------------------|-------------|--------------------------------------------|
 | `--verify`        | (off)       | Run ESBMC verification and report per-contract status |
 | `--no-cache`      | (off)       | Disable verification result caching        |
-| `--unwind <N>`    | `10`        | ESBMC loop unwind bound                   |
+| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
 
 ### `vow skill`
 
@@ -86,7 +86,7 @@ vow test [OPTIONS] [<path>]
 | `--mode debug`    | (default)   | Insert runtime vow checks                 |
 | `--mode release`  | `debug`     | Omit all vow checks for performance       |
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
-| `--unwind <N>`    | `10`        | ESBMC loop unwind bound (with --verify)    |
+| `--max-k-step <N>` | `50`       | ESBMC max k-induction step (with --verify) |
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.
 

--- a/docs/spec/contracts.md
+++ b/docs/spec/contracts.md
@@ -15,21 +15,16 @@ Contract clauses become IR opcodes. The C emitter translates `requires` to `__ES
 
 ### ESBMC Configuration
 
-- Loop unwind bound: **10** — loops are checked for up to 10 iterations
+- Verification strategy: **k-induction-parallel** (incremental BMC + k-induction proof)
+- Max k-induction step: **50** (default; override with `--max-k-step`)
 - Architecture: 64-bit
 - Array bounds / pointer checks disabled (Vow handles these in its own model)
 
 ### Collection Models for Verification
 
-ESBMC uses bounded models for collection types:
+Collections (`Vec<T>`, `String`, `HashMap<K, V>`) are modeled with unbounded, dynamically allocated storage — the same semantics as at runtime. There are no artificial capacity limits in the verification model. ESBMC reasons about container operations using k-induction to prove properties for all iterations.
 
-| Type              | Max Capacity | Supported Operations |
-|-------------------|-------------|----------------------------------------------|
-| `Vec<T>`          | 128         | `new`, `push`, `pop`, `len`, `get`, `set`    |
-| `String`          | 256         | `from`, `len`, `push_byte`, `byte_at`        |
-| `HashMap<K, V>`   | 64          | `new`, `insert`, `get`, `contains_key`, `len`|
-
-These support the same operations as the runtime but with bounded storage. `String::from` produces a nondeterministic length (0 to 255) in verification.
+`String::from` produces a nondeterministic non-negative length in verification.
 
 ## Blame Model
 
@@ -235,7 +230,7 @@ This is not inductive — `v.len() == n` is only true after the loop.
 
 ### Unbound Loop Iterations
 
-Without a bound on loop iterations, ESBMC may timeout (unwind bound is 10):
+Without a bound on loop iterations, ESBMC may timeout (max-k-step is 50):
 
 ```vow
 fn fill(n: i64) -> Vec<i64> vow {

--- a/docs/spec/examples.md
+++ b/docs/spec/examples.md
@@ -187,7 +187,7 @@ $ vow build examples/vec_fill.vow
 ```
 
 **Key points:**
-- `requires: n <= 8` keeps iterations within ESBMC's unwind bound (10)
+- `requires: n <= 8` keeps iterations tractable for verification
 - `invariant: i >= 0, invariant: i <= n` is inductive: true on entry, preserved by the loop body
 - The Vec model tracks `len`, so ESBMC can reason about `result.len() == n`
 

--- a/scripts/generate_help.py
+++ b/scripts/generate_help.py
@@ -31,7 +31,7 @@ MAIN_RS = REPO / "vow" / "src" / "main.rs"
 MAIN_VOW = REPO / "compiler" / "main.vow"
 
 SCHEMA_VERSION = "2"
-DEFAULT_UNWIND = 10
+DEFAULT_MAX_K_STEP = 50
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +144,7 @@ def normalize_option(
         option["value_kind"] = "enum"
         option["values"] = ["off", "calls", "full"]
         option["default"] = default
-    elif normalized_flag == "--unwind <N>":
+    elif normalized_flag == "--max-k-step <N>":
         option["default"] = int(default) if default.isdigit() else default
     elif output_default is not None:
         option["default"] = output_default
@@ -158,7 +158,7 @@ def normalize_option(
 # Build JSON structure from grammar.md + cli.md
 # ---------------------------------------------------------------------------
 
-def build_help_json(grammar: str, cli: str, contracts: str) -> dict:
+def build_help_json(grammar: str, cli: str, _contracts: str) -> dict:
     # --- Types ---
     prim_types = extract_table_col(grammar, "Primitive Types", 0)
     param_types = extract_table_col(grammar, "Built-in Parameterized Types", 0)
@@ -291,16 +291,11 @@ def build_help_json(grammar: str, cli: str, contracts: str) -> dict:
         contracts_options[key] = value
         contracts_option_entries.append(option)
 
-    # --- Verification limits from contracts.md ---
-    collection_rows = extract_table(contracts, "Collection Models for Verification")
-    verification_limits: dict[str, str | int] = {
-        "loop_unwind": DEFAULT_UNWIND,
+    # --- Verification defaults from contracts.md ---
+    verification_defaults: dict[str, str | int] = {
+        "strategy": "k-induction-parallel",
+        "max_k_step": DEFAULT_MAX_K_STEP,
     }
-    for row in collection_rows:
-        if len(row) >= 2:
-            type_name = row[0].strip()
-            capacity = int(row[1].strip())
-            verification_limits[type_name] = capacity
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -595,7 +590,7 @@ def build_help_json(grammar: str, cli: str, contracts: str) -> dict:
                 ],
             },
         },
-        "verification_limits": verification_limits,
+        "verification_defaults": verification_defaults,
     }
 
 
@@ -728,13 +723,12 @@ def build_help_human(data: dict) -> str:
     lines.append(f"OPERATORS : {arith}   {checked} (checked)   {comp}   {logical}   {bitwise_str} (bitwise, integer-only)   unary {unary}")
     lines.append("")
 
-    vlimits = data.get("verification_limits", {})
-    if vlimits:
-        lines.append("VERIFICATION LIMITS")
-        lines.append(f"  Loop unwind  : {vlimits.get('loop_unwind', DEFAULT_UNWIND)} iterations")
-        for key, val in vlimits.items():
-            if key != "loop_unwind":
-                lines.append(f"  {key:<14s}: {val} max capacity")
+    vdefaults = data.get("verification_defaults", {})
+    if vdefaults:
+        lines.append("VERIFICATION")
+        lines.append(f"  Strategy      : {vdefaults.get('strategy', 'k-induction-parallel')} (incremental BMC + k-induction)")
+        lines.append(f"  Max k step    : {vdefaults.get('max_k_step', DEFAULT_MAX_K_STEP)} (default; override with --max-k-step)")
+        lines.append("  Containers    : unbounded (no artificial capacity limits)")
 
     return "\n".join(lines)
 

--- a/tests/run/vec_grow_past_old_limit.vow
+++ b/tests/run/vec_grow_past_old_limit.vow
@@ -1,0 +1,20 @@
+module VecGrowPastOldLimit
+
+fn main() -> i32 [io] {
+    let v: Vec<i64> = Vec::new();
+    let mut i: i64 = 0;
+    while i < 200 {
+        v.push(i);
+        i = i + 1;
+    }
+    if v.len() != 200 {
+        return 1;
+    }
+    if v[0] != 0 {
+        return 1;
+    }
+    if v[199] != 199 {
+        return 1;
+    }
+    0
+}

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -725,7 +725,7 @@ fn emit_inst(
                         out.push_str(&format!(
                             "  v{id}.len = __VERIFIER_nondet_long();\n\
                              \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n\
-                             \x20 v{id}.data = (int8_t*)0;\n"
+                             \x20 v{id}.data = (v{id}.len > 0) ? (int8_t*)malloc((size_t)v{id}.len) : (int8_t*)0;\n"
                         ));
                     }
                     "__vow_string_len" => {
@@ -1084,19 +1084,20 @@ pub fn emit_c_function_full(
                         out.push_str(&format!(
                             "  __vow_vec_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
                              \x20 __ESBMC_assume(v{id}.len >= 0);\n\
-                             \x20 v{id}.data = (int64_t*)0;\n"
+                             \x20 v{id}.data = (v{id}.len > 0) ? (int64_t*)malloc(sizeof(int64_t) * (size_t)v{id}.len) : (int64_t*)0;\n"
                         ));
                     } else if string_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_string_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
                              \x20 __ESBMC_assume(v{id}.len >= 0);\n\
-                             \x20 v{id}.data = (int8_t*)0;\n"
+                             \x20 v{id}.data = (v{id}.len > 0) ? (int8_t*)malloc((size_t)v{id}.len) : (int8_t*)0;\n"
                         ));
                     } else if hashmap_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_hashmap_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
                              \x20 __ESBMC_assume(v{id}.len >= 0);\n\
-                             \x20 v{id}.keys = (int64_t*)0;\n  v{id}.vals = (int64_t*)0;\n"
+                             \x20 v{id}.keys = (v{id}.len > 0) ? (int64_t*)malloc(sizeof(int64_t) * (size_t)v{id}.len) : (int64_t*)0;\n\
+                             \x20 v{id}.vals = (v{id}.len > 0) ? (int64_t*)malloc(sizeof(int64_t) * (size_t)v{id}.len) : (int64_t*)0;\n"
                         ));
                     } else if option_vars.contains(&id) {
                         out.push_str(&format!("  __vow_option_t v{};\n  v{}.tag = 0;\n", id, id));

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -675,16 +675,14 @@ fn emit_inst(
             if let InstData::CallExtern(ref name) = inst.data {
                 match name.as_str() {
                     "__vow_vec_new" => {
-                        out.push_str(&format!(
-                            "  v{id}.len = 0;\n\
-                             \x20 v{id}.data = (int64_t*)malloc(sizeof(int64_t));\n"
-                        ));
+                        out.push_str(&format!("  v{id}.len = 0;\n  v{id}.data = (int64_t*)0;\n"));
                     }
                     "__vow_vec_push_val" => {
                         let vec = inst.args[0].0;
                         let val = inst.args[1].0;
                         out.push_str(&format!(
-                            "  v{vec}.data[v{vec}.len] = v{val};\n  v{vec}.len++;\n"
+                            "  v{vec}.data = (int64_t*)realloc(v{vec}.data, sizeof(int64_t) * (size_t)(v{vec}.len + 1));\n\
+                             \x20 v{vec}.data[v{vec}.len] = v{val};\n  v{vec}.len++;\n"
                         ));
                     }
                     "__vow_vec_get_val" => {
@@ -726,8 +724,7 @@ fn emit_inst(
                     "__vow_string_from_cstr" => {
                         out.push_str(&format!(
                             "  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n\
-                             \x20 v{id}.data = (int8_t*)malloc((size_t)v{id}.len + 1);\n"
+                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n"
                         ));
                     }
                     "__vow_string_len" => {
@@ -743,7 +740,8 @@ fn emit_inst(
                         let s = inst.args[0].0;
                         let byte = inst.args[1].0;
                         out.push_str(&format!(
-                            "  v{s}.data[v{s}.len] = (int8_t)v{byte};\n  v{s}.len++;\n"
+                            "  v{s}.data = (int8_t*)realloc(v{s}.data, (size_t)(v{s}.len + 1));\n\
+                             \x20 v{s}.data[v{s}.len] = (int8_t)v{byte};\n  v{s}.len++;\n"
                         ));
                     }
                     "__vow_string_byte_at" => {
@@ -820,9 +818,7 @@ fn emit_inst(
                 match name.as_str() {
                     "__vow_map_new" => {
                         out.push_str(&format!(
-                            "  v{id}.len = 0;\n\
-                             \x20 v{id}.keys = (int64_t*)malloc(sizeof(int64_t));\n\
-                             \x20 v{id}.vals = (int64_t*)malloc(sizeof(int64_t));\n"
+                            "  v{id}.len = 0;\n  v{id}.keys = (int64_t*)0;\n  v{id}.vals = (int64_t*)0;\n"
                         ));
                     }
                     "__vow_map_len" => {
@@ -840,6 +836,8 @@ fn emit_inst(
                              \x20     if (v{m}.keys[__i] == v{k}) {{ v{m}.vals[__i] = v{v}; __found = 1; break; }}\n\
                              \x20   }}\n\
                              \x20   if (!__found) {{\n\
+                             \x20     v{m}.keys = (int64_t*)realloc(v{m}.keys, sizeof(int64_t) * (size_t)(v{m}.len + 1));\n\
+                             \x20     v{m}.vals = (int64_t*)realloc(v{m}.vals, sizeof(int64_t) * (size_t)(v{m}.len + 1));\n\
                              \x20     v{m}.keys[v{m}.len] = v{k}; v{m}.vals[v{m}.len] = v{v}; v{m}.len++;\n\
                              \x20   }}\n\
                              \x20 }}\n"
@@ -1083,21 +1081,17 @@ pub fn emit_c_function_full(
                     if vec_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_vec_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
-                             \x20 v{id}.data = (int64_t*)malloc(sizeof(int64_t));\n"
+                             \x20 __ESBMC_assume(v{id}.len >= 0);\n"
                         ));
                     } else if string_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_string_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
-                             \x20 v{id}.data = (int8_t*)malloc((size_t)v{id}.len + 1);\n"
+                             \x20 __ESBMC_assume(v{id}.len >= 0);\n"
                         ));
                     } else if hashmap_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_hashmap_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
-                             \x20 v{id}.keys = (int64_t*)malloc(sizeof(int64_t));\n\
-                             \x20 v{id}.vals = (int64_t*)malloc(sizeof(int64_t));\n"
+                             \x20 __ESBMC_assume(v{id}.len >= 0);\n"
                         ));
                     } else if option_vars.contains(&id) {
                         out.push_str(&format!("  __vow_option_t v{};\n  v{}.tag = 0;\n", id, id));

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -48,14 +48,6 @@ pub fn detect_constant_functions(module: &Module) -> HashMap<FuncId, ConstantVal
 }
 
 // ---------------------------------------------------------------------------
-// Vec model capacity for bounded model checking
-// ---------------------------------------------------------------------------
-
-const VOW_VEC_MAX: usize = 128;
-const VOW_STRING_MAX: usize = 256;
-const VOW_HASHMAP_MAX: usize = 64;
-
-// ---------------------------------------------------------------------------
 // Type mapping
 // ---------------------------------------------------------------------------
 
@@ -683,15 +675,16 @@ fn emit_inst(
             if let InstData::CallExtern(ref name) = inst.data {
                 match name.as_str() {
                     "__vow_vec_new" => {
-                        out.push_str(&format!("  v{}.len = 0;\n", id));
+                        out.push_str(&format!(
+                            "  v{id}.len = 0;\n\
+                             \x20 v{id}.data = (int64_t*)malloc(sizeof(int64_t));\n"
+                        ));
                     }
                     "__vow_vec_push_val" => {
                         let vec = inst.args[0].0;
                         let val = inst.args[1].0;
                         out.push_str(&format!(
-                            "  __ESBMC_assert(v{vec}.len < {}, \"vec capacity\");\n\
-                             \x20 v{vec}.data[v{vec}.len] = v{val};\n  v{vec}.len++;\n",
-                            VOW_VEC_MAX
+                            "  v{vec}.data[v{vec}.len] = v{val};\n  v{vec}.len++;\n"
                         ));
                     }
                     "__vow_vec_get_val" => {
@@ -733,8 +726,8 @@ fn emit_inst(
                     "__vow_string_from_cstr" => {
                         out.push_str(&format!(
                             "  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {});\n",
-                            VOW_STRING_MAX
+                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n\
+                             \x20 v{id}.data = (int8_t*)malloc((size_t)v{id}.len + 1);\n"
                         ));
                     }
                     "__vow_string_len" => {
@@ -750,9 +743,7 @@ fn emit_inst(
                         let s = inst.args[0].0;
                         let byte = inst.args[1].0;
                         out.push_str(&format!(
-                            "  __ESBMC_assert(v{s}.len < {}, \"string capacity\");\n\
-                             \x20 v{s}.data[v{s}.len] = (int8_t)v{byte};\n  v{s}.len++;\n",
-                            VOW_STRING_MAX
+                            "  v{s}.data[v{s}.len] = (int8_t)v{byte};\n  v{s}.len++;\n"
                         ));
                     }
                     "__vow_string_byte_at" => {
@@ -801,10 +792,9 @@ fn emit_inst(
                             "  __ESBMC_assert(v{start} >= 0 && v{start} <= v{s}.len, \"substring start\");\n\
                              \x20 __ESBMC_assert(v{end} >= v{start} && v{end} <= v{s}.len, \"substring end\");\n\
                              \x20 v{id}.len = v{end} - v{start};\n\
-                             \x20 for (int64_t __i = 0; __i < v{id}.len && __i < {}; __i++) {{\n\
+                             \x20 for (int64_t __i = 0; __i < v{id}.len; __i++) {{\n\
                              \x20   v{id}.data[__i] = v{s}.data[v{start} + __i];\n\
-                             \x20 }}\n",
-                            VOW_STRING_MAX
+                             \x20 }}\n"
                         ));
                     }
                     "__vow_string_parse_i64_opt" | "__vow_string_parse_u64_opt" => {
@@ -829,7 +819,11 @@ fn emit_inst(
             if let InstData::CallExtern(ref name) = inst.data {
                 match name.as_str() {
                     "__vow_map_new" => {
-                        out.push_str(&format!("  v{id}.len = 0;\n"));
+                        out.push_str(&format!(
+                            "  v{id}.len = 0;\n\
+                             \x20 v{id}.keys = (int64_t*)malloc(sizeof(int64_t));\n\
+                             \x20 v{id}.vals = (int64_t*)malloc(sizeof(int64_t));\n"
+                        ));
                     }
                     "__vow_map_len" => {
                         let m = inst.args[0].0;
@@ -846,7 +840,6 @@ fn emit_inst(
                              \x20     if (v{m}.keys[__i] == v{k}) {{ v{m}.vals[__i] = v{v}; __found = 1; break; }}\n\
                              \x20   }}\n\
                              \x20   if (!__found) {{\n\
-                             \x20     __ESBMC_assert(v{m}.len < {VOW_HASHMAP_MAX}, \"hashmap capacity\");\n\
                              \x20     v{m}.keys[v{m}.len] = v{k}; v{m}.vals[v{m}.len] = v{v}; v{m}.len++;\n\
                              \x20   }}\n\
                              \x20 }}\n"
@@ -1088,11 +1081,24 @@ pub fn emit_c_function_full(
                 let id = inst.id.0;
                 if let Some(&(_, cl)) = arg_var_map.iter().find(|(ir, _)| *ir == idx) {
                     if vec_vars.contains(&id) {
-                        out.push_str(&format!("  __vow_vec_t v{};\n  v{}.len = 0;\n", id, id));
+                        out.push_str(&format!(
+                            "  __vow_vec_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
+                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
+                             \x20 v{id}.data = (int64_t*)malloc(sizeof(int64_t));\n"
+                        ));
                     } else if string_vars.contains(&id) {
-                        out.push_str(&format!("  __vow_string_t v{};\n  v{}.len = 0;\n", id, id));
+                        out.push_str(&format!(
+                            "  __vow_string_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
+                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
+                             \x20 v{id}.data = (int8_t*)malloc((size_t)v{id}.len + 1);\n"
+                        ));
                     } else if hashmap_vars.contains(&id) {
-                        out.push_str(&format!("  __vow_hashmap_t v{};\n  v{}.len = 0;\n", id, id));
+                        out.push_str(&format!(
+                            "  __vow_hashmap_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
+                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
+                             \x20 v{id}.keys = (int64_t*)malloc(sizeof(int64_t));\n\
+                             \x20 v{id}.vals = (int64_t*)malloc(sizeof(int64_t));\n"
+                        ));
                     } else if option_vars.contains(&id) {
                         out.push_str(&format!("  __vow_option_t v{};\n  v{}.tag = 0;\n", id, id));
                     } else {
@@ -1248,6 +1254,7 @@ pub fn emit_c_function_full(
 fn emit_c_preamble(out: &mut String) {
     out.push_str("#include <stdint.h>\n");
     out.push_str("#include <stdbool.h>\n");
+    out.push_str("#include <stdlib.h>\n");
     out.push_str("extern void __ESBMC_assume(_Bool);\n");
     out.push_str("extern void __ESBMC_assert(_Bool, const char*);\n");
     out.push_str("extern int __VERIFIER_nondet_int(void);\n");
@@ -1255,18 +1262,11 @@ fn emit_c_preamble(out: &mut String) {
     out.push_str("extern float __VERIFIER_nondet_float(void);\n");
     out.push_str("extern double __VERIFIER_nondet_double(void);\n");
     out.push_str("extern _Bool __VERIFIER_nondet_bool(void);\n\n");
-    out.push_str(&format!(
-        "typedef struct {{ int64_t len; int64_t data[{}]; }} __vow_vec_t;\n",
-        VOW_VEC_MAX
-    ));
-    out.push_str(&format!(
-        "typedef struct {{ int64_t len; int8_t data[{}]; }} __vow_string_t;\n",
-        VOW_STRING_MAX
-    ));
-    out.push_str(&format!(
-        "typedef struct {{ int64_t len; int64_t keys[{}]; int64_t vals[{}]; }} __vow_hashmap_t;\n",
-        VOW_HASHMAP_MAX, VOW_HASHMAP_MAX
-    ));
+    out.push_str("typedef struct { int64_t len; int64_t* data; } __vow_vec_t;\n");
+    out.push_str("typedef struct { int64_t len; int8_t* data; } __vow_string_t;\n");
+    out.push_str(
+        "typedef struct { int64_t len; int64_t* keys; int64_t* vals; } __vow_hashmap_t;\n",
+    );
     out.push_str("typedef struct { int64_t tag; int64_t payload; } __vow_option_t;\n");
     out.push_str(
         "static inline int64_t __vow_shl_i64(int64_t value, int64_t count) {\n\
@@ -2053,7 +2053,7 @@ mod tests {
         let out = emit_c_module(&[&f], &HashMap::new());
         assert!(out.contains("__vow_vec_t"), "vec typedef: {out}");
         assert!(out.contains("int64_t len"), "vec len field: {out}");
-        assert!(out.contains("int64_t data["), "vec data field: {out}");
+        assert!(out.contains("int64_t* data"), "vec data ptr field: {out}");
     }
 
     #[test]
@@ -2118,8 +2118,8 @@ mod tests {
         );
         let c = emit_c_function(&func, &HashMap::new());
         assert!(
-            c.contains("__ESBMC_assert(v2.len < 128, \"vec capacity\")"),
-            "push capacity: {c}"
+            !c.contains("vec capacity"),
+            "push must NOT have capacity assertion: {c}"
         );
         assert!(c.contains("v2.data[v2.len] = v3;"), "push store: {c}");
         assert!(c.contains("v2.len++;"), "push increment: {c}");
@@ -2354,7 +2354,7 @@ mod tests {
         );
         let out = emit_c_module(&[&f], &HashMap::new());
         assert!(out.contains("__vow_string_t"), "string typedef: {out}");
-        assert!(out.contains("int8_t data["), "string data field: {out}");
+        assert!(out.contains("int8_t* data"), "string data ptr field: {out}");
     }
 
     #[test]
@@ -2384,8 +2384,8 @@ mod tests {
             "nondet len: {c}"
         );
         assert!(
-            c.contains("__ESBMC_assume(v1.len >= 0 && v1.len < 256)"),
-            "len bounded: {c}"
+            c.contains("__ESBMC_assume(v1.len >= 0 && v1.len < INT64_MAX)"),
+            "len bounded by type: {c}"
         );
         assert!(
             c.contains("return 0; /* modelled type return */"),
@@ -2456,8 +2456,8 @@ mod tests {
         );
         let c = emit_c_function(&func, &HashMap::new());
         assert!(
-            c.contains("__ESBMC_assert(v1.len < 256, \"string capacity\")"),
-            "push_byte capacity: {c}"
+            !c.contains("string capacity"),
+            "push_byte must NOT have capacity assertion: {c}"
         );
         assert!(
             c.contains("v1.data[v1.len] = (int8_t)v2;"),
@@ -2824,8 +2824,8 @@ mod tests {
         assert!(c.contains("v0.keys[__i] == v1"), "key search: {c}");
         assert!(c.contains("v0.vals[__i] = v2"), "update existing: {c}");
         assert!(
-            c.contains("__ESBMC_assert(v0.len < 64, \"hashmap capacity\")"),
-            "insert capacity: {c}"
+            !c.contains("hashmap capacity"),
+            "insert must NOT have capacity assertion: {c}"
         );
         assert!(c.contains("v0.keys[v0.len] = v1"), "insert new key: {c}");
         assert!(c.contains("v0.vals[v0.len] = v2"), "insert new val: {c}");
@@ -2996,8 +2996,8 @@ mod tests {
             c.contains("__vow_hashmap_t"),
             "hashmap typedef in header: {c}"
         );
-        assert!(c.contains("int64_t keys["), "keys array in typedef: {c}");
-        assert!(c.contains("int64_t vals["), "vals array in typedef: {c}");
+        assert!(c.contains("int64_t* keys"), "keys ptr in typedef: {c}");
+        assert!(c.contains("int64_t* vals"), "vals ptr in typedef: {c}");
     }
 
     #[test]

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -1083,19 +1083,19 @@ pub fn emit_c_function_full(
                     if vec_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_vec_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
+                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n\
                              \x20 v{id}.data = (v{id}.len > 0) ? (int64_t*)malloc(sizeof(int64_t) * (size_t)v{id}.len) : (int64_t*)0;\n"
                         ));
                     } else if string_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_string_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
+                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n\
                              \x20 v{id}.data = (v{id}.len > 0) ? (int8_t*)malloc((size_t)v{id}.len) : (int8_t*)0;\n"
                         ));
                     } else if hashmap_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_hashmap_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
+                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n\
                              \x20 v{id}.keys = (v{id}.len > 0) ? (int64_t*)malloc(sizeof(int64_t) * (size_t)v{id}.len) : (int64_t*)0;\n\
                              \x20 v{id}.vals = (v{id}.len > 0) ? (int64_t*)malloc(sizeof(int64_t) * (size_t)v{id}.len) : (int64_t*)0;\n"
                         ));

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -724,7 +724,8 @@ fn emit_inst(
                     "__vow_string_from_cstr" => {
                         out.push_str(&format!(
                             "  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n"
+                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < INT64_MAX);\n\
+                             \x20 v{id}.data = (int8_t*)0;\n"
                         ));
                     }
                     "__vow_string_len" => {
@@ -790,6 +791,7 @@ fn emit_inst(
                             "  __ESBMC_assert(v{start} >= 0 && v{start} <= v{s}.len, \"substring start\");\n\
                              \x20 __ESBMC_assert(v{end} >= v{start} && v{end} <= v{s}.len, \"substring end\");\n\
                              \x20 v{id}.len = v{end} - v{start};\n\
+                             \x20 v{id}.data = (int8_t*)realloc((int8_t*)0, (size_t)(v{id}.len + 1));\n\
                              \x20 for (int64_t __i = 0; __i < v{id}.len; __i++) {{\n\
                              \x20   v{id}.data[__i] = v{s}.data[v{start} + __i];\n\
                              \x20 }}\n"
@@ -1081,17 +1083,20 @@ pub fn emit_c_function_full(
                     if vec_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_vec_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0);\n"
+                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
+                             \x20 v{id}.data = (int64_t*)0;\n"
                         ));
                     } else if string_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_string_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0);\n"
+                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
+                             \x20 v{id}.data = (int8_t*)0;\n"
                         ));
                     } else if hashmap_vars.contains(&id) {
                         out.push_str(&format!(
                             "  __vow_hashmap_t v{id};\n  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0);\n"
+                             \x20 __ESBMC_assume(v{id}.len >= 0);\n\
+                             \x20 v{id}.keys = (int64_t*)0;\n  v{id}.vals = (int64_t*)0;\n"
                         ));
                     } else if option_vars.contains(&id) {
                         out.push_str(&format!("  __vow_option_t v{};\n  v{}.tag = 0;\n", id, id));

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -185,7 +185,7 @@ fn parse_assignment_line(line: &str) -> Option<(String, String)> {
 // Debug: save C source and command for ESBMC debugging
 // ---------------------------------------------------------------------------
 
-fn save_esbmc_debug(esbmc: &std::path::Path, c_src: &str, func_name: &str) {
+fn save_esbmc_debug(esbmc: &std::path::Path, c_src: &str, func_name: &str, max_k_step: u32) {
     if std::env::var("VOW_VERIFY_DEBUG").is_err() {
         return;
     }
@@ -199,9 +199,10 @@ fn save_esbmc_debug(esbmc: &std::path::Path, c_src: &str, func_name: &str) {
     let _ = std::fs::write(debug_dir.join(&c_name), c_src);
 
     let cmd = format!(
-        "{} /tmp/vow-verify-debug/{} --no-bounds-check --no-pointer-check --k-induction-parallel --64\n",
+        "{} /tmp/vow-verify-debug/{} --no-bounds-check --no-pointer-check --k-induction-parallel --max-k-step {} --64\n",
         esbmc.display(),
         c_name,
+        max_k_step,
     );
     let _ = std::fs::write(debug_dir.join(&cmd_name), cmd);
 }
@@ -315,7 +316,7 @@ pub fn run_esbmc_with_max_k_step(
         return VerificationResult::ToolError(e.to_string());
     }
 
-    save_esbmc_debug(esbmc, c_src, func_name);
+    save_esbmc_debug(esbmc, c_src, func_name, max_k_step);
 
     let output = match Command::new(esbmc)
         .arg(tmp.path())

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -199,7 +199,7 @@ fn save_esbmc_debug(esbmc: &std::path::Path, c_src: &str, func_name: &str) {
     let _ = std::fs::write(debug_dir.join(&c_name), c_src);
 
     let cmd = format!(
-        "{} /tmp/vow-verify-debug/{} --no-bounds-check --no-pointer-check --unwind 10 --64\n",
+        "{} /tmp/vow-verify-debug/{} --no-bounds-check --no-pointer-check --k-induction-parallel --64\n",
         esbmc.display(),
         c_name,
     );
@@ -245,21 +245,26 @@ pub fn emit_verify_c_source(
     c_src
 }
 
-pub const DEFAULT_UNWIND: u32 = 10;
+pub const DEFAULT_MAX_K_STEP: u32 = 50;
 
 pub fn verify_function_with_module_and_const_fns(
     func: &Function,
     module: &Module,
     const_fns: &HashMap<FuncId, ConstantValue>,
 ) -> VerificationResult {
-    verify_function_with_module_and_const_fns_with_unwind(func, module, const_fns, DEFAULT_UNWIND)
+    verify_function_with_module_and_const_fns_with_max_k_step(
+        func,
+        module,
+        const_fns,
+        DEFAULT_MAX_K_STEP,
+    )
 }
 
-pub fn verify_function_with_module_and_const_fns_with_unwind(
+pub fn verify_function_with_module_and_const_fns_with_max_k_step(
     func: &Function,
     module: &Module,
     const_fns: &HashMap<FuncId, ConstantValue>,
-    unwind: u32,
+    max_k_step: u32,
 ) -> VerificationResult {
     let esbmc = match find_esbmc() {
         Some(p) => p,
@@ -267,7 +272,7 @@ pub fn verify_function_with_module_and_const_fns_with_unwind(
     };
 
     let c_src = emit_verify_c_source(func, module, const_fns);
-    run_esbmc_with_unwind(&esbmc, &c_src, unwind, &func.name)
+    run_esbmc_with_max_k_step(&esbmc, &c_src, max_k_step, &func.name)
 }
 
 fn verify_function_inner(
@@ -282,17 +287,21 @@ fn verify_function_inner(
     let mut c_src = emit_c_module(&[func], const_fns);
     c_src.push_str(&emit_harness(func));
 
-    run_esbmc(&esbmc, &c_src, &func.name)
+    run_esbmc_k_induction(&esbmc, &c_src, &func.name)
 }
 
-pub fn run_esbmc(esbmc: &std::path::Path, c_src: &str, func_name: &str) -> VerificationResult {
-    run_esbmc_with_unwind(esbmc, c_src, DEFAULT_UNWIND, func_name)
-}
-
-pub fn run_esbmc_with_unwind(
+pub fn run_esbmc_k_induction(
     esbmc: &std::path::Path,
     c_src: &str,
-    unwind: u32,
+    func_name: &str,
+) -> VerificationResult {
+    run_esbmc_with_max_k_step(esbmc, c_src, DEFAULT_MAX_K_STEP, func_name)
+}
+
+pub fn run_esbmc_with_max_k_step(
+    esbmc: &std::path::Path,
+    c_src: &str,
+    max_k_step: u32,
     func_name: &str,
 ) -> VerificationResult {
     let mut tmp = match tempfile::Builder::new().suffix(".c").tempfile() {
@@ -312,8 +321,9 @@ pub fn run_esbmc_with_unwind(
         .arg(tmp.path())
         .arg("--no-bounds-check")
         .arg("--no-pointer-check")
-        .arg("--unwind")
-        .arg(unwind.to_string())
+        .arg("--k-induction-parallel")
+        .arg("--max-k-step")
+        .arg(max_k_step.to_string())
         .arg("--64")
         .output()
     {

--- a/vow-verify/src/lib.rs
+++ b/vow-verify/src/lib.rs
@@ -3,9 +3,9 @@ pub mod esbmc;
 
 pub use c_emitter::detect_constant_functions;
 pub use esbmc::{
-    Counterexample, DEFAULT_UNWIND, VerificationResult, emit_verify_c_source, find_esbmc,
-    parse_esbmc_output, run_esbmc, run_esbmc_with_unwind, verify_function,
+    Counterexample, DEFAULT_MAX_K_STEP, VerificationResult, emit_verify_c_source, find_esbmc,
+    parse_esbmc_output, run_esbmc_k_induction, run_esbmc_with_max_k_step, verify_function,
     verify_function_with_const_fns, verify_function_with_module,
     verify_function_with_module_and_const_fns,
-    verify_function_with_module_and_const_fns_with_unwind,
+    verify_function_with_module_and_const_fns_with_max_k_step,
 };

--- a/vow/src/cache.rs
+++ b/vow/src/cache.rs
@@ -126,8 +126,8 @@ impl VerifyCache {
         Some(Self { dir })
     }
 
-    pub fn cache_key(c_source: &str, unwind: u32) -> String {
-        let combined = format!("{c_source}\n__unwind={unwind}");
+    pub fn cache_key(c_source: &str, max_k_step: u32) -> String {
+        let combined = format!("{c_source}\n__max_k_step={max_k_step}");
         let hash = fnv1a_hash(combined.as_bytes());
         format!("{hash:016x}")
     }
@@ -277,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    fn cache_key_includes_unwind() {
+    fn cache_key_includes_max_k_step() {
         let k1 = VerifyCache::cache_key("int f() { return 0; }", 10);
         let k2 = VerifyCache::cache_key("int f() { return 0; }", 20);
         assert_ne!(k1, k2);

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -14,9 +14,9 @@ use vow_codegen::linker::{find_runtime_lib, find_shim_lib, link};
 use vow_codegen::{Backend, BuildMode, TraceMode};
 use vow_diag::{CollectingEmitter, Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
 use vow_verify::{
-    Counterexample, DEFAULT_UNWIND, VerificationResult, detect_constant_functions,
-    emit_verify_c_source, find_esbmc, run_esbmc_with_unwind,
-    verify_function_with_module_and_const_fns_with_unwind,
+    Counterexample, DEFAULT_MAX_K_STEP, VerificationResult, detect_constant_functions,
+    emit_verify_c_source, find_esbmc, run_esbmc_with_max_k_step,
+    verify_function_with_module_and_const_fns_with_max_k_step,
 };
 
 use cache::{CachedVerifyResult, VerifyCache};
@@ -64,8 +64,8 @@ struct Args {
     debug_trace: TraceArg,
     #[arg(long)]
     no_cache: bool,
-    #[arg(long, default_value_t = DEFAULT_UNWIND)]
-    unwind: u32,
+    #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
+    max_k_step: u32,
     #[arg(long)]
     help: bool,
     #[arg(long)]
@@ -104,8 +104,8 @@ struct BuildArgs {
     debug_trace: TraceArg,
     #[arg(long)]
     no_cache: bool,
-    #[arg(long, default_value_t = DEFAULT_UNWIND)]
-    unwind: u32,
+    #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
+    max_k_step: u32,
     #[arg(long)]
     help: bool,
     #[arg(long)]
@@ -122,8 +122,8 @@ struct VerifyArgs {
     human: bool,
     #[arg(long)]
     no_cache: bool,
-    #[arg(long, default_value_t = DEFAULT_UNWIND)]
-    unwind: u32,
+    #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
+    max_k_step: u32,
 }
 
 #[derive(clap::Args, Debug)]
@@ -143,9 +143,9 @@ struct TestArgs {
     /// Per-test execution timeout in milliseconds
     #[arg(long, default_value = "30000")]
     timeout: u64,
-    /// ESBMC loop unwind bound (only with --verify)
-    #[arg(long, default_value = "10")]
-    unwind: u32,
+    /// ESBMC max k-induction step (only with --verify)
+    #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
+    max_k_step: u32,
     #[arg(long)]
     help: bool,
     #[arg(long)]
@@ -173,7 +173,7 @@ struct ContractsArgs {
     #[arg(long)]
     no_cache: bool,
     #[arg(long)]
-    unwind: Option<u32>,
+    max_k_step: Option<u32>,
     #[arg(long)]
     help: bool,
     #[arg(long)]
@@ -315,12 +315,12 @@ fn skill_json() -> String {
           "value_kind": "flag"
         },
         {
-          "form": "--unwind <N>",
-          "description": "ESBMC loop unwind bound (default: 10)",
-          "long": "--unwind",
+          "form": "--max-k-step <N>",
+          "description": "ESBMC max k-induction step (default: 50)",
+          "long": "--max-k-step",
           "value_name": "N",
           "value_kind": "integer",
-          "default": 10
+          "default": 50
         }
       ],
       "stdout": {
@@ -361,12 +361,12 @@ fn skill_json() -> String {
           "value_kind": "flag"
         },
         {
-          "form": "--unwind <N>",
-          "description": "ESBMC loop unwind bound (default: 10)",
-          "long": "--unwind",
+          "form": "--max-k-step <N>",
+          "description": "ESBMC max k-induction step (default: 50)",
+          "long": "--max-k-step",
           "value_name": "N",
           "value_kind": "integer",
-          "default": 10
+          "default": 50
         }
       ],
       "stdout": {
@@ -428,12 +428,12 @@ fn skill_json() -> String {
           "default": "30000"
         },
         {
-          "form": "--unwind <N>",
-          "description": "ESBMC loop unwind bound (with --verify)",
-          "long": "--unwind",
+          "form": "--max-k-step <N>",
+          "description": "ESBMC max k-induction step (with --verify)",
+          "long": "--max-k-step",
           "value_name": "N",
           "value_kind": "integer",
-          "default": 10
+          "default": 50
         }
       ],
       "stdout": {
@@ -502,12 +502,12 @@ fn skill_json() -> String {
           "value_kind": "flag"
         },
         {
-          "form": "--unwind <N>",
-          "description": "ESBMC loop unwind bound (default: 10)",
-          "long": "--unwind",
+          "form": "--max-k-step <N>",
+          "description": "ESBMC max k-induction step (default: 50)",
+          "long": "--max-k-step",
           "value_name": "N",
           "value_kind": "integer",
-          "default": 10
+          "default": 50
         }
       ],
       "stdout": {
@@ -527,18 +527,18 @@ fn skill_json() -> String {
     "--dump-ir": "Print IR text to stdout and exit (no JSON output, no codegen)",
     "--debug-trace <off|calls|full>": "Emit JSON trace lines to stderr at runtime (default: off)",
     "--no-cache": "Disable compile and verify caching",
-    "--unwind <N>": "ESBMC loop unwind bound (default: 10)"
+    "--max-k-step <N>": "ESBMC max k-induction step (default: 50)"
   },
   "verify_options": {
     "--no-cache": "Disable verification result caching",
-    "--unwind <N>": "ESBMC loop unwind bound (default: 10)"
+    "--max-k-step <N>": "ESBMC max k-induction step (default: 50)"
   },
   "test_options": {
     "--verify": "Run ESBMC verification on test files",
     "--filter <pat>": "Only run tests whose name contains pat (default: (none))",
     "--mode <debug|release>": "Build mode; debug inserts runtime vow checks (default: (default))",
     "--timeout <ms>": "Per-test execution timeout in milliseconds (default: 30000)",
-    "--unwind <N>": "ESBMC loop unwind bound (with --verify)"
+    "--max-k-step <N>": "ESBMC max k-induction step (with --verify)"
   },
   "decl_options": {
     "-o, --output <path>": "Output declaration file path (default: <source>.vow.d)"
@@ -546,7 +546,7 @@ fn skill_json() -> String {
   "contracts_options": {
     "--verify": "Run ESBMC verification and report per-contract status",
     "--no-cache": "Disable verification result caching",
-    "--unwind <N>": "ESBMC loop unwind bound (default: 10)"
+    "--max-k-step <N>": "ESBMC max k-induction step (default: 50)"
   },
   "global_options": {
     "--help": "Emit versioned JSON tool-help data",
@@ -658,6 +658,9 @@ fn skill_json() -> String {
       "print_i64": "fn(v: i64) -> () [io]",
       "print_u64": "fn(v: u64) -> () [io]",
       "eprintln_str": "fn(s: String) -> () [io]",
+      "debug_str": "fn(s: String) -> () []",
+      "debug_i64": "fn(v: i64) -> () []",
+      "debug_u64": "fn(v: u64) -> () []",
       "fs_read": "fn(path: String) -> String [read]",
       "fs_write": "fn(path: String, data: String) -> i64 [write]",
       "fs_exists": "fn(path: String) -> i64 [read]",
@@ -856,11 +859,9 @@ fn skill_json() -> String {
       ]
     }
   },
-  "verification_limits": {
-    "loop_unwind": 10,
-    "Vec<T>": 128,
-    "String": 256,
-    "HashMap<K, V>": 64
+  "verification_defaults": {
+    "strategy": "k-induction-parallel",
+    "max_k_step": 50
   }
 }"##
     .to_string()
@@ -887,23 +888,23 @@ BUILD OPTIONS
   --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)
   --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)
   --no-cache              Disable compile and verify caching
-  --unwind <N>            ESBMC loop unwind bound (default: 10)
+  --max-k-step <N>        ESBMC max k-induction step (default: 50)
 
 VERIFY OPTIONS
   --no-cache              Disable verification result caching
-  --unwind <N>            ESBMC loop unwind bound (default: 10)
+  --max-k-step <N>        ESBMC max k-induction step (default: 50)
 
 TEST OPTIONS
   --verify                Run ESBMC verification on test files
   --filter <pat>          Only run tests whose name contains pat (default: (none))
   --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: (default))
   --timeout <ms>          Per-test execution timeout in milliseconds (default: 30000)
-  --unwind <N>            ESBMC loop unwind bound (with --verify)
+  --max-k-step <N>        ESBMC max k-induction step (with --verify)
 
 CONTRACTS OPTIONS
   --verify                Run ESBMC verification and report per-contract status
   --no-cache              Disable verification result caching
-  --unwind <N>            ESBMC loop unwind bound (default: 10)
+  --max-k-step <N>        ESBMC max k-induction step (default: 50)
 
 DECL OPTIONS
   -o, --output <path>     Output declaration file path (default: <source>.vow.d)
@@ -951,16 +952,15 @@ LANGUAGE SUMMARY
 TYPES     : i32  i64  u8  u64  f32  f64  bool  ()  !  Vec<T>  Option<T>  Result<T, E>  String  HashMap<K, V>
 EFFECTS   : io  read  write  panic  unsafe
 BUILTINS  : print_str: fn(s: String) -> () [io]   print_i64: fn(v: i64) -> () [io]   print_u64: fn(v: u64) -> () [io]
-            eprintln_str: fn(s: String) -> () [io]   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]
+            eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]
 METHODS   : Vec: Vec::new/push/pop/len/clear/truncate/v[i]/v[i] = val   String: String::from/String::new/len/byte_at/push_byte/push_str/clear/contains/eq/substring/parse_i64/parse_u64
             HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap
 OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?
 
-VERIFICATION LIMITS
-  Loop unwind  : 10 iterations
-  Vec<T>        : 128 max capacity
-  String        : 256 max capacity
-  HashMap<K, V> : 64 max capacity"##
+VERIFICATION
+  Strategy      : k-induction-parallel (incremental BMC + k-induction)
+  Max k step    : 50 (default; override with --max-k-step)
+  Containers    : unbounded (no artificial capacity limits)"##
         .to_string()
 }
 // GENERATE:SKILL_HUMAN:END
@@ -1679,6 +1679,16 @@ Contract expressions (`requires`, `ensures`, `invariant`) must be pure — they 
 | `print_u64`      | `fn(v: u64) -> ()`                         | `[io]`     |
 | `eprintln_str`   | `fn(s: String) -> ()`                      | `[io]`     |
 
+#### Debug
+
+| Function         | Signature                                  | Effects    |
+|------------------|--------------------------------------------|------------|
+| `debug_str`      | `fn(s: String) -> ()`                      | `[]`       |
+| `debug_i64`      | `fn(v: i64) -> ()`                         | `[]`       |
+| `debug_u64`      | `fn(v: u64) -> ()`                         | `[]`       |
+
+**Debug print semantics:** Debug prints are effect-free and callable from pure functions. In debug and sanitize modes (`--mode debug`, `--mode sanitize`), they write to stderr. In release and profile modes, the debug call itself is not emitted — no function call occurs. However, argument expressions are still evaluated (e.g., `String::from("label")` still allocates). They are also no-ops during verification. Use them to trace values inside pure kernel code without restructuring the effect hierarchy.
+
 #### Filesystem
 
 | Function         | Signature                                  | Effects    |
@@ -1824,7 +1834,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |
 | `--debug-trace <off\|calls\|full>` | `off` | Emit JSON trace lines to stderr at runtime |
 | `--no-cache`    | (off)       | Disable compile and verify caching           |
-| `--unwind <N>`  | `10`        | ESBMC loop unwind bound                      |
+| `--max-k-step <N>` | `50`     | ESBMC max k-induction step                   |
 
 ### `vow verify`
 
@@ -1839,7 +1849,7 @@ vow verify [OPTIONS] <source.vow>
 | Flag              | Default     | Description                                |
 |-------------------|-------------|--------------------------------------------|
 | `--no-cache`      | (off)       | Disable verification result caching        |
-| `--unwind <N>`    | `10`        | ESBMC loop unwind bound                   |
+| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
 
 ### `vow contracts`
 
@@ -1855,7 +1865,7 @@ vow contracts [OPTIONS] <source.vow>
 |-------------------|-------------|--------------------------------------------|
 | `--verify`        | (off)       | Run ESBMC verification and report per-contract status |
 | `--no-cache`      | (off)       | Disable verification result caching        |
-| `--unwind <N>`    | `10`        | ESBMC loop unwind bound                   |
+| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
 
 ### `vow skill`
 
@@ -1889,7 +1899,7 @@ vow test [OPTIONS] [<path>]
 | `--mode debug`    | (default)   | Insert runtime vow checks                 |
 | `--mode release`  | `debug`     | Omit all vow checks for performance       |
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
-| `--unwind <N>`    | `10`        | ESBMC loop unwind bound (with --verify)    |
+| `--max-k-step <N>` | `50`       | ESBMC max k-induction step (with --verify) |
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.
 
@@ -2251,21 +2261,16 @@ Contract clauses become IR opcodes. The C emitter translates `requires` to `__ES
 
 ### ESBMC Configuration
 
-- Loop unwind bound: **10** — loops are checked for up to 10 iterations
+- Verification strategy: **k-induction-parallel** (incremental BMC + k-induction proof)
+- Max k-induction step: **50** (default; override with `--max-k-step`)
 - Architecture: 64-bit
 - Array bounds / pointer checks disabled (Vow handles these in its own model)
 
 ### Collection Models for Verification
 
-ESBMC uses bounded models for collection types:
+Collections (`Vec<T>`, `String`, `HashMap<K, V>`) are modeled with unbounded, dynamically allocated storage — the same semantics as at runtime. There are no artificial capacity limits in the verification model. ESBMC reasons about container operations using k-induction to prove properties for all iterations.
 
-| Type              | Max Capacity | Supported Operations |
-|-------------------|-------------|----------------------------------------------|
-| `Vec<T>`          | 128         | `new`, `push`, `pop`, `len`, `get`, `set`    |
-| `String`          | 256         | `from`, `len`, `push_byte`, `byte_at`        |
-| `HashMap<K, V>`   | 64          | `new`, `insert`, `get`, `contains_key`, `len`|
-
-These support the same operations as the runtime but with bounded storage. `String::from` produces a nondeterministic length (0 to 255) in verification.
+`String::from` produces a nondeterministic non-negative length in verification.
 
 ## Blame Model
 
@@ -2471,7 +2476,7 @@ This is not inductive — `v.len() == n` is only true after the loop.
 
 ### Unbound Loop Iterations
 
-Without a bound on loop iterations, ESBMC may timeout (unwind bound is 10):
+Without a bound on loop iterations, ESBMC may timeout (max-k-step is 50):
 
 ```vow
 fn fill(n: i64) -> Vec<i64> vow {
@@ -3008,7 +3013,7 @@ $ vow build examples/vec_fill.vow
 ```
 
 **Key points:**
-- `requires: n <= 8` keeps iterations within ESBMC's unwind bound (10)
+- `requires: n <= 8` keeps iterations tractable for verification
 - `invariant: i >= 0, invariant: i <= n` is inductive: true on entry, preserved by the loop body
 - The Vec model tracks `len`, so ESBMC can reason about `result.len() == n`
 
@@ -4409,7 +4414,7 @@ fn run_verification_sync(
     file: &str,
     call_site_index: &std::collections::HashMap<String, Vec<CallSiteInfo>>,
     verify_cache: Option<&VerifyCache>,
-    unwind: u32,
+    max_k_step: u32,
 ) -> VerifyOutcome {
     let const_fns = detect_constant_functions(ir_module);
     for func in &ir_module.functions {
@@ -4419,7 +4424,7 @@ fn run_verification_sync(
 
         let result = if let Some(vc) = verify_cache {
             let c_src = emit_verify_c_source(func, ir_module, &const_fns);
-            let key = VerifyCache::cache_key(&c_src, unwind);
+            let key = VerifyCache::cache_key(&c_src, max_k_step);
 
             if let Some(cached) = vc.lookup(&key) {
                 match cached {
@@ -4433,7 +4438,7 @@ fn run_verification_sync(
                     Some(p) => p,
                     None => return VerifyOutcome::ToolNotFound,
                 };
-                let res = run_esbmc_with_unwind(&esbmc, &c_src, unwind, &func.name);
+                let res = run_esbmc_with_max_k_step(&esbmc, &c_src, max_k_step, &func.name);
                 match &res {
                     VerificationResult::Proven => {
                         vc.store(&key, &CachedVerifyResult::Proven);
@@ -4455,8 +4460,8 @@ fn run_verification_sync(
                 res
             }
         } else {
-            verify_function_with_module_and_const_fns_with_unwind(
-                func, ir_module, &const_fns, unwind,
+            verify_function_with_module_and_const_fns_with_max_k_step(
+                func, ir_module, &const_fns, max_k_step,
             )
         };
 
@@ -4651,7 +4656,7 @@ pub fn run_verify_only(source: &Path) -> BuildOutput {
     run_verify_only_inner(source, false, 10)
 }
 
-fn run_verify_only_inner(source: &Path, no_cache: bool, unwind: u32) -> BuildOutput {
+fn run_verify_only_inner(source: &Path, no_cache: bool, max_k_step: u32) -> BuildOutput {
     let frontend = match compile_frontend(source) {
         Ok(f) => f,
         Err(output) => return *output,
@@ -4669,7 +4674,7 @@ fn run_verify_only_inner(source: &Path, no_cache: bool, unwind: u32) -> BuildOut
         &file,
         &call_site_index,
         verify_cache.as_ref(),
-        unwind,
+        max_k_step,
     );
     verify_outcome_to_output(outcome, frontend.diagnostics, None)
 }
@@ -4718,7 +4723,7 @@ fn run_pipeline_inner(
     dump_ir: bool,
     trace: TraceMode,
     no_cache: bool,
-    unwind: u32,
+    max_k_step: u32,
 ) -> BuildOutput {
     let frontend = match compile_frontend(source) {
         Ok(f) => f,
@@ -4726,7 +4731,7 @@ fn run_pipeline_inner(
     };
 
     run_pipeline_from_frontend(
-        frontend, source, output, mode, no_verify, dump_ir, trace, no_cache, unwind,
+        frontend, source, output, mode, no_verify, dump_ir, trace, no_cache, max_k_step,
     )
 }
 
@@ -4740,7 +4745,7 @@ fn run_pipeline_from_frontend(
     dump_ir: bool,
     trace: TraceMode,
     no_cache: bool,
-    unwind: u32,
+    max_k_step: u32,
 ) -> BuildOutput {
     let all_diagnostics = frontend.diagnostics;
     let ir_module = frontend.ir_module;
@@ -4780,7 +4785,7 @@ fn run_pipeline_from_frontend(
             &file_for_verify,
             &call_site_index,
             verify_cache.as_ref(),
-            unwind,
+            max_k_step,
         )
     });
 
@@ -4916,7 +4921,7 @@ fn run_test_command(
     filter: Option<&str>,
     mode: BuildMode,
     timeout_ms: u64,
-    unwind: u32,
+    max_k_step: u32,
 ) {
     if !path.exists() {
         let result = TestResult {
@@ -5003,7 +5008,7 @@ fn run_test_command(
             false,
             TraceMode::Off,
             true,
-            unwind,
+            max_k_step,
         );
 
         let diagnostics: Vec<DiagnosticJson> = result
@@ -5205,10 +5210,10 @@ fn run_build_command(
     dump_ir: bool,
     trace: TraceMode,
     no_cache: bool,
-    unwind: u32,
+    max_k_step: u32,
 ) {
     let result = run_pipeline_inner(
-        source, output, mode, no_verify, dump_ir, trace, no_cache, unwind,
+        source, output, mode, no_verify, dump_ir, trace, no_cache, max_k_step,
     );
     if !dump_ir {
         result.emit_json();
@@ -5287,8 +5292,8 @@ fn run_decl_command(source: &Path, output: Option<&Path>) {
     eprintln!("wrote {}", out_path.display());
 }
 
-fn run_verify_command(source: &Path, no_cache: bool, unwind: u32) {
-    let result = run_verify_only_inner(source, no_cache, unwind);
+fn run_verify_command(source: &Path, no_cache: bool, max_k_step: u32) {
+    let result = run_verify_only_inner(source, no_cache, max_k_step);
     result.emit_json();
     if matches!(
         &result.status,
@@ -5341,7 +5346,7 @@ fn update_contract_statuses(
     entries: &mut [ContractEntryJson],
     ir_module: &vow_ir::Module,
     verify_cache: Option<&VerifyCache>,
-    unwind: u32,
+    max_k_step: u32,
 ) {
     let const_fns = detect_constant_functions(ir_module);
     for func in &ir_module.functions {
@@ -5351,7 +5356,7 @@ fn update_contract_statuses(
 
         let result = if let Some(vc) = verify_cache {
             let c_src = emit_verify_c_source(func, ir_module, &const_fns);
-            let key = VerifyCache::cache_key(&c_src, unwind);
+            let key = VerifyCache::cache_key(&c_src, max_k_step);
 
             if let Some(cached) = vc.lookup(&key) {
                 match cached {
@@ -5372,7 +5377,7 @@ fn update_contract_statuses(
                         continue;
                     }
                 };
-                let res = run_esbmc_with_unwind(&esbmc, &c_src, unwind, &func.name);
+                let res = run_esbmc_with_max_k_step(&esbmc, &c_src, max_k_step, &func.name);
                 match &res {
                     VerificationResult::Proven => {
                         vc.store(&key, &CachedVerifyResult::Proven);
@@ -5394,8 +5399,8 @@ fn update_contract_statuses(
                 res
             }
         } else {
-            verify_function_with_module_and_const_fns_with_unwind(
-                func, ir_module, &const_fns, unwind,
+            verify_function_with_module_and_const_fns_with_max_k_step(
+                func, ir_module, &const_fns, max_k_step,
             )
         };
 
@@ -5424,7 +5429,7 @@ fn update_contract_statuses(
     }
 }
 
-fn run_contracts_command(source: &Path, verify: bool, no_cache: bool, unwind: u32) {
+fn run_contracts_command(source: &Path, verify: bool, no_cache: bool, max_k_step: u32) {
     let frontend = match compile_frontend(source) {
         Ok(f) => f,
         Err(output) => {
@@ -5469,7 +5474,7 @@ fn run_contracts_command(source: &Path, verify: bool, no_cache: bool, unwind: u3
             &mut entries,
             &frontend.ir_module,
             verify_cache.as_ref(),
-            unwind,
+            max_k_step,
         );
     }
 
@@ -5521,7 +5526,7 @@ fn main() {
                 b.dump_ir,
                 trace,
                 b.no_cache,
-                b.unwind,
+                b.max_k_step,
             );
         }
         Some(Command::Verify(v)) => {
@@ -5540,7 +5545,7 @@ fn main() {
                     std::process::exit(1);
                 }
             };
-            run_verify_command(&source, v.no_cache, v.unwind);
+            run_verify_command(&source, v.no_cache, v.max_k_step);
         }
         Some(Command::Test(t)) => {
             if t.help {
@@ -5567,7 +5572,7 @@ fn main() {
                 t.filter.as_deref(),
                 mode,
                 t.timeout,
-                t.unwind,
+                t.max_k_step,
             );
         }
         Some(Command::Decl(d)) => {
@@ -5608,7 +5613,7 @@ fn main() {
                 &source,
                 c.verify,
                 c.no_cache,
-                c.unwind.unwrap_or(DEFAULT_UNWIND),
+                c.max_k_step.unwrap_or(DEFAULT_MAX_K_STEP),
             );
         }
         Some(Command::Skill(s)) => {
@@ -5667,7 +5672,7 @@ fn main() {
                 args.dump_ir,
                 trace,
                 args.no_cache,
-                args.unwind,
+                args.max_k_step,
             );
         }
     }
@@ -6074,19 +6079,20 @@ fn main() -> i32 [io] {
     }
 
     #[test]
-    fn build_args_accept_unwind_flag() {
-        let args = Args::try_parse_from(["vow", "build", "--unwind", "5", "main.vow"]).unwrap();
+    fn build_args_accept_max_k_step_flag() {
+        let args = Args::try_parse_from(["vow", "build", "--max-k-step", "5", "main.vow"]).unwrap();
         match args.command {
-            Some(Command::Build(build)) => assert_eq!(build.unwind, 5),
+            Some(Command::Build(build)) => assert_eq!(build.max_k_step, 5),
             other => panic!("expected build command, got {other:?}"),
         }
     }
 
     #[test]
-    fn verify_args_accept_unwind_flag() {
-        let args = Args::try_parse_from(["vow", "verify", "--unwind", "7", "main.vow"]).unwrap();
+    fn verify_args_accept_max_k_step_flag() {
+        let args =
+            Args::try_parse_from(["vow", "verify", "--max-k-step", "7", "main.vow"]).unwrap();
         match args.command {
-            Some(Command::Verify(verify)) => assert_eq!(verify.unwind, 7),
+            Some(Command::Verify(verify)) => assert_eq!(verify.max_k_step, 7),
             other => panic!("expected verify command, got {other:?}"),
         }
     }

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -4653,7 +4653,7 @@ fn verify_outcome_to_output(
 // ---------------------------------------------------------------------------
 
 pub fn run_verify_only(source: &Path) -> BuildOutput {
-    run_verify_only_inner(source, false, 10)
+    run_verify_only_inner(source, false, DEFAULT_MAX_K_STEP)
 }
 
 fn run_verify_only_inner(source: &Path, no_cache: bool, max_k_step: u32) -> BuildOutput {


### PR DESCRIPTION
## Summary

- Remove hardcoded container capacity limits (128/256/64) from the C verification model — containers are now unbounded, matching runtime semantics
- Switch ESBMC from fixed-bound BMC (`--unwind N`) to `--k-induction-parallel --max-k-step N`, which proves properties for all iterations via k-induction
- Replace `--unwind` CLI flag with `--max-k-step` (default 50) across both compilers
- Update docs, help text, and `generate_help.py` to reflect the new verification strategy

Closes #156

## Test plan

- [x] 640 Rust unit tests pass (`cargo test --all`)
- [x] Clippy clean, fmt clean
- [x] Bootstrap succeeds with binary fixed point (vowc2 == vowc3)
- [x] Regression test `tests/run/vec_grow_past_old_limit.vow` grows Vec to 200 elements
- [ ] CI passes