### PR TITLE
docs: add development discipline guidance (deep modules, surgical changes, small files)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@ Vow is a serious, production-grade project. All implementation decisions must re
 - **Scalability is a requirement.** Data structures, algorithms, and compiler passes must be chosen for reasonable asymptotic behavior, not just correctness on small inputs.
 - **No "experimental" excuses.** Do not defer correctness, robustness, or resource discipline with the rationale that the project is early-stage or experimental. Treat every change as if it will run in production.
 
+## Development Discipline
+
+These principles apply to all work in this repo — compiler code, self-hosted compiler, tooling, and benchmarks. They also apply to Vow programs written by agents (see `docs/spec/index.md`, which embeds the same guidance into the skill).
+
+- **Deep modules.** Favor deep modules (lots of functionality, simple interface, hides complexity) over shallow ones (thin wrappers, complex interface, surface complexity). When a module's interface is nearly as wide as its implementation, collapse it or widen its responsibilities. Many exported symbols and pass-through functions are a shallow-module smell.
+- **Surgical changes.** Many small changes beat one large change. They are easier to review, debug, `git bisect`, and revert. Do not bundle refactors, formatting, or unrelated cleanups into a bug fix. If a task grows, split it.
+- **Small files, smaller functions.** Context is precious — every file read consumes budget. Keep files and functions short enough that an agent can load the relevant unit without displacing other context. Split by responsibility as soon as a unit stops fitting a single coherent idea.
+
 ## Contract Authoring
 
 Contracts express **semantic correctness** — what is mathematically required for a function to be correct. They must never be weakened or artificially bounded to satisfy ESBMC's verification limits.

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -1934,6 +1934,16 @@ fn skill_full() -> String {
     r.push_str(String::from("Hello, world!\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
+    r.push_str(String::from("## Development Discipline\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("Vow is written by agents under a finite context window. These principles apply to every task, not just language design.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Deep modules, not shallow ones.** A deep module packs a lot of functionality behind a simple interface and hides complexity. A shallow module exposes a complex interface for not much functionality and surfaces complexity to every caller. Prefer deep. When you design or extend a module, ask: does the interface hide more complexity than it exposes? If not, collapse the module or move its logic behind a narrower boundary. Many exported symbols, thin wrappers, and \"pass-through\" functions are signs of a shallow module.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Surgical changes.** Prefer many small changes over one large change. Small changes are easier to review, debug, bisect with `git bisect`, and revert. A bug fix fixes the bug -- it does not also refactor the surrounding code, rename variables, or reformat the file. Unrelated improvements belong in their own commits or PRs. If a task grows, split it; do not bundle.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Keep files small, functions smaller.** Context is precious. Every file an agent reads consumes budget that could go toward solving the problem. A 2000-line file forces whole-file reads and pushes other context out; a 200-line file does not. A 100-line function is harder to reason about than four 25-line functions with clear names. Split by responsibility as soon as a unit stops fitting a single coherent idea. This applies to both Vow source code and any tooling around it.\n"));
+    r.push_str(String::from("\n"));
     r.push_str(String::from("---\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("# Vow Grammar Reference\n"));

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -40,6 +40,16 @@ $ ulimit -v 2000000; ./hello
 Hello, world!
 ```
 
+## Development Discipline
+
+Vow is written by agents under a finite context window. These principles apply to every task, not just language design.
+
+**Deep modules, not shallow ones.** A deep module packs a lot of functionality behind a simple interface and hides complexity. A shallow module exposes a complex interface for not much functionality and surfaces complexity to every caller. Prefer deep. When you design or extend a module, ask: does the interface hide more complexity than it exposes? If not, collapse the module or move its logic behind a narrower boundary. Many exported symbols, thin wrappers, and "pass-through" functions are signs of a shallow module.
+
+**Surgical changes.** Prefer many small changes over one large change. Small changes are easier to review, debug, bisect with `git bisect`, and revert. A bug fix fixes the bug — it does not also refactor the surrounding code, rename variables, or reformat the file. Unrelated improvements belong in their own commits or PRs. If a task grows, split it; do not bundle.
+
+**Keep files small, functions smaller.** Context is precious. Every file an agent reads consumes budget that could go toward solving the problem. A 2000-line file forces whole-file reads and pushes other context out; a 200-line file does not. A 100-line function is harder to reason about than four 25-line functions with clear names. Split by responsibility as soon as a unit stops fitting a single coherent idea. This applies to both Vow source code and any tooling around it.
+
 <!-- OMIT-FROM-SKILL-START -->
 ## Reference Files
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1359,6 +1359,16 @@ $ ulimit -v 2000000; ./hello
 Hello, world!
 ```
 
+## Development Discipline
+
+Vow is written by agents under a finite context window. These principles apply to every task, not just language design.
+
+**Deep modules, not shallow ones.** A deep module packs a lot of functionality behind a simple interface and hides complexity. A shallow module exposes a complex interface for not much functionality and surfaces complexity to every caller. Prefer deep. When you design or extend a module, ask: does the interface hide more complexity than it exposes? If not, collapse the module or move its logic behind a narrower boundary. Many exported symbols, thin wrappers, and "pass-through" functions are signs of a shallow module.
+
+**Surgical changes.** Prefer many small changes over one large change. Small changes are easier to review, debug, bisect with `git bisect`, and revert. A bug fix fixes the bug — it does not also refactor the surrounding code, rename variables, or reformat the file. Unrelated improvements belong in their own commits or PRs. If a task grows, split it; do not bundle.
+
+**Keep files small, functions smaller.** Context is precious. Every file an agent reads consumes budget that could go toward solving the problem. A 2000-line file forces whole-file reads and pushes other context out; a 200-line file does not. A 100-line function is harder to reason about than four 25-line functions with clear names. Split by responsibility as soon as a unit stops fitting a single coherent idea. This applies to both Vow source code and any tooling around it.
+
 ---
 
 # Vow Grammar Reference


### PR DESCRIPTION
## Summary
- Encode three development principles for both compiler-repo work and agents writing Vow programs: **deep modules** over shallow ones, **surgical changes** over bundled ones, and **small files/functions** since agent context is finite.
- Added to `CLAUDE.md` (compiler-repo audience) and to `docs/spec/index.md` so the same guidance flows into the embedded skill served by the skill subcommand (Vow-using-agent audience).
- Regenerated `vow/src/main.rs` and `compiler/main.vow` via `scripts/generate_help.py` so both compilers carry the updated skill text.

Source of the framing: Matt Pocock / Ousterhout's "A Philosophy of Software Design" on deep vs. shallow modules, plus the common LLM failure mode of doing way too much.

## Test plan
- [ ] `scripts/check_help_coverage.py` passes (no drift between spec and embedded help/skill).
- [ ] `scripts/full_test.sh` passes.
- [ ] After a fresh bootstrap, the compiler's skill print output includes the new "Development Discipline" section.