### PR TITLE
fix: isolate alloc scope around RHS of short-circuit && / || (#184)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1040,9 +1040,17 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             br_args.push(lhs_id);
             lctx_emit(ctx, IOP_BRANCH(), ITY_UNIT(), br_args, IDATA_BRANCH_TARGETS(), then_target, else_target, String::from(""));
 
-            // RHS block: evaluate RHS, Upsilon, Jump to merge
+            // RHS block: evaluate RHS, free temporaries, Upsilon, Jump to merge.
+            // Allocs inside the RHS must be freed in rhs_block (before the
+            // jump) — if tracked in the outer scope, the short-circuit path
+            // would still emit frees for values that were never allocated,
+            // causing double-free / invalid free.
             lctx_switch_to_block(ctx, rhs_block);
+            lctx_push_alloc_scope(ctx);
             let rhs_id: i64 = lower_expr(ctx, rhs_eid);
+            let rhs_live_out: Vec<i64> = Vec::new();
+            rhs_live_out.push(rhs_id);
+            lctx_pop_alloc_scope_frees(ctx, rhs_live_out);
             let rhs_up_args: Vec<i64> = Vec::new();
             rhs_up_args.push(rhs_id);
             let rhs_up_id: i64 = lctx_emit(ctx, IOP_UPSILON(), ITY_UNIT(), rhs_up_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
@@ -1082,12 +1090,14 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let eq_id: i64 = lctx_emit(ctx, IOP_CALL(), ITY_BOOL(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_eq"));
             let lhs_tag: i64 = expr_tag(a, lhs_eid);
             if lhs_tag == EXPR_LIT_STR() {
+                lctx_mark_escaped(ctx, lhs_id);
                 let free_args: Vec<i64> = Vec::new();
                 free_args.push(lhs_id);
                 lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_free"));
             }
             let rhs_tag: i64 = expr_tag(a, rhs_eid);
             if rhs_tag == EXPR_LIT_STR() {
+                lctx_mark_escaped(ctx, rhs_id);
                 let free_args: Vec<i64> = Vec::new();
                 free_args.push(rhs_id);
                 lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_free"));

--- a/tests/run/short_circuit_string_alloc.vow
+++ b/tests/run/short_circuit_string_alloc.vow
@@ -1,0 +1,43 @@
+// TEST: stdout "ok"
+// Regression test for #184: short-circuit && / || must isolate alloc scope
+// for the RHS. Without the isolation, a short-circuited RHS would free an
+// uninitialized String handle on the merge path, causing invalid-free /
+// double-free crashes.
+module ShortCircuitStringAlloc
+
+fn classify(tn: String) -> i64 {
+    // `||` where RHS allocates a String via String::from.
+    if tn == String::from("String") || tn == String::from("str") {
+        return 0;
+    }
+    // `&&` where RHS allocates a String via String::from.
+    if tn == String::from("i64") && String::from("i64") == tn {
+        return 1;
+    }
+    // `||` with a direct string literal on RHS (tracked alloc + manual free).
+    if tn == String::from("f64") || tn == "f64" {
+        return 3;
+    }
+    2
+}
+
+fn main() -> i32 [io] {
+    let tags: Vec<String> = Vec::new();
+    tags.push(String::from("i64"));
+    tags.push(String::from("String"));
+    tags.push(String::from("other"));
+
+    let mut i: i64 = 0;
+    let mut sum: i64 = 0;
+    while i < tags.len() {
+        sum = sum + classify(tags[i]);
+        i = i + 1;
+    }
+
+    if sum == 3 {
+        print_str(String::from("ok"));
+    } else {
+        print_str(String::from("fail"));
+    }
+    0
+}

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -785,11 +785,15 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     span,
                 );
 
-                // RHS block: evaluate RHS, feed into Phi
+                // RHS block: evaluate RHS, free temporaries, feed into Phi.
+                // Allocs inside the RHS must be freed in rhs_block (before the
+                // jump) — if they were tracked in the outer scope, the short-
+                // circuit path would still emit frees for values that were
+                // never allocated, causing double-free / invalid free.
                 ctx.switch_to_block(rhs_block);
                 ctx.push_alloc_scope();
                 let rhs_id = lower_expr(ctx, rhs);
-                ctx.alloc_scopes.pop();
+                ctx.pop_alloc_scope_frees(&[rhs_id], span);
                 let rhs_upsilon = ctx.emit(
                     Opcode::Upsilon,
                     Ty::Unit,


### PR DESCRIPTION
## Summary

- Fixes Stage 3 self-hosted bootstrap crash (`free(): invalid pointer`) reported in #184.
- `compiler/lower.vow` and `vow-ir/src/lower/mod.rs`: wrap RHS lowering of `&&`/`||` in a dedicated alloc scope so RHS-local String/Vec/HashMap temporaries are freed in `rhs_block` (only when RHS actually runs), not in the outer scope where the short-circuit path would free unallocated memory.
- `compiler/lower.vow`: mark literal operands escaped before the manual `__vow_string_free` in the string-equality path, mirroring `vow-ir::lower::emit_string_free`, so the outer scope pass does not double-free them.
- Adds `tests/run/short_circuit_string_alloc.vow` covering `||` + allocating RHS, `&&` + allocating RHS, and `||` with a literal-string RHS.

## Test plan

- [x] Reproduced crash on clean `main` (HEAD `4c65504`) via the issue reproducer.
- [x] After fix: Stage 1→2→3→4 bootstrap (`--no-verify`) yields `sha256(vowc2) == sha256(vowc3) == sha256(vowc4)` — byte-identical self-hosted fixed point.
- [x] `cargo test --all` passes (0 failures).
- [x] `cargo clippy --all -- -D warnings`, `cargo fmt --all --check` clean.
- [x] `tests/run_tests.sh --no-bootstrap --no-verify`: 70 passed, 1 pre-existing failure (`bitwise_ops`, unrelated parse issue on `main`), 1 skipped.
- [x] Regression test runs and prints `ok`.
- [ ] `scripts/bootstrap.sh` end-to-end (blocked by the orthogonal `keyword_bool_val` ESBMC verification issue, as the report itself notes).