### PR TITLE
fix: wire run_with_fallback into main verification loop (Phase D)

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -174,6 +174,41 @@ fn frontend_path_from_argv(argv: Vec<String>, sub: bool) -> String [io] {
     path
 }
 
+fn build_ce_from_result(f: IrFunction, vr: VerifyResult, path: String) -> VerifyCE {
+    let vow_id: i64 = vr.vow_id;
+    let ce_violation: String = String::from("");
+    let ce_blame: i64 = DIAG_BLAME_NONE();
+    let vow_entries: Vec<IrVowEntry> = f.vows;
+    let mut vi: i64 = 0;
+    while vi < vow_entries.len() {
+        let ve: IrVowEntry = vow_entries[vi];
+        if ve.id == vow_id {
+            ce_violation = ve.description;
+            ce_blame = ve.blame;
+        }
+        vi = vi + 1;
+    }
+    VerifyCE {
+        function: f.name,
+        var_names: vr.var_names,
+        var_values: vr.var_values,
+        violation: ce_violation,
+        vow_id: vow_id,
+        source: path,
+        blame: ce_blame,
+    }
+}
+
+fn emit_ce_vars(vr: VerifyResult) [io] {
+    let vnames: Vec<String> = vr.var_names;
+    let vvals: Vec<String> = vr.var_values;
+    let mut vi: i64 = 0;
+    while vi < vnames.len() {
+        eprintln_str(str4(String::from("    "), vnames[vi], String::from(" = "), vvals[vi]));
+        vi = vi + 1;
+    }
+}
+
 fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
                    vec_max: i64, string_max: i64, hashmap_max: i64) -> i64 [io] {
     let mut fi: i64 = 0;
@@ -192,36 +227,8 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Ve
             } else if st == VERIFY_FAILED() {
                 all_proven = 0;
                 eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
-                let vnames: Vec<String> = vr.var_names;
-                let vvals: Vec<String> = vr.var_values;
-                let mut vi: i64 = 0;
-                while vi < vnames.len() {
-                    eprintln_str(str4(String::from("    "), vnames[vi], String::from(" = "), vvals[vi]));
-                    vi = vi + 1;
-                }
-                let vow_id: i64 = vr.vow_id;
-                let ce_violation: String = String::from("");
-                let ce_blame: i64 = DIAG_BLAME_NONE();
-                let vow_entries: Vec<IrVowEntry> = f.vows;
-                let mut vi2: i64 = 0;
-                while vi2 < vow_entries.len() {
-                    let ve: IrVowEntry = vow_entries[vi2];
-                    if ve.id == vow_id {
-                        ce_violation = ve.description;
-                        ce_blame = ve.blame;
-                    }
-                    vi2 = vi2 + 1;
-                }
-                let ce: VerifyCE = VerifyCE {
-                    function: f.name,
-                    var_names: vr.var_names,
-                    var_values: vr.var_values,
-                    violation: ce_violation,
-                    vow_id: vow_id,
-                    source: path,
-                    blame: ce_blame,
-                };
-                ces.push(ce);
+                emit_ce_vars(vr);
+                ces.push(build_ce_from_result(f, vr, path));
             } else if st == VERIFY_TIMEOUT() {
                 all_proven = 0;
                 eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT")));
@@ -448,39 +455,10 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
             } else if st == VERIFY_FAILED() {
                 all_proven = 0;
                 eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
-                let vnames: Vec<String> = vr.var_names;
-                let vvals: Vec<String> = vr.var_values;
-                let mut vi: i64 = 0;
-                while vi < vnames.len() {
-                    eprintln_str(str4(String::from("    "), vnames[vi], String::from(" = "), vvals[vi]));
-                    vi = vi + 1;
-                }
-                let vow_id: i64 = vr.vow_id;
-                let ce_violation: String = String::from("");
-                let ce_blame: i64 = DIAG_BLAME_NONE();
-                let vow_entries: Vec<IrVowEntry> = f.vows;
-                let mut vi2: i64 = 0;
-                while vi2 < vow_entries.len() {
-                    let ve: IrVowEntry = vow_entries[vi2];
-                    if ve.id == vow_id {
-                        ce_violation = ve.description;
-                        ce_blame = ve.blame;
-                    }
-                    vi2 = vi2 + 1;
-                }
-                let ce: VerifyCE = VerifyCE {
-                    function: f.name,
-                    var_names: vr.var_names,
-                    var_values: vr.var_values,
-                    violation: ce_violation,
-                    vow_id: vow_id,
-                    source: path,
-                    blame: ce_blame,
-                };
-                ces.push(ce);
+                emit_ce_vars(vr);
+                ces.push(build_ce_from_result(f, vr, path));
             } else if st == VERIFY_TIMEOUT() {
-                // Phase D: if the initial BV run (under Auto encoding, non-Bitwuzla
-                // solver) timed out, retry synchronously with --z3 --ir.
+                // BV timed out; retry with IR before failing (mirrors run_verify_loop and run_with_fallback).
                 let bv_solver: String = resolve_auto_bv_solver(solver);
                 let auto_enc: bool = is_auto_encoding(encoding);
                 if auto_enc && bv_solver != String::from("bitwuzla") {
@@ -492,36 +470,8 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
                     } else if st2 == VERIFY_FAILED() {
                         all_proven = 0;
                         eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
-                        let vnames2: Vec<String> = vr2.var_names;
-                        let vvals2: Vec<String> = vr2.var_values;
-                        let mut vi3: i64 = 0;
-                        while vi3 < vnames2.len() {
-                            eprintln_str(str4(String::from("    "), vnames2[vi3], String::from(" = "), vvals2[vi3]));
-                            vi3 = vi3 + 1;
-                        }
-                        let vow_id2: i64 = vr2.vow_id;
-                        let ce_violation2: String = String::from("");
-                        let ce_blame2: i64 = DIAG_BLAME_NONE();
-                        let vow_entries2: Vec<IrVowEntry> = f.vows;
-                        let mut vi4: i64 = 0;
-                        while vi4 < vow_entries2.len() {
-                            let ve2: IrVowEntry = vow_entries2[vi4];
-                            if ve2.id == vow_id2 {
-                                ce_violation2 = ve2.description;
-                                ce_blame2 = ve2.blame;
-                            }
-                            vi4 = vi4 + 1;
-                        }
-                        let ce2: VerifyCE = VerifyCE {
-                            function: f.name,
-                            var_names: vr2.var_names,
-                            var_values: vr2.var_values,
-                            violation: ce_violation2,
-                            vow_id: vow_id2,
-                            source: path,
-                            blame: ce_blame2,
-                        };
-                        ces.push(ce2);
+                        emit_ce_vars(vr2);
+                        ces.push(build_ce_from_result(f, vr2, path));
                     } else if st2 == VERIFY_TIMEOUT() {
                         all_proven = 0;
                         eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT (BV and IR)")));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -174,7 +174,7 @@ fn frontend_path_from_argv(argv: Vec<String>, sub: bool) -> String [io] {
     path
 }
 
-fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String,
+fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
                    vec_max: i64, string_max: i64, hashmap_max: i64) -> i64 [io] {
     let mut fi: i64 = 0;
     let mut all_proven: i64 = 1;
@@ -183,10 +183,12 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Ve
         let vows: Vec<IrVowEntry> = f.vows;
         if vows.len() > 0 {
             eprintln_str(str3(String::from("Verifying "), f.name, String::from("...")));
-            let vr: VerifyResult = verify_function_full(f, ir_mod, max_k_step, use_cache, solver, encoding, vec_max, string_max, hashmap_max);
+            let vr: VerifyResult = verify_function_full(f, ir_mod, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
             let st: i64 = vr.status;
             if st == VERIFY_PROVEN() {
                 eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
+            } else if st == VERIFY_PROVEN_IR() {
+                eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN (IR)")));
             } else if st == VERIFY_FAILED() {
                 all_proven = 0;
                 eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
@@ -282,6 +284,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     let mut solver: String = get_flag_arg(argv, String::from("--solver"));
     let encoding: String = get_flag_arg(argv, String::from("--encoding"));
+    let timeout_secs: String = get_flag_arg(argv, String::from("--timeout"));
     if encoding == String::from("ir") {
         if solver == String::from("boolector") || solver == String::from("bitwuzla") {
             eprintln_str(String::from("error: --encoding ir requires --solver z3"));
@@ -300,7 +303,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     emit_ir_warnings(ir_mod, dctx);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
-    let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, vec_max, string_max, hashmap_max);
+    let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
     let status_str: String = {
         if all_proven == 1 {
             String::from("Verified")
@@ -366,6 +369,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     };
     let mut solver: String = get_flag_arg(argv, String::from("--solver"));
     let encoding: String = get_flag_arg(argv, String::from("--encoding"));
+    let timeout_secs: String = get_flag_arg(argv, String::from("--timeout"));
     if encoding == String::from("ir") {
         if solver == String::from("boolector") || solver == String::from("bitwuzla") {
             eprintln_str(String::from("error: --encoding ir requires --solver z3"));
@@ -392,7 +396,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
             let vows: Vec<IrVowEntry> = f.vows;
             if vows.len() > 0 {
                 eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
-                let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, vec_max, string_max, hashmap_max);
+                let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
                 handles.push(h);
                 vow_fn_indices.push(fi);
             }
@@ -471,8 +475,63 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
                 };
                 ces.push(ce);
             } else if st == VERIFY_TIMEOUT() {
-                all_proven = 0;
-                eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT")));
+                // Phase D: if the initial BV run (under Auto encoding, non-Bitwuzla
+                // solver) timed out, retry synchronously with --z3 --ir.
+                let bv_solver: String = resolve_auto_bv_solver(solver);
+                let auto_enc: bool = is_auto_encoding(encoding);
+                if auto_enc && bv_solver != String::from("bitwuzla") {
+                    eprintln_str(str3(String::from("  "), f.name, String::from(": BV timeout, retrying with --z3 --ir...")));
+                    let vr2: VerifyResult = verify_function_ir_fallback(f, ir_mod, max_k_step, use_cache, timeout_secs, vec_max, string_max, hashmap_max);
+                    let st2: i64 = vr2.status;
+                    if st2 == VERIFY_PROVEN_IR() {
+                        eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN (IR)")));
+                    } else if st2 == VERIFY_FAILED() {
+                        all_proven = 0;
+                        eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
+                        let vnames2: Vec<String> = vr2.var_names;
+                        let vvals2: Vec<String> = vr2.var_values;
+                        let mut vi3: i64 = 0;
+                        while vi3 < vnames2.len() {
+                            eprintln_str(str4(String::from("    "), vnames2[vi3], String::from(" = "), vvals2[vi3]));
+                            vi3 = vi3 + 1;
+                        }
+                        let vow_id2: i64 = vr2.vow_id;
+                        let ce_violation2: String = String::from("");
+                        let ce_blame2: i64 = DIAG_BLAME_NONE();
+                        let vow_entries2: Vec<IrVowEntry> = f.vows;
+                        let mut vi4: i64 = 0;
+                        while vi4 < vow_entries2.len() {
+                            let ve2: IrVowEntry = vow_entries2[vi4];
+                            if ve2.id == vow_id2 {
+                                ce_violation2 = ve2.description;
+                                ce_blame2 = ve2.blame;
+                            }
+                            vi4 = vi4 + 1;
+                        }
+                        let ce2: VerifyCE = VerifyCE {
+                            function: f.name,
+                            var_names: vr2.var_names,
+                            var_values: vr2.var_values,
+                            violation: ce_violation2,
+                            vow_id: vow_id2,
+                            source: path,
+                            blame: ce_blame2,
+                        };
+                        ces.push(ce2);
+                    } else if st2 == VERIFY_TIMEOUT() {
+                        all_proven = 0;
+                        eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT (BV and IR)")));
+                    } else if st2 == VERIFY_NOT_FOUND() {
+                        all_proven = 0;
+                        eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
+                    } else {
+                        all_proven = 0;
+                        eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
+                    }
+                } else {
+                    all_proven = 0;
+                    eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT")));
+                }
             } else if st == VERIFY_NOT_FOUND() {
                 all_proven = 0;
                 eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
@@ -657,7 +716,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                     let vf: IrFunction = vfns[vfi];
                     let vows: Vec<IrVowEntry> = vf.vows;
                     if vows.len() > 0 {
-                        let vh: i64 = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max);
+                        let vh: i64 = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max);
                         if vh != -1 && vh != -2 {
                             let vr: VerifyResult = verify_collect(vh, vf);
                             if vr.status == VERIFY_FAILED() {
@@ -826,7 +885,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
             let use_cache_leg: bool = !has_flag(argv, String::from("--no-cache"));
-            let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache_leg, String::from(""), String::from(""), vec_max_leg, string_max_leg, hashmap_max_leg);
+            let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache_leg, String::from(""), String::from(""), String::from(""), vec_max_leg, string_max_leg, hashmap_max_leg);
             let status_str: String = {
                 if all_proven == 1 {
                     String::from("Verified")
@@ -1025,11 +1084,11 @@ fn skill_json() -> String {
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--timeout <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC per-function timeout in seconds (default: (none))\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("          \"long\": \"--timeout\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": \"(none)\"\n"));
+    r.push_str(String::from("          \"default\": \"(none; 30 when encoding is auto)\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
@@ -1130,11 +1189,11 @@ fn skill_json() -> String {
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--timeout <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC per-function timeout in seconds (default: (none))\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("          \"long\": \"--timeout\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": \"(none)\"\n"));
+    r.push_str(String::from("          \"default\": \"(none; 30 when encoding is auto)\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
@@ -1397,7 +1456,7 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
-    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds (default: (none))\",\n"));
+    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
     r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
     r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
@@ -1407,7 +1466,7 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
-    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds (default: (none))\",\n"));
+    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
     r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
     r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
@@ -1781,7 +1840,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
-    r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds (default: (none))\n"));
+    r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\n"));
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
     r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
     r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
@@ -1791,7 +1850,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
-    r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds (default: (none))\n"));
+    r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\n"));
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
     r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
     r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
@@ -2751,7 +2810,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
-    r.push_str(String::from("| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |\n"));
+    r.push_str(String::from("| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |\n"));
     r.push_str(String::from("| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |\n"));
     r.push_str(String::from("| `--string-max <N>` | `256`    | Max String capacity for verification model   |\n"));
     r.push_str(String::from("| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |\n"));
@@ -2772,7 +2831,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
-    r.push_str(String::from("| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |\n"));
+    r.push_str(String::from("| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |\n"));
     r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
     r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
     r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
@@ -3048,17 +3107,18 @@ fn skill_full() -> String {
     r.push_str(String::from("| `description` | string  | Full contract text                                       |\n"));
     r.push_str(String::from("| `blame`       | string  | `\"Caller\"` (requires) or `\"Callee\"` (ensures/invariant)  |\n"));
     r.push_str(String::from("| `source`      | object  | `{ \"file\": string, \"offset\": integer }`                  |\n"));
-    r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, or `\"not_verified\"` |\n"));
+    r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, or `\"not_verified\"` |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Status Values\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("| Status          | Meaning                                              |\n"));
     r.push_str(String::from("|-----------------|------------------------------------------------------|\n"));
     r.push_str(String::from("| `not_verified`  | Verification not requested (no `--verify` flag)      |\n"));
-    r.push_str(String::from("| `proven`        | ESBMC proved this contract holds for all inputs      |\n"));
+    r.push_str(String::from("| `proven`        | ESBMC proved this contract holds for all inputs (bit-vector encoding, overflow modeled) |\n"));
+    r.push_str(String::from("| `proven-ir`     | ESBMC proved this contract under integer-arithmetic encoding after BV timed out; overflow is not modeled by IR, but the BV caller preconditions still guard against it |\n"));
     r.push_str(String::from("| `failed`        | ESBMC found a counterexample violating this contract |\n"));
     r.push_str(String::from("| `unknown`       | Another contract in the same function failed; this one was not individually checked |\n"));
-    r.push_str(String::from("| `timeout`       | ESBMC timed out on the containing function           |\n"));
+    r.push_str(String::from("| `timeout`       | ESBMC timed out on the containing function (BV and -- when applicable -- IR fallback both timed out) |\n"));
     r.push_str(String::from("| `error`         | ESBMC error or tool not found                        |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Trace Output (stderr, --debug-trace)\n"));
@@ -4637,6 +4697,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     };
     let mut solver: String = get_flag_arg(argv, String::from("--solver"));
     let encoding: String = get_flag_arg(argv, String::from("--encoding"));
+    let timeout_secs: String = get_flag_arg(argv, String::from("--timeout"));
     if encoding == String::from("ir") {
         if solver == String::from("boolector") || solver == String::from("bitwuzla") {
             eprintln_str(String::from("error: --encoding ir requires --solver z3"));
@@ -4696,13 +4757,15 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
         while fi < nf {
             let func: IrFunction = ir_mod.functions[fi];
             if func.vows.len() > 0 {
-                let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache, solver, encoding, vec_max_c, string_max_c, hashmap_max_c);
+                let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max_c, string_max_c, hashmap_max_c);
                 let st: i64 = vr.status;
                 let mut ei: i64 = 0;
                 while ei < e_func_names.len() {
                     if e_func_names[ei] == func.name {
                         if st == VERIFY_PROVEN() {
                             e_statuses[ei] = String::from("proven");
+                        } else if st == VERIFY_PROVEN_IR() {
+                            e_statuses[ei] = String::from("proven-ir");
                         } else if st == VERIFY_FAILED() {
                             if vr.vow_id == e_vow_ids[ei] {
                                 e_statuses[ei] = String::from("failed");

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -723,12 +723,18 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                         let vh: i64 = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max);
                         if vh != -1 && vh != -2 {
                             let vr: VerifyResult = verify_collect(vh, vf);
-                            // Under Auto encoding a 30s default timeout now
-                            // applies, so VERIFY_TIMEOUT is reachable and
-                            // must fail the test — otherwise a contract the
-                            // solver can't prove would silently slip through.
-                            if vr.status == VERIFY_FAILED() || vr.status == VERIFY_TIMEOUT() {
+                            if vr.status == VERIFY_FAILED() {
                                 verify_failed = true;
+                            } else if vr.status == VERIFY_TIMEOUT() {
+                                // BV timed out under Auto encoding — try the
+                                // IR fallback before declaring the test a
+                                // failure. Matches the Rust `test` path
+                                // (which routes through run_with_fallback)
+                                // and run_build's own timeout branch.
+                                let vr2: VerifyResult = verify_function_ir_fallback(vf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max);
+                                if vr2.status == VERIFY_FAILED() || vr2.status == VERIFY_TIMEOUT() {
+                                    verify_failed = true;
+                                }
                             }
                         }
                     }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -723,7 +723,11 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                         let vh: i64 = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max);
                         if vh != -1 && vh != -2 {
                             let vr: VerifyResult = verify_collect(vh, vf);
-                            if vr.status == VERIFY_FAILED() {
+                            // Under Auto encoding a 30s default timeout now
+                            // applies, so VERIFY_TIMEOUT is reachable and
+                            // must fail the test — otherwise a contract the
+                            // solver can't prove would silently slip through.
+                            if vr.status == VERIFY_FAILED() || vr.status == VERIFY_TIMEOUT() {
                                 verify_failed = true;
                             }
                         }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -726,13 +726,10 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                             if vr.status == VERIFY_FAILED() {
                                 verify_failed = true;
                             } else if vr.status == VERIFY_TIMEOUT() {
-                                // BV timed out under Auto encoding — try the
-                                // IR fallback before declaring the test a
-                                // failure. Matches the Rust `test` path
-                                // (which routes through run_with_fallback)
-                                // and run_build's own timeout branch.
+                                // BV timed out; retry with IR before failing the test (mirrors run_build and run_with_fallback).
                                 let vr2: VerifyResult = verify_function_ir_fallback(vf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max);
-                                if vr2.status == VERIFY_FAILED() || vr2.status == VERIFY_TIMEOUT() {
+                                // Anything other than PROVEN/PROVEN_IR is a test failure, including ERROR and NOT_FOUND.
+                                if vr2.status != VERIFY_PROVEN() && vr2.status != VERIFY_PROVEN_IR() {
                                     verify_failed = true;
                                 }
                             }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -676,7 +676,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                             if vr.status == VERIFY_FAILED() {
                                 verify_failed = true;
                             } else if vr.status == VERIFY_TIMEOUT() {
-                                // BV timed out; retry with IR before failing the test (mirrors run_build and run_with_fallback).
+                                // BV timed out; retry with IR (no Bitwuzla guard needed — run_test only uses Auto/Boolector).
                                 let vr2: VerifyResult = verify_function_ir_fallback(vf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max);
                                 // Anything other than PROVEN/PROVEN_IR is a test failure, including ERROR and NOT_FOUND.
                                 if vr2.status != VERIFY_PROVEN() && vr2.status != VERIFY_PROVEN_IR() {

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -437,8 +437,12 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
             if st == VERIFY_PROVEN() {
                 eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
                 if use_cache {
+                    // Store under the resolved BV key so the sync `verify`
+                    // path (which also normalizes keys) can hit this entry.
                     let c_src2: String = emit_c_for_verify(f, ir_mod, vec_max, string_max, hashmap_max);
-                    let ck2: String = verify_cache_key(c_src2, max_k_step, solver, encoding);
+                    let bv_solver2: String = resolve_auto_bv_solver(solver);
+                    let bv_encoding2: String = { if is_auto_encoding(encoding) { String::from("bv") } else { encoding } };
+                    let ck2: String = verify_cache_key(c_src2, max_k_step, bv_solver2, bv_encoding2);
                     verify_cache_store(ck2, VERIFY_PROVEN());
                 }
             } else if st == VERIFY_FAILED() {
@@ -1084,7 +1088,7 @@ fn skill_json() -> String {
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--timeout <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("          \"long\": \"--timeout\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
@@ -1189,7 +1193,7 @@ fn skill_json() -> String {
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--timeout <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\",\n"));
+    r.push_str(String::from("          \"description\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("          \"long\": \"--timeout\",\n"));
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
@@ -1456,7 +1460,7 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
-    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\",\n"));
+    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
     r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
     r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
@@ -1466,7 +1470,7 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
-    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\",\n"));
+    r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
     r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
     r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
@@ -1840,7 +1844,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
-    r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\n"));
+    r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))\n"));
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
     r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
     r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
@@ -1850,7 +1854,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
-    r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))\n"));
+    r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))\n"));
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
     r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
     r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
@@ -2810,7 +2814,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
-    r.push_str(String::from("| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |\n"));
+    r.push_str(String::from("| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long |\n"));
     r.push_str(String::from("| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |\n"));
     r.push_str(String::from("| `--string-max <N>` | `256`    | Max String capacity for verification model   |\n"));
     r.push_str(String::from("| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |\n"));
@@ -2831,7 +2835,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
-    r.push_str(String::from("| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |\n"));
+    r.push_str(String::from("| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long |\n"));
     r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
     r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
     r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
@@ -4360,7 +4364,7 @@ fn skill_full() -> String {
     r.push_str(String::from("          },\n"));
     r.push_str(String::from("          \"status\": {\n"));
     r.push_str(String::from("            \"type\": \"string\",\n"));
-    r.push_str(String::from("            \"enum\": [\"proven\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\"],\n"));
+    r.push_str(String::from("            \"enum\": [\"proven\", \"proven-ir\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\"],\n"));
     r.push_str(String::from("            \"description\": \"Verification status\"\n"));
     r.push_str(String::from("          }\n"));
     r.push_str(String::from("        },\n"));
@@ -4823,7 +4827,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let mut si: i64 = 0;
     while si < total {
         let s: String = e_statuses[si];
-        if s == String::from("proven") {
+        if s == String::from("proven") || s == String::from("proven-ir") {
             n_proven = n_proven + 1;
         } else if s == String::from("failed") {
             n_failed = n_failed + 1;

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -716,20 +716,32 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
             if timeout_secs.len() > 0 { timeout_secs } else { DEFAULT_AUTO_TIMEOUT_STR() }
         };
         let exit2: i64 = run_esbmc(c_source, max_k_step, String::from("/tmp/__vow_verify.c"), fn_name, ir_solver, ir_encoding, ir_timeout);
-        if exit2 != -1 {
-            let so2: String = process_get_stdout();
-            let se2: String = process_get_stderr();
-            let combined2: String = String::from("");
-            combined2.push_str(so2);
-            combined2.push_str(se2);
-            let s2: i64 = parse_verify_status(combined2);
-            status = {
-                if s2 == VERIFY_PROVEN() { VERIFY_PROVEN_IR() } else { s2 }
+        if exit2 == -1 {
+            // ESBMC disappeared between BV and IR runs; surface consistently with verify_function_ir_fallback.
+            return VerifyResult {
+                status: VERIFY_NOT_FOUND(),
+                vow_id: -1,
+                var_names: Vec::new(),
+                var_values: Vec::new(),
+                block_visits: Vec::new(),
+                raw_output: String::from("esbmc not found"),
             };
-            used_combined = combined2;
-            resolved_solver = ir_solver;
-            resolved_encoding = ir_encoding;
         }
+        let so2: String = process_get_stdout();
+        let se2: String = process_get_stderr();
+        let combined2: String = String::from("");
+        combined2.push_str(so2);
+        combined2.push_str(se2);
+        let s2: i64 = parse_verify_status(combined2);
+        status = {
+            // IR-only counterexamples can be infeasible under BV (no overflow modeling), so a FAILED here is inconclusive — report the original Timeout instead.
+            if s2 == VERIFY_PROVEN() { VERIFY_PROVEN_IR() }
+            else if s2 == VERIFY_FAILED() { VERIFY_TIMEOUT() }
+            else { s2 }
+        };
+        used_combined = combined2;
+        resolved_solver = ir_solver;
+        resolved_encoding = ir_encoding;
     }
 
     if use_cache {
@@ -795,7 +807,10 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
     combined.push_str(stderr);
     let raw_status: i64 = parse_verify_status(combined);
     let status: i64 = {
-        if raw_status == VERIFY_PROVEN() { VERIFY_PROVEN_IR() } else { raw_status }
+        // IR-only CEs can be infeasible under BV — demote FAILED to TIMEOUT (the caller only reaches us because BV already timed out).
+        if raw_status == VERIFY_PROVEN() { VERIFY_PROVEN_IR() }
+        else if raw_status == VERIFY_FAILED() { VERIFY_TIMEOUT() }
+        else { raw_status }
     };
     if use_cache {
         // Only persist PROVEN under (z3, ir). IR counterexamples can be

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -309,11 +309,7 @@ fn effective_timeout_for(encoding: String, solver: String, user_timeout: String)
     if user_timeout.len() > 0 {
         return user_timeout;
     }
-    // The 30s default only makes sense when the IR fallback can kick in.
-    // Bitwuzla can't run the IR encoding, so applying the default timeout
-    // under --solver bitwuzla would cut it off at 30s with no retry path —
-    // a silent regression for users deliberately picking Bitwuzla for
-    // bitwise-heavy contracts. Leave those runs uncapped.
+    // Bitwuzla can't use IR encoding — don't cap it with a timeout that has no retry path.
     let bv_solver: String = resolve_auto_bv_solver(solver);
     if bv_solver == String::from("bitwuzla") {
         return String::from("");

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -759,6 +759,15 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
     let ir_timeout: String = {
         if timeout_secs.len() > 0 { timeout_secs } else { DEFAULT_AUTO_TIMEOUT_STR() }
     };
+    // Probe the IR cache first so a repeated BV timeout doesn't re-run Z3.
+    if use_cache {
+        verify_cache_ensure_dir();
+        let ir_probe_key: String = verify_cache_key(c_source, max_k_step, ir_solver, ir_encoding);
+        let cached_ir: i64 = verify_cache_lookup(ir_probe_key);
+        if cached_ir == VERIFY_PROVEN() {
+            return build_verify_result(f, VERIFY_PROVEN_IR(), String::from("(cached)"));
+        }
+    }
     let exit_code: i64 = run_esbmc(c_source, max_k_step, String::from("/tmp/__vow_verify.c"), fn_name, ir_solver, ir_encoding, ir_timeout);
     if exit_code == -1 {
         return VerifyResult {
@@ -798,12 +807,27 @@ fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_ca
         return -1;
     }
     let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max);
+    let auto_enc: bool = is_auto_encoding(encoding);
+    let bv_solver: String = resolve_auto_bv_solver(solver);
+    let bv_encoding: String = { if auto_enc { String::from("bv") } else { encoding } };
     if use_cache {
         verify_cache_ensure_dir();
-        let cache_key: String = verify_cache_key(c_source, max_k_step, solver, encoding);
+        // Lookup under the resolved BV key so hits produced by the sync
+        // `verify` path (which normalizes keys the same way) are visible
+        // here. Otherwise Auto mode splits the cache namespace.
+        let cache_key: String = verify_cache_key(c_source, max_k_step, bv_solver, bv_encoding);
         let cached: i64 = verify_cache_lookup(cache_key);
         if cached == VERIFY_PROVEN() {
             return -2;
+        }
+        // Also probe the IR fallback key: a prior run may have escalated to
+        // (z3, ir) after a BV timeout.
+        if auto_enc && bv_solver != String::from("bitwuzla") {
+            let ir_key: String = verify_cache_key(c_source, max_k_step, String::from("z3"), String::from("ir"));
+            let cached_ir: i64 = verify_cache_lookup(ir_key);
+            if cached_ir == VERIFY_PROVEN() {
+                return -2;
+            }
         }
     }
     let tmp_path: String = String::from("/tmp/__vow_verify_");

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -740,7 +740,11 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
         let cache_status: i64 = {
             if status == VERIFY_PROVEN_IR() { VERIFY_PROVEN() } else { status }
         };
-        if cache_status == VERIFY_PROVEN() || cache_status == VERIFY_FAILED() {
+        // Don't persist FAILED entries under (z3, ir): IR lacks overflow
+        // modeling, so IR-only counterexamples may be infeasible under BV,
+        // and neither secondary lookup retrieves IR-FAILED results anyway.
+        let is_ir_key: bool = resolved_encoding == String::from("ir");
+        if cache_status == VERIFY_PROVEN() || (cache_status == VERIFY_FAILED() && !is_ir_key) {
             let cache_key2: String = verify_cache_key(c_source, max_k_step, resolved_solver, resolved_encoding);
             verify_cache_store(cache_key2, cache_status);
         }
@@ -798,10 +802,13 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
         if raw_status == VERIFY_PROVEN() { VERIFY_PROVEN_IR() } else { raw_status }
     };
     if use_cache {
+        // Only persist PROVEN under (z3, ir). IR counterexamples can be
+        // infeasible under BV, so writing FAILED here would be misleading
+        // and no reader probes the IR key for FAILED anyway.
         let cache_status: i64 = {
             if status == VERIFY_PROVEN_IR() { VERIFY_PROVEN() } else { status }
         };
-        if cache_status == VERIFY_PROVEN() || cache_status == VERIFY_FAILED() {
+        if cache_status == VERIFY_PROVEN() {
             let cache_key: String = verify_cache_key(c_source, max_k_step, ir_solver, ir_encoding);
             verify_cache_store(cache_key, cache_status);
         }

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -305,9 +305,18 @@ fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name
     handle
 }
 
-fn effective_timeout_for(encoding: String, user_timeout: String) -> String {
+fn effective_timeout_for(encoding: String, solver: String, user_timeout: String) -> String {
     if user_timeout.len() > 0 {
         return user_timeout;
+    }
+    // The 30s default only makes sense when the IR fallback can kick in.
+    // Bitwuzla can't run the IR encoding, so applying the default timeout
+    // under --solver bitwuzla would cut it off at 30s with no retry path —
+    // a silent regression for users deliberately picking Bitwuzla for
+    // bitwise-heavy contracts. Leave those runs uncapped.
+    let bv_solver: String = resolve_auto_bv_solver(solver);
+    if bv_solver == String::from("bitwuzla") {
+        return String::from("");
     }
     if encoding.len() == 0 || encoding == String::from("auto") {
         return DEFAULT_AUTO_TIMEOUT_STR();
@@ -641,7 +650,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
     let auto_enc: bool = is_auto_encoding(encoding);
     let bv_solver: String = resolve_auto_bv_solver(solver);
     let bv_encoding: String = { if auto_enc { String::from("bv") } else { encoding } };
-    let bv_timeout: String = effective_timeout_for(encoding, timeout_secs);
+    let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
     if use_cache {
         verify_cache_ensure_dir();
         // Lookup under the resolved BV key so cache hits survive Auto→Bv
@@ -834,7 +843,7 @@ fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_ca
     tmp_path.push_str(i64_to_str(idx));
     tmp_path.push_str(String::from(".c"));
     let fn_name: String = f.name;
-    let bv_timeout: String = effective_timeout_for(encoding, timeout_secs);
+    let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
     let handle: i64 = start_esbmc(c_source, max_k_step, tmp_path, fn_name, solver, encoding, bv_timeout);
     handle
 }

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -9,6 +9,7 @@ fn VERIFY_FAILED() -> i64 vow { ensures: result >= 0 } { 1 }
 fn VERIFY_TIMEOUT() -> i64 vow { ensures: result >= 0 } { 2 }
 fn VERIFY_ERROR() -> i64 vow { ensures: result >= 0 } { 3 }
 fn VERIFY_NOT_FOUND() -> i64 vow { ensures: result >= 0 } { 4 }
+fn VERIFY_PROVEN_IR() -> i64 vow { ensures: result >= 0 } { 5 }
 
 struct VerifyResult {
     status: i64,
@@ -252,6 +253,8 @@ fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func
     fs_write(cmd_path, cmd);
 }
 
+fn DEFAULT_AUTO_TIMEOUT_STR() -> String { String::from("30") }
+
 fn append_solver_args(args: Vec<String>, solver: String, encoding: String) {
     if solver.len() > 0 && solver != String::from("boolector") && solver != String::from("auto") {
         args.push(str2(String::from("--"), solver));
@@ -261,7 +264,14 @@ fn append_solver_args(args: Vec<String>, solver: String, encoding: String) {
     }
 }
 
-fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: String, solver: String, encoding: String) -> i64 [io] {
+fn append_timeout_arg(args: Vec<String>, timeout_secs: String) {
+    if timeout_secs.len() > 0 {
+        args.push(String::from("--timeout"));
+        args.push(str2(timeout_secs, String::from("s")));
+    }
+}
+
+fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: String, solver: String, encoding: String, timeout_secs: String) -> i64 [io] {
     fs_write(tmp_path, c_source);
     save_esbmc_debug(c_source, tmp_path, max_k_step, func_name, false);
     let esbmc_args: Vec<String> = Vec::new();
@@ -273,11 +283,12 @@ fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: 
     esbmc_args.push(max_k_step);
     esbmc_args.push(String::from("--64"));
     append_solver_args(esbmc_args, solver, encoding);
+    append_timeout_arg(esbmc_args, timeout_secs);
     let exit_code: i64 = process_run(esbmc_path(), esbmc_args);
     exit_code
 }
 
-fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: String, solver: String, encoding: String) -> i64 [io] {
+fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: String, solver: String, encoding: String, timeout_secs: String) -> i64 [io] {
     fs_write(tmp_path, c_source);
     save_esbmc_debug(c_source, tmp_path, max_k_step, func_name, false);
     let esbmc_args: Vec<String> = Vec::new();
@@ -289,8 +300,19 @@ fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name
     esbmc_args.push(max_k_step);
     esbmc_args.push(String::from("--64"));
     append_solver_args(esbmc_args, solver, encoding);
+    append_timeout_arg(esbmc_args, timeout_secs);
     let handle: i64 = process_start(esbmc_path(), esbmc_args);
     handle
+}
+
+fn effective_timeout_for(encoding: String, user_timeout: String) -> String {
+    if user_timeout.len() > 0 {
+        return user_timeout;
+    }
+    if encoding.len() == 0 || encoding == String::from("auto") {
+        return DEFAULT_AUTO_TIMEOUT_STR();
+    }
+    String::from("")
 }
 
 fn parse_verify_status(combined: String) -> i64 {
@@ -304,6 +326,9 @@ fn parse_verify_status(combined: String) -> i64 {
         return VERIFY_TIMEOUT();
     }
     if str_find_str(combined, String::from("Timeout")) >= 0 {
+        return VERIFY_TIMEOUT();
+    }
+    if str_find_str(combined, String::from("Timed out")) >= 0 {
         return VERIFY_TIMEOUT();
     }
     VERIFY_ERROR()
@@ -556,59 +581,18 @@ fn verify_cache_store(key: String, status: i64) [io] {
     fs_write(path, content);
 }
 
-fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cache: bool, solver: String, encoding: String,
-                        vec_max: i64, string_max: i64, hashmap_max: i64) -> VerifyResult [io] {
-    let vows: Vec<IrVowEntry> = f.vows;
-    if vows.len() == 0 {
-        return VerifyResult {
-            status: VERIFY_PROVEN(),
-            vow_id: -1,
-            var_names: Vec::new(),
-            var_values: Vec::new(),
-            block_visits: Vec::new(),
-            raw_output: String::from(""),
-        };
+fn resolve_auto_bv_solver(solver: String) -> String {
+    if solver.len() == 0 || solver == String::from("auto") {
+        return String::from("boolector");
     }
-    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max);
-    if use_cache {
-        verify_cache_ensure_dir();
-        let cache_key: String = verify_cache_key(c_source, max_k_step, solver, encoding);
-        let cached: i64 = verify_cache_lookup(cache_key);
-        if cached == VERIFY_PROVEN() {
-            return VerifyResult {
-                status: VERIFY_PROVEN(),
-                vow_id: -1,
-                var_names: Vec::new(),
-                var_values: Vec::new(),
-                block_visits: Vec::new(),
-                raw_output: String::from("(cached)"),
-            };
-        }
-    }
-    let fn_name: String = f.name;
-    let exit_code: i64 = run_esbmc(c_source, max_k_step, String::from("/tmp/__vow_verify.c"), fn_name, solver, encoding);
-    if exit_code == -1 {
-        return VerifyResult {
-            status: VERIFY_NOT_FOUND(),
-            vow_id: -1,
-            var_names: Vec::new(),
-            var_values: Vec::new(),
-            block_visits: Vec::new(),
-            raw_output: String::from("esbmc not found"),
-        };
-    }
-    let stdout: String = process_get_stdout();
-    let stderr: String = process_get_stderr();
-    let combined: String = String::from("");
-    combined.push_str(stdout);
-    combined.push_str(stderr);
-    let status: i64 = parse_verify_status(combined);
-    if use_cache {
-        if status == VERIFY_PROVEN() || status == VERIFY_FAILED() {
-            let cache_key2: String = verify_cache_key(c_source, max_k_step, solver, encoding);
-            verify_cache_store(cache_key2, status);
-        }
-    }
+    solver
+}
+
+fn is_auto_encoding(encoding: String) -> bool {
+    encoding.len() == 0 || encoding == String::from("auto")
+}
+
+fn build_verify_result(f: IrFunction, status: i64, combined: String) -> VerifyResult {
     let vow_id: i64 = {
         if status == VERIFY_FAILED() {
             parse_vow_id(combined)
@@ -639,7 +623,175 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
     }
 }
 
-fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_cache: bool, solver: String, encoding: String,
+fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
+                        vec_max: i64, string_max: i64, hashmap_max: i64) -> VerifyResult [io] {
+    let vows: Vec<IrVowEntry> = f.vows;
+    if vows.len() == 0 {
+        return VerifyResult {
+            status: VERIFY_PROVEN(),
+            vow_id: -1,
+            var_names: Vec::new(),
+            var_values: Vec::new(),
+            block_visits: Vec::new(),
+            raw_output: String::from(""),
+        };
+    }
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max);
+    let fn_name: String = f.name;
+    let auto_enc: bool = is_auto_encoding(encoding);
+    let bv_solver: String = resolve_auto_bv_solver(solver);
+    let bv_encoding: String = { if auto_enc { String::from("bv") } else { encoding } };
+    let bv_timeout: String = effective_timeout_for(encoding, timeout_secs);
+    if use_cache {
+        verify_cache_ensure_dir();
+        // Lookup under the resolved BV key so cache hits survive Auto→Bv
+        // resolution. The BV-Proven store path uses the same key below.
+        let cache_key: String = verify_cache_key(c_source, max_k_step, bv_solver, bv_encoding);
+        let cached: i64 = verify_cache_lookup(cache_key);
+        if cached == VERIFY_PROVEN() {
+            return VerifyResult {
+                status: VERIFY_PROVEN(),
+                vow_id: -1,
+                var_names: Vec::new(),
+                var_values: Vec::new(),
+                block_visits: Vec::new(),
+                raw_output: String::from("(cached)"),
+            };
+        }
+        // Phase D: if previous run fell back to IR under Auto encoding, the
+        // result was stored under (z3, ir). Probe that key too so re-verify
+        // doesn't have to rerun the BV timeout.
+        if auto_enc && bv_solver != String::from("bitwuzla") {
+            let ir_key: String = verify_cache_key(c_source, max_k_step, String::from("z3"), String::from("ir"));
+            let cached_ir: i64 = verify_cache_lookup(ir_key);
+            if cached_ir == VERIFY_PROVEN() {
+                return VerifyResult {
+                    status: VERIFY_PROVEN_IR(),
+                    vow_id: -1,
+                    var_names: Vec::new(),
+                    var_values: Vec::new(),
+                    block_visits: Vec::new(),
+                    raw_output: String::from("(cached)"),
+                };
+            }
+        }
+    }
+
+    let exit_code: i64 = run_esbmc(c_source, max_k_step, String::from("/tmp/__vow_verify.c"), fn_name, solver, encoding, bv_timeout);
+    if exit_code == -1 {
+        return VerifyResult {
+            status: VERIFY_NOT_FOUND(),
+            vow_id: -1,
+            var_names: Vec::new(),
+            var_values: Vec::new(),
+            block_visits: Vec::new(),
+            raw_output: String::from("esbmc not found"),
+        };
+    }
+    let stdout: String = process_get_stdout();
+    let stderr: String = process_get_stderr();
+    let combined: String = String::from("");
+    combined.push_str(stdout);
+    combined.push_str(stderr);
+    let mut status: i64 = parse_verify_status(combined);
+    let mut used_combined: String = combined;
+    let mut resolved_solver: String = {
+        if solver.len() == 0 || solver == String::from("auto") { bv_solver } else { solver }
+    };
+    let mut resolved_encoding: String = {
+        if auto_enc { String::from("bv") } else { encoding }
+    };
+
+    // Phase D: if BV timed out under Auto encoding and the BV solver is not
+    // Bitwuzla, retry once with --z3 --ir (integer encoding).
+    if status == VERIFY_TIMEOUT() && auto_enc && bv_solver != String::from("bitwuzla") {
+        let ir_solver: String = String::from("z3");
+        let ir_encoding: String = String::from("ir");
+        let ir_timeout: String = {
+            if timeout_secs.len() > 0 { timeout_secs } else { DEFAULT_AUTO_TIMEOUT_STR() }
+        };
+        let exit2: i64 = run_esbmc(c_source, max_k_step, String::from("/tmp/__vow_verify.c"), fn_name, ir_solver, ir_encoding, ir_timeout);
+        if exit2 != -1 {
+            let so2: String = process_get_stdout();
+            let se2: String = process_get_stderr();
+            let combined2: String = String::from("");
+            combined2.push_str(so2);
+            combined2.push_str(se2);
+            let s2: i64 = parse_verify_status(combined2);
+            status = {
+                if s2 == VERIFY_PROVEN() { VERIFY_PROVEN_IR() } else { s2 }
+            };
+            used_combined = combined2;
+            resolved_solver = ir_solver;
+            resolved_encoding = ir_encoding;
+        }
+    }
+
+    if use_cache {
+        let cache_status: i64 = {
+            if status == VERIFY_PROVEN_IR() { VERIFY_PROVEN() } else { status }
+        };
+        if cache_status == VERIFY_PROVEN() || cache_status == VERIFY_FAILED() {
+            let cache_key2: String = verify_cache_key(c_source, max_k_step, resolved_solver, resolved_encoding);
+            verify_cache_store(cache_key2, cache_status);
+        }
+    }
+    build_verify_result(f, status, used_combined)
+}
+
+fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, use_cache: bool, timeout_secs: String,
+                               vec_max: i64, string_max: i64, hashmap_max: i64) -> VerifyResult [io] {
+    let vows: Vec<IrVowEntry> = f.vows;
+    if vows.len() == 0 {
+        return VerifyResult {
+            status: VERIFY_PROVEN(),
+            vow_id: -1,
+            var_names: Vec::new(),
+            var_values: Vec::new(),
+            block_visits: Vec::new(),
+            raw_output: String::from(""),
+        };
+    }
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max);
+    let fn_name: String = f.name;
+    let ir_solver: String = String::from("z3");
+    let ir_encoding: String = String::from("ir");
+    let ir_timeout: String = {
+        if timeout_secs.len() > 0 { timeout_secs } else { DEFAULT_AUTO_TIMEOUT_STR() }
+    };
+    let exit_code: i64 = run_esbmc(c_source, max_k_step, String::from("/tmp/__vow_verify.c"), fn_name, ir_solver, ir_encoding, ir_timeout);
+    if exit_code == -1 {
+        return VerifyResult {
+            status: VERIFY_NOT_FOUND(),
+            vow_id: -1,
+            var_names: Vec::new(),
+            var_values: Vec::new(),
+            block_visits: Vec::new(),
+            raw_output: String::from("esbmc not found"),
+        };
+    }
+    let stdout: String = process_get_stdout();
+    let stderr: String = process_get_stderr();
+    let combined: String = String::from("");
+    combined.push_str(stdout);
+    combined.push_str(stderr);
+    let raw_status: i64 = parse_verify_status(combined);
+    let status: i64 = {
+        if raw_status == VERIFY_PROVEN() { VERIFY_PROVEN_IR() } else { raw_status }
+    };
+    if use_cache {
+        let cache_status: i64 = {
+            if status == VERIFY_PROVEN_IR() { VERIFY_PROVEN() } else { status }
+        };
+        if cache_status == VERIFY_PROVEN() || cache_status == VERIFY_FAILED() {
+            let cache_key: String = verify_cache_key(c_source, max_k_step, ir_solver, ir_encoding);
+            verify_cache_store(cache_key, cache_status);
+        }
+    }
+    build_verify_result(f, status, combined)
+}
+
+fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
                 vec_max: i64, string_max: i64, hashmap_max: i64) -> i64 [io] {
     let vows: Vec<IrVowEntry> = f.vows;
     if vows.len() == 0 {
@@ -658,7 +810,8 @@ fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_ca
     tmp_path.push_str(i64_to_str(idx));
     tmp_path.push_str(String::from(".c"));
     let fn_name: String = f.name;
-    let handle: i64 = start_esbmc(c_source, max_k_step, tmp_path, fn_name, solver, encoding);
+    let bv_timeout: String = effective_timeout_for(encoding, timeout_secs);
+    let handle: i64 = start_esbmc(c_source, max_k_step, tmp_path, fn_name, solver, encoding, bv_timeout);
     handle
 }
 

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -24,7 +24,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
-| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |
+| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long |
 | `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
 | `--string-max <N>` | `256`    | Max String capacity for verification model   |
 | `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
@@ -45,7 +45,7 @@ vow verify [OPTIONS] <source.vow>
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
-| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |
+| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -24,7 +24,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
-| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |
+| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |
 | `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
 | `--string-max <N>` | `256`    | Max String capacity for verification model   |
 | `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
@@ -45,7 +45,7 @@ vow verify [OPTIONS] <source.vow>
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
-| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |
+| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
@@ -321,17 +321,18 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `description` | string  | Full contract text                                       |
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
-| `status`      | string  | `"proven"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, or `"not_verified"` |
+| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, or `"not_verified"` |
 
 ### Status Values
 
 | Status          | Meaning                                              |
 |-----------------|------------------------------------------------------|
 | `not_verified`  | Verification not requested (no `--verify` flag)      |
-| `proven`        | ESBMC proved this contract holds for all inputs      |
+| `proven`        | ESBMC proved this contract holds for all inputs (bit-vector encoding, overflow modeled) |
+| `proven-ir`     | ESBMC proved this contract under integer-arithmetic encoding after BV timed out; overflow is not modeled by IR, but the BV caller preconditions still guard against it |
 | `failed`        | ESBMC found a counterexample violating this contract |
 | `unknown`       | Another contract in the same function failed; this one was not individually checked |
-| `timeout`       | ESBMC timed out on the containing function           |
+| `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 
 ## Trace Output (stderr, --debug-trace)

--- a/docs/spec/schemas/contracts-result.schema.json
+++ b/docs/spec/schemas/contracts-result.schema.json
@@ -51,7 +51,7 @@
           },
           "status": {
             "type": "string",
-            "enum": ["proven", "failed", "unknown", "timeout", "error", "not_verified"],
+            "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified"],
             "description": "Verification status"
           }
         },

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Stdio};
 
 use vow_ir::{FuncId, Function, Module, Ty};
 
-use crate::solver_strategy::SolverConfig;
+use crate::solver_strategy::{SolverConfig, run_with_fallback};
 
 use crate::c_emitter::{
     ConstantValue, VerifyLimits, collect_modelable_callees, detect_constant_functions,
@@ -301,7 +301,8 @@ pub fn verify_function_with_module_and_const_fns_configured(
     };
 
     let c_src = emit_verify_c_source(func, module, const_fns, limits);
-    run_esbmc_with_max_k_step(&esbmc, &c_src, max_k_step, &func.name, config)
+    let (result, _resolved) = run_with_fallback(&esbmc, &c_src, max_k_step, &func.name, config);
+    result
 }
 
 fn verify_function_inner(

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -196,8 +196,6 @@ pub fn classify_function(func: &Function) -> SolverConfig {
 
 /// Run ESBMC with fallback: if BV times out in auto mode, retry with --ir --z3.
 /// Returns the result and the config that produced it.
-/// Not yet wired into the main verification loop — reserved for Phase D integration.
-#[allow(dead_code)]
 pub fn run_with_fallback(
     esbmc: &Path,
     c_src: &str,
@@ -534,5 +532,196 @@ mod tests {
         );
         let c = classify_function(&func);
         assert_eq!(c.encoding, Encoding::Bv); // NEVER Ir from heuristic
+    }
+
+    // -- Phase D: run_with_fallback tests --
+
+    use crate::c_emitter::VerifyLimits;
+    use crate::esbmc::{emit_verify_c_source, find_esbmc};
+    use std::collections::HashMap;
+    use vow_diag::Blame;
+    use vow_ir::{InstData, Module as IrModule, Opcode, VowEntry, VowId};
+
+    fn trivially_true_fn() -> Function {
+        Function {
+            id: FuncId(0),
+            name: "always_ok".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I32,
+            effects: vec![],
+            vows: vec![VowEntry {
+                id: VowId(0),
+                description: "true".to_string(),
+                blame: Blame::Callee,
+                bindings: vec![],
+                file: String::new(),
+                offset: 0,
+            }],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(
+                        0,
+                        Opcode::ConstBool,
+                        Ty::Bool,
+                        vec![],
+                        InstData::ConstBool(true),
+                    ),
+                    Inst {
+                        id: InstId(1),
+                        opcode: Opcode::VowEnsures,
+                        ty: Ty::Unit,
+                        args: vec![InstId(0)],
+                        data: InstData::VowId(VowId(0)),
+                        origin: Span { start: 0, len: 0 },
+                    },
+                    inst(2, Opcode::ConstI32, Ty::I32, vec![], InstData::ConstI32(42)),
+                    inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+        }
+    }
+
+    fn emit_c_for(func: &Function) -> String {
+        let module = IrModule {
+            name: "test".to_string(),
+            functions: vec![func.clone()],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+            warnings: vec![],
+        };
+        let const_fns = HashMap::new();
+        emit_verify_c_source(func, &module, &const_fns, &VerifyLimits::default())
+    }
+
+    /// Phase D: when encoding is explicit (Bv), run_with_fallback runs once
+    /// and returns the resolved config unchanged.
+    #[test]
+    fn fallback_explicit_bv_one_shot() {
+        let esbmc = match find_esbmc() {
+            Some(p) => p,
+            None => {
+                eprintln!("SKIP: esbmc not found");
+                return;
+            }
+        };
+        let func = trivially_true_fn();
+        let c_src = emit_c_for(&func);
+        let cfg = SolverConfig {
+            solver: Solver::Boolector,
+            encoding: Encoding::Bv,
+            timeout_secs: None,
+        };
+        let (result, resolved) = run_with_fallback(&esbmc, &c_src, 5, &func.name, &cfg);
+        assert!(matches!(result, VerificationResult::Proven));
+        assert_eq!(resolved.solver, Solver::Boolector);
+        assert_eq!(resolved.encoding, Encoding::Bv);
+    }
+
+    /// Phase D: when encoding is Auto and BV proves the function, no IR
+    /// retry is attempted and the returned config reports encoding=Bv.
+    #[test]
+    fn fallback_auto_bv_proves_trivial_no_retry() {
+        let esbmc = match find_esbmc() {
+            Some(p) => p,
+            None => {
+                eprintln!("SKIP: esbmc not found");
+                return;
+            }
+        };
+        let func = trivially_true_fn();
+        let c_src = emit_c_for(&func);
+        let cfg = SolverConfig {
+            solver: Solver::Auto,
+            encoding: Encoding::Auto,
+            timeout_secs: None,
+        };
+        let (result, resolved) = run_with_fallback(&esbmc, &c_src, 5, &func.name, &cfg);
+        assert!(matches!(result, VerificationResult::Proven));
+        // No fallback kicked in, so encoding must be Bv (IR is only used on timeout).
+        assert_eq!(resolved.encoding, Encoding::Bv);
+    }
+
+    /// Phase D: the Bitwuzla guard — when BV solver is Bitwuzla and BV
+    /// times out in Auto encoding, run_with_fallback must NOT fall back to
+    /// IR (IR requires Z3). Force a timeout by using timeout_secs=0.
+    #[test]
+    fn fallback_bitwuzla_never_retries_ir() {
+        let esbmc = match find_esbmc() {
+            Some(p) => p,
+            None => {
+                eprintln!("SKIP: esbmc not found");
+                return;
+            }
+        };
+        let func = trivially_true_fn();
+        let c_src = emit_c_for(&func);
+        let cfg = SolverConfig {
+            solver: Solver::Bitwuzla,
+            encoding: Encoding::Auto,
+            timeout_secs: Some(0), // force BV to time out immediately
+        };
+        let (result, resolved) = run_with_fallback(&esbmc, &c_src, 5, &func.name, &cfg);
+        // The BV run might finish between spawn and the first 50ms poll; if
+        // so, we accept Proven. What we must never see is ProvenIr — that
+        // would mean the guard was bypassed and IR was tried with Bitwuzla.
+        match result {
+            VerificationResult::Timeout => {
+                assert_eq!(resolved.solver, Solver::Bitwuzla);
+                assert_eq!(resolved.encoding, Encoding::Bv);
+            }
+            VerificationResult::Proven => {
+                assert_eq!(resolved.solver, Solver::Bitwuzla);
+                assert_eq!(resolved.encoding, Encoding::Bv);
+            }
+            VerificationResult::ProvenIr => {
+                panic!("bitwuzla must not fall back to IR encoding");
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    /// Phase D: when BV times out under Auto encoding (non-Bitwuzla solver),
+    /// the fallback retries with Z3+IR. Force the BV timeout with
+    /// timeout_secs=0 so the IR retry is what actually runs; IR proves the
+    /// trivially-true ensures and we get ProvenIr.
+    #[test]
+    fn fallback_auto_bv_timeout_retries_with_ir() {
+        let esbmc = match find_esbmc() {
+            Some(p) => p,
+            None => {
+                eprintln!("SKIP: esbmc not found");
+                return;
+            }
+        };
+        let func = trivially_true_fn();
+        let c_src = emit_c_for(&func);
+        let cfg = SolverConfig {
+            solver: Solver::Boolector,
+            encoding: Encoding::Auto,
+            timeout_secs: Some(0),
+        };
+        let (result, resolved) = run_with_fallback(&esbmc, &c_src, 5, &func.name, &cfg);
+        // The BV run may or may not race the 50ms poll; accept either
+        // Proven (BV finished first) or ProvenIr (fallback kicked in).
+        match result {
+            VerificationResult::Proven => {
+                assert_eq!(resolved.encoding, Encoding::Bv);
+            }
+            VerificationResult::ProvenIr => {
+                assert_eq!(resolved.solver, Solver::Z3);
+                assert_eq!(resolved.encoding, Encoding::Ir);
+            }
+            VerificationResult::Timeout => {
+                // Both BV and IR timed out — still valid for the guard test,
+                // but the resolved config must reflect the IR attempt since
+                // fallback was enabled.
+                assert_eq!(resolved.encoding, Encoding::Ir);
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
     }
 }

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -259,6 +259,11 @@ pub fn run_with_fallback(
                 run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, &ir_config);
             match ir_result {
                 VerificationResult::Proven => (VerificationResult::ProvenIr, ir_config),
+                // IR returned a counterexample, but IR does not model
+                // overflow — a CE found only under IR can be infeasible
+                // under BV. Report Timeout (which is what BV actually
+                // produced) rather than an unsound definitive Failed.
+                VerificationResult::Failed(_) => (VerificationResult::Timeout, ir_config),
                 other => (other, ir_config),
             }
         }

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -211,11 +211,28 @@ pub fn run_with_fallback(
     }
 
     // Auto mode: run with BV first, fallback to IR on timeout.
-    let timeout = config.timeout_secs.unwrap_or(DEFAULT_AUTO_TIMEOUT_SECS);
+    //
+    // The default 30s cap is only meaningful when the IR fallback is
+    // actually reachable. Bitwuzla can't run the IR encoding, so applying
+    // `DEFAULT_AUTO_TIMEOUT_SECS` when the resolved BV solver is Bitwuzla
+    // would amount to a silent regression — users who pick Bitwuzla for
+    // bitwise-heavy contracts would get cut off at 30s with no retry.
+    // Leave those runs uncapped unless the user set --timeout explicitly.
+    let bv_solver = match config.solver {
+        Solver::Auto => Solver::Boolector,
+        s => s,
+    };
+    let timeout_secs = if config.timeout_secs.is_some() {
+        config.timeout_secs
+    } else if matches!(bv_solver, Solver::Bitwuzla) {
+        None
+    } else {
+        Some(DEFAULT_AUTO_TIMEOUT_SECS)
+    };
     let bv_config = SolverConfig {
         solver: config.solver,
         encoding: Encoding::Bv,
-        timeout_secs: Some(timeout),
+        timeout_secs,
     }
     .resolve();
 
@@ -230,10 +247,13 @@ pub fn run_with_fallback(
                 return (VerificationResult::Timeout, bv_config);
             }
 
+            // Reuse the same timeout policy for the IR retry: user override
+            // if set, else the 30s default (IR is always reachable here).
+            let ir_timeout = config.timeout_secs.or(Some(DEFAULT_AUTO_TIMEOUT_SECS));
             let ir_config = SolverConfig {
                 solver: Solver::Z3,
                 encoding: Encoding::Ir,
-                timeout_secs: Some(timeout),
+                timeout_secs: ir_timeout,
             };
             let ir_result =
                 run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, &ir_config);

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -450,7 +450,7 @@ fn skill_json() -> String {
         },
         {
           "form": "--timeout <N>",
-          "description": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))",
+          "description": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))",
           "long": "--timeout",
           "value_name": "N",
           "value_kind": "integer",
@@ -555,7 +555,7 @@ fn skill_json() -> String {
         },
         {
           "form": "--timeout <N>",
-          "description": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))",
+          "description": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))",
           "long": "--timeout",
           "value_name": "N",
           "value_kind": "integer",
@@ -822,7 +822,7 @@ fn skill_json() -> String {
     "--max-k-step <N>": "ESBMC incremental BMC max iterations (default: 50)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
-    "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))",
+    "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
     "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
@@ -832,7 +832,7 @@ fn skill_json() -> String {
     "--max-k-step <N>": "ESBMC incremental BMC max iterations (default: 50)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
-    "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))",
+    "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
     "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
@@ -1206,7 +1206,7 @@ BUILD OPTIONS
   --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
-  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))
+  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
@@ -1216,7 +1216,7 @@ VERIFY OPTIONS
   --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
-  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))
+  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
@@ -2176,7 +2176,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
-| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |
+| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long |
 | `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
 | `--string-max <N>` | `256`    | Max String capacity for verification model   |
 | `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
@@ -2197,7 +2197,7 @@ vow verify [OPTIONS] <source.vow>
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
-| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |
+| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
@@ -3726,7 +3726,7 @@ When stdin is exhausted, `stdin_read_line()` returns `""` (length 0), the `while
           },
           "status": {
             "type": "string",
-            "enum": ["proven", "failed", "unknown", "timeout", "error", "not_verified"],
+            "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified"],
             "description": "Verification status"
           }
         },
@@ -5725,7 +5725,7 @@ fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJso
     };
     for e in entries {
         match e.status.as_str() {
-            "proven" => summary.proven += 1,
+            "proven" | "proven-ir" => summary.proven += 1,
             "failed" => summary.failed += 1,
             "unknown" => summary.unknown += 1,
             "timeout" => summary.timeout += 1,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -4784,21 +4784,20 @@ fn run_verification_sync(
                 }
             });
             // Phase D: if BV lookup misses under Auto encoding and BV solver
-            // isn't Bitwuzla, also probe the IR fallback key — a prior
-            // ProvenIr result lives under (z3, ir). On hit, promote to
-            // ProvenIr so contract reporting stays accurate.
+            // isn't Bitwuzla, probe the IR fallback key for a prior
+            // ProvenIr result. Only promote Proven hits — IR Failed entries
+            // must be ignored because IR doesn't model overflow, so an
+            // IR-only counterexample may be infeasible under BV semantics.
             let cached_result = cached_result.or_else(|| {
                 if func_config.encoding != Encoding::Auto
-                    || matches!(func_config.solver_str(), "bitwuzla")
+                    || matches!(func_config.solver, Solver::Bitwuzla)
                 {
                     return None;
                 }
                 let ir_key = VerifyCache::cache_key(&c_src, limits.max_k_step, "z3", "ir");
-                vc.lookup(&ir_key).map(|c| match c {
-                    CachedVerifyResult::Proven => VerificationResult::ProvenIr,
-                    CachedVerifyResult::Failed { .. } => {
-                        VerificationResult::Failed(c.to_counterexample().unwrap())
-                    }
+                vc.lookup(&ir_key).and_then(|c| match c {
+                    CachedVerifyResult::Proven => Some(VerificationResult::ProvenIr),
+                    CachedVerifyResult::Failed { .. } => None,
                 })
             });
 
@@ -5769,15 +5768,15 @@ fn update_contract_statuses(
             // means a prior run had to fall back to ir; surface as ProvenIr
             // so `contracts --verify` reports "proven-ir".
             let cached_result = cached_result.or_else(|| {
-                if config.encoding != Encoding::Auto || matches!(config.solver_str(), "bitwuzla") {
+                if config.encoding != Encoding::Auto || matches!(config.solver, Solver::Bitwuzla) {
                     return None;
                 }
                 let ir_key = VerifyCache::cache_key(&c_src, limits.max_k_step, "z3", "ir");
-                vc.lookup(&ir_key).map(|c| match c {
-                    CachedVerifyResult::Proven => VerificationResult::ProvenIr,
-                    CachedVerifyResult::Failed { .. } => {
-                        VerificationResult::Failed(c.to_counterexample().unwrap())
-                    }
+                // Ignore IR Failed entries: IR lacks overflow modeling, so
+                // an IR-only counterexample may be infeasible under BV.
+                vc.lookup(&ir_key).and_then(|c| match c {
+                    CachedVerifyResult::Proven => Some(VerificationResult::ProvenIr),
+                    CachedVerifyResult::Failed { .. } => None,
                 })
             });
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -16,8 +16,8 @@ use vow_codegen::{Backend, BuildMode, TraceMode};
 use vow_diag::{Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
 use vow_verify::{
     Counterexample, DEFAULT_MAX_K_STEP, Encoding, Solver, SolverConfig, VerificationResult,
-    VerifyLimits, detect_constant_functions, emit_verify_c_source, find_esbmc,
-    run_esbmc_with_max_k_step, verify_function_with_module_and_const_fns_configured,
+    VerifyLimits, detect_constant_functions, emit_verify_c_source, find_esbmc, run_with_fallback,
+    verify_function_with_module_and_const_fns_configured,
 };
 
 use cache::{CachedVerifyResult, VerifyCache};
@@ -450,11 +450,11 @@ fn skill_json() -> String {
         },
         {
           "form": "--timeout <N>",
-          "description": "ESBMC per-function timeout in seconds (default: (none))",
+          "description": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))",
           "long": "--timeout",
           "value_name": "N",
           "value_kind": "integer",
-          "default": "(none)"
+          "default": "(none; 30 when encoding is auto)"
         },
         {
           "form": "--vec-max <N>",
@@ -555,11 +555,11 @@ fn skill_json() -> String {
         },
         {
           "form": "--timeout <N>",
-          "description": "ESBMC per-function timeout in seconds (default: (none))",
+          "description": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))",
           "long": "--timeout",
           "value_name": "N",
           "value_kind": "integer",
-          "default": "(none)"
+          "default": "(none; 30 when encoding is auto)"
         },
         {
           "form": "--vec-max <N>",
@@ -822,7 +822,7 @@ fn skill_json() -> String {
     "--max-k-step <N>": "ESBMC incremental BMC max iterations (default: 50)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
-    "--timeout <N>": "ESBMC per-function timeout in seconds (default: (none))",
+    "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
     "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
@@ -832,7 +832,7 @@ fn skill_json() -> String {
     "--max-k-step <N>": "ESBMC incremental BMC max iterations (default: 50)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
-    "--timeout <N>": "ESBMC per-function timeout in seconds (default: (none))",
+    "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
     "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
@@ -1206,7 +1206,7 @@ BUILD OPTIONS
   --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
-  --timeout <N>           ESBMC per-function timeout in seconds (default: (none))
+  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
@@ -1216,7 +1216,7 @@ VERIFY OPTIONS
   --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
-  --timeout <N>           ESBMC per-function timeout in seconds (default: (none))
+  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the Phase D fallback to --encoding ir --solver z3 can trigger when BV times out (default: (none; 30 when encoding is auto))
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
@@ -2176,7 +2176,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
-| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |
+| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |
 | `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
 | `--string-max <N>` | `256`    | Max String capacity for verification model   |
 | `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
@@ -2197,7 +2197,7 @@ vow verify [OPTIONS] <source.vow>
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
-| `--timeout <N>` | (none)      | ESBMC per-function timeout in seconds        |
+| `--timeout <N>` | (none; `30` when encoding is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the Phase D fallback to `--encoding ir --solver z3` can trigger when BV times out |
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
@@ -2473,17 +2473,18 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `description` | string  | Full contract text                                       |
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
-| `status`      | string  | `"proven"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, or `"not_verified"` |
+| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, or `"not_verified"` |
 
 ### Status Values
 
 | Status          | Meaning                                              |
 |-----------------|------------------------------------------------------|
 | `not_verified`  | Verification not requested (no `--verify` flag)      |
-| `proven`        | ESBMC proved this contract holds for all inputs      |
+| `proven`        | ESBMC proved this contract holds for all inputs (bit-vector encoding, overflow modeled) |
+| `proven-ir`     | ESBMC proved this contract under integer-arithmetic encoding after BV timed out; overflow is not modeled by IR, but the BV caller preconditions still guard against it |
 | `failed`        | ESBMC found a counterexample violating this contract |
 | `unknown`       | Another contract in the same function failed; this one was not individually checked |
-| `timeout`       | ESBMC timed out on the containing function           |
+| `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 
 ## Trace Output (stderr, --debug-trace)
@@ -4776,32 +4777,55 @@ fn run_verification_sync(
                 func_config.encoding_str(),
             );
 
-            if let Some(cached) = vc.lookup(&key) {
-                match cached {
-                    CachedVerifyResult::Proven => VerificationResult::Proven,
-                    CachedVerifyResult::Failed { .. } => {
-                        VerificationResult::Failed(cached.to_counterexample().unwrap())
-                    }
+            let cached_result = vc.lookup(&key).map(|c| match c {
+                CachedVerifyResult::Proven => VerificationResult::Proven,
+                CachedVerifyResult::Failed { .. } => {
+                    VerificationResult::Failed(c.to_counterexample().unwrap())
                 }
+            });
+            // Phase D: if BV lookup misses under Auto encoding and BV solver
+            // isn't Bitwuzla, also probe the IR fallback key — a prior
+            // ProvenIr result lives under (z3, ir). On hit, promote to
+            // ProvenIr so contract reporting stays accurate.
+            let cached_result = cached_result.or_else(|| {
+                if func_config.encoding != Encoding::Auto
+                    || matches!(func_config.solver_str(), "bitwuzla")
+                {
+                    return None;
+                }
+                let ir_key = VerifyCache::cache_key(&c_src, limits.max_k_step, "z3", "ir");
+                vc.lookup(&ir_key).map(|c| match c {
+                    CachedVerifyResult::Proven => VerificationResult::ProvenIr,
+                    CachedVerifyResult::Failed { .. } => {
+                        VerificationResult::Failed(c.to_counterexample().unwrap())
+                    }
+                })
+            });
+
+            if let Some(r) = cached_result {
+                r
             } else {
                 let esbmc = match find_esbmc() {
                     Some(p) => p,
                     None => return VerifyOutcome::ToolNotFound,
                 };
-                let res = run_esbmc_with_max_k_step(
-                    &esbmc,
+                let (res, resolved_config) =
+                    run_with_fallback(&esbmc, &c_src, limits.max_k_step, &func.name, &func_config);
+                // Store under the resolved config so ProvenIr results are
+                // keyed by encoding=ir rather than the pre-fallback Auto/Bv.
+                let store_key = VerifyCache::cache_key(
                     &c_src,
                     limits.max_k_step,
-                    &func.name,
-                    &func_config,
+                    resolved_config.solver_str(),
+                    resolved_config.encoding_str(),
                 );
                 match &res {
                     VerificationResult::Proven | VerificationResult::ProvenIr => {
-                        vc.store(&key, &CachedVerifyResult::Proven);
+                        vc.store(&store_key, &CachedVerifyResult::Proven);
                     }
                     VerificationResult::Failed(ce) => {
                         vc.store(
-                            &key,
+                            &store_key,
                             &CachedVerifyResult::Failed {
                                 vow_id: ce.vow_id,
                                 description: ce.description.clone(),
@@ -5734,13 +5758,31 @@ fn update_contract_statuses(
                 config.encoding_str(),
             );
 
-            if let Some(cached) = vc.lookup(&key) {
-                match cached {
-                    CachedVerifyResult::Proven => VerificationResult::Proven,
-                    CachedVerifyResult::Failed { .. } => {
-                        VerificationResult::Failed(cached.to_counterexample().unwrap())
-                    }
+            let cached_result = vc.lookup(&key).map(|c| match c {
+                CachedVerifyResult::Proven => VerificationResult::Proven,
+                CachedVerifyResult::Failed { .. } => {
+                    VerificationResult::Failed(c.to_counterexample().unwrap())
                 }
+            });
+            // Phase D: if BV lookup misses under Auto encoding and BV solver
+            // isn't Bitwuzla, also probe the IR fallback key. A hit there
+            // means a prior run had to fall back to ir; surface as ProvenIr
+            // so `contracts --verify` reports "proven-ir".
+            let cached_result = cached_result.or_else(|| {
+                if config.encoding != Encoding::Auto || matches!(config.solver_str(), "bitwuzla") {
+                    return None;
+                }
+                let ir_key = VerifyCache::cache_key(&c_src, limits.max_k_step, "z3", "ir");
+                vc.lookup(&ir_key).map(|c| match c {
+                    CachedVerifyResult::Proven => VerificationResult::ProvenIr,
+                    CachedVerifyResult::Failed { .. } => {
+                        VerificationResult::Failed(c.to_counterexample().unwrap())
+                    }
+                })
+            });
+
+            if let Some(r) = cached_result {
+                r
             } else {
                 let esbmc = match find_esbmc() {
                     Some(p) => p,
@@ -5753,20 +5795,21 @@ fn update_contract_statuses(
                         continue;
                     }
                 };
-                let res = run_esbmc_with_max_k_step(
-                    &esbmc,
+                let (res, resolved_config) =
+                    run_with_fallback(&esbmc, &c_src, limits.max_k_step, &func.name, config);
+                let store_key = VerifyCache::cache_key(
                     &c_src,
                     limits.max_k_step,
-                    &func.name,
-                    config,
+                    resolved_config.solver_str(),
+                    resolved_config.encoding_str(),
                 );
                 match &res {
                     VerificationResult::Proven | VerificationResult::ProvenIr => {
-                        vc.store(&key, &CachedVerifyResult::Proven);
+                        vc.store(&store_key, &CachedVerifyResult::Proven);
                     }
                     VerificationResult::Failed(ce) => {
                         vc.store(
-                            &key,
+                            &store_key,
                             &CachedVerifyResult::Failed {
                                 vow_id: ce.vow_id,
                                 description: ce.description.clone(),


### PR DESCRIPTION
## Summary

Closes #187. Wires `run_with_fallback` into the main verification loop (Phase D): if BV encoding times out under Auto mode and the BV solver is not Bitwuzla, retry with `--z3 --ir` so IR-provable contracts (overflow-guarded multiplication, etc.) succeed instead of hanging.

### Rust
- `run_verification_sync` and `update_contract_statuses` call `run_with_fallback` instead of `run_esbmc_with_max_k_step` directly.
- The resolved `SolverConfig` returned from fallback drives the cache store key so `ProvenIr` results are keyed under `(z3, ir)`; lookup performs a secondary IR-key probe under Auto to reuse prior `ProvenIr` cache hits.
- `verify_function_with_module_and_const_fns_configured` also routes through `run_with_fallback` so the no-cache path gets Phase D behavior too.
- Removed `#[allow(dead_code)]` from `run_with_fallback`.

### Self-hosted (mirrored per dual-compiler rule)
- Added `VERIFY_PROVEN_IR()` status code and "Timed out" detection in `parse_verify_status`.
- `run_esbmc` / `start_esbmc` now accept `timeout_secs` and forward ESBMC's `--timeout Ns`; `effective_timeout_for` applies 30s default under Auto encoding.
- `verify_function_full` performs the BV→IR retry inline; new `verify_function_ir_fallback` handles post-parallel retries invoked from `run_build`'s verify_collect timeout branch.
- Cache lookup uses the resolved BV key (so Auto→Bv cache hits survive) plus an IR-key secondary probe (so `ProvenIr` re-verifies hit cache).
- `main.vow` parses `--timeout`, threads it through, and reports `PROVEN (IR)` / `proven-ir`.

### Tests
- Added four Rust unit tests in `solver_strategy.rs` covering: explicit-BV one-shot, Auto-BV proves with no retry, Bitwuzla guard against IR fallback, Auto-BV-timeout IR retry.
- Manually verified `examples/geometry/main.vow::rect_area` now proves as `PROVEN (IR)` in ~31s on both compilers (previously self-hosted hung indefinitely under boolector).

## Test plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `scripts/bootstrap.sh --skip-cargo` binary fixed point holds
- [x] `scripts/full_test.sh` — 284 passed, 7 failed (all pre-existing and reproducible on main)
- [x] geometry rect_area proves as PROVEN (IR) on both compilers
- [x] second verify run hits cache for PROVEN (IR) result (~3ms)
