### PR TITLE
Harden Claude workflow trigger to trusted actors

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,18 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+      contains(github.event.review.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+      (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,4 +55,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,8 +11,39 @@ on:
     types: [submitted]
 
 jobs:
+  verify-issue-assigner:
+    # The `issues` event payload exposes `author_association` for the issue
+    # opener only. On `assigned`, the trusted actor is the assigner (the
+    # sender), not the opener, so we verify collaborator status explicitly.
+    if: github.event_name == 'issues' && github.event.action == 'assigned'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require sender to be a repository collaborator
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const username = context.payload.sender.login;
+            try {
+              await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              core.info(`${username} is a repository collaborator.`);
+            } catch (error) {
+              core.setFailed(`${username} is not a trusted collaborator; refusing to invoke Claude.`);
+            }
+
   claude:
+    needs: [verify-issue-assigner]
+    # always() lets this job run when verify-issue-assigner is skipped
+    # (non-assigned events). The per-branch conditions below enforce trust:
+    # every event path either gates on author_association or, for
+    # issues:assigned, requires the verify job to have succeeded.
     if: |
+      always() && (
       (github.event_name == 'issue_comment' &&
       contains(github.event.comment.body, '@claude') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
@@ -22,9 +53,13 @@ jobs:
       (github.event_name == 'pull_request_review' &&
       contains(github.event.review.body, '@claude') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' &&
+      (github.event_name == 'issues' && github.event.action == 'opened' &&
       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned' &&
+      (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+      needs.verify-issue-assigner.result == 'success')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### Motivation
- Close a CI security gap where public issue/PR comments containing `@claude` could trigger a workflow that has write permissions and access to `secrets`, allowing untrusted users to potentially exfiltrate secrets or modify repository content.
- Ensure the `Claude Code` action only runs when invoked by trusted repository actors to preserve existing functionality for maintainers and collaborators while blocking untrusted public triggers.

### Description
- Modified `if` condition in `.github/workflows/claude.yml` so each supported event now requires the event author association to be one of `OWNER`, `MEMBER`, or `COLLABORATOR` using `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.*.author_association)`.
- Applied the author-association check to `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` branches of the condition while leaving the rest of the job (permissions, steps, and action usage) unchanged.
- Kept existing permissions and secret usage intact but limited the set of actors who can trigger the job.

### Testing
- Verified the file changes with `git diff -- .github/workflows/claude.yml` which shows the updated `if` condition and minimal edits. (succeeded)
- Confirmed repository status with `git status --short` and the committed change. (succeeded)
- Printed the updated workflow with `nl -ba .github/workflows/claude.yml | sed -n '1,120p'` to validate the final conditional logic lines. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7b5b3bd883328fec5e7c4bd52ec6)