### PR TITLE
[codex] deepen self-hosted frontend boundary

### DIFF
--- a/compiler/frontend.vow
+++ b/compiler/frontend.vow
@@ -14,7 +14,6 @@ struct CheckedFrontend {
     path: String,
     dctx: DiagCtx,
     sources: Vec<String>,
-    merged: Module,
     n_items: i64,
     n_errors: i64,
 }
@@ -26,6 +25,7 @@ struct LoweredFrontend {
 
 struct FrontendPrep {
     checked: CheckedFrontend,
+    merged: Module,
     str_eids: Vec<i64>,
 }
 
@@ -131,19 +131,14 @@ fn frontend_prepare_path(path: String) -> FrontendPrep [io] {
         path: path,
         dctx: dctx,
         sources: visited,
-        merged: merged,
         n_items: n_items,
         n_errors: dctx.error_count,
     };
     FrontendPrep {
         checked: checked,
+        merged: merged,
         str_eids: e.expr_str_eids,
     }
-}
-
-fn frontend_check_path(path: String) -> CheckedFrontend [io] {
-    let prep: FrontendPrep = frontend_prepare_path(path);
-    prep.checked
 }
 
 fn frontend_lower_path(path: String) -> LoweredFrontend [io] {
@@ -154,7 +149,7 @@ fn frontend_lower_path(path: String) -> LoweredFrontend [io] {
             // Keep callers on one lowered entry point even when checking fails.
             ir_module_new(checked.path)
         } else {
-            lower_module_vow(checked.merged, prep.str_eids, checked.path)
+            lower_module_vow(prep.merged, prep.str_eids, checked.path)
         }
     };
     LoweredFrontend {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -524,13 +524,15 @@ if matches_filter "$name"; then
   contracts_json="$(run_vowc contracts "$stack_main" 2>/dev/null)"
   contracts_exit=$?
   set -e
-  contracts_total="$(json_path_field "$contracts_json" "summary.total")"
   if [[ "$contracts_exit" -ne 0 ]]; then
     fail "$name" "exit $contracts_exit"
-  elif [[ "$contracts_total" != "2" ]]; then
-    fail "$name" "summary.total=$contracts_total (expected 2)"
   else
-    pass "$name"
+    contracts_total="$(json_path_field "$contracts_json" "summary.total")"
+    if [[ "$contracts_total" != "2" ]]; then
+      fail "$name" "summary.total=$contracts_total (expected 2)"
+    else
+      pass "$name"
+    fi
   fi
 fi
 
@@ -540,16 +542,18 @@ if matches_filter "$name"; then
   test_json="$(run_vowc test "$stack_main" 2>/dev/null)"
   test_exit=$?
   set -e
-  test_status="$(json_field "$test_json" "status")"
-  test_passed="$(json_field "$test_json" "passed")"
   if [[ "$test_exit" -ne 0 ]]; then
     fail "$name" "exit $test_exit"
-  elif [[ "$test_status" != "TestsPassed" ]]; then
-    fail "$name" "status=$test_status (expected TestsPassed)"
-  elif [[ "$test_passed" != "1" ]]; then
-    fail "$name" "passed=$test_passed (expected 1)"
   else
-    pass "$name"
+    test_status="$(json_field "$test_json" "status")"
+    test_passed="$(json_field "$test_json" "passed")"
+    if [[ "$test_status" != "TestsPassed" ]]; then
+      fail "$name" "status=$test_status (expected TestsPassed)"
+    elif [[ "$test_passed" != "1" ]]; then
+      fail "$name" "passed=$test_passed (expected 1)"
+    else
+      pass "$name"
+    fi
   fi
 fi
 
@@ -565,13 +569,15 @@ else
     verify_json="$(run_vowc verify "$geometry_main" 2>/dev/null)"
     verify_exit=$?
     set -e
-    verify_status="$(json_field "$verify_json" "status")"
     if [[ "$verify_exit" -ne 0 ]]; then
       fail "$name" "exit $verify_exit"
-    elif [[ "$verify_status" != "Verified" ]]; then
-      fail "$name" "status=$verify_status (expected Verified)"
     else
-      pass "$name"
+      verify_status="$(json_field "$verify_json" "status")"
+      if [[ "$verify_status" != "Verified" ]]; then
+        fail "$name" "status=$verify_status (expected Verified)"
+      else
+        pass "$name"
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
- add `compiler/frontend.vow` with staged `CheckedFrontend` and `LoweredFrontend` artifacts behind `frontend_check_path` and `frontend_lower_path`
- route self-hosted `build`, `verify`, `test`, `contracts`, and legacy mode through the shared frontend boundary instead of caller-managed `merged` + `str_eids` plumbing
- update bootstrap concatenation and add frontend regression checks for multi-module `contracts`, `test`, and `verify`

## Why
`compiler/main.vow` still owned module resolution, recursive loading, merge order, semantic checking setup, and the checker-to-lowerer handshake directly. That kept the frontend shallow, leaked assembly details into command handlers, and made regression coverage depend on ad hoc seams instead of a durable boundary.

## Impact
- self-hosted command handlers now depend on staged frontend results rather than assembling compiler state themselves
- dependency loading, visited tracking, diagnostics setup, and lowering prep are internal to the frontend module
- the fixed-point bootstrap concat path now includes the extracted frontend module

## Validation
- `./target/release/vow build --no-verify compiler/main.vow -o build/vowc`
- `bash tests/run_tests.sh --no-bootstrap --no-verify --filter frontend_`
- `bash tests/run_tests.sh --no-bootstrap --filter frontend_geometry_verify`
- `./build/vowc build --no-verify compiler/main.vow -o /tmp/vowc_issue171_self`
- `bash scripts/concat_vow.sh clif > /tmp/compiler_clif_issue171.vow && ./build/vowc build --no-verify /tmp/compiler_clif_issue171.vow -o /tmp/vowc_issue171_concat`

Closes #171