### PR TITLE
fix: propagate mutable variable state through loop break (#166)

### DIFF
--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -38,6 +38,8 @@ struct LowerCtx {
     loop_break_up_blocks: Vec<i64>,
     loop_break_up_tys: Vec<i64>,
     loop_break_counts: Vec<i64>,
+    loop_exit_phi_names: Vec<Vec<String>>,
+    loop_exit_phi_ids: Vec<Vec<i64>>,
     vec_elem_inst_ids: Vec<i64>,
     vec_elem_names: Vec<String>,
     warnings: Vec<String>,
@@ -95,6 +97,8 @@ fn lctx_new(name: String, return_ty: i64, effects: i64, arena: AstArena, str_eid
         loop_break_up_blocks: Vec::new(),
         loop_break_up_tys: Vec::new(),
         loop_break_counts: Vec::new(),
+        loop_exit_phi_names: Vec::new(),
+        loop_exit_phi_ids: Vec::new(),
         vec_elem_inst_ids: Vec::new(),
         vec_elem_names: Vec::new(),
         warnings: Vec::new(),
@@ -1466,6 +1470,31 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         }
 
         let cond_id: i64 = lower_expr(ctx, cond_eid);
+        let cond_block: i64 = ctx.current_block;
+
+        // Pre-emit exit-block Phis for mutation variables.
+        let exit_phi_ids: Vec<i64> = Vec::new();
+        let exit_phi_names: Vec<String> = Vec::new();
+        lctx_switch_to_block(ctx, exit_block);
+        let mut epi: i64 = 0;
+        while epi < nassigned {
+            let ep_args: Vec<i64> = Vec::new();
+            let ep_id: i64 = lctx_emit(ctx, IOP_PHI(), ITY_I64(), ep_args, IDATA_NONE(), 0, 0, String::from(""));
+            exit_phi_ids.push(ep_id);
+            exit_phi_names.push(assigned[epi]);
+            epi = epi + 1;
+        }
+        lctx_switch_to_block(ctx, cond_block);
+
+        // Upsilons for natural exit (condition false): header Phi values → exit Phis.
+        let mut eui: i64 = 0;
+        while eui < nassigned {
+            let up_args: Vec<i64> = Vec::new();
+            up_args.push(phi_ids[eui]);
+            lctx_emit(ctx, IOP_UPSILON(), ITY_I64(), up_args, IDATA_PHI_TARGET(), exit_phi_ids[eui], 0, String::from(""));
+            eui = eui + 1;
+        }
+
         let br_args: Vec<i64> = Vec::new();
         br_args.push(cond_id);
         lctx_emit(ctx, IOP_BRANCH(), ITY_UNIT(), br_args, IDATA_BRANCH_TARGETS(), body_block, exit_block, String::from(""));
@@ -1489,6 +1518,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         }
         ctx.loop_continue_phi_names.push(cpn);
         ctx.loop_continue_phi_ids.push(cpi);
+        ctx.loop_exit_phi_names.push(exit_phi_names);
+        ctx.loop_exit_phi_ids.push(exit_phi_ids);
         ctx.loop_continue_idx_phi.push(-1);
         ctx.loop_continue_scope_depth.push(ctx.scope_vars.len());
         ctx.loop_is_loop.push(0);
@@ -1497,10 +1528,16 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_alloc_scope_depths.push(ctx.alloc_ids.len());
         lower_block(ctx, body_bid);
         ctx.loop_alloc_scope_depths.pop();
+        // Save exit phi info before popping.
+        let epn_idx: i64 = ctx.loop_exit_phi_names.len() - 1;
+        let w_exit_phi_names: Vec<String> = ctx.loop_exit_phi_names[epn_idx];
+        let w_exit_phi_ids: Vec<i64> = ctx.loop_exit_phi_ids[epn_idx];
         ctx.loop_break_counts.pop();
         ctx.loop_is_loop.pop();
         ctx.loop_continue_scope_depth.pop();
         ctx.loop_continue_idx_phi.pop();
+        ctx.loop_exit_phi_ids.pop();
+        ctx.loop_exit_phi_names.pop();
         ctx.loop_continue_phi_ids.pop();
         ctx.loop_continue_phi_names.pop();
         ctx.loop_header_blocks.pop();
@@ -1546,10 +1583,12 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args, IDATA_JUMP_TARGET(), header_block, 0, String::from(""));
         }
 
+        // Bind names to exit-block Phis so post-loop code reads correct values.
+        let w_nexit: i64 = w_exit_phi_names.len();
         let mut ai4: i64 = 0;
-        while ai4 < nassigned {
-            let vname: String = assigned[ai4];
-            lctx_assign(ctx, vname, phi_ids[ai4]);
+        while ai4 < w_nexit {
+            let vname: String = w_exit_phi_names[ai4];
+            lctx_assign(ctx, vname, w_exit_phi_ids[ai4]);
             ai4 = ai4 + 1;
         }
 
@@ -1610,6 +1649,20 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             bpi = bpi + 1;
         }
 
+        // Pre-emit exit-block Phis for mutation variables.
+        let l_exit_phi_ids: Vec<i64> = Vec::new();
+        let l_exit_phi_names: Vec<String> = Vec::new();
+        lctx_switch_to_block(ctx, exit_block);
+        let mut lepi: i64 = 0;
+        while lepi < nassigned {
+            let lep_args: Vec<i64> = Vec::new();
+            let lep_id: i64 = lctx_emit(ctx, IOP_PHI(), ITY_I64(), lep_args, IDATA_NONE(), 0, 0, String::from(""));
+            l_exit_phi_ids.push(lep_id);
+            l_exit_phi_names.push(assigned[lepi]);
+            lepi = lepi + 1;
+        }
+        lctx_switch_to_block(ctx, header_block);
+
         ctx.loop_exit_blocks.push(exit_block);
         ctx.loop_header_blocks.push(header_block);
         let lcpn: Vec<String> = Vec::new();
@@ -1622,6 +1675,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         }
         ctx.loop_continue_phi_names.push(lcpn);
         ctx.loop_continue_phi_ids.push(lcpi);
+        ctx.loop_exit_phi_names.push(l_exit_phi_names);
+        ctx.loop_exit_phi_ids.push(l_exit_phi_ids);
         ctx.loop_continue_idx_phi.push(-1);
         ctx.loop_continue_scope_depth.push(ctx.scope_vars.len());
         ctx.loop_is_loop.push(1);
@@ -1633,10 +1688,16 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_alloc_scope_depths.pop();
         let break_count_idx: i64 = ctx.loop_break_counts.len() - 1;
         let break_count: i64 = ctx.loop_break_counts[break_count_idx];
+        // Save exit phi info before popping.
+        let lepn_idx: i64 = ctx.loop_exit_phi_names.len() - 1;
+        let l_saved_exit_names: Vec<String> = ctx.loop_exit_phi_names[lepn_idx];
+        let l_saved_exit_ids: Vec<i64> = ctx.loop_exit_phi_ids[lepn_idx];
         ctx.loop_break_counts.pop();
         ctx.loop_is_loop.pop();
         ctx.loop_continue_scope_depth.pop();
         ctx.loop_continue_idx_phi.pop();
+        ctx.loop_exit_phi_ids.pop();
+        ctx.loop_exit_phi_names.pop();
         ctx.loop_continue_phi_ids.pop();
         ctx.loop_continue_phi_names.pop();
         ctx.loop_header_blocks.pop();
@@ -1682,10 +1743,12 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args2, IDATA_JUMP_TARGET(), header_block, 0, String::from(""));
         }
 
+        // Bind names to exit-block Phis so post-loop code reads correct values.
+        let l_nexit: i64 = l_saved_exit_names.len();
         let mut ai4: i64 = 0;
-        while ai4 < nassigned {
-            let vname: String = assigned[ai4];
-            lctx_assign(ctx, vname, phi_ids[ai4]);
+        while ai4 < l_nexit {
+            let vname: String = l_saved_exit_names[ai4];
+            lctx_assign(ctx, vname, l_saved_exit_ids[ai4]);
             ai4 = ai4 + 1;
         }
 
@@ -1784,6 +1847,30 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         cond_args.push(idx_phi);
         cond_args.push(len_id);
         let cond_id: i64 = lctx_emit(ctx, IOP_LT_I64(), ITY_BOOL(), cond_args, IDATA_NONE(), 0, 0, String::from(""));
+
+        // Pre-emit exit-block Phis for mutation variables.
+        let f_exit_phi_ids: Vec<i64> = Vec::new();
+        let f_exit_phi_names: Vec<String> = Vec::new();
+        lctx_switch_to_block(ctx, exit_block);
+        let mut fepi: i64 = 0;
+        while fepi < nassigned {
+            let fep_args: Vec<i64> = Vec::new();
+            let fep_id: i64 = lctx_emit(ctx, IOP_PHI(), ITY_I64(), fep_args, IDATA_NONE(), 0, 0, String::from(""));
+            f_exit_phi_ids.push(fep_id);
+            f_exit_phi_names.push(assigned[fepi]);
+            fepi = fepi + 1;
+        }
+        lctx_switch_to_block(ctx, header_block);
+
+        // Upsilons for natural exit (condition false): header Phi values → exit Phis.
+        let mut feui: i64 = 0;
+        while feui < nassigned {
+            let up_args: Vec<i64> = Vec::new();
+            up_args.push(phi_ids[feui]);
+            lctx_emit(ctx, IOP_UPSILON(), ITY_I64(), up_args, IDATA_PHI_TARGET(), f_exit_phi_ids[feui], 0, String::from(""));
+            feui = feui + 1;
+        }
+
         let br_args: Vec<i64> = Vec::new();
         br_args.push(cond_id);
         lctx_emit(ctx, IOP_BRANCH(), ITY_UNIT(), br_args, IDATA_BRANCH_TARGETS(), body_block, exit_block, String::from(""));
@@ -1821,6 +1908,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         }
         ctx.loop_continue_phi_names.push(fcpn);
         ctx.loop_continue_phi_ids.push(fcpi);
+        ctx.loop_exit_phi_names.push(f_exit_phi_names);
+        ctx.loop_exit_phi_ids.push(f_exit_phi_ids);
         ctx.loop_continue_idx_phi.push(idx_phi);
         ctx.loop_continue_scope_depth.push(for_scope_depth);
         ctx.loop_is_loop.push(0);
@@ -1829,10 +1918,16 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_alloc_scope_depths.push(ctx.alloc_ids.len());
         lower_block(ctx, body_bid);
         ctx.loop_alloc_scope_depths.pop();
+        // Save exit phi info before popping.
+        let fepn_idx: i64 = ctx.loop_exit_phi_names.len() - 1;
+        let f_saved_exit_names: Vec<String> = ctx.loop_exit_phi_names[fepn_idx];
+        let f_saved_exit_ids: Vec<i64> = ctx.loop_exit_phi_ids[fepn_idx];
         ctx.loop_break_counts.pop();
         ctx.loop_is_loop.pop();
         ctx.loop_continue_scope_depth.pop();
         ctx.loop_continue_idx_phi.pop();
+        ctx.loop_exit_phi_ids.pop();
+        ctx.loop_exit_phi_names.pop();
         ctx.loop_continue_phi_ids.pop();
         ctx.loop_continue_phi_names.pop();
         ctx.loop_header_blocks.pop();
@@ -1890,13 +1985,16 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args, IDATA_JUMP_TARGET(), header_block, 0, String::from(""));
         }
 
+        // Bind names to exit-block Phis so post-loop code reads correct values.
+        let f_nexit: i64 = f_saved_exit_names.len();
         let mut ai4: i64 = 0;
-        while ai4 < nassigned {
-            let vname: String = assigned[ai4];
-            lctx_assign(ctx, vname, phi_ids[ai4]);
+        while ai4 < f_nexit {
+            let vname: String = f_saved_exit_names[ai4];
+            lctx_assign(ctx, vname, f_saved_exit_ids[ai4]);
             ai4 = ai4 + 1;
         }
 
+        // Exit block (Phis already emitted above).
         lctx_switch_to_block(ctx, exit_block);
 
         let u_args: Vec<i64> = Vec::new();
@@ -2799,6 +2897,25 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     ctx.loop_break_counts[cnt_idx] = old_cnt + 1;
                 }
             }
+            // Emit Upsilons for exit-block Phis with current mutation values.
+            let nep: i64 = ctx.loop_exit_phi_names.len();
+            if nep > 0 {
+                let ep_names: Vec<String> = ctx.loop_exit_phi_names[nep - 1];
+                let ep_ids: Vec<i64> = ctx.loop_exit_phi_ids[nep - 1];
+                let nep2: i64 = ep_names.len();
+                let mut epi: i64 = 0;
+                while epi < nep2 {
+                    let vname: String = ep_names[epi];
+                    let cur_val: i64 = lctx_lookup(ctx, vname);
+                    if cur_val != -1 {
+                        let up_args: Vec<i64> = Vec::new();
+                        up_args.push(cur_val);
+                        lctx_emit(ctx, IOP_UPSILON(), ITY_I64(), up_args, IDATA_PHI_TARGET(), ep_ids[epi], 0, String::from(""));
+                    }
+                    epi = epi + 1;
+                }
+            }
+
             // Free loop body allocations before jumping to exit.
             // Trace transitive sources of break value through Phi/Upsilon chains.
             let nlasd: i64 = ctx.loop_alloc_scope_depths.len();

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -2917,7 +2917,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             }
 
             // Free loop body allocations before jumping to exit.
-            // Trace transitive sources of break value through Phi/Upsilon chains.
+            // Trace transitive sources of break value and mutation variables
+            // through Phi/Upsilon chains so they aren't freed prematurely.
             let nlasd: i64 = ctx.loop_alloc_scope_depths.len();
             if nlasd > 0 {
                 let depth: i64 = ctx.loop_alloc_scope_depths[nlasd - 1];
@@ -2928,6 +2929,27 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     while si < sources.len() {
                         break_live_out.push(sources[si]);
                         si = si + 1;
+                    }
+                }
+                // Include mutation variable values so they survive the free.
+                let nep3: i64 = ctx.loop_exit_phi_names.len();
+                if nep3 > 0 {
+                    let mv_names: Vec<String> = ctx.loop_exit_phi_names[nep3 - 1];
+                    let nmv: i64 = mv_names.len();
+                    let mut mvi: i64 = 0;
+                    while mvi < nmv {
+                        let mv_name: String = mv_names[mvi];
+                        let mv_val: i64 = lctx_lookup(ctx, mv_name);
+                        if mv_val != -1 {
+                            break_live_out.push(mv_val);
+                            let mv_sources: Vec<i64> = lctx_collect_return_sources(ctx, mv_val);
+                            let mut msi: i64 = 0;
+                            while msi < mv_sources.len() {
+                                break_live_out.push(mv_sources[msi]);
+                                msi = msi + 1;
+                            }
+                        }
+                        mvi = mvi + 1;
                     }
                 }
                 lctx_emit_alloc_frees_to_depth(ctx, depth, break_live_out);

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -2898,7 +2898,11 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 }
             }
             // Emit Upsilons for exit-block Phis with current mutation values.
+            // Use lookup_at_depth to resolve from the loop header scope,
+            // not the current scope, to avoid picking up shadowed bindings.
             let nep: i64 = ctx.loop_exit_phi_names.len();
+            let nlh2: i64 = ctx.loop_continue_scope_depth.len();
+            let brk_scope_depth: i64 = ctx.loop_continue_scope_depth[nlh2 - 1];
             if nep > 0 {
                 let ep_names: Vec<String> = ctx.loop_exit_phi_names[nep - 1];
                 let ep_ids: Vec<i64> = ctx.loop_exit_phi_ids[nep - 1];
@@ -2906,7 +2910,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 let mut epi: i64 = 0;
                 while epi < nep2 {
                     let vname: String = ep_names[epi];
-                    let cur_val: i64 = lctx_lookup(ctx, vname);
+                    let cur_val: i64 = lctx_lookup_at_depth(ctx, vname, brk_scope_depth);
                     if cur_val != -1 {
                         let up_args: Vec<i64> = Vec::new();
                         up_args.push(cur_val);
@@ -2919,6 +2923,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             // Free loop body allocations before jumping to exit.
             // Trace transitive sources of break value and mutation variables
             // through Phi/Upsilon chains so they aren't freed prematurely.
+            // Resolve mutation vars at loop header scope depth.
             let nlasd: i64 = ctx.loop_alloc_scope_depths.len();
             if nlasd > 0 {
                 let depth: i64 = ctx.loop_alloc_scope_depths[nlasd - 1];
@@ -2939,7 +2944,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     let mut mvi: i64 = 0;
                     while mvi < nmv {
                         let mv_name: String = mv_names[mvi];
-                        let mv_val: i64 = lctx_lookup(ctx, mv_name);
+                        let mv_val: i64 = lctx_lookup_at_depth(ctx, mv_name, brk_scope_depth);
                         if mv_val != -1 {
                             break_live_out.push(mv_val);
                             let mv_sources: Vec<i64> = lctx_collect_return_sources(ctx, mv_val);

--- a/tests/run/foreach_break_state.vow
+++ b/tests/run/foreach_break_state.vow
@@ -1,0 +1,19 @@
+// TEST: stdout "10\n"
+module ForeachBreakState
+
+fn main() -> i32 [io] {
+    let xs: Vec<i64> = Vec::new();
+    xs.push(5);
+    xs.push(10);
+    xs.push(15);
+    let mut hit: i64 = 0;
+    for x in xs {
+        if x == 10 {
+            hit = x;
+            break;
+        }
+    }
+    print_i64(hit);
+    print_str("\n");
+    0
+}

--- a/tests/run/loop_break_state.vow
+++ b/tests/run/loop_break_state.vow
@@ -1,0 +1,27 @@
+// TEST: stdout "1 10\n"
+module LoopBreakState
+
+fn main() -> i32 [io] {
+    let xs: Vec<i64> = Vec::new();
+    xs.push(10);
+    let mut idx: i64 = 0;
+    let mut found: i64 = 0;
+    let mut value: i64 = 0;
+    loop {
+        if idx >= xs.len() {
+            break;
+        }
+        let cand: i64 = xs[idx];
+        idx = idx + 1;
+        if cand == 10 {
+            value = cand;
+            found = 1;
+            break;
+        }
+    }
+    print_i64(found);
+    print_str(" ");
+    print_i64(value);
+    print_str("\n");
+    0
+}

--- a/tests/run/while_break_state.vow
+++ b/tests/run/while_break_state.vow
@@ -1,0 +1,15 @@
+// TEST: stdout "5\n"
+module WhileBreakState
+
+fn main() -> i32 [io] {
+    let mut x: i64 = 0;
+    while x < 10 {
+        x = x + 1;
+        if x == 5 {
+            break;
+        }
+    }
+    print_i64(x);
+    print_str("\n");
+    0
+}

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -1830,10 +1830,16 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
 
             // Emit Upsilons for loop mutation variables targeting the
             // exit-block Phis so the exit block receives updated values.
-            // Must be emitted before alloc frees so values are captured first.
+            // Use lookup_at_depth to resolve from the loop header scope,
+            // not the current scope, to avoid picking up shadowed bindings.
             let exit_phis = ctx.loop_exit_phis.last().cloned().unwrap_or_default();
+            let scope_depth = ctx
+                .loop_continue_scope_depth
+                .last()
+                .copied()
+                .unwrap_or(0);
             for (name, exit_phi) in &exit_phis {
-                if let Some(cur_val) = ctx.lookup(name) {
+                if let Some(cur_val) = ctx.lookup_at_depth(name, scope_depth) {
                     ctx.emit(
                         Opcode::Upsilon,
                         ctx.inst_ty(cur_val),
@@ -1847,6 +1853,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             // Free loop body allocations before jumping to exit.
             // Use collect_return_sources to trace through Phi/Upsilon chains —
             // break_val and mutation variables may alias heap allocations.
+            // Resolve mutation vars at loop header scope depth.
             if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
                 let mut live_out: Vec<InstId> = if let Some(bv) = break_val {
                     ctx.collect_return_sources(bv).into_iter().collect()
@@ -1854,7 +1861,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     vec![]
                 };
                 for (name, _) in &exit_phis {
-                    if let Some(cur_val) = ctx.lookup(name) {
+                    if let Some(cur_val) = ctx.lookup_at_depth(name, scope_depth) {
                         live_out.extend(ctx.collect_return_sources(cur_val));
                     }
                 }

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -163,6 +163,9 @@ pub struct LowerCtx {
     // Per-loop break-value Upsilon collector.  `Some(vec)` for `loop` (collects
     // (source_block, upsilon_id, value_ty)), `None` for `while`.
     loop_break_upsilons: Vec<Option<Vec<(BlockId, InstId, Ty)>>>,
+    // Per-loop exit-block Phi IDs for mutation variables.  Break emits Upsilons
+    // targeting these so the exit block receives updated values.
+    loop_exit_phis: Vec<Vec<(String, InstId)>>,
     // InstId of a Vec allocation → element type name (for struct-in-Vec field access)
     inst_vec_elem_type: HashMap<InstId, String>,
     // struct name → per-field Vec element type name (for FieldGet → Vec propagation)
@@ -237,6 +240,7 @@ impl LowerCtx {
             loop_continue_idx_phi: Vec::new(),
             loop_continue_scope_depth: Vec::new(),
             loop_break_upsilons: Vec::new(),
+            loop_exit_phis: Vec::new(),
             inst_vec_elem_type: HashMap::new(),
             struct_field_vec_elems,
             warnings: Vec::new(),
@@ -1299,6 +1303,34 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
 
             // Lower condition, then branch.
             let cond_id = lower_expr(ctx, condition);
+            // Save the block we're in after condition lowering (may differ from
+            // header_block if the condition created new blocks, e.g. &&/||).
+            let cond_block = ctx.current_block;
+
+            // Pre-emit exit-block Phis for mutation variables so break sites
+            // (and the natural condition-false exit) can supply updated values.
+            let mut exit_phi_ids: Vec<(String, InstId)> = vec![];
+            ctx.switch_to_block(exit_block);
+            for (name, pre_val) in &loop_vars {
+                let ty = ctx.inst_ty(*pre_val);
+                let phi_id = ctx.emit(Opcode::Phi, ty, vec![], InstData::None, span);
+                exit_phi_ids.push((name.clone(), phi_id));
+            }
+            ctx.switch_to_block(cond_block);
+
+            // Upsilons for natural exit (condition false → exit_block):
+            // pass header Phi values into exit-block Phis.
+            for (name, exit_phi) in &exit_phi_ids {
+                let header_phi = phi_ids.iter().find(|(n, _)| n == name).unwrap().1;
+                ctx.emit(
+                    Opcode::Upsilon,
+                    ctx.inst_ty(header_phi),
+                    vec![header_phi],
+                    InstData::PhiTarget(*exit_phi),
+                    span,
+                );
+            }
+
             ctx.emit(
                 Opcode::Branch,
                 Ty::Unit,
@@ -1315,6 +1347,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_exit_blocks.push(exit_block);
             ctx.loop_header_blocks.push(header_block);
             ctx.loop_continue_phis.push(phi_ids.clone());
+            ctx.loop_exit_phis.push(exit_phi_ids.clone());
             ctx.loop_continue_idx_phi.push(None);
             ctx.loop_continue_scope_depth.push(ctx.scope.len());
             ctx.loop_break_upsilons.push(None);
@@ -1325,6 +1358,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_break_upsilons.pop();
             ctx.loop_continue_scope_depth.pop();
             ctx.loop_continue_idx_phi.pop();
+            ctx.loop_exit_phis.pop();
             ctx.loop_continue_phis.pop();
             ctx.loop_header_blocks.pop();
             ctx.loop_exit_blocks.pop();
@@ -1367,12 +1401,12 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 );
             }
 
-            // Restore scope to Phi values so the exit block sees the loop-exit values.
-            for (name, phi_id) in &phi_ids {
-                ctx.assign(name, *phi_id);
+            // Bind names to exit-block Phis so post-loop code reads correct values.
+            for (name, exit_phi) in &exit_phi_ids {
+                ctx.assign(name, *exit_phi);
             }
 
-            // Exit block.
+            // Exit block (Phis already emitted above).
             ctx.switch_to_block(exit_block);
             ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
         }
@@ -1480,6 +1514,31 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 InstData::None,
                 span,
             );
+
+            // Pre-emit exit-block Phis for mutation variables so break sites
+            // (and the natural condition-false exit) can supply updated values.
+            let mut exit_phi_ids: Vec<(String, InstId)> = vec![];
+            ctx.switch_to_block(exit_block);
+            for (name, pre_val) in &loop_vars {
+                let ty = ctx.inst_ty(*pre_val);
+                let phi_id = ctx.emit(Opcode::Phi, ty, vec![], InstData::None, span);
+                exit_phi_ids.push((name.clone(), phi_id));
+            }
+            ctx.switch_to_block(header_block);
+
+            // Upsilons for natural exit (condition false → exit_block):
+            // pass header Phi values into exit-block Phis.
+            for (name, exit_phi) in &exit_phi_ids {
+                let header_phi = phi_ids.iter().find(|(n, _)| n == name).unwrap().1;
+                ctx.emit(
+                    Opcode::Upsilon,
+                    ctx.inst_ty(header_phi),
+                    vec![header_phi],
+                    InstData::PhiTarget(*exit_phi),
+                    span,
+                );
+            }
+
             ctx.emit(
                 Opcode::Branch,
                 Ty::Unit,
@@ -1516,6 +1575,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_exit_blocks.push(exit_block);
             ctx.loop_header_blocks.push(header_block);
             ctx.loop_continue_phis.push(phi_ids.clone());
+            ctx.loop_exit_phis.push(exit_phi_ids.clone());
             ctx.loop_continue_idx_phi.push(Some(idx_phi));
             ctx.loop_continue_scope_depth.push(for_scope_depth);
             ctx.push_alloc_scope();
@@ -1524,6 +1584,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_alloc_scope_depth.pop();
             ctx.loop_continue_scope_depth.pop();
             ctx.loop_continue_idx_phi.pop();
+            ctx.loop_exit_phis.pop();
             ctx.loop_continue_phis.pop();
             ctx.loop_header_blocks.pop();
             ctx.loop_exit_blocks.pop();
@@ -1589,11 +1650,12 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 );
             }
 
-            // Restore scope to Phi values for exit
-            for (name, phi_id) in &phi_ids {
-                ctx.assign(name, *phi_id);
+            // Bind names to exit-block Phis so post-loop code reads correct values.
+            for (name, exit_phi) in &exit_phi_ids {
+                ctx.assign(name, *exit_phi);
             }
 
+            // Exit block (Phis already emitted above).
             ctx.switch_to_block(exit_block);
             ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
         }
@@ -1650,9 +1712,21 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 vow::lower_invariant(ctx, lv);
             }
 
+            // Pre-emit exit-block Phis for mutation variables so break sites
+            // can supply updated values via Upsilons.
+            let mut exit_phi_ids: Vec<(String, InstId)> = vec![];
+            ctx.switch_to_block(exit_block);
+            for (name, pre_val) in &loop_vars {
+                let ty = ctx.inst_ty(*pre_val);
+                let phi_id = ctx.emit(Opcode::Phi, ty, vec![], InstData::None, span);
+                exit_phi_ids.push((name.clone(), phi_id));
+            }
+            ctx.switch_to_block(header_block);
+
             ctx.loop_exit_blocks.push(exit_block);
             ctx.loop_header_blocks.push(header_block);
             ctx.loop_continue_phis.push(phi_ids.clone());
+            ctx.loop_exit_phis.push(exit_phi_ids.clone());
             ctx.loop_continue_idx_phi.push(None);
             ctx.loop_continue_scope_depth.push(ctx.scope.len());
             ctx.loop_break_upsilons.push(Some(Vec::new()));
@@ -1663,6 +1737,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             let break_ups = ctx.loop_break_upsilons.pop().unwrap();
             ctx.loop_continue_scope_depth.pop();
             ctx.loop_continue_idx_phi.pop();
+            ctx.loop_exit_phis.pop();
             ctx.loop_continue_phis.pop();
             ctx.loop_header_blocks.pop();
             ctx.loop_exit_blocks.pop();
@@ -1700,8 +1775,9 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 );
             }
 
-            for (name, phi_id) in &phi_ids {
-                ctx.assign(name, *phi_id);
+            // Bind names to exit-block Phis so post-loop code reads correct values.
+            for (name, exit_phi) in &exit_phi_ids {
+                ctx.assign(name, *exit_phi);
             }
 
             ctx.switch_to_block(exit_block);
@@ -1762,6 +1838,21 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     vec![]
                 };
                 ctx.emit_alloc_frees_to_depth(depth, &live_out, span);
+            }
+
+            // Emit Upsilons for loop mutation variables targeting the
+            // exit-block Phis so the exit block receives updated values.
+            let exit_phis = ctx.loop_exit_phis.last().cloned().unwrap_or_default();
+            for (name, exit_phi) in &exit_phis {
+                if let Some(cur_val) = ctx.lookup(name) {
+                    ctx.emit(
+                        Opcode::Upsilon,
+                        ctx.inst_ty(cur_val),
+                        vec![cur_val],
+                        InstData::PhiTarget(*exit_phi),
+                        span,
+                    );
+                }
             }
 
             ctx.emit(

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -1833,11 +1833,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             // Use lookup_at_depth to resolve from the loop header scope,
             // not the current scope, to avoid picking up shadowed bindings.
             let exit_phis = ctx.loop_exit_phis.last().cloned().unwrap_or_default();
-            let scope_depth = ctx
-                .loop_continue_scope_depth
-                .last()
-                .copied()
-                .unwrap_or(0);
+            let scope_depth = ctx.loop_continue_scope_depth.last().copied().unwrap_or(0);
             for (name, exit_phi) in &exit_phis {
                 if let Some(cur_val) = ctx.lookup_at_depth(name, scope_depth) {
                     ctx.emit(

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -1828,20 +1828,9 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 None
             };
 
-            // Free loop body allocations before jumping to exit.
-            // Use collect_return_sources to trace through Phi/Upsilon chains —
-            // break_val may alias multiple heap allocations (e.g., from if-else).
-            if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
-                let live_out: Vec<InstId> = if let Some(bv) = break_val {
-                    ctx.collect_return_sources(bv).into_iter().collect()
-                } else {
-                    vec![]
-                };
-                ctx.emit_alloc_frees_to_depth(depth, &live_out, span);
-            }
-
             // Emit Upsilons for loop mutation variables targeting the
             // exit-block Phis so the exit block receives updated values.
+            // Must be emitted before alloc frees so values are captured first.
             let exit_phis = ctx.loop_exit_phis.last().cloned().unwrap_or_default();
             for (name, exit_phi) in &exit_phis {
                 if let Some(cur_val) = ctx.lookup(name) {
@@ -1853,6 +1842,23 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         span,
                     );
                 }
+            }
+
+            // Free loop body allocations before jumping to exit.
+            // Use collect_return_sources to trace through Phi/Upsilon chains —
+            // break_val and mutation variables may alias heap allocations.
+            if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
+                let mut live_out: Vec<InstId> = if let Some(bv) = break_val {
+                    ctx.collect_return_sources(bv).into_iter().collect()
+                } else {
+                    vec![]
+                };
+                for (name, _) in &exit_phis {
+                    if let Some(cur_val) = ctx.lookup(name) {
+                        live_out.extend(ctx.collect_return_sources(cur_val));
+                    }
+                }
+                ctx.emit_alloc_frees_to_depth(depth, &live_out, span);
             }
 
             ctx.emit(


### PR DESCRIPTION
## Summary

- Fixes #166 — local variable assignments before `break` inside `loop { ... }` were lost
- Root cause: exit blocks had no Phi nodes for mutation variables, so post-loop code read stale pre-loop values from header Phis
- Fix: emit dedicated exit-block Phis for each loop mutation variable in all three loop forms (while, loop, for-each) in both compilers
- Applied to both the Rust compiler (`vow-ir/src/lower/mod.rs`) and the self-hosted compiler (`compiler/lower.vow`)

## Test plan

- [x] Regression test `tests/run/loop_break_state.vow` added — reproduces the exact scenario from the issue
- [x] Both compilers produce correct output `1 10` (was `0 0`)
- [x] Bootstrap triple test passes (binary fixed point confirmed)
- [x] All existing loop/break/continue/for-each tests pass with matching output between compilers
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all --check` clean