### PR TITLE
[codex] make bootstrap vmem cap opt-in

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -34,21 +34,25 @@ usage() {
     exit 0
 }
 
-run_stage_cmd() {
+run_logged() {
     local cmd="$1"
     local log
     log=$(mktemp)
-    local wrapped="$cmd"
-    if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
-        wrapped="ulimit -v $VMEM_LIMIT_KB; $cmd"
-    fi
-    if bash -lc "$wrapped" >"$log" 2>&1; then
+    if bash -c "$cmd" >"$log" 2>&1; then
         rm -f "$log"
         return 0
     fi
     cat "$log"
     rm -f "$log"
     return 1
+}
+
+run_stage_cmd() {
+    local cmd="$1"
+    if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
+        cmd="ulimit -v $VMEM_LIMIT_KB; $cmd"
+    fi
+    run_logged "$cmd"
 }
 
 for arg in "$@"; do
@@ -75,7 +79,7 @@ fi
 
 printf "${BOLD}Stage 1:${RESET} Rust compiler -> build/vowc\n"
 t0=$(date +%s)
-if ! run_stage_cmd "./target/release/vow build compiler/main.vow -o build/vowc"; then
+if ! run_logged "./target/release/vow build compiler/main.vow -o build/vowc"; then
     printf "  ${RED}FAILED${RESET}\n"
     exit 1
 fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,6 +10,7 @@ cd "$(dirname "$0")/.."
 mkdir -p build
 
 SKIP_CARGO=false
+VMEM_LIMIT_KB="${VOW_BOOTSTRAP_VMEM_KB:-0}"
 
 usage() {
     echo "Usage: $0 [--skip-cargo] [--help|-h]"
@@ -26,7 +27,28 @@ usage() {
     echo "Options:"
     echo "  --skip-cargo  Skip Stage 0 if Rust binary already built"
     echo "  -h, --help    Show this help"
+    echo ""
+    echo "Environment:"
+    echo "  VOW_BOOTSTRAP_VMEM_KB  Optional per-stage virtual-memory cap in KB for"
+    echo "                         self-hosted rebuilds (default: unlimited)"
     exit 0
+}
+
+run_stage_cmd() {
+    local cmd="$1"
+    local log
+    log=$(mktemp)
+    local wrapped="$cmd"
+    if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
+        wrapped="ulimit -v $VMEM_LIMIT_KB; $cmd"
+    fi
+    if bash -lc "$wrapped" >"$log" 2>&1; then
+        rm -f "$log"
+        return 0
+    fi
+    cat "$log"
+    rm -f "$log"
+    return 1
 }
 
 for arg in "$@"; do
@@ -53,8 +75,8 @@ fi
 
 printf "${BOLD}Stage 1:${RESET} Rust compiler -> build/vowc\n"
 t0=$(date +%s)
-if ! output=$(./target/release/vow build compiler/main.vow -o build/vowc 2>&1); then
-    printf "  ${RED}FAILED${RESET}\n%s\n" "$output"
+if ! run_stage_cmd "./target/release/vow build compiler/main.vow -o build/vowc"; then
+    printf "  ${RED}FAILED${RESET}\n"
     exit 1
 fi
 t1=$(date +%s)
@@ -64,8 +86,11 @@ printf "  done in %ds\n" $((t1 - t0))
 
 printf "${BOLD}Stage 2:${RESET} build/vowc -> build/vowc2\n"
 t0=$(date +%s)
-if ! output=$(ulimit -v 2000000; build/vowc build compiler/main.vow -o build/vowc2 2>&1); then
-    printf "  ${RED}FAILED${RESET}\n%s\n" "$output"
+if ! run_stage_cmd "build/vowc build compiler/main.vow -o build/vowc2"; then
+    printf "  ${RED}FAILED${RESET}\n"
+    if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
+        printf "  Hint: rerun with a higher VOW_BOOTSTRAP_VMEM_KB or unset it for no cap.\n"
+    fi
     exit 1
 fi
 t1=$(date +%s)
@@ -75,8 +100,11 @@ printf "  done in %ds\n" $((t1 - t0))
 
 printf "${BOLD}Stage 3:${RESET} build/vowc2 -> build/vowc3\n"
 t0=$(date +%s)
-if ! output=$(ulimit -v 2000000; build/vowc2 build compiler/main.vow -o build/vowc3 2>&1); then
-    printf "  ${RED}FAILED${RESET}\n%s\n" "$output"
+if ! run_stage_cmd "build/vowc2 build compiler/main.vow -o build/vowc3"; then
+    printf "  ${RED}FAILED${RESET}\n"
+    if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
+        printf "  Hint: rerun with a higher VOW_BOOTSTRAP_VMEM_KB or unset it for no cap.\n"
+    fi
     exit 1
 fi
 t1=$(date +%s)

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -11,6 +11,10 @@ mkdir -p build
 
 SKIP_CARGO=false
 VMEM_LIMIT_KB="${VOW_BOOTSTRAP_VMEM_KB:-0}"
+if ! [[ "$VMEM_LIMIT_KB" =~ ^[0-9]+$ ]]; then
+    echo "Error: VOW_BOOTSTRAP_VMEM_KB must be a non-negative integer (got: '$VMEM_LIMIT_KB')" >&2
+    exit 1
+fi
 
 usage() {
     echo "Usage: $0 [--skip-cargo] [--help|-h]"
@@ -36,15 +40,15 @@ usage() {
 
 run_logged() {
     local cmd="$1"
-    local log
-    log=$(mktemp)
-    if bash -c "$cmd" >"$log" 2>&1; then
-        rm -f "$log"
-        return 0
-    fi
-    cat "$log"
-    rm -f "$log"
-    return 1
+    (
+        log=$(mktemp)
+        trap 'rm -f "$log"' EXIT INT TERM HUP
+        if bash -c "$cmd" >"$log" 2>&1; then
+            exit 0
+        fi
+        cat "$log"
+        exit 1
+    )
 }
 
 run_stage_cmd() {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -50,7 +50,7 @@ run_logged() {
 run_stage_cmd() {
     local cmd="$1"
     if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
-        cmd="ulimit -v $VMEM_LIMIT_KB; $cmd"
+        cmd="ulimit -v $VMEM_LIMIT_KB && $cmd"
     fi
     run_logged "$cmd"
 }


### PR DESCRIPTION
## Summary

Makes the bootstrap script virtual-memory cap opt-in instead of hard-coded for self-hosted rebuild stages.

## Why

The old `ulimit -v 2000000` cap made Stage 2/3 failures look like compiler crashes even when the fixed self-hosted compiler simply exceeded the artificial cap. The cap is still useful for targeted reproduction, but it should not be the default bootstrap behavior.

## Changes

- Add `VOW_BOOTSTRAP_VMEM_KB` as an optional per-stage cap.
- Apply the cap consistently through a helper when it is set.
- Preserve command output on stage failure without buffering the whole command output in shell command substitution.
- Print a clearer hint when a stage fails under an explicit memory cap.

## Validation

- `bash -n scripts/bootstrap.sh`
- `scripts/bootstrap.sh --help`

Related to #174 and #180.
