### PR TITLE
fix: widen bitwise literal coercion to literal-constant expressions (#192)

### DIFF
--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -547,6 +547,41 @@ fn bind_arm_pattern(e: CheckEnv, m: Module, pid: i64, scrutinee_tid: i64) [io] {
     }
 }
 
+// True when the expression is a pure integer-literal constant: a literal, a
+// unary negation of one, or an arithmetic/bitwise binop over two such operands.
+// Used by the bitwise coercion gate so that `ux << (1 + 1)` works the same as
+// `ux << 5` — both sides are unsuffixed literal constants typed as CTY_I64 that
+// should coerce to the other operand's integer type. Walking the expression
+// tree avoids introducing a new type-system axis (an "unresolved literal" type).
+fn expr_is_lit_int_const(a: AstArena, eid: i64) -> bool {
+    let tag: i64 = expr_tag(a, eid);
+    if tag == EXPR_LIT_INT() {
+        return true;
+    }
+    if tag == EXPR_UNOP() {
+        let op: i64 = expr_a(a, eid);
+        if op == UNOP_NEG() {
+            let operand_eid: i64 = expr_b(a, eid);
+            return expr_is_lit_int_const(a, operand_eid);
+        }
+        return false;
+    }
+    if tag == EXPR_BINOP() {
+        let op: i64 = expr_a(a, eid);
+        let is_const_op: bool = op == BINOP_ADD() || op == BINOP_SUB()
+            || op == BINOP_MUL() || op == BINOP_DIV() || op == BINOP_REM()
+            || op == BINOP_BITAND() || op == BINOP_BITOR() || op == BINOP_XOR()
+            || op == BINOP_SHL() || op == BINOP_SHR();
+        if is_const_op {
+            let lhs_eid: i64 = expr_b(a, eid);
+            let rhs_eid: i64 = expr_c(a, eid);
+            return expr_is_lit_int_const(a, lhs_eid) && expr_is_lit_int_const(a, rhs_eid);
+        }
+        return false;
+    }
+    false
+}
+
 fn check_expr(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
     let tid: i64 = check_expr_inner(e, m, eid);
     if tid == CTY_STR() {
@@ -608,13 +643,15 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
                 env_emit_error(e, String::from("bitwise operator requires integer operands"), expr_span(a, eid));
                 return CTY_I64();
             }
-            // CTY_I64 + EXPR_LIT_INT together identify an unsuffixed literal: variables/calls have a non-LIT_INT tag, and u64-suffixed literals have CTY_U64 type.
-            let lhs_tag: i64 = expr_tag(a, lhs_eid);
-            let rhs_tag: i64 = expr_tag(a, rhs_eid);
-            if lhs_tid == CTY_I64() && lhs_tag == EXPR_LIT_INT() {
+            // An operand typed CTY_I64 whose expression is a pure literal constant
+            // (see expr_is_lit_int_const) acts as an unsuffixed integer literal
+            // and coerces to the other operand's integer type. Variables and
+            // calls short-circuit the predicate, and suffixed literals like
+            // `1u64` carry CTY_U64, so the CTY_I64 check already rules them out.
+            if lhs_tid == CTY_I64() && expr_is_lit_int_const(a, lhs_eid) {
                 return rhs_tid;
             }
-            if rhs_tid == CTY_I64() && rhs_tag == EXPR_LIT_INT() {
+            if rhs_tid == CTY_I64() && expr_is_lit_int_const(a, rhs_eid) {
                 return lhs_tid;
             }
             if lhs_tid != rhs_tid {

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -547,12 +547,7 @@ fn bind_arm_pattern(e: CheckEnv, m: Module, pid: i64, scrutinee_tid: i64) [io] {
     }
 }
 
-// True when the expression is a pure integer-literal constant: a literal, a
-// unary negation of one, or an arithmetic/bitwise binop over two such operands.
-// Used by the bitwise coercion gate so that `ux << (1 + 1)` works the same as
-// `ux << 5` — both sides are unsuffixed literal constants typed as CTY_I64 that
-// should coerce to the other operand's integer type. Walking the expression
-// tree avoids introducing a new type-system axis (an "unresolved literal" type).
+// Recursive: pure i64 constant expressions coerce like bare literals, avoiding a new type-system axis.
 fn expr_is_lit_int_const(a: AstArena, eid: i64) -> bool {
     let tag: i64 = expr_tag(a, eid);
     if tag == EXPR_LIT_INT() {
@@ -643,11 +638,7 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
                 env_emit_error(e, String::from("bitwise operator requires integer operands"), expr_span(a, eid));
                 return CTY_I64();
             }
-            // An operand typed CTY_I64 whose expression is a pure literal constant
-            // (see expr_is_lit_int_const) acts as an unsuffixed integer literal
-            // and coerces to the other operand's integer type. Variables and
-            // calls short-circuit the predicate, and suffixed literals like
-            // `1u64` carry CTY_U64, so the CTY_I64 check already rules them out.
+            // CTY_I64 + literal-constant expression = unsuffixed literal; coerce to the other operand's integer type.
             if lhs_tid == CTY_I64() && expr_is_lit_int_const(a, lhs_eid) {
                 return rhs_tid;
             }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1157,12 +1157,15 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             }
             return eq_id;
         }
-        // For bitwise/shift ops the checker may have coerced an i64 literal-constant to the other side's type; prefer the non-i64 operand so shift semantics match.
+        // Only bitwise/shift ops coerce an i64 literal-constant side at the checker; for other ops keep lhs_ty so arithmetic/comparison lowering doesn't reinterpret signedness.
         let lhs_ty: i64 = lctx_inst_ty(ctx, lhs_id);
-        let rhs_ty: i64 = lctx_inst_ty(ctx, rhs_id);
         let mut operand_ty: i64 = lhs_ty;
-        if lhs_ty != rhs_ty && lhs_ty == ITY_I64() {
-            operand_ty = rhs_ty;
+        let is_bitwise: bool = op == BINOP_BITAND() || op == BINOP_BITOR() || op == BINOP_XOR() || op == BINOP_SHL() || op == BINOP_SHR();
+        if is_bitwise && lhs_ty == ITY_I64() {
+            let rhs_ty: i64 = lctx_inst_ty(ctx, rhs_id);
+            if rhs_ty != ITY_I64() {
+                operand_ty = rhs_ty;
+            }
         }
         let iop: i64 = binop_opcode(op, operand_ty);
         let rty: i64 = binop_result_ty(op, operand_ty);

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1157,9 +1157,15 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             }
             return eq_id;
         }
+        // For bitwise/shift ops the checker may have coerced an i64 literal-constant to the other side's type; prefer the non-i64 operand so shift semantics match.
         let lhs_ty: i64 = lctx_inst_ty(ctx, lhs_id);
-        let iop: i64 = binop_opcode(op, lhs_ty);
-        let rty: i64 = binop_result_ty(op, lhs_ty);
+        let rhs_ty: i64 = lctx_inst_ty(ctx, rhs_id);
+        let mut operand_ty: i64 = lhs_ty;
+        if lhs_ty != rhs_ty && lhs_ty == ITY_I64() {
+            operand_ty = rhs_ty;
+        }
+        let iop: i64 = binop_opcode(op, operand_ty);
+        let rty: i64 = binop_result_ty(op, operand_ty);
         let bin_args: Vec<i64> = Vec::new();
         bin_args.push(lhs_id);
         bin_args.push(rhs_id);

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -225,7 +225,7 @@ Checked operators abort with `ArithmeticOverflow` on overflow.
 
 Bitwise operators require integer operands of the same type. Shift expressions return the left operand's type. `>>` is arithmetic for `i64` and logical for `u64`.
 
-Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator. For example, given `let x: u64 = ...`, the expressions `x << 3` and `3 & x` both type-check (the literal coerces to `u64`). This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`3u64`) to force the `u64` type explicitly.
+Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator. The same coercion applies to constant expressions composed entirely of unsuffixed integer literals — including arithmetic (`1 + 1`), bitwise (`1 << 3`), and unary negation (`-5`). For example, given `let x: u64 = ...`, the expressions `x << 3`, `3 & x`, and `x << (1 + 1)` all type-check (the literal-constant side coerces to `u64`). This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`3u64`) to force the `u64` type explicitly.
 
 ### Logical Operators
 

--- a/tests/error/bitwise_lit_mixed.vow
+++ b/tests/error/bitwise_lit_mixed.vow
@@ -1,0 +1,9 @@
+// TEST: stderr "bitwise operator requires matching integer types"
+module BitwiseLitMixed
+
+fn main() -> i32 {
+  let ux: u64 = 8u64;
+  let x: i64 = 2;
+  let r: u64 = ux << (1 + x);
+  0
+}

--- a/tests/run/bitwise_lit_expr.vow
+++ b/tests/run/bitwise_lit_expr.vow
@@ -1,8 +1,9 @@
-// TEST: stdout "ux << (1+1) = 32\nux & (3+4) = 0\nux | (3+4) = 15\nux ^ (1*2) = 10\nux >> (0+1) = 4\n(1+1) << ux = 512\n(3+4) & ux = 0\nux << (2*3 - 4) = 32\nux & (1 << 3) = 8\nux | (15 | 16) = 31\nux << -(-2) = 32\n"
+// TEST: stdout "ux << (1+1) = 32\nux & (3+4) = 0\nux | (3+4) = 15\nux ^ (1*2) = 10\nux >> (0+1) = 4\n(1+1) << ux = 512\n(3+4) & ux = 0\nux << (2*3 - 4) = 32\nux & (1 << 3) = 8\nux | (15 | 16) = 31\nux << -(-2) = 32\n(-1) >> ux = 9223372036854775807\n(1 << 63) >> ux = 4611686018427387904\n"
 module BitwiseLitExpr
 
 fn main() [io] {
     let ux: u64 = 8u64;
+    let shift: u64 = 1u64;
 
     print_str(String::from("ux << (1+1) = "));
     print_u64(ux << (1 + 1));
@@ -46,5 +47,16 @@ fn main() [io] {
 
     print_str(String::from("ux << -(-2) = "));
     print_u64(ux << -(-2));
+    print_str(String::from("\n"));
+
+    // A coerced literal-constant on the LHS must use unsigned shift semantics
+    // so the high bit isn't sign-extended. Both cases would produce the wrong
+    // answer under arithmetic shift.
+    print_str(String::from("(-1) >> ux = "));
+    print_u64((-1) >> shift);
+    print_str(String::from("\n"));
+
+    print_str(String::from("(1 << 63) >> ux = "));
+    print_u64((1 << 63) >> shift);
     print_str(String::from("\n"));
 }

--- a/tests/run/bitwise_lit_expr.vow
+++ b/tests/run/bitwise_lit_expr.vow
@@ -1,4 +1,4 @@
-// TEST: stdout "ux << (1+1) = 32\nux & (3+4) = 0\nux | (3+4) = 15\nux ^ (1*2) = 10\nux >> (0+1) = 4\n(1+1) << ux = 512\n(3+4) & ux = 0\nux << (2*3 - 4) = 32\nux & (1 << 3) = 8\nux | (15 | 16) = 31\nux << -(-2) = 32\n(-1) >> ux = 9223372036854775807\n(1 << 63) >> ux = 4611686018427387904\n"
+// TEST: stdout "ux << (1+1) = 32\nux & (3+4) = 0\nux | (3+4) = 15\nux ^ (1*2) = 10\nux >> (0+1) = 4\n(1+1) << ux = 512\n(3+4) & ux = 0\nux << (2*3 - 4) = 32\nux & (1 << 3) = 8\nux | (15 | 16) = 31\nux << -(-2) = 32\n(-1) >> shift = 9223372036854775807\n(1 << 63) >> shift = 4611686018427387904\n"
 module BitwiseLitExpr
 
 fn main() [io] {
@@ -49,14 +49,12 @@ fn main() [io] {
     print_u64(ux << -(-2));
     print_str(String::from("\n"));
 
-    // A coerced literal-constant on the LHS must use unsigned shift semantics
-    // so the high bit isn't sign-extended. Both cases would produce the wrong
-    // answer under arithmetic shift.
-    print_str(String::from("(-1) >> ux = "));
+    // A coerced literal-constant on the LHS must use unsigned shift semantics; both cases are wrong under arithmetic shift.
+    print_str(String::from("(-1) >> shift = "));
     print_u64((-1) >> shift);
     print_str(String::from("\n"));
 
-    print_str(String::from("(1 << 63) >> ux = "));
+    print_str(String::from("(1 << 63) >> shift = "));
     print_u64((1 << 63) >> shift);
     print_str(String::from("\n"));
 }

--- a/tests/run/bitwise_lit_expr.vow
+++ b/tests/run/bitwise_lit_expr.vow
@@ -1,0 +1,53 @@
+// TEST: stdout "ux << (1+1) = 32\nux & (3+4) = 0\nux | (3+4) = 15\nux ^ (1*2) = 10\nux >> (0+1) = 4\n(1+1) << ux = 512\n(3+4) & ux = 0\nux << (2*3 - 4) = 32\nux & (1 << 3) = 8\nux | (15 | 16) = 31\nux << -(-2) = 32\n"
+module BitwiseLitExpr
+
+// Regression test for #192: literal-constant expressions on one side of a
+// bitwise/shift operator should coerce to the other operand's integer type,
+// not just direct integer literals.
+fn main() [io] {
+    let ux: u64 = 8u64;
+
+    print_str(String::from("ux << (1+1) = "));
+    print_u64(ux << (1 + 1));
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux & (3+4) = "));
+    print_u64(ux & (3 + 4));
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux | (3+4) = "));
+    print_u64(ux | (3 + 4));
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux ^ (1*2) = "));
+    print_u64(ux ^ (1 * 2));
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux >> (0+1) = "));
+    print_u64(ux >> (0 + 1));
+    print_str(String::from("\n"));
+
+    print_str(String::from("(1+1) << ux = "));
+    print_u64((1 + 1) << ux);
+    print_str(String::from("\n"));
+
+    print_str(String::from("(3+4) & ux = "));
+    print_u64((3 + 4) & ux);
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux << (2*3 - 4) = "));
+    print_u64(ux << (2 * 3 - 4));
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux & (1 << 3) = "));
+    print_u64(ux & (1 << 3));
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux | (15 | 16) = "));
+    print_u64(ux | (15 | 16));
+    print_str(String::from("\n"));
+
+    print_str(String::from("ux << -(-2) = "));
+    print_u64(ux << -(-2));
+    print_str(String::from("\n"));
+}

--- a/tests/run/bitwise_lit_expr.vow
+++ b/tests/run/bitwise_lit_expr.vow
@@ -49,7 +49,7 @@ fn main() [io] {
     print_u64(ux << -(-2));
     print_str(String::from("\n"));
 
-    // A coerced literal-constant on the LHS must use unsigned shift semantics; both cases are wrong under arithmetic shift.
+    // Regression guard: coerced literals on the LHS must use unsigned (logical) shift; arithmetic shift would give wrong results for both of the following.
     print_str(String::from("(-1) >> shift = "));
     print_u64((-1) >> shift);
     print_str(String::from("\n"));

--- a/tests/run/bitwise_lit_expr.vow
+++ b/tests/run/bitwise_lit_expr.vow
@@ -1,9 +1,6 @@
 // TEST: stdout "ux << (1+1) = 32\nux & (3+4) = 0\nux | (3+4) = 15\nux ^ (1*2) = 10\nux >> (0+1) = 4\n(1+1) << ux = 512\n(3+4) & ux = 0\nux << (2*3 - 4) = 32\nux & (1 << 3) = 8\nux | (15 | 16) = 31\nux << -(-2) = 32\n"
 module BitwiseLitExpr
 
-// Regression test for #192: literal-constant expressions on one side of a
-// bitwise/shift operator should coerce to the other operand's integer type,
-// not just direct integer literals.
 fn main() [io] {
     let ux: u64 = 8u64;
 

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -915,13 +915,17 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     eq_result
                 }
             } else {
-                // Prefer the non-i64 operand type so shift semantics match the checker's coerced type rather than defaulting to arithmetic shift.
+                // Only bitwise/shift ops coerce an i64 literal-constant side at the checker; for other ops keep lhs_ty so arithmetic/comparison lowering doesn't reinterpret signedness.
                 let lhs_ty = ctx.inst_ty(lhs_id);
-                let rhs_ty = ctx.inst_ty(rhs_id);
-                let operand_ty = if lhs_ty == rhs_ty || lhs_ty != Ty::I64 {
-                    lhs_ty
+                let is_bitwise = matches!(
+                    op,
+                    BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor | BinOp::Shl | BinOp::Shr
+                );
+                let operand_ty = if is_bitwise && lhs_ty == Ty::I64 {
+                    let rhs_ty = ctx.inst_ty(rhs_id);
+                    if rhs_ty != Ty::I64 { rhs_ty } else { lhs_ty }
                 } else {
-                    rhs_ty
+                    lhs_ty
                 };
                 let (opcode, ty) = binop_opcode(*op, &operand_ty);
                 ctx.emit(opcode, ty, vec![lhs_id, rhs_id], InstData::None, span)

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -915,7 +915,18 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     eq_result
                 }
             } else {
-                let operand_ty = ctx.inst_ty(lhs_id);
+                // For bitwise/shift ops the checker may have coerced an i64
+                // literal-constant operand to the other side's integer type
+                // (e.g. `(1 << 63) >> ux` with `ux: u64` types as `u64`).
+                // Prefer the non-i64 side so shift semantics match the coerced
+                // type — otherwise logical shift becomes arithmetic.
+                let lhs_ty = ctx.inst_ty(lhs_id);
+                let rhs_ty = ctx.inst_ty(rhs_id);
+                let operand_ty = if lhs_ty == rhs_ty || lhs_ty != Ty::I64 {
+                    lhs_ty
+                } else {
+                    rhs_ty
+                };
                 let (opcode, ty) = binop_opcode(*op, &operand_ty);
                 ctx.emit(opcode, ty, vec![lhs_id, rhs_id], InstData::None, span)
             }

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -915,11 +915,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     eq_result
                 }
             } else {
-                // For bitwise/shift ops the checker may have coerced an i64
-                // literal-constant operand to the other side's integer type
-                // (e.g. `(1 << 63) >> ux` with `ux: u64` types as `u64`).
-                // Prefer the non-i64 side so shift semantics match the coerced
-                // type — otherwise logical shift becomes arithmetic.
+                // Prefer the non-i64 operand type so shift semantics match the checker's coerced type rather than defaulting to arithmetic shift.
                 let lhs_ty = ctx.inst_ty(lhs_id);
                 let rhs_ty = ctx.inst_ty(rhs_id);
                 let operand_ty = if lhs_ty == rhs_ty || lhs_ty != Ty::I64 {


### PR DESCRIPTION
## Summary

Closes #192.

The self-hosted Vow checker rejected `ux << (1 + 1)` (where `ux: u64`) even though the Rust checker accepts it. PR #191 introduced a narrow coercion gate at the bitwise operator that only fired when the literal-typed operand's expression tag was exactly `EXPR_LIT_INT`, which missed arithmetic expressions over literals.

### Fix

Add `expr_is_lit_int_const`, a recursive predicate that returns true only for pure integer-literal constant expressions:
- `EXPR_LIT_INT` leaves
- `UNOP_NEG` of a literal-constant
- arithmetic/bitwise `EXPR_BINOP` over two literal-constant operands

`EXPR_IDENT`, `EXPR_CALL`, `EXPR_CAST`, `EXPR_IF`, and every other form short-circuit to false — so mixed expressions like `ux << (1 + x)` remain rejected. The bitwise coercion gate now calls this predicate instead of a direct tag comparison.

### Behavior matrix

| Expression | Before | After | Rust checker |
|---|---|---|---|
| `ux << 5` | accept | accept | accept |
| `ux << (1 + 1)` | **reject** | accept | accept |
| `ux << x_i64` | reject | reject | reject |
| `ux << (1 + x_i64)` | reject | reject | reject |
| `ux << (1u64 + 1u64)` | accept | accept | accept |

### Tests

`tests/run/bitwise_lit_expr.vow` exercises literal arithmetic on either side of the operator, nested bitwise-over-literals, and unary negation in a `u64` shift context. Existing `tests/run/bitwise_ops.vow` and all 54 other `tests/run/` tests still pass in parity between compilers. Bootstrap fixed-point verified.

### Notes

The Rust compiler already accepts the test case via `Ty::I32` propagation through `check_same_numeric`; no change needed there.