### PR TITLE
[codex] stage frontend boundary behind FrontendBundle

### DIFF
--- a/compiler/frontend.vow
+++ b/compiler/frontend.vow
@@ -1,0 +1,164 @@
+module Frontend
+
+use lexer
+use token
+use ast
+use parser
+use env
+use checker
+use lower
+use ir
+use diag
+
+struct CheckedFrontend {
+    path: String,
+    dctx: DiagCtx,
+    sources: Vec<String>,
+    merged: Module,
+    n_items: i64,
+    n_errors: i64,
+}
+
+struct LoweredFrontend {
+    checked: CheckedFrontend,
+    ir_mod: IrModule,
+}
+
+struct FrontendPrep {
+    checked: CheckedFrontend,
+    str_eids: Vec<i64>,
+}
+
+fn frontend_dir_path(path: String) -> String {
+    let mut last_slash: i64 = -1;
+    let mut i: i64 = 0;
+    let n: i64 = path.len();
+    while i < n {
+        if path.byte_at(i) == 47 {
+            last_slash = i;
+        }
+        i = i + 1;
+    }
+    if last_slash == -1 {
+        String::from(".")
+    } else {
+        let r: String = String::from("");
+        let mut j: i64 = 0;
+        while j < last_slash {
+            r.push_byte(path.byte_at(j));
+            j = j + 1;
+        }
+        r
+    }
+}
+
+fn resolve_use_path(arena: AstArena, root_dir: String, use_lid: i64) -> String {
+    let r: String = String::from("");
+    r.push_str(root_dir);
+    let n: i64 = list_len(arena, use_lid);
+    let mut i: i64 = 0;
+    while i < n {
+        let sid: i64 = list_get(arena, use_lid, i);
+        let component: String = arena.strs[sid];
+        r.push_byte(47);
+        r.push_str(component);
+        i = i + 1;
+    }
+    r.push_str(String::from(".vow"));
+    r
+}
+
+fn load_frontend_deps(root_dir: String, m: Module, arena: AstArena, all_items: Vec<i64>, visited: Vec<String>, dctx: DiagCtx) [io] {
+    let uses: Vec<i64> = m.uses;
+    let n_uses: i64 = uses.len();
+    let mut ui: i64 = 0;
+    while ui < n_uses {
+        let use_lid: i64 = uses[ui];
+        let dep_path: String = resolve_use_path(arena, root_dir, use_lid);
+        if !vec_contains_str(visited, dep_path) {
+            visited.push(dep_path);
+            let src: String = fs_read(dep_path);
+            if src.len() == 0 {
+                let d: Diagnostic = diag_error(EC_IO_ERROR(), str2(String::from("cannot read "), dep_path), dep_path, 0, 0);
+                diag_ctx_emit(dctx, d);
+            } else {
+                diag_ctx_add_source(dctx, dep_path, src);
+                let tokens: Vec<Token> = lex(src);
+                let dep_m: Module = parse_module_into(tokens, arena, dctx, dep_path);
+                load_frontend_deps(root_dir, dep_m, arena, all_items, visited, dctx);
+                let dep_items: Vec<i64> = dep_m.items;
+                let n_dep: i64 = dep_items.len();
+                let mut di: i64 = 0;
+                while di < n_dep {
+                    all_items.push(dep_items[di]);
+                    di = di + 1;
+                }
+            }
+        }
+        ui = ui + 1;
+    }
+}
+
+fn frontend_prepare_path(path: String) -> FrontendPrep [io] {
+    let dctx: DiagCtx = diag_ctx_new();
+    let src: String = fs_read(path);
+    diag_ctx_add_source(dctx, path, src);
+    let tokens: Vec<Token> = lex(src);
+    let arena: AstArena = arena_new();
+    let m: Module = parse_module_into(tokens, arena, dctx, path);
+    let root_dir: String = frontend_dir_path(path);
+    let all_items: Vec<i64> = Vec::new();
+    let visited: Vec<String> = Vec::new();
+    visited.push(path);
+    load_frontend_deps(root_dir, m, arena, all_items, visited, dctx);
+    let root_items: Vec<i64> = m.items;
+    let n_root: i64 = root_items.len();
+    let mut ri: i64 = 0;
+    while ri < n_root {
+        all_items.push(root_items[ri]);
+        ri = ri + 1;
+    }
+    let merged: Module = Module {
+        name_sid: 0,
+        uses: Vec::new(),
+        items: all_items,
+        arena: arena,
+    };
+    let n_items: i64 = all_items.len();
+    let e: CheckEnv = env_new(dctx, path);
+    check_module(e, merged);
+    let checked: CheckedFrontend = CheckedFrontend {
+        path: path,
+        dctx: dctx,
+        sources: visited,
+        merged: merged,
+        n_items: n_items,
+        n_errors: dctx.error_count,
+    };
+    FrontendPrep {
+        checked: checked,
+        str_eids: e.expr_str_eids,
+    }
+}
+
+fn frontend_check_path(path: String) -> CheckedFrontend [io] {
+    let prep: FrontendPrep = frontend_prepare_path(path);
+    prep.checked
+}
+
+fn frontend_lower_path(path: String) -> LoweredFrontend [io] {
+    let prep: FrontendPrep = frontend_prepare_path(path);
+    let checked: CheckedFrontend = prep.checked;
+    let ir_mod: IrModule = {
+        if checked.n_errors > 0 {
+            // Keep callers on one lowered entry point even when checking fails.
+            ir_module_new(checked.path)
+        } else {
+            lower_module_vow(checked.merged, prep.str_eids, checked.path)
+        }
+    };
+    LoweredFrontend {
+        checked: checked,
+        ir_mod: ir_mod,
+    }
+}

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -1,15 +1,8 @@
 module Main
 
-use lexer
-use token
-use ast
-use parser
-use types
-use env
-use checker
 use ir
 use ir_printer
-use lower
+use frontend
 use clif
 use c_emitter
 use verifier
@@ -136,76 +129,6 @@ fn default_output(path: String) -> String {
     r
 }
 
-fn get_dir_path(path: String) -> String {
-    let mut last_slash: i64 = -1;
-    let mut i: i64 = 0;
-    let n: i64 = path.len();
-    while i < n {
-        if path.byte_at(i) == 47 {
-            last_slash = i;
-        }
-        i = i + 1;
-    }
-    if last_slash == -1 {
-        String::from(".")
-    } else {
-        let r: String = String::from("");
-        let mut j: i64 = 0;
-        while j < last_slash {
-            r.push_byte(path.byte_at(j));
-            j = j + 1;
-        }
-        r
-    }
-}
-
-fn resolve_use_path(arena: AstArena, root_dir: String, use_lid: i64) -> String {
-    let r: String = String::from("");
-    r.push_str(root_dir);
-    let n: i64 = list_len(arena, use_lid);
-    let mut i: i64 = 0;
-    while i < n {
-        let sid: i64 = list_get(arena, use_lid, i);
-        let component: String = arena.strs[sid];
-        r.push_byte(47);
-        r.push_str(component);
-        i = i + 1;
-    }
-    r.push_str(String::from(".vow"));
-    r
-}
-
-fn load_deps(root_dir: String, m: Module, arena: AstArena, all_items: Vec<i64>, visited: Vec<String>, dctx: DiagCtx) [io] {
-    let uses: Vec<i64> = m.uses;
-    let n_uses: i64 = uses.len();
-    let mut ui: i64 = 0;
-    while ui < n_uses {
-        let use_lid: i64 = uses[ui];
-        let dep_path: String = resolve_use_path(arena, root_dir, use_lid);
-        if !vec_contains_str(visited, dep_path) {
-            visited.push(dep_path);
-            let src: String = fs_read(dep_path);
-            if src.len() == 0 {
-                let d: Diagnostic = diag_error(EC_IO_ERROR(), str2(String::from("cannot read "), dep_path), dep_path, 0, 0);
-                diag_ctx_emit(dctx, d);
-            } else {
-                diag_ctx_add_source(dctx, dep_path, src);
-                let tokens: Vec<Token> = lex(src);
-                let dep_m: Module = parse_module_into(tokens, arena, dctx, dep_path);
-                load_deps(root_dir, dep_m, arena, all_items, visited, dctx);
-                let dep_items: Vec<i64> = dep_m.items;
-                let n_dep: i64 = dep_items.len();
-                let mut di: i64 = 0;
-                while di < n_dep {
-                    all_items.push(dep_items[di]);
-                    di = di + 1;
-                }
-            }
-        }
-        ui = ui + 1;
-    }
-}
-
 fn CMD_NONE() -> i64 vow { ensures: result >= 0 } { 0 }
 fn CMD_BUILD() -> i64 vow { ensures: result >= 0 } { 1 }
 fn CMD_VERIFY() -> i64 vow { ensures: result >= 0 } { 2 }
@@ -236,56 +159,7 @@ fn get_subcommand(argv: Vec<String>) -> i64 {
     CMD_NONE()
 }
 
-struct FrontendResult {
-    path: String,
-    dctx: DiagCtx,
-    merged: Module,
-    str_eids: Vec<i64>,
-    n_items: i64,
-    n_errors: i64,
-}
-
-fn run_frontend_for_path(path: String) -> FrontendResult [io] {
-    let dctx: DiagCtx = diag_ctx_new();
-    let src: String = fs_read(path);
-    diag_ctx_add_source(dctx, path, src);
-    let tokens: Vec<Token> = lex(src);
-    let arena: AstArena = arena_new();
-    let m: Module = parse_module_into(tokens, arena, dctx, path);
-    let root_dir: String = get_dir_path(path);
-    let all_items: Vec<i64> = Vec::new();
-    let visited: Vec<String> = Vec::new();
-    visited.push(path);
-    load_deps(root_dir, m, arena, all_items, visited, dctx);
-    let root_items: Vec<i64> = m.items;
-    let n_root: i64 = root_items.len();
-    let mut ri: i64 = 0;
-    while ri < n_root {
-        all_items.push(root_items[ri]);
-        ri = ri + 1;
-    }
-    let merged: Module = Module {
-        name_sid: 0,
-        uses: Vec::new(),
-        items: all_items,
-        arena: arena,
-    };
-    let n_items: i64 = all_items.len();
-    let e: CheckEnv = env_new(dctx, path);
-    check_module(e, merged);
-    let n_errors: i64 = dctx.error_count;
-    let str_eids: Vec<i64> = e.expr_str_eids;
-    FrontendResult {
-        path: path,
-        dctx: dctx,
-        merged: merged,
-        str_eids: str_eids,
-        n_items: n_items,
-        n_errors: n_errors,
-    }
-}
-
-fn run_frontend(argv: Vec<String>, sub: bool) -> FrontendResult [io] {
+fn frontend_path_from_argv(argv: Vec<String>, sub: bool) -> String [io] {
     let path: String = {
         if sub {
             get_source_path_sub(argv)
@@ -297,7 +171,7 @@ fn run_frontend(argv: Vec<String>, sub: bool) -> FrontendResult [io] {
         eprintln_str("usage: vowc <command> [options] <file.vow>");
         process_exit(1);
     }
-    run_frontend_for_path(path)
+    path
 }
 
 fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String) -> i64 [io] {
@@ -373,13 +247,12 @@ fn emit_ir_warnings(ir_mod: IrModule, dctx: DiagCtx) [io] {
 }
 
 fn run_verify(argv: Vec<String>) -> i32 [io] {
-    let fr: FrontendResult = run_frontend(argv, true);
-    let path: String = fr.path;
-    let dctx: DiagCtx = fr.dctx;
-    let merged: Module = fr.merged;
-    let str_eids: Vec<i64> = fr.str_eids;
-    let n_items: i64 = fr.n_items;
-    let n_errors: i64 = fr.n_errors;
+    let path: String = frontend_path_from_argv(argv, true);
+    let fr: LoweredFrontend = frontend_lower_path(path);
+    let checked: CheckedFrontend = fr.checked;
+    let dctx: DiagCtx = checked.dctx;
+    let n_items: i64 = checked.n_items;
+    let n_errors: i64 = checked.n_errors;
     diag_ctx_print_all(dctx);
     eprintln_str(str4(i64_to_str(n_items), String::from(" items, "), i64_to_str(n_errors), String::from(" errors")));
     if n_errors > 0 {
@@ -408,7 +281,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
         diag_emit_verify_json(String::from("VerifyFailed"), dctx, Vec::new());
         return 1;
     }
-    let ir_mod: IrModule = lower_module_vow(merged, str_eids, path);
+    let ir_mod: IrModule = fr.ir_mod;
     emit_ir_warnings(ir_mod, dctx);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
@@ -428,13 +301,12 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
 }
 
 fn run_build(argv: Vec<String>) -> i32 [io] {
-    let fr: FrontendResult = run_frontend(argv, true);
-    let path: String = fr.path;
-    let dctx: DiagCtx = fr.dctx;
-    let merged: Module = fr.merged;
-    let str_eids: Vec<i64> = fr.str_eids;
-    let n_items: i64 = fr.n_items;
-    let n_errors: i64 = fr.n_errors;
+    let path: String = frontend_path_from_argv(argv, true);
+    let fr: LoweredFrontend = frontend_lower_path(path);
+    let checked: CheckedFrontend = fr.checked;
+    let dctx: DiagCtx = checked.dctx;
+    let n_items: i64 = checked.n_items;
+    let n_errors: i64 = checked.n_errors;
     diag_ctx_print_all(dctx);
     eprintln_str(str4(i64_to_str(n_items), String::from(" items, "), i64_to_str(n_errors), String::from(" errors")));
     if n_errors > 0 {
@@ -461,7 +333,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         else if trace_str == String::from("full") { 2 }
         else { 0 }
     };
-    let ir_mod: IrModule = lower_module_vow(merged, str_eids, path);
+    let ir_mod: IrModule = fr.ir_mod;
     emit_ir_warnings(ir_mod, dctx);
     let do_verify: bool = !has_flag(argv, String::from("--no-verify"));
     if do_verify {
@@ -717,8 +589,9 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
         let start_time: i64 = time_unix_ms();
 
         // Compile
-        let fr: FrontendResult = run_frontend_for_path(test_path);
-        if fr.n_errors > 0 {
+        let fr: LoweredFrontend = frontend_lower_path(test_path);
+        let checked: CheckedFrontend = fr.checked;
+        if checked.n_errors > 0 {
             let duration: i64 = time_unix_ms() - start_time;
             let diag_json: String = String::from("[{\"error_code\":\"CompileError\",\"message\":\"compilation failed\",\"severity\":\"error\"}]");
             let entry: String = emit_test_entry_json(test_path, short_name, String::from("compile_error"), -1, String::from(""), String::from(""), duration, diag_json);
@@ -726,7 +599,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
             failed = failed + 1;
             ti = ti + 1;
         } else {
-            let ir_mod: IrModule = lower_module_vow(fr.merged, fr.str_eids, test_path);
+            let ir_mod: IrModule = fr.ir_mod;
 
             // Count contract density
             let fns2: Vec<IrFunction> = ir_mod.functions;
@@ -879,34 +752,12 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
         eprintln_str("usage: main [-o <output>] <file.vow>");
         return 1;
     }
-    let dctx: DiagCtx = diag_ctx_new();
-    let src: String = fs_read(path);
-    diag_ctx_add_source(dctx, path, src);
-    let tokens: Vec<Token> = lex(src);
-    let arena: AstArena = arena_new();
-    let m: Module = parse_module_into(tokens, arena, dctx, path);
-    let root_dir: String = get_dir_path(path);
-    let all_items: Vec<i64> = Vec::new();
-    let visited: Vec<String> = Vec::new();
-    visited.push(path);
-    load_deps(root_dir, m, arena, all_items, visited, dctx);
-    let root_items: Vec<i64> = m.items;
-    let n_root: i64 = root_items.len();
-    let mut ri: i64 = 0;
-    while ri < n_root {
-        all_items.push(root_items[ri]);
-        ri = ri + 1;
-    }
-    let merged: Module = Module {
-        name_sid: 0,
-        uses: Vec::new(),
-        items: all_items,
-        arena: arena,
-    };
-    let n_items: i64 = all_items.len();
-    let e: CheckEnv = env_new(dctx, path);
-    check_module(e, merged);
-    let n_errors: i64 = dctx.error_count;
+    let fr: LoweredFrontend = frontend_lower_path(path);
+    let checked: CheckedFrontend = fr.checked;
+    let dctx: DiagCtx = checked.dctx;
+    let n_items: i64 = checked.n_items;
+    let n_errors: i64 = checked.n_errors;
+    let ir_mod: IrModule = fr.ir_mod;
     diag_ctx_print_all(dctx);
     let emit_c: bool = has_flag(argv, String::from("--emit-c"));
     let do_verify: bool = has_flag(argv, String::from("--verify"));
@@ -936,8 +787,6 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
                 if mks_str.len() > 0 { mks_str }
                 else { String::from("50") }
             };
-            let str_eids: Vec<i64> = e.expr_str_eids;
-            let ir_mod: IrModule = lower_module_vow(merged, str_eids, path);
             emit_ir_warnings(ir_mod, dctx);
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
@@ -955,8 +804,6 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
                 return 1;
             }
         } else if emit_c {
-            let str_eids: Vec<i64> = e.expr_str_eids;
-            let ir_mod: IrModule = lower_module_vow(merged, str_eids, path);
             emit_ir_warnings(ir_mod, dctx);
             let c_code: String = emit_c_module(ir_mod);
             print_str(c_code);
@@ -975,8 +822,6 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
                 else if trace_str == String::from("full") { 2 }
                 else { 0 }
             };
-            let str_eids: Vec<i64> = e.expr_str_eids;
-            let ir_mod: IrModule = lower_module_vow(merged, str_eids, path);
             emit_ir_warnings(ir_mod, dctx);
             let result: i64 = clif_emit_module(ir_mod, out, mode, trace);
             if result == -1 {
@@ -989,8 +834,6 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
                 diag_emit_build_json(String::from("Unverified"), out, dctx);
             }
         } else {
-            let str_eids: Vec<i64> = e.expr_str_eids;
-            let ir_mod: IrModule = lower_module_vow(merged, str_eids, path);
             emit_ir_warnings(ir_mod, dctx);
             let ir_text: String = print_module(ir_mod);
             print_str(ir_text);
@@ -4558,18 +4401,17 @@ fn vow_kind_from_desc(desc: String) -> String {
 }
 
 fn run_contracts(argv: Vec<String>) -> i32 [io] {
-    let fr: FrontendResult = run_frontend(argv, true);
-    let path: String = fr.path;
-    let dctx: DiagCtx = fr.dctx;
-    let merged: Module = fr.merged;
-    let str_eids: Vec<i64> = fr.str_eids;
-    let n_errors: i64 = fr.n_errors;
+    let path: String = frontend_path_from_argv(argv, true);
+    let fr: LoweredFrontend = frontend_lower_path(path);
+    let checked: CheckedFrontend = fr.checked;
+    let dctx: DiagCtx = checked.dctx;
+    let n_errors: i64 = checked.n_errors;
     diag_ctx_print_all(dctx);
     if n_errors > 0 {
         diag_emit_verify_json(String::from("CompileFailed"), dctx, Vec::new());
         return 1;
     }
-    let ir_mod: IrModule = lower_module_vow(merged, str_eids, path);
+    let ir_mod: IrModule = fr.ir_mod;
 
     let do_verify: bool = has_flag(argv, String::from("--verify"));
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));

--- a/scripts/concat_vow.sh
+++ b/scripts/concat_vow.sh
@@ -18,9 +18,9 @@ echo "module Compiler"
 echo
 
 if [[ "$MODE" == "ir" ]]; then
-    FILES=(span diag token lexer ast parser types env checker ir ir_printer lower main)
+    FILES=(span diag token lexer ast parser types env checker ir ir_printer lower frontend main)
 elif [[ "$MODE" == "clif" ]]; then
-    FILES=(span diag token lexer ast parser types env checker ir ir_printer lower clif c_emitter verifier main)
+    FILES=(span diag token lexer ast parser types env checker ir ir_printer lower frontend clif c_emitter verifier main)
 fi
 
 for f in "${FILES[@]}"; do

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -75,6 +75,28 @@ json_field() {
   python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('$field',''))" <<< "$json"
 }
 
+json_path_field() {
+  local json="$1"
+  local path="$2"
+  JSON_PATH="$path" python3 -c "
+import json
+import os
+import sys
+
+cur = json.loads(sys.stdin.read())
+for part in os.environ['JSON_PATH'].split('.'):
+    if isinstance(cur, dict):
+        cur = cur.get(part, '')
+    else:
+        cur = ''
+        break
+if isinstance(cur, (dict, list)):
+    print(json.dumps(cur))
+else:
+    print(cur)
+" <<< "$json"
+}
+
 json_cx_field() {
   local json="$1"
   local field="$2"
@@ -490,6 +512,69 @@ for d in "$SCRIPT_DIR"/multi/*/; do
 done
 
 # --- Summary ---
+
+section_header "Phase 7: frontend/ (staged boundary regressions)"
+
+stack_main="$SCRIPT_DIR/multi/stack/main.vow"
+geometry_main="$SCRIPT_DIR/multi/geometry/main.vow"
+
+name="frontend_stack_contracts"
+if matches_filter "$name"; then
+  set +e
+  contracts_json="$(run_vowc contracts "$stack_main" 2>/dev/null)"
+  contracts_exit=$?
+  set -e
+  contracts_total="$(json_path_field "$contracts_json" "summary.total")"
+  if [[ "$contracts_exit" -ne 0 ]]; then
+    fail "$name" "exit $contracts_exit"
+  elif [[ "$contracts_total" != "2" ]]; then
+    fail "$name" "summary.total=$contracts_total (expected 2)"
+  else
+    pass "$name"
+  fi
+fi
+
+name="frontend_stack_test"
+if matches_filter "$name"; then
+  set +e
+  test_json="$(run_vowc test "$stack_main" 2>/dev/null)"
+  test_exit=$?
+  set -e
+  test_status="$(json_field "$test_json" "status")"
+  test_passed="$(json_field "$test_json" "passed")"
+  if [[ "$test_exit" -ne 0 ]]; then
+    fail "$name" "exit $test_exit"
+  elif [[ "$test_status" != "TestsPassed" ]]; then
+    fail "$name" "status=$test_status (expected TestsPassed)"
+  elif [[ "$test_passed" != "1" ]]; then
+    fail "$name" "passed=$test_passed (expected 1)"
+  else
+    pass "$name"
+  fi
+fi
+
+name="frontend_geometry_verify"
+if [[ "$NO_VERIFY" == true ]]; then
+  if matches_filter "$name"; then
+    echo -e "  ${YELLOW}SKIP${RESET} frontend_geometry_verify — --no-verify"
+    SKIP=$((SKIP + 1))
+  fi
+else
+  if matches_filter "$name"; then
+    set +e
+    verify_json="$(run_vowc verify "$geometry_main" 2>/dev/null)"
+    verify_exit=$?
+    set -e
+    verify_status="$(json_field "$verify_json" "status")"
+    if [[ "$verify_exit" -ne 0 ]]; then
+      fail "$name" "exit $verify_exit"
+    elif [[ "$verify_status" != "Verified" ]]; then
+      fail "$name" "status=$verify_status (expected Verified)"
+    else
+      pass "$name"
+    fi
+  fi
+fi
 
 echo ""
 echo -e "${BOLD}=== Summary ===${RESET}"

--- a/vow/src/cache.rs
+++ b/vow/src/cache.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 
 use vow_verify::Counterexample;
 
+use crate::frontend::DependencyManifest;
+
 pub struct CompileCache {
     dir: PathBuf,
 }
@@ -22,9 +24,10 @@ impl CompileCache {
         Some(Self { dir })
     }
 
-    pub fn cache_key(source_files: &[PathBuf], mode: &str, trace: &str) -> String {
+    pub fn cache_key(deps: &DependencyManifest, mode: &str, trace: &str) -> String {
         let mut hasher = DefaultHasher::new();
-        let mut entries: Vec<(String, u64)> = source_files
+        let mut entries: Vec<(String, u64)> = deps
+            .paths()
             .iter()
             .filter_map(|p| {
                 let canon = p.canonicalize().ok()?;
@@ -232,6 +235,7 @@ fn parse_cached_result(content: &str) -> Option<CachedVerifyResult> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn verify_cache_roundtrip_proven() {
@@ -289,6 +293,40 @@ mod tests {
     fn cache_key_includes_solver_encoding() {
         let k1 = VerifyCache::cache_key("int f() { return 0; }", 10, "boolector", "bv");
         let k2 = VerifyCache::cache_key("int f() { return 0; }", 10, "z3", "ir");
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn compile_cache_key_ignores_dependency_order() {
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.vow");
+        let b = dir.path().join("b.vow");
+        std::fs::write(&a, "module A").unwrap();
+        std::fs::write(&b, "module B").unwrap();
+
+        let deps_ab = DependencyManifest::from_paths(vec![a.clone(), b.clone()]);
+        let deps_ba = DependencyManifest::from_paths(vec![b, a]);
+
+        let k1 = CompileCache::cache_key(&deps_ab, "Release", "Off");
+        let k2 = CompileCache::cache_key(&deps_ba, "Release", "Off");
+
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn compile_cache_key_changes_when_dependency_set_changes() {
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.vow");
+        let b = dir.path().join("b.vow");
+        std::fs::write(&a, "module A").unwrap();
+        std::fs::write(&b, "module B").unwrap();
+
+        let deps_a = DependencyManifest::from_paths(vec![a.clone()]);
+        let deps_ab = DependencyManifest::from_paths(vec![a, b]);
+
+        let k1 = CompileCache::cache_key(&deps_a, "Release", "Off");
+        let k2 = CompileCache::cache_key(&deps_ab, "Release", "Off");
+
         assert_ne!(k1, k2);
     }
 }

--- a/vow/src/frontend.rs
+++ b/vow/src/frontend.rs
@@ -1,0 +1,287 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use vow_diag::{CollectingEmitter, Diagnostic, DiagnosticEmitter, Severity};
+use vow_syntax::ast::Module;
+
+use crate::module_loader;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FrontendGoal {
+    MergedAst,
+    LoweredIr,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DependencyManifest {
+    source_files: Vec<PathBuf>,
+}
+
+impl DependencyManifest {
+    pub(crate) fn from_paths(source_files: Vec<PathBuf>) -> Self {
+        Self { source_files }
+    }
+
+    pub(crate) fn paths(&self) -> &[PathBuf] {
+        &self.source_files
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FrontendBundle {
+    diagnostics: Vec<Diagnostic>,
+    module: Module,
+    deps: DependencyManifest,
+    ir: Option<Arc<vow_ir::Module>>,
+}
+
+impl FrontendBundle {
+    pub(crate) fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+
+    pub(crate) fn module(&self) -> &Module {
+        &self.module
+    }
+
+    pub(crate) fn dependencies(&self) -> &DependencyManifest {
+        &self.deps
+    }
+
+    pub(crate) fn ir(&self) -> Option<&Arc<vow_ir::Module>> {
+        self.ir.as_ref()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum FrontendError {
+    Io(String),
+    Diagnostics {
+        stage: FrontendStage,
+        diagnostics: Vec<Diagnostic>,
+    },
+}
+
+impl FrontendError {
+    pub(crate) fn diagnostics(&self) -> &[Diagnostic] {
+        match self {
+            Self::Io(_) => &[],
+            Self::Diagnostics { diagnostics, .. } => diagnostics,
+        }
+    }
+
+    pub(crate) fn into_diagnostics(self) -> Vec<Diagnostic> {
+        match self {
+            Self::Io(_) => vec![],
+            Self::Diagnostics { diagnostics, .. } => diagnostics,
+        }
+    }
+
+    pub(crate) fn failure_message(&self) -> &str {
+        match self {
+            Self::Io(message) => message.as_str(),
+            Self::Diagnostics { stage, .. } => stage.failure_message(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FrontendStage {
+    Parse,
+    ModuleLoad,
+    TypeCheck,
+}
+
+impl FrontendStage {
+    fn failure_message(self) -> &'static str {
+        match self {
+            Self::Parse => "parse error",
+            Self::ModuleLoad => "module load error",
+            Self::TypeCheck => "type error",
+        }
+    }
+}
+
+struct NullEmitter;
+
+impl DiagnosticEmitter for NullEmitter {
+    fn emit(&mut self, _: &Diagnostic) {}
+
+    fn finish(&mut self) {}
+}
+
+pub(crate) fn prepare_frontend(
+    source: &Path,
+    goal: FrontendGoal,
+) -> Result<FrontendBundle, FrontendError> {
+    let src = std::fs::read_to_string(source).map_err(|e| FrontendError::Io(e.to_string()))?;
+    let file_str = source.to_string_lossy();
+
+    let mut diagnostics = Vec::new();
+    let (root_ast, parse_diags) = vow_syntax::parser::parse_module(&src, &file_str);
+    let parse_failed = parse_diags.iter().any(|d| d.severity == Severity::Error);
+    diagnostics.extend(parse_diags);
+    if parse_failed {
+        return Err(FrontendError::Diagnostics {
+            stage: FrontendStage::Parse,
+            diagnostics,
+        });
+    }
+
+    let graph = match module_loader::load_modules(source, &root_ast) {
+        Ok(graph) => graph,
+        Err(diags) => {
+            diagnostics.extend(diags);
+            return Err(FrontendError::Diagnostics {
+                stage: FrontendStage::ModuleLoad,
+                diagnostics,
+            });
+        }
+    };
+
+    let deps = DependencyManifest::from_paths(
+        graph.modules.iter().map(|(path, _)| path.clone()).collect(),
+    );
+    let ast = module_loader::merge_modules(graph);
+
+    let mut null_emit = NullEmitter;
+    let mut collecting_emit = CollectingEmitter::new(&mut null_emit);
+    let mut checker =
+        vow_types::check::Checker::new(source.to_string_lossy().to_string(), &mut collecting_emit);
+    checker.check_module(&ast);
+    let has_errors = checker.has_errors();
+    let string_exprs = if matches!(goal, FrontendGoal::LoweredIr) && !has_errors {
+        Some(checker.into_string_exprs())
+    } else {
+        drop(checker);
+        None
+    };
+    diagnostics.extend(collecting_emit.into_diagnostics());
+    if has_errors {
+        return Err(FrontendError::Diagnostics {
+            stage: FrontendStage::TypeCheck,
+            diagnostics,
+        });
+    }
+
+    let ir = match goal {
+        FrontendGoal::MergedAst => None,
+        FrontendGoal::LoweredIr => {
+            let string_exprs = string_exprs.expect("LoweredIr goal must preserve string exprs");
+            let module = vow_ir::lower_module(&ast, &source.to_string_lossy(), &string_exprs);
+            diagnostics.extend(module.warnings.iter().cloned());
+            Some(Arc::new(module))
+        }
+    };
+
+    Ok(FrontendBundle {
+        diagnostics,
+        module: ast,
+        deps,
+        ir,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_vow(dir: &TempDir, name: &str, src: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, src).unwrap();
+        path
+    }
+
+    #[test]
+    fn merged_ast_goal_merges_dependency_items() {
+        let dir = TempDir::new().unwrap();
+        write_vow(&dir, "lib.vow", "module Lib\nfn helper() -> i64 { 0 }");
+        let root = write_vow(
+            &dir,
+            "main.vow",
+            "module Main\nuse lib\nfn main_fn() -> i64 { helper() }",
+        );
+
+        let bundle = prepare_frontend(&root, FrontendGoal::MergedAst).unwrap();
+
+        assert_eq!(bundle.module().name, "Main");
+        assert!(bundle.module().uses.is_empty());
+        assert_eq!(bundle.module().items.len(), 2);
+        assert!(bundle.ir().is_none());
+        assert_eq!(bundle.dependencies().paths().len(), 2);
+        assert!(
+            bundle
+                .dependencies()
+                .paths()
+                .iter()
+                .any(|path| path.ends_with("lib.vow"))
+        );
+    }
+
+    #[test]
+    fn lowered_ir_goal_returns_ir_and_dependency_manifest() {
+        let dir = TempDir::new().unwrap();
+        write_vow(&dir, "lib.vow", "module Lib\nfn helper() -> i64 { 0 }");
+        let root = write_vow(
+            &dir,
+            "main.vow",
+            "module Main\nuse lib\nfn main_fn() -> i64 { helper() }",
+        );
+
+        let bundle = prepare_frontend(&root, FrontendGoal::LoweredIr).unwrap();
+
+        assert!(bundle.diagnostics().is_empty());
+        assert!(bundle.ir().is_some());
+        assert_eq!(bundle.dependencies().paths().len(), 2);
+        assert!(
+            bundle
+                .dependencies()
+                .paths()
+                .iter()
+                .any(|path| path.ends_with("main.vow"))
+        );
+    }
+
+    #[test]
+    fn missing_import_reports_module_load_error() {
+        let dir = TempDir::new().unwrap();
+        let root = write_vow(
+            &dir,
+            "main.vow",
+            "module Main\nuse missing\nfn main_fn() -> i64 { 0 }",
+        );
+
+        let error = prepare_frontend(&root, FrontendGoal::MergedAst).unwrap_err();
+
+        assert_eq!(error.failure_message(), "module load error");
+        assert!(
+            error
+                .diagnostics()
+                .iter()
+                .any(|diag| diag.message.contains("cannot load module `missing`"))
+        );
+    }
+
+    #[test]
+    fn merged_ast_and_lowered_ir_share_typecheck_rules() {
+        let dir = TempDir::new().unwrap();
+        write_vow(&dir, "lib.vow", "module Lib\nfn helper() -> i64 { 0 }");
+        let root = write_vow(
+            &dir,
+            "main.vow",
+            "module Main\nuse lib\nfn main_fn() -> i64 { true }",
+        );
+
+        let merged = prepare_frontend(&root, FrontendGoal::MergedAst).unwrap_err();
+        let lowered = prepare_frontend(&root, FrontendGoal::LoweredIr).unwrap_err();
+
+        assert_eq!(merged.failure_message(), "type error");
+        assert_eq!(lowered.failure_message(), "type error");
+        assert_eq!(merged.diagnostics().len(), lowered.diagnostics().len());
+        assert_eq!(
+            merged.diagnostics()[0].message,
+            lowered.diagnostics()[0].message
+        );
+    }
+}

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1,5 +1,6 @@
-pub mod cache;
-pub mod module_loader;
+mod cache;
+mod frontend;
+mod module_loader;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -12,7 +13,7 @@ use serde::Serialize;
 use vow_codegen::cranelift_backend::CraneliftBackend;
 use vow_codegen::linker::{find_runtime_lib, find_shim_lib, link};
 use vow_codegen::{Backend, BuildMode, TraceMode};
-use vow_diag::{CollectingEmitter, Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
+use vow_diag::{Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
 use vow_verify::{
     Counterexample, DEFAULT_MAX_K_STEP, Encoding, Solver, SolverConfig, VerificationResult,
     detect_constant_functions, emit_verify_c_source, find_esbmc, run_esbmc_with_max_k_step,
@@ -20,6 +21,7 @@ use vow_verify::{
 };
 
 use cache::{CachedVerifyResult, VerifyCache};
+use frontend::{FrontendBundle, FrontendError, FrontendGoal, prepare_frontend};
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -4482,107 +4484,38 @@ fn build_call_site_index(
 // Frontend (parse → module load → type check → IR lower)
 // ---------------------------------------------------------------------------
 
-struct FrontendResult {
-    ir_module: Arc<vow_ir::Module>,
-    diagnostics: Vec<Diagnostic>,
-    source_files: Vec<PathBuf>,
+fn emit_frontend_diagnostics(diagnostics: &[Diagnostic]) {
+    let mut stderr_emit = HumanEmitter::new(Box::new(std::io::stderr()));
+    for diagnostic in diagnostics {
+        stderr_emit.emit(diagnostic);
+    }
+    stderr_emit.finish();
 }
 
-fn compile_frontend(source: &Path) -> Result<FrontendResult, Box<BuildOutput>> {
-    let src = match std::fs::read_to_string(source) {
-        Ok(s) => s,
-        Err(e) => {
-            return Err(Box::new(BuildOutput {
-                status: BuildStatus::CompileFailed {
-                    message: e.to_string(),
-                },
-                executable: None,
-                diagnostics: vec![],
-                counterexamples: vec![],
-                verify_status: None,
-                verify_message: None,
-            }));
+fn frontend_error_to_output(error: FrontendError) -> BuildOutput {
+    let message = error.failure_message().to_string();
+    let diagnostics = error.into_diagnostics();
+    BuildOutput {
+        status: BuildStatus::CompileFailed { message },
+        executable: None,
+        diagnostics,
+        counterexamples: vec![],
+        verify_status: None,
+        verify_message: None,
+    }
+}
+
+fn compile_frontend(source: &Path) -> Result<FrontendBundle, Box<BuildOutput>> {
+    match prepare_frontend(source, FrontendGoal::LoweredIr) {
+        Ok(bundle) => {
+            emit_frontend_diagnostics(bundle.diagnostics());
+            Ok(bundle)
         }
-    };
-
-    let mut stderr_emit = HumanEmitter::new(Box::new(std::io::stderr()));
-    let mut all_diagnostics: Vec<Diagnostic> = Vec::new();
-
-    let file_str = source.to_string_lossy();
-    let (root_ast, parse_diags) = vow_syntax::parser::parse_module(&src, &file_str);
-    let parse_failed = parse_diags.iter().any(|d| d.severity == Severity::Error);
-    for d in &parse_diags {
-        stderr_emit.emit(d);
-    }
-    all_diagnostics.extend(parse_diags);
-    if parse_failed {
-        return Err(Box::new(BuildOutput {
-            status: BuildStatus::CompileFailed {
-                message: "parse error".to_string(),
-            },
-            executable: None,
-            diagnostics: all_diagnostics,
-            counterexamples: vec![],
-            verify_status: None,
-            verify_message: None,
-        }));
-    }
-
-    let (ast, source_files) = match module_loader::load_modules(source, &root_ast) {
-        Ok(graph) => {
-            let files: Vec<PathBuf> = graph.modules.iter().map(|(p, _)| p.clone()).collect();
-            (module_loader::merge_modules(graph), files)
+        Err(error) => {
+            emit_frontend_diagnostics(error.diagnostics());
+            Err(Box::new(frontend_error_to_output(error)))
         }
-        Err(diags) => {
-            for d in &diags {
-                stderr_emit.emit(d);
-            }
-            all_diagnostics.extend(diags);
-            return Err(Box::new(BuildOutput {
-                status: BuildStatus::CompileFailed {
-                    message: "module load error".to_string(),
-                },
-                executable: None,
-                diagnostics: all_diagnostics,
-                counterexamples: vec![],
-                verify_status: None,
-                verify_message: None,
-            }));
-        }
-    };
-
-    let mut collecting_emit = CollectingEmitter::new(&mut stderr_emit);
-    let mut checker =
-        vow_types::check::Checker::new(source.to_string_lossy().to_string(), &mut collecting_emit);
-    checker.check_module(&ast);
-    let has_errors = checker.has_errors();
-    let string_exprs = checker.into_string_exprs();
-    all_diagnostics.extend(collecting_emit.into_diagnostics());
-    if has_errors {
-        return Err(Box::new(BuildOutput {
-            status: BuildStatus::CompileFailed {
-                message: "type error".to_string(),
-            },
-            executable: None,
-            diagnostics: all_diagnostics,
-            counterexamples: vec![],
-            verify_status: None,
-            verify_message: None,
-        }));
     }
-
-    let module = vow_ir::lower_module(&ast, &source.to_string_lossy(), &string_exprs);
-    for w in &module.warnings {
-        stderr_emit.emit(w);
-    }
-    all_diagnostics.extend(module.warnings.iter().cloned());
-    let ir_module = Arc::new(module);
-
-    Ok(FrontendResult {
-        ir_module,
-        diagnostics: all_diagnostics,
-        source_files,
-    })
 }
 
 // ---------------------------------------------------------------------------
@@ -4875,23 +4808,27 @@ fn run_verify_only_inner(
         Ok(f) => f,
         Err(output) => return *output,
     };
+    let all_diagnostics = frontend.diagnostics().to_vec();
+    let ir_module = frontend
+        .ir()
+        .expect("LoweredIr goal must produce IR for verify-only");
 
     if find_esbmc().is_none() {
-        return verify_outcome_to_output(VerifyOutcome::ToolNotFound, frontend.diagnostics, None);
+        return verify_outcome_to_output(VerifyOutcome::ToolNotFound, all_diagnostics, None);
     }
 
     let verify_cache = if no_cache { None } else { VerifyCache::new() };
     let file = source.to_string_lossy().to_string();
-    let call_site_index = build_call_site_index(&frontend.ir_module, &file);
+    let call_site_index = build_call_site_index(ir_module, &file);
     let outcome = run_verification_sync(
-        &frontend.ir_module,
+        ir_module,
         &file,
         &call_site_index,
         verify_cache.as_ref(),
         max_k_step,
         config,
     );
-    verify_outcome_to_output(outcome, frontend.diagnostics, None)
+    verify_outcome_to_output(outcome, all_diagnostics, None)
 }
 
 // ---------------------------------------------------------------------------
@@ -4963,7 +4900,7 @@ fn run_pipeline_inner(
 
 #[allow(clippy::too_many_arguments)]
 fn run_pipeline_from_frontend(
-    frontend: FrontendResult,
+    frontend: FrontendBundle,
     source: &Path,
     output: Option<&Path>,
     mode: BuildMode,
@@ -4974,8 +4911,11 @@ fn run_pipeline_from_frontend(
     max_k_step: u32,
     config: &SolverConfig,
 ) -> BuildOutput {
-    let all_diagnostics = frontend.diagnostics;
-    let ir_module = frontend.ir_module;
+    let all_diagnostics = frontend.diagnostics().to_vec();
+    let ir_module = frontend
+        .ir()
+        .cloned()
+        .expect("LoweredIr goal must produce IR for build pipeline");
 
     if dump_ir {
         print!("{}", vow_ir::print_module(&ir_module));
@@ -5032,7 +4972,7 @@ fn run_pipeline_from_frontend(
     } else {
         cache::CompileCache::new()
     };
-    let cache_key = cache::CompileCache::cache_key(&frontend.source_files, &mode_str, &trace_str);
+    let cache_key = cache::CompileCache::cache_key(frontend.dependencies(), &mode_str, &trace_str);
 
     if let Some(ref cc) = compile_cache
         && let Some(cached_obj) = cc.lookup(&cache_key)
@@ -5219,7 +5159,11 @@ fn run_test_command(
             }
         };
 
-        let density = count_contract_density(&frontend.ir_module);
+        let density = count_contract_density(
+            frontend
+                .ir()
+                .expect("LoweredIr goal must produce IR for test density"),
+        );
         total_density.functions_total += density.functions_total;
         total_density.functions_with_vows += density.functions_with_vows;
 
@@ -5455,50 +5399,19 @@ fn run_build_command(
 }
 
 fn run_decl_command(source: &Path, output: Option<&Path>) {
-    let src = match std::fs::read_to_string(source) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("vow decl: {}", e);
+    let frontend = match prepare_frontend(source, FrontendGoal::MergedAst) {
+        Ok(bundle) => {
+            emit_frontend_diagnostics(bundle.diagnostics());
+            bundle
+        }
+        Err(error) => {
+            emit_frontend_diagnostics(error.diagnostics());
+            eprintln!("vow decl: {}", error.failure_message());
             std::process::exit(1);
         }
     };
 
-    let file_str = source.to_string_lossy();
-    let (root_ast, parse_diags) = vow_syntax::parser::parse_module(&src, &file_str);
-    let mut stderr_emit = HumanEmitter::new(Box::new(std::io::stderr()));
-    let parse_failed = parse_diags.iter().any(|d| d.severity == Severity::Error);
-    for d in &parse_diags {
-        stderr_emit.emit(d);
-    }
-    if parse_failed {
-        eprintln!("vow decl: parse errors");
-        std::process::exit(1);
-    }
-
-    let (ast, _source_files) = match module_loader::load_modules(source, &root_ast) {
-        Ok(graph) => {
-            let files: Vec<PathBuf> = graph.modules.iter().map(|(p, _)| p.clone()).collect();
-            (module_loader::merge_modules(graph), files)
-        }
-        Err(diags) => {
-            for d in &diags {
-                stderr_emit.emit(d);
-            }
-            eprintln!("vow decl: module load error");
-            std::process::exit(1);
-        }
-    };
-
-    let mut collecting_emit = CollectingEmitter::new(&mut stderr_emit);
-    let mut checker =
-        vow_types::check::Checker::new(source.to_string_lossy().to_string(), &mut collecting_emit);
-    checker.check_module(&ast);
-    if checker.has_errors() {
-        eprintln!("vow decl: type errors");
-        std::process::exit(1);
-    }
-
-    let decl_text = vow_syntax::printer::print_declarations(&ast);
+    let decl_text = vow_syntax::printer::print_declarations(frontend.module());
 
     let out_path = match output {
         Some(p) => p.to_path_buf(),
@@ -5680,9 +5593,13 @@ fn run_contracts_command(
             std::process::exit(1);
         }
     };
+    let all_diagnostics = frontend.diagnostics().to_vec();
+    let ir_module = frontend
+        .ir()
+        .expect("LoweredIr goal must produce IR for contracts");
 
     let mut entries: Vec<ContractEntryJson> = Vec::new();
-    for func in &frontend.ir_module.functions {
+    for func in &ir_module.functions {
         for vow in &func.vows {
             let kind = vow_kind_from_description(&vow.description);
             let blame = match vow.blame {
@@ -5708,14 +5625,14 @@ fn run_contracts_command(
     if verify {
         if find_esbmc().is_none() {
             let output =
-                verify_outcome_to_output(VerifyOutcome::ToolNotFound, frontend.diagnostics, None);
+                verify_outcome_to_output(VerifyOutcome::ToolNotFound, all_diagnostics, None);
             output.emit_json();
             std::process::exit(1);
         }
         let verify_cache = if no_cache { None } else { VerifyCache::new() };
         update_contract_statuses(
             &mut entries,
-            &frontend.ir_module,
+            ir_module,
             verify_cache.as_ref(),
             max_k_step,
             config,

--- a/vow/src/module_loader.rs
+++ b/vow/src/module_loader.rs
@@ -4,12 +4,12 @@ use std::path::{Path, PathBuf};
 use vow_diag::{Blame, Diagnostic, ErrorCode, Severity, SourceLocation};
 use vow_syntax::ast::Module;
 
-pub struct ModuleGraph {
+pub(crate) struct ModuleGraph {
     /// Modules in dependency-first order; root is last.
     pub modules: Vec<(PathBuf, Module)>,
 }
 
-pub fn load_modules(root: &Path, root_ast: &Module) -> Result<ModuleGraph, Vec<Diagnostic>> {
+pub(crate) fn load_modules(root: &Path, root_ast: &Module) -> Result<ModuleGraph, Vec<Diagnostic>> {
     let root_dir = root.parent().unwrap_or(root);
     let mut modules: Vec<(PathBuf, Module)> = Vec::new();
     let mut visited: HashSet<PathBuf> = HashSet::new();
@@ -59,7 +59,7 @@ fn load_deps(
             Err(e) => {
                 errors.push(Diagnostic {
                     severity: Severity::Error,
-                    code: ErrorCode::TypeMismatch,
+                    code: ErrorCode::IoError,
                     message: format!("cannot load module `{}`: {e}", use_decl.path.join(".")),
                     primary: SourceLocation {
                         file: use_decl.path.join("."),
@@ -83,68 +83,9 @@ fn resolve_use(root_dir: &Path, path: &[String]) -> PathBuf {
     result.with_extension("vow")
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    fn write_vow(dir: &TempDir, name: &str, src: &str) -> PathBuf {
-        let path = dir.path().join(name);
-        std::fs::write(&path, src).unwrap();
-        path
-    }
-
-    #[test]
-    fn load_modules_missing_import_returns_error() {
-        let dir = TempDir::new().unwrap();
-        let src = "module Main\nuse nonexistent\nfn f() -> i32 { 0 }";
-        let path = write_vow(&dir, "main.vow", src);
-        let (ast, diags) = vow_syntax::parser::parse_module(src, &path.to_string_lossy());
-        assert!(diags.is_empty());
-        let result = load_modules(&path, &ast);
-        assert!(result.is_err(), "should fail when import not found");
-        let errors = result.err().unwrap();
-        assert!(!errors.is_empty());
-        assert!(errors[0].message.contains("nonexistent"));
-    }
-
-    #[test]
-    fn load_modules_duplicate_import_not_loaded_twice() {
-        let dir = TempDir::new().unwrap();
-        write_vow(&dir, "lib.vow", "module Lib\nfn helper() -> i32 { 0 }");
-        let src = "module Main\nuse lib\nuse lib\nfn f() -> i32 { 0 }";
-        let path = write_vow(&dir, "main.vow", src);
-        let (ast, diags) = vow_syntax::parser::parse_module(src, &path.to_string_lossy());
-        assert!(diags.is_empty());
-        let result = load_modules(&path, &ast);
-        assert!(result.is_ok(), "should succeed with duplicate import");
-        let graph = result.unwrap();
-        let lib_count = graph
-            .modules
-            .iter()
-            .filter(|(p, _)| p.ends_with("lib.vow"))
-            .count();
-        assert_eq!(lib_count, 1, "lib should only appear once");
-    }
-
-    #[test]
-    fn merge_modules_combines_items() {
-        let dir = TempDir::new().unwrap();
-        write_vow(&dir, "lib.vow", "module Lib\nfn helper() -> i32 { 0 }");
-        let src = "module Main\nuse lib\nfn main_fn() -> i32 { 0 }";
-        let path = write_vow(&dir, "main.vow", src);
-        let (ast, _) = vow_syntax::parser::parse_module(src, &path.to_string_lossy());
-        let graph = load_modules(&path, &ast).unwrap();
-        let merged = merge_modules(graph);
-        assert_eq!(merged.name, "Main");
-        assert_eq!(merged.items.len(), 2, "should have helper + main_fn");
-        assert!(merged.uses.is_empty(), "merged module has no uses");
-    }
-}
-
 /// Merge all modules into a single Module for unified type-checking and lowering.
 /// All items from dependency modules are visible as if declared in the root.
-pub fn merge_modules(graph: ModuleGraph) -> Module {
+pub(crate) fn merge_modules(graph: ModuleGraph) -> Module {
     let (_, root_module) = graph
         .modules
         .last()


### PR DESCRIPTION
## Summary
- add a staged frontend boundary in `vow/src/frontend.rs` with `prepare_frontend`, `FrontendGoal`, `FrontendBundle`, and `DependencyManifest`
- route `build`, `verify`, `test`, `contracts`, and `decl` through the shared frontend boundary so callers stop stitching module loading and type checking themselves
- move compile-cache invalidation onto the frontend-owned dependency manifest and reduce `module_loader` to an internal implementation detail

## Why
The frontend pipeline lived in `main.rs`, with `decl` duplicating much of the same parse/load/typecheck flow. That made the module boundary shallow, leaked dependency tracking into callers, and created drift risk between command paths.

## Impact
- callers now choose a frontend goal instead of orchestrating the pipeline manually
- `decl` stops at merged AST while build-oriented commands request lowered IR
- compile-cache keys derive from the frontend dependency manifest instead of a raw path list

## Validation
- `cargo test -p vow`

Closes #170