### PR TITLE
fix: accept i64-sized literals in bitwise/shift ops (#185)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -608,7 +608,7 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
                 env_emit_error(e, String::from("bitwise operator requires integer operands"), expr_span(a, eid));
                 return CTY_I64();
             }
-            // Prevents i64 variables from accidentally coercing — only unsuffixed literals carry EXPR_LIT_INT.
+            // CTY_I64 + EXPR_LIT_INT together identify an unsuffixed literal: variables/calls have a non-LIT_INT tag, and u64-suffixed literals have CTY_U64 type.
             let lhs_tag: i64 = expr_tag(a, lhs_eid);
             let rhs_tag: i64 = expr_tag(a, rhs_eid);
             if lhs_tid == CTY_I64() && lhs_tag == EXPR_LIT_INT() {

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -608,6 +608,18 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
                 env_emit_error(e, String::from("bitwise operator requires integer operands"), expr_span(a, eid));
                 return CTY_I64();
             }
+            // Unsuffixed integer literals are typed as CTY_I64; coerce to the
+            // other operand's integer type so `y: u64 << 3` type-checks.
+            // Matches the Rust checker's I32-to-integer coercion (Rust uses
+            // Ty::I32 as its bare-literal marker; self-hosted uses CTY_I64).
+            let lhs_tag: i64 = expr_tag(a, lhs_eid);
+            let rhs_tag: i64 = expr_tag(a, rhs_eid);
+            if lhs_tid == CTY_I64() && lhs_tag == EXPR_LIT_INT() && ty_is_integer(e.ts, rhs_tid) {
+                return rhs_tid;
+            }
+            if rhs_tid == CTY_I64() && rhs_tag == EXPR_LIT_INT() && ty_is_integer(e.ts, lhs_tid) {
+                return lhs_tid;
+            }
             if lhs_tid != rhs_tid {
                 env_emit_error(e, String::from("bitwise operator requires matching integer types"), expr_span(a, eid));
                 return CTY_I64();

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -612,10 +612,10 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
             // so `u64 << 3` coerces while `i64_var op u64_var` still errors.
             let lhs_tag: i64 = expr_tag(a, lhs_eid);
             let rhs_tag: i64 = expr_tag(a, rhs_eid);
-            if lhs_tid == CTY_I64() && lhs_tag == EXPR_LIT_INT() && ty_is_integer(e.ts, rhs_tid) {
+            if lhs_tid == CTY_I64() && lhs_tag == EXPR_LIT_INT() {
                 return rhs_tid;
             }
-            if rhs_tid == CTY_I64() && rhs_tag == EXPR_LIT_INT() && ty_is_integer(e.ts, lhs_tid) {
+            if rhs_tid == CTY_I64() && rhs_tag == EXPR_LIT_INT() {
                 return lhs_tid;
             }
             if lhs_tid != rhs_tid {

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -608,10 +608,8 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
                 env_emit_error(e, String::from("bitwise operator requires integer operands"), expr_span(a, eid));
                 return CTY_I64();
             }
-            // Unsuffixed integer literals are typed as CTY_I64; coerce to the
-            // other operand's integer type so `y: u64 << 3` type-checks.
-            // Matches the Rust checker's I32-to-integer coercion (Rust uses
-            // Ty::I32 as its bare-literal marker; self-hosted uses CTY_I64).
+            // EXPR_LIT_INT gate disambiguates unsuffixed literals from i64 vars,
+            // so `u64 << 3` coerces while `i64_var op u64_var` still errors.
             let lhs_tag: i64 = expr_tag(a, lhs_eid);
             let rhs_tag: i64 = expr_tag(a, rhs_eid);
             if lhs_tid == CTY_I64() && lhs_tag == EXPR_LIT_INT() && ty_is_integer(e.ts, rhs_tid) {

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -608,8 +608,7 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
                 env_emit_error(e, String::from("bitwise operator requires integer operands"), expr_span(a, eid));
                 return CTY_I64();
             }
-            // EXPR_LIT_INT gate disambiguates unsuffixed literals from i64 vars,
-            // so `u64 << 3` coerces while `i64_var op u64_var` still errors.
+            // Prevents i64 variables from accidentally coercing — only unsuffixed literals carry EXPR_LIT_INT.
             let lhs_tag: i64 = expr_tag(a, lhs_eid);
             let rhs_tag: i64 = expr_tag(a, rhs_eid);
             if lhs_tid == CTY_I64() && lhs_tag == EXPR_LIT_INT() {

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -2163,7 +2163,7 @@ fn skill_full() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("Bitwise operators require integer operands of the same type. Shift expressions return the left operand's type. `>>` is arithmetic for `i64` and logical for `u64`.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator, so `x: i64 << 5` and `y: u64 << 3` both type-check. This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`5u64`) to force the `u64` type.\n"));
+    r.push_str(String::from("Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator. For example, given `let x: u64 = ...`, the expressions `x << 3` and `3 & x` both type-check (the literal coerces to `u64`). This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`3u64`) to force the `u64` type explicitly.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Logical Operators\n"));
     r.push_str(String::from("\n"));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -990,7 +990,7 @@ fn skill_json() -> String {
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--max-k-step <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC max k-induction step (default: 50)\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("          \"long\": \"--max-k-step\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
@@ -1095,7 +1095,7 @@ fn skill_json() -> String {
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--max-k-step <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC max k-induction step (default: 50)\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("          \"long\": \"--max-k-step\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
@@ -1221,7 +1221,7 @@ fn skill_json() -> String {
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--max-k-step <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC max k-induction step (with --verify)\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC incremental BMC max iterations (with --verify)\",\n"));
     r.push_str(String::from("          \"long\": \"--max-k-step\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
@@ -1319,7 +1319,7 @@ fn skill_json() -> String {
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--max-k-step <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC max k-induction step (default: 50)\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("          \"long\": \"--max-k-step\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
@@ -1394,7 +1394,7 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--dump-ir\": \"Print IR text to stdout and exit (no JSON output, no codegen)\",\n"));
     r.push_str(String::from("    \"--debug-trace <off|calls|full>\": \"Emit JSON trace lines to stderr at runtime (default: off)\",\n"));
     r.push_str(String::from("    \"--no-cache\": \"Disable compile and verify caching\",\n"));
-    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (default: 50)\",\n"));
+    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
     r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds (default: (none))\",\n"));
@@ -1404,7 +1404,7 @@ fn skill_json() -> String {
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"verify_options\": {\n"));
     r.push_str(String::from("    \"--no-cache\": \"Disable verification result caching\",\n"));
-    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (default: 50)\",\n"));
+    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
     r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds (default: (none))\",\n"));
@@ -1417,7 +1417,7 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--filter <pat>\": \"Only run tests whose name contains pat (default: (none))\",\n"));
     r.push_str(String::from("    \"--mode <debug|release>\": \"Build mode; debug inserts runtime vow checks (default: (default))\",\n"));
     r.push_str(String::from("    \"--timeout <ms>\": \"Per-test execution timeout in milliseconds (default: 30000)\",\n"));
-    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (with --verify)\",\n"));
+    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (with --verify)\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
     r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
     r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
@@ -1428,7 +1428,7 @@ fn skill_json() -> String {
     r.push_str(String::from("  \"contracts_options\": {\n"));
     r.push_str(String::from("    \"--verify\": \"Run ESBMC verification and report per-contract status\",\n"));
     r.push_str(String::from("    \"--no-cache\": \"Disable verification result caching\",\n"));
-    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC max k-induction step (default: 50)\",\n"));
+    r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver (with --verify)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode (with --verify); ir requires z3 (default: auto)\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
@@ -1778,7 +1778,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)\n"));
     r.push_str(String::from("  --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)\n"));
     r.push_str(String::from("  --no-cache              Disable compile and verify caching\n"));
-    r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (default: 50)\n"));
+    r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
     r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds (default: (none))\n"));
@@ -1788,7 +1788,7 @@ fn skill_human() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("VERIFY OPTIONS\n"));
     r.push_str(String::from("  --no-cache              Disable verification result caching\n"));
-    r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (default: 50)\n"));
+    r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
     r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds (default: (none))\n"));
@@ -1801,7 +1801,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --filter <pat>          Only run tests whose name contains pat (default: (none))\n"));
     r.push_str(String::from("  --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: (default))\n"));
     r.push_str(String::from("  --timeout <ms>          Per-test execution timeout in milliseconds (default: 30000)\n"));
-    r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (with --verify)\n"));
+    r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (with --verify)\n"));
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
     r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
     r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
@@ -1809,7 +1809,7 @@ fn skill_human() -> String {
     r.push_str(String::from("CONTRACTS OPTIONS\n"));
     r.push_str(String::from("  --verify                Run ESBMC verification and report per-contract status\n"));
     r.push_str(String::from("  --no-cache              Disable verification result caching\n"));
-    r.push_str(String::from("  --max-k-step <N>        ESBMC max k-induction step (default: 50)\n"));
+    r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver (with --verify)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode (with --verify); ir requires z3 (default: auto)\n"));
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
@@ -1867,12 +1867,12 @@ fn skill_human() -> String {
     r.push_str(String::from("            HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap\n"));
     r.push_str(String::from("OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("VERIFICATION\n"));
-    r.push_str(String::from("  Strategy      : k-induction-parallel (incremental BMC + k-induction)\n"));
-    r.push_str(String::from("  Max k step    : 50 (default; override with --max-k-step)\n"));
-    r.push_str(String::from("  Vec<T>        : 128 max capacity (override with --vec-max)\n"));
-    r.push_str(String::from("  String        : 256 max capacity (override with --string-max)\n"));
-    r.push_str(String::from("  HashMap<K, V> : 64 max capacity (override with --hashmap-max)\n"));
+    r.push_str(String::from("VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max)\n"));
+    r.push_str(String::from("  Strategy        : k-induction-parallel (incremental BMC + k-induction)\n"));
+    r.push_str(String::from("  Max k step      : 50 max iterations (--max-k-step)\n"));
+    r.push_str(String::from("  Vec<T>          : 128 max capacity\n"));
+    r.push_str(String::from("  String          : 256 max capacity\n"));
+    r.push_str(String::from("  HashMap<K, V>   : 64 max capacity\n"));
     r
 }
 // GENERATE:SKILL_HUMAN:END
@@ -2162,6 +2162,8 @@ fn skill_full() -> String {
     r.push_str(String::from("| `>>`     | Right shift  |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("Bitwise operators require integer operands of the same type. Shift expressions return the left operand's type. `>>` is arithmetic for `i64` and logical for `u64`.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator, so `x: i64 << 5` and `y: u64 << 3` both type-check. This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`5u64`) to force the `u64` type.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Logical Operators\n"));
     r.push_str(String::from("\n"));
@@ -2746,7 +2748,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |\n"));
     r.push_str(String::from("| `--debug-trace <off\\|calls\\|full>` | `off` | Emit JSON trace lines to stderr at runtime |\n"));
     r.push_str(String::from("| `--no-cache`    | (off)       | Disable compile and verify caching           |\n"));
-    r.push_str(String::from("| `--max-k-step <N>` | `50`     | ESBMC max k-induction step                   |\n"));
+    r.push_str(String::from("| `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
     r.push_str(String::from("| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |\n"));
@@ -2767,7 +2769,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| Flag              | Default     | Description                                |\n"));
     r.push_str(String::from("|-------------------|-------------|--------------------------------------------|\n"));
     r.push_str(String::from("| `--no-cache`      | (off)       | Disable verification result caching        |\n"));
-    r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |\n"));
+    r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
     r.push_str(String::from("| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |\n"));
@@ -2789,7 +2791,7 @@ fn skill_full() -> String {
     r.push_str(String::from("|-------------------|-------------|--------------------------------------------|\n"));
     r.push_str(String::from("| `--verify`        | (off)       | Run ESBMC verification and report per-contract status |\n"));
     r.push_str(String::from("| `--no-cache`      | (off)       | Disable verification result caching        |\n"));
-    r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |\n"));
+    r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |\n"));
     r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
@@ -2828,7 +2830,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--mode debug`    | (default)   | Insert runtime vow checks                 |\n"));
     r.push_str(String::from("| `--mode release`  | `debug`     | Omit all vow checks for performance       |\n"));
     r.push_str(String::from("| `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |\n"));
-    r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC max k-induction step (with --verify) |\n"));
+    r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations (with --verify) |\n"));
     r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
     r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
     r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
@@ -3194,15 +3196,21 @@ fn skill_full() -> String {
     r.push_str(String::from("### ESBMC Configuration\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("- Verification strategy: **k-induction-parallel** (incremental BMC + k-induction proof)\n"));
-    r.push_str(String::from("- Max k-induction step: **50** (default; override with `--max-k-step`)\n"));
+    r.push_str(String::from("- Incremental BMC with `--max-k-step` (default: **50**) -- loops are verified incrementally up to N iterations\n"));
     r.push_str(String::from("- Architecture: 64-bit\n"));
     r.push_str(String::from("- Array bounds / pointer checks disabled (Vow handles these in its own model)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Collection Models for Verification\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("Collections (`Vec<T>`, `String`, `HashMap<K, V>`) are modeled with unbounded, dynamically allocated storage -- the same semantics as at runtime. There are no artificial capacity limits in the verification model. ESBMC reasons about container operations using k-induction to prove properties for all iterations.\n"));
+    r.push_str(String::from("ESBMC uses bounded models for collection types. Defaults are shown below; override with `--vec-max`, `--string-max`, `--hashmap-max`:\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("`String::from` produces a nondeterministic non-negative length in verification.\n"));
+    r.push_str(String::from("| Type              | Default Max Capacity | CLI Flag | Supported Operations |\n"));
+    r.push_str(String::from("|-------------------|---------------------|----------|----------------------------------------------|\n"));
+    r.push_str(String::from("| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |\n"));
+    r.push_str(String::from("| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `byte_at`        |\n"));
+    r.push_str(String::from("| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("These support the same operations as the runtime but with bounded storage. `String::from` produces a nondeterministic length (0 to max-1) in verification.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Blame Model\n"));
     r.push_str(String::from("\n"));
@@ -3408,7 +3416,7 @@ fn skill_full() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Unbound Loop Iterations\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("Without a bound on loop iterations, ESBMC may timeout (max-k-step is 50):\n"));
+    r.push_str(String::from("Without a bound on loop iterations, ESBMC may timeout (default max-k-step is 50):\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("```vow\n"));
     r.push_str(String::from("fn fill(n: i64) -> Vec<i64> vow {\n"));
@@ -3668,6 +3676,23 @@ fn skill_full() -> String {
     r.push_str(String::from("**Output:** `extern block requires a vow contract`\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("**Fix:** Add a `vow { ... }` block to the extern declaration with `requires` and/or `ensures` clauses.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("### ContractTypeMismatch\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Phase:** Type Checker\n"));
+    r.push_str(String::from("**Meaning:** A `requires`, `ensures`, or `invariant` clause expression does not have type `bool`.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("```vow\n"));
+    r.push_str(String::from("fn add(a: i64, b: i64) -> i64 vow {\n"));
+    r.push_str(String::from("    requires: a + b\n"));
+    r.push_str(String::from("} {\n"));
+    r.push_str(String::from("    a + b\n"));
+    r.push_str(String::from("}\n"));
+    r.push_str(String::from("```\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Output:** `` `requires` clause has type `i64` but must be `bool` ``\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Fix:** Ensure every contract clause is a boolean expression (comparison, logical operator, or a call to a predicate function returning `bool`).\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### VowRequiresViolated\n"));
     r.push_str(String::from("\n"));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -1869,7 +1869,7 @@ fn skill_human() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max)\n"));
     r.push_str(String::from("  Strategy        : k-induction-parallel (incremental BMC + k-induction)\n"));
-    r.push_str(String::from("  Max k step      : 50 max iterations (--max-k-step)\n"));
+    r.push_str(String::from("  Incremental BMC : 50 max iterations (--max-k-step)\n"));
     r.push_str(String::from("  Vec<T>          : 128 max capacity\n"));
     r.push_str(String::from("  String          : 256 max capacity\n"));
     r.push_str(String::from("  HashMap<K, V>   : 64 max capacity\n"));

--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -517,11 +517,15 @@ fn parse_expr(p: Parser) -> i64 {
 }
 
 fn is_shift_left_op(p: Parser) -> bool {
-    at(p, tok_lt()) && peek_offset(p, 1).tag == tok_lt()
+    let is_lt: bool = at(p, tok_lt());
+    let t: Token = peek_offset(p, 1);
+    is_lt && t.tag == tok_lt()
 }
 
 fn is_shift_right_op(p: Parser) -> bool {
-    at(p, tok_gt()) && peek_offset(p, 1).tag == tok_gt()
+    let is_gt: bool = at(p, tok_gt());
+    let t: Token = peek_offset(p, 1);
+    is_gt && t.tag == tok_gt()
 }
 
 fn current_binop_prec(p: Parser) -> i64 {

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -225,6 +225,8 @@ Checked operators abort with `ArithmeticOverflow` on overflow.
 
 Bitwise operators require integer operands of the same type. Shift expressions return the left operand's type. `>>` is arithmetic for `i64` and logical for `u64`.
 
+Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator, so `x: i64 << 5` and `y: u64 << 3` both type-check. This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`5u64`) to force the `u64` type.
+
 ### Logical Operators
 
 | Operator | Meaning    |

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -225,7 +225,7 @@ Checked operators abort with `ArithmeticOverflow` on overflow.
 
 Bitwise operators require integer operands of the same type. Shift expressions return the left operand's type. `>>` is arithmetic for `i64` and logical for `u64`.
 
-Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator, so `x: i64 << 5` and `y: u64 << 3` both type-check. This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`5u64`) to force the `u64` type.
+Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator. For example, given `let x: u64 = ...`, the expressions `x << 3` and `3 & x` both type-check (the literal coerces to `u64`). This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`3u64`) to force the `u64` type explicitly.
 
 ### Logical Operators
 

--- a/scripts/generate_help.py
+++ b/scripts/generate_help.py
@@ -732,7 +732,7 @@ def build_help_human(data: dict) -> str:
     if vdefaults:
         lines.append("VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max)")
         lines.append(f"  Strategy        : {vdefaults.get('strategy', 'k-induction-parallel')} (incremental BMC + k-induction)")
-        lines.append(f"  Max k step      : {vdefaults.get('max_k_step', DEFAULT_MAX_K_STEP)} max iterations (--max-k-step)")
+        lines.append(f"  Incremental BMC : {vdefaults.get('max_k_step', DEFAULT_MAX_K_STEP)} max iterations (--max-k-step)")
         lines.append(f"  Vec<T>          : {vdefaults.get('vec_max', 128)} max capacity")
         lines.append(f"  String          : {vdefaults.get('string_max', 256)} max capacity")
         lines.append(f"  HashMap<K, V>   : {vdefaults.get('hashmap_max', 64)} max capacity")

--- a/tests/run/bitwise_ops.vow
+++ b/tests/run/bitwise_ops.vow
@@ -1,4 +1,4 @@
-// TEST: stdout "6 & 3 = 2\n6 | 3 = 7\n1 << 5 = 32\n-8 >> 1 = -4\n8u64 >> 1u64 = 4\n6u64 & 3u64 = 2\n6u64 | 3u64 = 7\n1u64 << 5u64 = 32\nux << 3 = 64\nux >> 1 = 4\n3 & ux = 0\n"
+// TEST: stdout "6 & 3 = 2\n6 | 3 = 7\n1 << 5 = 32\n-8 >> 1 = -4\n8u64 >> 1u64 = 4\n6u64 & 3u64 = 2\n6u64 | 3u64 = 7\n1u64 << 5u64 = 32\nux << 3 = 64\nux >> 1 = 4\n3 & ux = 0\nux | 3 = 11\nux ^ 3 = 11\n3 << ux = 768\n"
 module BitwiseOps
 
 fn main() [io] {
@@ -51,5 +51,17 @@ fn main() [io] {
 
     print_str(String::from("3 & ux = "));
     print_u64(3 & ux);
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux | 3 = "));
+    print_u64(ux | 3);
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux ^ 3 = "));
+    print_u64(ux ^ 3);
+    print_str(String::from("\n"));
+
+    print_str(String::from("3 << ux = "));
+    print_u64(3 << ux);
     print_str(String::from("\n"));
 }

--- a/tests/run/bitwise_ops.vow
+++ b/tests/run/bitwise_ops.vow
@@ -1,4 +1,4 @@
-// TEST: stdout "6 & 3 = 2\n6 | 3 = 7\n1 << 5 = 32\n-8 >> 1 = -4\n8u64 >> 1u64 = 4\n6u64 & 3u64 = 2\n6u64 | 3u64 = 7\n1u64 << 5u64 = 32\n"
+// TEST: stdout "6 & 3 = 2\n6 | 3 = 7\n1 << 5 = 32\n-8 >> 1 = -4\n8u64 >> 1u64 = 4\n6u64 & 3u64 = 2\n6u64 | 3u64 = 7\n1u64 << 5u64 = 32\nux << 3 = 64\nux >> 1 = 4\n"
 module BitwiseOps
 
 fn main() [io] {
@@ -39,5 +39,13 @@ fn main() [io] {
 
     print_str(String::from("1u64 << 5u64 = "));
     print_u64(1u64 << 5u64);
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux << 3 = "));
+    print_u64(ux << 3);
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux >> 1 = "));
+    print_u64(ux >> 1);
     print_str(String::from("\n"));
 }

--- a/tests/run/bitwise_ops.vow
+++ b/tests/run/bitwise_ops.vow
@@ -1,4 +1,4 @@
-// TEST: stdout "6 & 3 = 2\n6 | 3 = 7\n1 << 5 = 32\n-8 >> 1 = -4\n8u64 >> 1u64 = 4\n6u64 & 3u64 = 2\n6u64 | 3u64 = 7\n1u64 << 5u64 = 32\nux << 3 = 64\nux >> 1 = 4\n"
+// TEST: stdout "6 & 3 = 2\n6 | 3 = 7\n1 << 5 = 32\n-8 >> 1 = -4\n8u64 >> 1u64 = 4\n6u64 & 3u64 = 2\n6u64 | 3u64 = 7\n1u64 << 5u64 = 32\nux << 3 = 64\nux >> 1 = 4\n3 & ux = 0\n"
 module BitwiseOps
 
 fn main() [io] {
@@ -47,5 +47,9 @@ fn main() [io] {
 
     print_str(String::from("ux >> 1 = "));
     print_u64(ux >> 1);
+    print_str(String::from("\n"));
+
+    print_str(String::from("3 & ux = "));
+    print_u64(3 & ux);
     print_str(String::from("\n"));
 }

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -1515,6 +1515,13 @@ impl<'e> Checker<'e> {
         if rhs == Ty::Never {
             return lhs;
         }
+        let (lhs, rhs) = if lhs == Ty::I32 && rhs.is_integer() {
+            (rhs.clone(), rhs)
+        } else if rhs == Ty::I32 && lhs.is_integer() {
+            (lhs.clone(), lhs)
+        } else {
+            (lhs, rhs)
+        };
         if !lhs.is_integer() {
             self.emit_error_with_hints(
                 ErrorCode::TypeMismatch,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1294,7 +1294,7 @@ OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   &
 
 VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max)
   Strategy        : k-induction-parallel (incremental BMC + k-induction)
-  Max k step      : 50 max iterations (--max-k-step)
+  Incremental BMC : 50 max iterations (--max-k-step)
   Vec<T>          : 128 max capacity
   String          : 256 max capacity
   HashMap<K, V>   : 64 max capacity"##

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -415,35 +415,11 @@ fn skill_json() -> String {
         },
         {
           "form": "--max-k-step <N>",
-          "description": "ESBMC max k-induction step (default: 50)",
+          "description": "ESBMC incremental BMC max iterations (default: 50)",
           "long": "--max-k-step",
           "value_name": "N",
           "value_kind": "integer",
           "default": 50
-        },
-        {
-          "form": "--vec-max <N>",
-          "description": "Max Vec capacity for verification model (default: 128)",
-          "long": "--vec-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 128
-        },
-        {
-          "form": "--string-max <N>",
-          "description": "Max String capacity for verification model (default: 256)",
-          "long": "--string-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 256
-        },
-        {
-          "form": "--hashmap-max <N>",
-          "description": "Max HashMap capacity for verification model (default: 64)",
-          "long": "--hashmap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
         },
         {
           "form": "--solver <boolector|z3|bitwuzla|auto>",
@@ -479,6 +455,30 @@ fn skill_json() -> String {
           "value_name": "N",
           "value_kind": "integer",
           "default": "(none)"
+        },
+        {
+          "form": "--vec-max <N>",
+          "description": "Max Vec capacity for verification model (default: 128)",
+          "long": "--vec-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 128
+        },
+        {
+          "form": "--string-max <N>",
+          "description": "Max String capacity for verification model (default: 256)",
+          "long": "--string-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 256
+        },
+        {
+          "form": "--hashmap-max <N>",
+          "description": "Max HashMap capacity for verification model (default: 64)",
+          "long": "--hashmap-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 64
         }
       ],
       "stdout": {
@@ -520,35 +520,11 @@ fn skill_json() -> String {
         },
         {
           "form": "--max-k-step <N>",
-          "description": "ESBMC max k-induction step (default: 50)",
+          "description": "ESBMC incremental BMC max iterations (default: 50)",
           "long": "--max-k-step",
           "value_name": "N",
           "value_kind": "integer",
           "default": 50
-        },
-        {
-          "form": "--vec-max <N>",
-          "description": "Max Vec capacity for verification model (default: 128)",
-          "long": "--vec-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 128
-        },
-        {
-          "form": "--string-max <N>",
-          "description": "Max String capacity for verification model (default: 256)",
-          "long": "--string-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 256
-        },
-        {
-          "form": "--hashmap-max <N>",
-          "description": "Max HashMap capacity for verification model (default: 64)",
-          "long": "--hashmap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
         },
         {
           "form": "--solver <boolector|z3|bitwuzla|auto>",
@@ -584,6 +560,30 @@ fn skill_json() -> String {
           "value_name": "N",
           "value_kind": "integer",
           "default": "(none)"
+        },
+        {
+          "form": "--vec-max <N>",
+          "description": "Max Vec capacity for verification model (default: 128)",
+          "long": "--vec-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 128
+        },
+        {
+          "form": "--string-max <N>",
+          "description": "Max String capacity for verification model (default: 256)",
+          "long": "--string-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 256
+        },
+        {
+          "form": "--hashmap-max <N>",
+          "description": "Max HashMap capacity for verification model (default: 64)",
+          "long": "--hashmap-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 64
         }
       ],
       "stdout": {
@@ -646,7 +646,7 @@ fn skill_json() -> String {
         },
         {
           "form": "--max-k-step <N>",
-          "description": "ESBMC max k-induction step (with --verify)",
+          "description": "ESBMC incremental BMC max iterations (with --verify)",
           "long": "--max-k-step",
           "value_name": "N",
           "value_kind": "integer",
@@ -744,35 +744,11 @@ fn skill_json() -> String {
         },
         {
           "form": "--max-k-step <N>",
-          "description": "ESBMC max k-induction step (default: 50)",
+          "description": "ESBMC incremental BMC max iterations (default: 50)",
           "long": "--max-k-step",
           "value_name": "N",
           "value_kind": "integer",
           "default": 50
-        },
-        {
-          "form": "--vec-max <N>",
-          "description": "Max Vec capacity for verification model (default: 128)",
-          "long": "--vec-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 128
-        },
-        {
-          "form": "--string-max <N>",
-          "description": "Max String capacity for verification model (default: 256)",
-          "long": "--string-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 256
-        },
-        {
-          "form": "--hashmap-max <N>",
-          "description": "Max HashMap capacity for verification model (default: 64)",
-          "long": "--hashmap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
         },
         {
           "form": "--solver <boolector|z3|bitwuzla|auto>",
@@ -800,6 +776,30 @@ fn skill_json() -> String {
             "auto"
           ],
           "default": "auto"
+        },
+        {
+          "form": "--vec-max <N>",
+          "description": "Max Vec capacity for verification model (default: 128)",
+          "long": "--vec-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 128
+        },
+        {
+          "form": "--string-max <N>",
+          "description": "Max String capacity for verification model (default: 256)",
+          "long": "--string-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 256
+        },
+        {
+          "form": "--hashmap-max <N>",
+          "description": "Max HashMap capacity for verification model (default: 64)",
+          "long": "--hashmap-max",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": 64
         }
       ],
       "stdout": {
@@ -819,30 +819,30 @@ fn skill_json() -> String {
     "--dump-ir": "Print IR text to stdout and exit (no JSON output, no codegen)",
     "--debug-trace <off|calls|full>": "Emit JSON trace lines to stderr at runtime (default: off)",
     "--no-cache": "Disable compile and verify caching",
-    "--max-k-step <N>": "ESBMC max k-induction step (default: 50)",
-    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
-    "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
+    "--max-k-step <N>": "ESBMC incremental BMC max iterations (default: 50)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
-    "--timeout <N>": "ESBMC per-function timeout in seconds (default: (none))"
+    "--timeout <N>": "ESBMC per-function timeout in seconds (default: (none))",
+    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
+    "--string-max <N>": "Max String capacity for verification model (default: 256)",
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
   },
   "verify_options": {
     "--no-cache": "Disable verification result caching",
-    "--max-k-step <N>": "ESBMC max k-induction step (default: 50)",
-    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
-    "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
+    "--max-k-step <N>": "ESBMC incremental BMC max iterations (default: 50)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
-    "--timeout <N>": "ESBMC per-function timeout in seconds (default: (none))"
+    "--timeout <N>": "ESBMC per-function timeout in seconds (default: (none))",
+    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
+    "--string-max <N>": "Max String capacity for verification model (default: 256)",
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
   },
   "test_options": {
     "--verify": "Run ESBMC verification on test files",
     "--filter <pat>": "Only run tests whose name contains pat (default: (none))",
     "--mode <debug|release>": "Build mode; debug inserts runtime vow checks (default: (default))",
     "--timeout <ms>": "Per-test execution timeout in milliseconds (default: 30000)",
-    "--max-k-step <N>": "ESBMC max k-induction step (with --verify)",
+    "--max-k-step <N>": "ESBMC incremental BMC max iterations (with --verify)",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
     "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
@@ -853,12 +853,12 @@ fn skill_json() -> String {
   "contracts_options": {
     "--verify": "Run ESBMC verification and report per-contract status",
     "--no-cache": "Disable verification result caching",
-    "--max-k-step <N>": "ESBMC max k-induction step (default: 50)",
+    "--max-k-step <N>": "ESBMC incremental BMC max iterations (default: 50)",
+    "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver (with --verify)",
+    "--encoding <bv|ir|auto>": "ESBMC encoding mode (with --verify); ir requires z3 (default: auto)",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
-    "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver (with --verify)",
-    "--encoding <bv|ir|auto>": "ESBMC encoding mode (with --verify); ir requires z3 (default: auto)"
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
   },
   "global_options": {
     "--help": "Emit versioned JSON tool-help data",
@@ -1203,30 +1203,30 @@ BUILD OPTIONS
   --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)
   --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)
   --no-cache              Disable compile and verify caching
-  --max-k-step <N>        ESBMC max k-induction step (default: 50)
-  --vec-max <N>           Max Vec capacity for verification model (default: 128)
-  --string-max <N>        Max String capacity for verification model (default: 256)
-  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
+  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
   --timeout <N>           ESBMC per-function timeout in seconds (default: (none))
+  --vec-max <N>           Max Vec capacity for verification model (default: 128)
+  --string-max <N>        Max String capacity for verification model (default: 256)
+  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
 
 VERIFY OPTIONS
   --no-cache              Disable verification result caching
-  --max-k-step <N>        ESBMC max k-induction step (default: 50)
-  --vec-max <N>           Max Vec capacity for verification model (default: 128)
-  --string-max <N>        Max String capacity for verification model (default: 256)
-  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
+  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
   --timeout <N>           ESBMC per-function timeout in seconds (default: (none))
+  --vec-max <N>           Max Vec capacity for verification model (default: 128)
+  --string-max <N>        Max String capacity for verification model (default: 256)
+  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
 
 TEST OPTIONS
   --verify                Run ESBMC verification on test files
   --filter <pat>          Only run tests whose name contains pat (default: (none))
   --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: (default))
   --timeout <ms>          Per-test execution timeout in milliseconds (default: 30000)
-  --max-k-step <N>        ESBMC max k-induction step (with --verify)
+  --max-k-step <N>        ESBMC incremental BMC max iterations (with --verify)
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
@@ -1234,12 +1234,12 @@ TEST OPTIONS
 CONTRACTS OPTIONS
   --verify                Run ESBMC verification and report per-contract status
   --no-cache              Disable verification result caching
-  --max-k-step <N>        ESBMC max k-induction step (default: 50)
+  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)
+  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver (with --verify)
+  --encoding <bv|ir|auto>  ESBMC encoding mode (with --verify); ir requires z3 (default: auto)
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
-  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver (with --verify)
-  --encoding <bv|ir|auto>  ESBMC encoding mode (with --verify); ir requires z3 (default: auto)
 
 DECL OPTIONS
   -o, --output <path>     Output declaration file path (default: <source>.vow.d)
@@ -1293,10 +1293,11 @@ METHODS   : Vec: Vec::new/push/pop/len/clear/truncate/v[i]/v[i] = val   String: 
 OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?
 
 VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max)
-  Incremental BMC : 50 max iterations (--max-k-step)
-  Vec<T>        : 128 max capacity (--vec-max)
-  String        : 256 max capacity (--string-max)
-  HashMap<K, V> : 64 max capacity (--hashmap-max)"##
+  Strategy        : k-induction-parallel (incremental BMC + k-induction)
+  Max k step      : 50 max iterations (--max-k-step)
+  Vec<T>          : 128 max capacity
+  String          : 256 max capacity
+  HashMap<K, V>   : 64 max capacity"##
         .to_string()
 }
 // GENERATE:SKILL_HUMAN:END
@@ -1586,6 +1587,8 @@ Checked operators abort with `ArithmeticOverflow` on overflow.
 | `>>`     | Right shift  |
 
 Bitwise operators require integer operands of the same type. Shift expressions return the left operand's type. `>>` is arithmetic for `i64` and logical for `u64`.
+
+Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator, so `x: i64 << 5` and `y: u64 << 3` both type-check. This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`5u64`) to force the `u64` type.
 
 ### Logical Operators
 
@@ -2170,10 +2173,13 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |
 | `--debug-trace <off\|calls\|full>` | `off` | Emit JSON trace lines to stderr at runtime |
 | `--no-cache`    | (off)       | Disable compile and verify caching           |
-| `--max-k-step <N>` | `50`     | ESBMC max k-induction step                   |
-| `--vec-max <N>` | `128`      | Max Vec capacity for verification model       |
-| `--string-max <N>` | `256`   | Max String capacity for verification model    |
-| `--hashmap-max <N>` | `64`   | Max HashMap capacity for verification model   |
+| `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |
+| `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
+| `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
+| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |
+| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
+| `--string-max <N>` | `256`    | Max String capacity for verification model   |
+| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
 
 ### `vow verify`
 
@@ -2188,7 +2194,10 @@ vow verify [OPTIONS] <source.vow>
 | Flag              | Default     | Description                                |
 |-------------------|-------------|--------------------------------------------|
 | `--no-cache`      | (off)       | Disable verification result caching        |
-| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
+| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
+| `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
+| `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
+| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
@@ -2207,7 +2216,9 @@ vow contracts [OPTIONS] <source.vow>
 |-------------------|-------------|--------------------------------------------|
 | `--verify`        | (off)       | Run ESBMC verification and report per-contract status |
 | `--no-cache`      | (off)       | Disable verification result caching        |
-| `--max-k-step <N>` | `50`       | ESBMC max k-induction step                |
+| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
+| `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |
+| `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
@@ -2244,7 +2255,7 @@ vow test [OPTIONS] [<path>]
 | `--mode debug`    | (default)   | Insert runtime vow checks                 |
 | `--mode release`  | `debug`     | Omit all vow checks for performance       |
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
-| `--max-k-step <N>` | `50`       | ESBMC max k-induction step (with --verify) |
+| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations (with --verify) |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
@@ -2610,15 +2621,21 @@ Contract clauses become IR opcodes. The C emitter translates `requires` to `__ES
 ### ESBMC Configuration
 
 - Verification strategy: **k-induction-parallel** (incremental BMC + k-induction proof)
-- Max k-induction step: **50** (default; override with `--max-k-step`)
+- Incremental BMC with `--max-k-step` (default: **50**) — loops are verified incrementally up to N iterations
 - Architecture: 64-bit
 - Array bounds / pointer checks disabled (Vow handles these in its own model)
 
 ### Collection Models for Verification
 
-Collections (`Vec<T>`, `String`, `HashMap<K, V>`) are modeled with unbounded, dynamically allocated storage — the same semantics as at runtime. There are no artificial capacity limits in the verification model. ESBMC reasons about container operations using k-induction to prove properties for all iterations.
+ESBMC uses bounded models for collection types. Defaults are shown below; override with `--vec-max`, `--string-max`, `--hashmap-max`:
 
-`String::from` produces a nondeterministic non-negative length in verification.
+| Type              | Default Max Capacity | CLI Flag | Supported Operations |
+|-------------------|---------------------|----------|----------------------------------------------|
+| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |
+| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `byte_at`        |
+| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|
+
+These support the same operations as the runtime but with bounded storage. `String::from` produces a nondeterministic length (0 to max-1) in verification.
 
 ## Blame Model
 
@@ -2824,7 +2841,7 @@ This is not inductive — `v.len() == n` is only true after the loop.
 
 ### Unbound Loop Iterations
 
-Without a bound on loop iterations, ESBMC may timeout (max-k-step is 50):
+Without a bound on loop iterations, ESBMC may timeout (default max-k-step is 50):
 
 ```vow
 fn fill(n: i64) -> Vec<i64> vow {
@@ -3084,6 +3101,23 @@ extern "C" {
 **Output:** `extern block requires a vow contract`
 
 **Fix:** Add a `vow { ... }` block to the extern declaration with `requires` and/or `ensures` clauses.
+
+### ContractTypeMismatch
+
+**Phase:** Type Checker
+**Meaning:** A `requires`, `ensures`, or `invariant` clause expression does not have type `bool`.
+
+```vow
+fn add(a: i64, b: i64) -> i64 vow {
+    requires: a + b
+} {
+    a + b
+}
+```
+
+**Output:** `` `requires` clause has type `i64` but must be `bool` ``
+
+**Fix:** Ensure every contract clause is a boolean expression (comparison, logical operator, or a call to a predicate function returning `bool`).
 
 ### VowRequiresViolated
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1588,7 +1588,7 @@ Checked operators abort with `ArithmeticOverflow` on overflow.
 
 Bitwise operators require integer operands of the same type. Shift expressions return the left operand's type. `>>` is arithmetic for `i64` and logical for `u64`.
 
-Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator, so `x: i64 << 5` and `y: u64 << 3` both type-check. This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`5u64`) to force the `u64` type.
+Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator. For example, given `let x: u64 = ...`, the expressions `x << 3` and `3 & x` both type-check (the literal coerces to `u64`). This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`3u64`) to force the `u64` type explicitly.
 
 ### Logical Operators
 


### PR DESCRIPTION
## Summary
- **Self-hosted parser**: `is_shift_left_op` / `is_shift_right_op` used a chained `peek_offset(p, 1).tag` — the CLAUDE.md gotcha meant the field read returned the wrong value, so `advance_binop` silently failed to double-advance on `<<` / `>>`. Split into a typed `let t: Token` binding.
- **Rust type checker**: `check_same_integer` had its I32 coercion stripped in aa4b79b on the false premise that self-hosted was strict (self-hosted types bare literals as `CTY_I64`, so its tests passed). Restored the same coercion used by `check_same_numeric` and the comparison path so `let x: i64 = left << 5;` type-checks again.
- `docs/spec/grammar.md` documents the coercion; `scripts/generate_help.py` was rerun so the embedded help / skill docs stay in sync.

Closes #185.

## Test plan
- [x] `tests/run/bitwise_ops.vow` compiles + runs with expected stdout on both Rust and self-hosted compilers
- [x] All 117 `.vow` files under `tests/` and `examples/` produce matching build status between compilers
- [x] All 53 `tests/run/*.vow` runtime outputs match byte-for-byte between compilers
- [x] `cargo test --all` passes
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `scripts/check_help_coverage.py` passes for both compilers
- [x] Codex second-opinion review addressed (spec wording corrected; embedded help regenerated)
