### PR TITLE
[codex] fix call return ownership lowering

### DIFF
--- a/compiler/ast.vow
+++ b/compiler/ast.vow
@@ -210,6 +210,17 @@ fn cdef_name_sid(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 3] }
 fn cdef_type_tid(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 3 + 1] }
 fn cdef_value_eid(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 3 + 2] }
 
+fn clone_string(src: String) -> String {
+    let out: String = String::from("");
+    let n: i64 = src.len();
+    let mut i: i64 = 0;
+    while i < n {
+        out.push_byte(src.byte_at(i));
+        i = i + 1;
+    }
+    out
+}
+
 fn arena_str(a: AstArena, sid: i64) -> String { a.strs[sid] }
 
 fn expr_span(a: AstArena, eid: i64) -> i64 { a.expr_data[eid * 5 + 4] }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1254,6 +1254,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             }
             let ret_ty: i64 = ctx.func_ret_tys[fidx];
             let result: i64 = lctx_emit(ctx, IOP_CALL(), ret_ty, call_args, IDATA_CALL_TARGET(), fidx, 0, String::from(""));
+            // Tag but don't track: can't distinguish owned heap from arena alias without ownership annotations.
             let ret_tag: String = ctx.func_ret_tags[fidx];
             if ret_tag.len() > 0 {
                 lctx_tag(ctx, result, ret_tag);

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -701,7 +701,7 @@ fn lower_ast_type_tag_name(a: AstArena, tid: i64) -> String {
     }
     if tag == TY_GENERIC() {
         let name_sid: i64 = type_a(a, tid);
-        return arena_str(a, name_sid);
+        return clone_string(arena_str(a, name_sid));
     }
     String::from("")
 }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -666,7 +666,7 @@ fn lower_ast_ty(a: AstArena, tid: i64) -> i64 {
     if tag == TY_NEVER() { return ITY_UNIT(); }
     if tag == TY_NAMED() {
         let name_sid: i64 = type_a(a, tid);
-        let name: String = clone_string(arena_str(a, name_sid));
+        let name: String = arena_str(a, name_sid);
         if name == String::from("i32") { return ITY_I32(); }
         if name == String::from("i64") { return ITY_I64(); }
         if name == String::from("u64") { return ITY_U64(); }
@@ -711,7 +711,7 @@ fn lower_ast_type_vec_elem_name(a: AstArena, tid: i64) -> String {
     let tag: i64 = type_tag(a, tid);
     if tag != TY_GENERIC() { return String::from(""); }
     let name_sid: i64 = type_a(a, tid);
-    let name: String = clone_string(arena_str(a, name_sid));
+    let name: String = arena_str(a, name_sid);
     if name != String::from("Vec") { return String::from(""); }
     let args_lid: i64 = type_b(a, tid);
     if list_len(a, args_lid) == 0 { return String::from(""); }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -724,6 +724,7 @@ fn lower_ast_type_vec_elem_name(a: AstArena, tid: i64) -> String {
        elem_name == String::from("f32") || elem_name == String::from("f64") || elem_name == String::from("bool") {
         return String::from("");
     }
+    if elem_name == String::from("str") { return String::from("String"); }
     elem_name
 }
 

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -689,7 +689,7 @@ fn lower_ast_type_tag_name(a: AstArena, tid: i64) -> String {
     let tag: i64 = type_tag(a, tid);
     if tag == TY_NAMED() {
         let name_sid: i64 = type_a(a, tid);
-        let name: String = clone_string(arena_str(a, name_sid));
+        let name: String = arena_str(a, name_sid);
         if name == String::from("i32") || name == String::from("i64") || name == String::from("u64") ||
            name == String::from("f32") || name == String::from("f64") || name == String::from("bool") {
             return String::from("");
@@ -697,7 +697,7 @@ fn lower_ast_type_tag_name(a: AstArena, tid: i64) -> String {
         if name == String::from("str") {
             return String::from("String");
         }
-        return name;
+        return clone_string(name);
     }
     if tag == TY_GENERIC() {
         let name_sid: i64 = type_a(a, tid);
@@ -719,13 +719,13 @@ fn lower_ast_type_vec_elem_name(a: AstArena, tid: i64) -> String {
     let elem_tag: i64 = type_tag(a, elem_tid);
     if elem_tag != TY_NAMED() { return String::from(""); }
     let elem_sid: i64 = type_a(a, elem_tid);
-    let elem_name: String = clone_string(arena_str(a, elem_sid));
+    let elem_name: String = arena_str(a, elem_sid);
     if elem_name == String::from("i32") || elem_name == String::from("i64") || elem_name == String::from("u64") ||
        elem_name == String::from("f32") || elem_name == String::from("f64") || elem_name == String::from("bool") {
         return String::from("");
     }
     if elem_name == String::from("str") { return String::from("String"); }
-    elem_name
+    clone_string(elem_name)
 }
 
 fn is_valid_binop(op: i64) -> bool {

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -13,6 +13,8 @@ struct LowerCtx {
     string_pool: Vec<String>,
     func_names: Vec<String>,
     func_ret_tys: Vec<i64>,
+    func_ret_tags: Vec<String>,
+    func_ret_vec_elems: Vec<String>,
     struct_names: Vec<String>,
     struct_field_lists: Vec<Vec<String>>,
     struct_field_type_names: Vec<Vec<String>>,
@@ -72,6 +74,8 @@ fn lctx_new(name: String, return_ty: i64, effects: i64, arena: AstArena, str_eid
         string_pool: Vec::new(),
         func_names: Vec::new(),
         func_ret_tys: Vec::new(),
+        func_ret_tags: Vec::new(),
+        func_ret_vec_elems: Vec::new(),
         struct_names: Vec::new(),
         struct_field_lists: Vec::new(),
         struct_field_type_names: Vec::new(),
@@ -662,7 +666,7 @@ fn lower_ast_ty(a: AstArena, tid: i64) -> i64 {
     if tag == TY_NEVER() { return ITY_UNIT(); }
     if tag == TY_NAMED() {
         let name_sid: i64 = type_a(a, tid);
-        let name: String = arena_str(a, name_sid);
+        let name: String = clone_string(arena_str(a, name_sid));
         if name == String::from("i32") { return ITY_I32(); }
         if name == String::from("i64") { return ITY_I64(); }
         if name == String::from("u64") { return ITY_U64(); }
@@ -678,6 +682,49 @@ fn lower_ast_ty(a: AstArena, tid: i64) -> i64 {
     if tag == TY_SLICE() { return ITY_PTR(); }
     if tag == TY_TUPLE() { return ITY_PTR(); }
     -1
+}
+
+fn lower_ast_type_tag_name(a: AstArena, tid: i64) -> String {
+    if tid == -1 { return String::from(""); }
+    let tag: i64 = type_tag(a, tid);
+    if tag == TY_NAMED() {
+        let name_sid: i64 = type_a(a, tid);
+        let name: String = clone_string(arena_str(a, name_sid));
+        if name == String::from("i32") || name == String::from("i64") || name == String::from("u64") ||
+           name == String::from("f32") || name == String::from("f64") || name == String::from("bool") {
+            return String::from("");
+        }
+        if name == String::from("str") {
+            return String::from("String");
+        }
+        return name;
+    }
+    if tag == TY_GENERIC() {
+        let name_sid: i64 = type_a(a, tid);
+        return arena_str(a, name_sid);
+    }
+    String::from("")
+}
+
+fn lower_ast_type_vec_elem_name(a: AstArena, tid: i64) -> String {
+    if tid == -1 { return String::from(""); }
+    let tag: i64 = type_tag(a, tid);
+    if tag != TY_GENERIC() { return String::from(""); }
+    let name_sid: i64 = type_a(a, tid);
+    let name: String = clone_string(arena_str(a, name_sid));
+    if name != String::from("Vec") { return String::from(""); }
+    let args_lid: i64 = type_b(a, tid);
+    if list_len(a, args_lid) == 0 { return String::from(""); }
+    let elem_tid: i64 = list_get(a, args_lid, 0);
+    let elem_tag: i64 = type_tag(a, elem_tid);
+    if elem_tag != TY_NAMED() { return String::from(""); }
+    let elem_sid: i64 = type_a(a, elem_tid);
+    let elem_name: String = clone_string(arena_str(a, elem_sid));
+    if elem_name == String::from("i32") || elem_name == String::from("i64") || elem_name == String::from("u64") ||
+       elem_name == String::from("f32") || elem_name == String::from("f64") || elem_name == String::from("bool") {
+        return String::from("");
+    }
+    elem_name
 }
 
 fn is_valid_binop(op: i64) -> bool {
@@ -1205,7 +1252,16 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 ai = ai + 1;
             }
             let ret_ty: i64 = ctx.func_ret_tys[fidx];
-            return lctx_emit(ctx, IOP_CALL(), ret_ty, call_args, IDATA_CALL_TARGET(), fidx, 0, String::from(""));
+            let result: i64 = lctx_emit(ctx, IOP_CALL(), ret_ty, call_args, IDATA_CALL_TARGET(), fidx, 0, String::from(""));
+            let ret_tag: String = ctx.func_ret_tags[fidx];
+            if ret_tag.len() > 0 {
+                lctx_tag(ctx, result, ret_tag);
+            }
+            let ret_vec_elem: String = ctx.func_ret_vec_elems[fidx];
+            if ret_vec_elem.len() > 0 {
+                lctx_tag_vec_elem(ctx, result, ret_vec_elem);
+            }
+            return result;
         }
         let call_args: Vec<i64> = Vec::new();
         let nargs: i64 = list_len(a, args_lid);
@@ -3583,6 +3639,8 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>, file_path: String) -> IrModul
 
     let func_names: Vec<String> = Vec::new();
     let func_ret_tys: Vec<i64> = Vec::new();
+    let func_ret_tags: Vec<String> = Vec::new();
+    let func_ret_vec_elems: Vec<String> = Vec::new();
     let struct_names: Vec<String> = Vec::new();
     let struct_field_lists: Vec<Vec<String>> = Vec::new();
     let struct_field_type_names: Vec<Vec<String>> = Vec::new();
@@ -3603,6 +3661,8 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>, file_path: String) -> IrModul
             let ir_ret: i64 = lower_ast_ty(a, ret_tid);
             func_names.push(name);
             func_ret_tys.push(ir_ret);
+            func_ret_tags.push(lower_ast_type_tag_name(a, ret_tid));
+            func_ret_vec_elems.push(lower_ast_type_vec_elem_name(a, ret_tid));
         } else if ik == ITEM_STRUCT() {
             let sname_sid: i64 = sdef_name_sid(a, iid);
             let sname: String = arena_str(a, sname_sid);
@@ -3776,6 +3836,8 @@ fn lower_module_vow(m: Module, str_eids: Vec<i64>, file_path: String) -> IrModul
     ctx.file = file_path;
     ctx.func_names = func_names;
     ctx.func_ret_tys = func_ret_tys;
+    ctx.func_ret_tags = func_ret_tags;
+    ctx.func_ret_vec_elems = func_ret_vec_elems;
     ctx.struct_names = struct_names;
     ctx.struct_field_lists = struct_field_lists;
     ctx.struct_field_type_names = struct_field_type_names;

--- a/vow-ir/src/lib.rs
+++ b/vow-ir/src/lib.rs
@@ -7,7 +7,7 @@ pub mod validator;
 
 pub use effects::{AbstractHeap, Effects, HeapSet, inst_effects};
 pub use insertion_set::InsertionSet;
-pub use lower::{StringExprSet, lower_function, lower_module};
+pub use lower::{StringExprSet, lower_module};
 pub use printer::{print_function, print_module};
 pub use types::{
     BasicBlock, BlockId, EnumLayout, FieldLayout, FuncId, Function, Inst, InstData, InstId, Module,

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -955,6 +955,11 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     InstData::CallTarget(call_info.id),
                     span,
                 );
+                // Record the return-type tag as metadata, but deliberately do not
+                // call `track_heap_alloc`: a user-defined helper may return an
+                // alias (e.g. arena-backed string) rather than a freshly-owned
+                // allocation, and freeing at the call site would invalidate
+                // still-live arena storage.
                 if let Some(ret_tag) = call_info.ret_tag {
                     ctx.inst_struct_type.insert(result, ret_tag);
                 }

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -4376,6 +4376,90 @@ mod tests {
     }
 
     #[test]
+    fn multiple_arena_aliased_bindings_emit_no_frees_at_scope_exit() {
+        // Defense-in-depth: the single-binding case above proves the call site
+        // doesn't emit a free.  This variant pins the scope-exit behaviour for
+        // a realistic multi-binding sequence (the bootstrap crash path involved
+        // many arena-aliased String locals in a single lowering function).
+        let body = Block {
+            stmts: vec![
+                let_stmt(
+                    "a",
+                    Some(Type::Named {
+                        name: "String".to_string(),
+                        span: sp(),
+                    }),
+                    Expr {
+                        kind: ExprKind::Call {
+                            callee: Box::new(ident_expr("arena_str")),
+                            args: vec![],
+                        },
+                        span: sp(),
+                    },
+                ),
+                let_stmt(
+                    "b",
+                    Some(Type::Named {
+                        name: "String".to_string(),
+                        span: sp(),
+                    }),
+                    Expr {
+                        kind: ExprKind::Call {
+                            callee: Box::new(ident_expr("arena_str")),
+                            args: vec![],
+                        },
+                        span: sp(),
+                    },
+                ),
+            ],
+            trailing_expr: Some(Box::new(int_expr(0))),
+            span: sp(),
+        };
+        let fn_def = make_fn("f", vec![], i64_ty(), body, vec![]);
+
+        let mut func_index = HashMap::new();
+        func_index.insert(
+            "arena_str".to_string(),
+            FuncSigInfo {
+                id: FuncId(0),
+                ret_ty: Ty::Ptr,
+                ret_tag: Some("String".to_string()),
+                ret_vec_elem: None,
+            },
+        );
+
+        let (func, _, warnings) = lower_function(
+            &fn_def,
+            "",
+            &func_index,
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+        assert!(
+            warnings.is_empty(),
+            "unexpected lowering warnings: {warnings:?}"
+        );
+
+        let free_count = func
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|i| {
+                i.opcode == Opcode::Call
+                    && i.data == InstData::CallExtern("__vow_string_free".to_string())
+            })
+            .count();
+        assert_eq!(
+            free_count, 0,
+            "arena-aliased let bindings must emit zero __vow_string_free calls at scope exit, got {free_count}"
+        );
+    }
+
+    #[test]
     fn region_free_emitted_for_unused_struct() {
         // fn f() -> i64 { let p = Pair{a:1, b:2}; 42 }
         let body = Block {

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -123,7 +123,7 @@ pub(crate) fn lower_ty(ast_ty: &AstType) -> Ty {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FuncSigInfo {
+pub(crate) struct FuncSigInfo {
     id: FuncId,
     ret_ty: Ty,
     ret_tag: Option<String>,
@@ -166,7 +166,7 @@ fn vec_named_elem_type(ast_ty: &AstType) -> Option<String> {
 
 const FIELD_IDX_SENTINEL: usize = u32::MAX as usize;
 
-pub struct LowerCtx {
+pub(crate) struct LowerCtx {
     pub(super) func: Function,
     pub(super) current_block: BlockId,
     next_inst_id: u32,
@@ -223,7 +223,7 @@ pub struct LowerCtx {
 
 impl LowerCtx {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         name: String,
         params: Vec<Ty>,
         param_names: Vec<String>,
@@ -3176,7 +3176,7 @@ fn lower_block_inner(ctx: &mut LowerCtx, block: &Block) -> InstId {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn lower_function(
+pub(crate) fn lower_function(
     fn_def: &FnDef,
     file: &str,
     func_index: &HashMap<String, FuncSigInfo>,

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -4282,7 +4282,10 @@ mod tests {
         struct_field_map.insert("Pair".to_string(), vec!["a".to_string(), "b".to_string()]);
 
         let mut struct_field_type_names = HashMap::new();
-        struct_field_type_names.insert("Pair".to_string(), vec!["i64".to_string(), "i64".to_string()]);
+        struct_field_type_names.insert(
+            "Pair".to_string(),
+            vec!["i64".to_string(), "i64".to_string()],
+        );
 
         let (func, _, warnings) = lower_function(
             &fn_def,
@@ -4296,7 +4299,10 @@ mod tests {
             &HashMap::new(),
         );
 
-        assert!(warnings.is_empty(), "unexpected lowering warnings: {warnings:?}");
+        assert!(
+            warnings.is_empty(),
+            "unexpected lowering warnings: {warnings:?}"
+        );
 
         let field_get = func
             .blocks
@@ -4352,7 +4358,10 @@ mod tests {
             &HashMap::new(),
         );
 
-        assert!(warnings.is_empty(), "unexpected lowering warnings: {warnings:?}");
+        assert!(
+            warnings.is_empty(),
+            "unexpected lowering warnings: {warnings:?}"
+        );
 
         let has_string_free = func.blocks.iter().flat_map(|b| b.insts.iter()).any(|i| {
             i.opcode == Opcode::Call

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -955,14 +955,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     InstData::CallTarget(call_info.id),
                     span,
                 );
-                // Record the return-type tag as metadata, but deliberately do not
-                // call `track_heap_alloc`: without ownership annotations in the
-                // function signature we cannot distinguish an alias (e.g. an
-                // arena-backed string) from a freshly-owned allocation.  We
-                // conservatively omit the free, accepting that fresh-heap
-                // user-defined returns will leak until ownership is tracked,
-                // since the alternative would reintroduce use-after-free on
-                // aliased returns.
+                // Tag but don't track: can't distinguish owned heap from arena alias without ownership annotations.
                 if let Some(ret_tag) = call_info.ret_tag {
                     ctx.inst_struct_type.insert(result, ret_tag);
                 }

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -122,6 +122,48 @@ pub(crate) fn lower_ty(ast_ty: &AstType) -> Ty {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FuncSigInfo {
+    id: FuncId,
+    ret_ty: Ty,
+    ret_tag: Option<String>,
+    ret_vec_elem: Option<String>,
+}
+
+fn non_scalar_type_tag(ast_ty: &AstType) -> Option<String> {
+    match ast_ty {
+        AstType::Named { name, .. }
+            if matches!(
+                name.as_str(),
+                "i32" | "i64" | "u64" | "f32" | "f64" | "bool"
+            ) =>
+        {
+            None
+        }
+        AstType::Named { name, .. } if name == "str" => Some("String".to_string()),
+        AstType::Named { name, .. } => Some(name.clone()),
+        AstType::Generic { name, .. } => Some(name.clone()),
+        _ => None,
+    }
+}
+
+fn vec_named_elem_type(ast_ty: &AstType) -> Option<String> {
+    match ast_ty {
+        AstType::Generic { name, args, .. } if name == "Vec" => match args.first() {
+            Some(AstType::Named { name, .. })
+                if !matches!(
+                    name.as_str(),
+                    "i32" | "i64" | "u64" | "f32" | "f64" | "bool"
+                ) =>
+            {
+                Some(name.clone())
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 const FIELD_IDX_SENTINEL: usize = u32::MAX as usize;
 
 pub struct LowerCtx {
@@ -132,7 +174,7 @@ pub struct LowerCtx {
     pub(super) vow_block: Option<VowBlock>,
     pub(super) string_pool: Vec<String>,
     string_pool_index: HashMap<String, u32>,
-    func_index: HashMap<String, (FuncId, Ty)>,
+    func_index: HashMap<String, FuncSigInfo>,
     // struct name → field names in declaration order
     pub(super) struct_field_map: HashMap<String, Vec<String>>,
     // enum name → variant names in declaration order (index = tag)
@@ -188,7 +230,7 @@ impl LowerCtx {
         return_ty: Ty,
         effects: Vec<Effect>,
         file: String,
-        func_index: HashMap<String, (FuncId, Ty)>,
+        func_index: HashMap<String, FuncSigInfo>,
         struct_field_map: HashMap<String, Vec<String>>,
         enum_variant_map: HashMap<String, Vec<String>>,
         struct_field_type_names: HashMap<String, Vec<String>>,
@@ -901,18 +943,25 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 ExprKind::Ident(name) => name.clone(),
                 _ => todo!("non-ident callee in Call lowering"),
             };
-            let call_info = ctx.func_index.get(&callee_name).copied();
-            if let Some((fid, ret_ty)) = call_info {
+            let call_info = ctx.func_index.get(&callee_name).cloned();
+            if let Some(call_info) = call_info {
                 for &aid in &arg_ids {
                     ctx.mark_escaped(aid);
                 }
-                ctx.emit(
+                let result = ctx.emit(
                     Opcode::Call,
-                    ret_ty,
+                    call_info.ret_ty,
                     arg_ids,
-                    InstData::CallTarget(fid),
+                    InstData::CallTarget(call_info.id),
                     span,
-                )
+                );
+                if let Some(ret_tag) = call_info.ret_tag {
+                    ctx.inst_struct_type.insert(result, ret_tag);
+                }
+                if let Some(ret_vec_elem) = call_info.ret_vec_elem {
+                    ctx.inst_vec_elem_type.insert(result, ret_vec_elem);
+                }
+                result
             } else if let Some((sym, ret_ty)) = vow_debug_builtin_to_runtime(&callee_name) {
                 ctx.emit(
                     Opcode::DebugCall,
@@ -3125,7 +3174,7 @@ fn lower_block_inner(ctx: &mut LowerCtx, block: &Block) -> InstId {
 pub fn lower_function(
     fn_def: &FnDef,
     file: &str,
-    func_index: &HashMap<String, (FuncId, Ty)>,
+    func_index: &HashMap<String, FuncSigInfo>,
     struct_field_map: HashMap<String, Vec<String>>,
     enum_variant_map: HashMap<String, Vec<String>>,
     struct_field_type_names: HashMap<String, Vec<String>>,
@@ -3247,12 +3296,19 @@ pub fn lower_module(module: &AstModule, file: &str, string_exprs: &StringExprSet
         })
         .collect();
 
-    let func_index: HashMap<String, (FuncId, Ty)> = fn_items
+    let func_index: HashMap<String, FuncSigInfo> = fn_items
         .iter()
         .enumerate()
         .map(|(idx, fn_def)| {
-            let ret_ty = lower_ty(&fn_def.return_ty);
-            (fn_def.name.clone(), (FuncId(idx as u32), ret_ty))
+            (
+                fn_def.name.clone(),
+                FuncSigInfo {
+                    id: FuncId(idx as u32),
+                    ret_ty: lower_ty(&fn_def.return_ty),
+                    ret_tag: non_scalar_type_tag(&fn_def.return_ty),
+                    ret_vec_elem: vec_named_elem_type(&fn_def.return_ty),
+                },
+            )
         })
         .collect();
 
@@ -4188,6 +4244,124 @@ mod tests {
             &HashMap::new(),
         );
         func
+    }
+
+    #[test]
+    fn user_defined_call_results_keep_struct_tags_for_field_access() {
+        let body = Block {
+            stmts: vec![],
+            trailing_expr: Some(Box::new(Expr {
+                kind: ExprKind::FieldAccess {
+                    base: Box::new(Expr {
+                        kind: ExprKind::Call {
+                            callee: Box::new(ident_expr("make_pair")),
+                            args: vec![],
+                        },
+                        span: sp(),
+                    }),
+                    field: "a".to_string(),
+                },
+                span: sp(),
+            })),
+            span: sp(),
+        };
+        let fn_def = make_fn("caller", vec![], i64_ty(), body, vec![]);
+
+        let mut func_index = HashMap::new();
+        func_index.insert(
+            "make_pair".to_string(),
+            FuncSigInfo {
+                id: FuncId(0),
+                ret_ty: Ty::Ptr,
+                ret_tag: Some("Pair".to_string()),
+                ret_vec_elem: None,
+            },
+        );
+
+        let mut struct_field_map = HashMap::new();
+        struct_field_map.insert("Pair".to_string(), vec!["a".to_string(), "b".to_string()]);
+
+        let mut struct_field_type_names = HashMap::new();
+        struct_field_type_names.insert("Pair".to_string(), vec!["i64".to_string(), "i64".to_string()]);
+
+        let (func, _, warnings) = lower_function(
+            &fn_def,
+            "",
+            &func_index,
+            struct_field_map,
+            HashMap::new(),
+            struct_field_type_names,
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        assert!(warnings.is_empty(), "unexpected lowering warnings: {warnings:?}");
+
+        let field_get = func
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .find(|i| i.opcode == Opcode::FieldGet)
+            .expect("expected FieldGet");
+        assert_eq!(field_get.data, InstData::FieldIndex(0));
+    }
+
+    #[test]
+    fn user_defined_string_calls_do_not_assume_owned_heap_results() {
+        let body = Block {
+            stmts: vec![let_stmt(
+                "s",
+                Some(Type::Named {
+                    name: "String".to_string(),
+                    span: sp(),
+                }),
+                Expr {
+                    kind: ExprKind::Call {
+                        callee: Box::new(ident_expr("arena_str")),
+                        args: vec![],
+                    },
+                    span: sp(),
+                },
+            )],
+            trailing_expr: Some(Box::new(int_expr(0))),
+            span: sp(),
+        };
+        let fn_def = make_fn("f", vec![], i64_ty(), body, vec![]);
+
+        let mut func_index = HashMap::new();
+        func_index.insert(
+            "arena_str".to_string(),
+            FuncSigInfo {
+                id: FuncId(0),
+                ret_ty: Ty::Ptr,
+                ret_tag: Some("String".to_string()),
+                ret_vec_elem: None,
+            },
+        );
+
+        let (func, _, warnings) = lower_function(
+            &fn_def,
+            "",
+            &func_index,
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        assert!(warnings.is_empty(), "unexpected lowering warnings: {warnings:?}");
+
+        let has_string_free = func.blocks.iter().flat_map(|b| b.insts.iter()).any(|i| {
+            i.opcode == Opcode::Call
+                && i.data == InstData::CallExtern("__vow_string_free".to_string())
+        });
+        assert!(
+            !has_string_free,
+            "user-defined String calls may return aliases and must not be freed at the call site"
+        );
     }
 
     #[test]

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -956,10 +956,13 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     span,
                 );
                 // Record the return-type tag as metadata, but deliberately do not
-                // call `track_heap_alloc`: a user-defined helper may return an
-                // alias (e.g. arena-backed string) rather than a freshly-owned
-                // allocation, and freeing at the call site would invalidate
-                // still-live arena storage.
+                // call `track_heap_alloc`: without ownership annotations in the
+                // function signature we cannot distinguish an alias (e.g. an
+                // arena-backed string) from a freshly-owned allocation.  We
+                // conservatively omit the free, accepting that fresh-heap
+                // user-defined returns will leak until ownership is tracked,
+                // since the alternative would reintroduce use-after-free on
+                // aliased returns.
                 if let Some(ret_tag) = call_info.ret_tag {
                     ctx.inst_struct_type.insert(result, ret_tag);
                 }

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -150,6 +150,7 @@ fn non_scalar_type_tag(ast_ty: &AstType) -> Option<String> {
 fn vec_named_elem_type(ast_ty: &AstType) -> Option<String> {
     match ast_ty {
         AstType::Generic { name, args, .. } if name == "Vec" => match args.first() {
+            Some(AstType::Named { name, .. }) if name == "str" => Some("String".to_string()),
             Some(AstType::Named { name, .. })
                 if !matches!(
                     name.as_str(),

--- a/vow-ir/src/lower/vow.rs
+++ b/vow-ir/src/lower/vow.rs
@@ -196,7 +196,7 @@ fn expand_ptr_bindings(
     result
 }
 
-pub fn lower_requires(ctx: &mut LowerCtx, vow_block: &VowBlock) {
+pub(crate) fn lower_requires(ctx: &mut LowerCtx, vow_block: &VowBlock) {
     for clause in &vow_block.clauses {
         if let VowClause::Requires { span, .. } = clause {
             let desc = clause_description(clause);
@@ -215,7 +215,7 @@ pub fn lower_requires(ctx: &mut LowerCtx, vow_block: &VowBlock) {
     }
 }
 
-pub fn lower_param_refinements(ctx: &mut LowerCtx, params: &[Param]) {
+pub(crate) fn lower_param_refinements(ctx: &mut LowerCtx, params: &[Param]) {
     for param in params {
         if let Some(ref refinement) = param.refinement {
             let clause = VowClause::Requires {
@@ -242,7 +242,7 @@ pub fn lower_param_refinements(ctx: &mut LowerCtx, params: &[Param]) {
     }
 }
 
-pub fn lower_ensures(ctx: &mut LowerCtx, vow_block: &VowBlock, result_id: InstId) {
+pub(crate) fn lower_ensures(ctx: &mut LowerCtx, vow_block: &VowBlock, result_id: InstId) {
     ctx.push_scope();
     ctx.define("result".to_string(), result_id);
     for clause in &vow_block.clauses {
@@ -264,7 +264,7 @@ pub fn lower_ensures(ctx: &mut LowerCtx, vow_block: &VowBlock, result_id: InstId
     ctx.pop_scope();
 }
 
-pub fn lower_invariant(ctx: &mut LowerCtx, vow_block: &VowBlock) {
+pub(crate) fn lower_invariant(ctx: &mut LowerCtx, vow_block: &VowBlock) {
     for clause in &vow_block.clauses {
         if let VowClause::Invariant { span, .. } = clause {
             let desc = clause_description(clause);


### PR DESCRIPTION
## Summary

Fixes the ownership metadata used when lowering user-defined function calls that return heap-like values.

User-defined call results now keep enough return-type metadata for downstream field access and vector element typing, but are not automatically treated as freshly-owned heap allocations. This avoids freeing aliasing results such as arena-backed strings.

## Root cause

The lowerers preserved heap-like return tags too aggressively. A user-defined helper such as `arena_str()` could be treated as returning an owned `String`, even though it aliases parser arena storage. That made the lowering lifetime cleanup emit frees for values it did not own, producing invalid frees/use-after-free during bootstrap.

## Changes

- Add return metadata for user-defined calls in the Rust lowerer without marking returned values as owned.
- Mirror the return metadata handling in the self-hosted lowerer.
- Clone arena strings only where the lowerer needs owned type-name strings.
- Add Rust regression coverage for struct return tags and non-owned user-defined `String` results.

## Validation

- `cargo test --all`
- `build/vowc test compiler --timeout 30000`
