### PR TITLE
feat: bound ESBMC verifier concurrency via --verify-jobs (#175)

### DIFF
--- a/compiler/env.vow
+++ b/compiler/env.vow
@@ -231,6 +231,7 @@ fn env_new(dctx: DiagCtx, file: String) -> CheckEnv {
     env_define_fn(e, String::from("vec_sort"), vec_of_1(vec_i64_tid), vec_i64_tid, 0);
     env_define_fn(e, String::from("time_unix"), Vec::new(), i64_tid, eff_io);
     env_define_fn(e, String::from("time_unix_ms"), Vec::new(), i64_tid, eff_io);
+    env_define_fn(e, String::from("num_cpus"), Vec::new(), i64_tid, eff_io);
     env_define_fn(e, String::from("hex_encode"), vec_of_1(vec_u8_tid), str_tid, 0);
     env_define_fn(e, String::from("hex_decode"), vec_of_1(str_tid), vec_u8_tid, 0);
     env_define_fn(e, String::from("args"), Vec::new(), vec_str_tid, eff_read);

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -810,6 +810,7 @@ fn builtin_to_extern(name: String) -> String {
     if name == String::from("vec_sort") { return String::from("__vow_vec_sort"); }
     if name == String::from("time_unix") { return String::from("__vow_time_unix"); }
     if name == String::from("time_unix_ms") { return String::from("__vow_time_unix_ms"); }
+    if name == String::from("num_cpus") { return String::from("__vow_num_cpus"); }
     if name == String::from("hex_encode") { return String::from("__vow_hex_encode"); }
     if name == String::from("hex_decode") { return String::from("__vow_hex_decode"); }
     if name == String::from("args") { return String::from("__vow_args"); }
@@ -864,6 +865,7 @@ fn builtin_ret_ty(name: String) -> i64 {
     if name == String::from("vec_sort") { return ITY_PTR(); }
     if name == String::from("time_unix") { return ITY_I64(); }
     if name == String::from("time_unix_ms") { return ITY_I64(); }
+    if name == String::from("num_cpus") { return ITY_I64(); }
     if name == String::from("hex_encode") { return ITY_PTR(); }
     if name == String::from("hex_decode") { return ITY_PTR(); }
     if name == String::from("args") { return ITY_PTR(); }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -40,7 +40,7 @@ fn get_source_path(argv: Vec<String>) -> String {
         if first_byte != 45 {
             if i > 1 {
                 let prev: String = argv[i - 1];
-                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") || prev == String::from("--solver") || prev == String::from("--encoding") || prev == String::from("--vec-max") || prev == String::from("--string-max") || prev == String::from("--hashmap-max") {
+                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") || prev == String::from("--solver") || prev == String::from("--encoding") || prev == String::from("--vec-max") || prev == String::from("--string-max") || prev == String::from("--hashmap-max") || prev == String::from("--verify-jobs") {
                     i = i - 1;
                 } else {
                     return a;
@@ -63,7 +63,7 @@ fn get_source_path_sub(argv: Vec<String>) -> String {
         if first_byte != 45 {
             if i > 2 {
                 let prev: String = argv[i - 1];
-                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") || prev == String::from("--solver") || prev == String::from("--encoding") || prev == String::from("--vec-max") || prev == String::from("--string-max") || prev == String::from("--hashmap-max") {
+                if prev == String::from("-o") || prev == String::from("--mode") || prev == String::from("--max-k-step") || prev == String::from("--debug-trace") || prev == String::from("--filter") || prev == String::from("--timeout") || prev == String::from("--solver") || prev == String::from("--encoding") || prev == String::from("--vec-max") || prev == String::from("--string-max") || prev == String::from("--hashmap-max") || prev == String::from("--verify-jobs") {
                     i = i - 1;
                 } else {
                     return a;
@@ -210,37 +210,47 @@ fn emit_ce_vars(vr: VerifyResult) [io] {
 }
 
 fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
-                   vec_max: i64, string_max: i64, hashmap_max: i64) -> i64 [io] {
-    let mut fi: i64 = 0;
+                   vec_max: i64, string_max: i64, hashmap_max: i64, jobs: i64) -> i64 [io] {
     let mut all_proven: i64 = 1;
+    // Bounded pool: ≤ jobs ESBMC processes in flight, FIFO drain. See #175.
+    let in_flight_h: Vec<i64> = Vec::new();
+    let in_flight_fi: Vec<i64> = Vec::new();
+    let mut fi: i64 = 0;
     while fi < fns.len() {
         let f: IrFunction = fns[fi];
         let vows: Vec<IrVowEntry> = f.vows;
-        if vows.len() > 0 {
-            eprintln_str(str3(String::from("Verifying "), f.name, String::from("...")));
-            let vr: VerifyResult = verify_function_full(f, ir_mod, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
-            let st: i64 = vr.status;
-            if st == VERIFY_PROVEN() {
-                eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
-            } else if st == VERIFY_PROVEN_IR() {
-                eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN (IR)")));
-            } else if st == VERIFY_FAILED() {
-                all_proven = 0;
-                eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
-                emit_ce_vars(vr);
-                ces.push(build_ce_from_result(f, vr, path));
-            } else if st == VERIFY_TIMEOUT() {
-                all_proven = 0;
-                eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT")));
-            } else if st == VERIFY_NOT_FOUND() {
-                all_proven = 0;
-                eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
-            } else {
-                all_proven = 0;
-                eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
+        // Stop launching new ESBMC jobs once any in-flight verification has failed.
+        if vows.len() > 0 && all_proven == 1 {
+            while in_flight_h.len() >= jobs {
+                let oldest_h: i64 = in_flight_h[0];
+                let oldest_fi: i64 = in_flight_fi[0];
+                let oldest_f: IrFunction = fns[oldest_fi];
+                vec_i64_remove_front(in_flight_h);
+                vec_i64_remove_front(in_flight_fi);
+                let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
+                if proven == 0 {
+                    all_proven = 0;
+                }
+            }
+            if all_proven == 1 {
+                eprintln_str(str3(String::from("Verifying "), f.name, String::from("...")));
+                let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
+                in_flight_h.push(h);
+                in_flight_fi.push(fi);
             }
         }
         fi = fi + 1;
+    }
+    while in_flight_h.len() > 0 {
+        let oldest_h: i64 = in_flight_h[0];
+        let oldest_fi: i64 = in_flight_fi[0];
+        let oldest_f: IrFunction = fns[oldest_fi];
+        vec_i64_remove_front(in_flight_h);
+        vec_i64_remove_front(in_flight_fi);
+        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
+        if proven == 0 {
+            all_proven = 0;
+        }
     }
     all_proven
 }
@@ -261,6 +271,115 @@ fn validate_limits(vec_max: i64, string_max: i64, hashmap_max: i64) [io] {
         eprintln_str(String::from("error: --vec-max, --string-max, and --hashmap-max must be >= 1"));
         process_exit(1);
     }
+}
+
+fn resolve_verify_jobs(argv: Vec<String>) -> i64 [io] {
+    let raw: String = get_flag_arg(argv, String::from("--verify-jobs"));
+    if raw.len() == 0 {
+        let n: i64 = num_cpus() / 2;
+        if n < 1 { 1 } else { n }
+    } else {
+        let n: i64 = parse_i64(raw);
+        if n < 1 {
+            eprintln_str(String::from("error: --verify-jobs must be >= 1"));
+            process_exit(1);
+            1
+        } else {
+            n
+        }
+    }
+}
+
+fn vec_i64_remove_front(v: Vec<i64>) {
+    // Caller-enforced invariant: v.len() > 0 (drain loops guard this).
+    // Guard defensively so an empty Vec becomes a no-op rather than popping below zero.
+    let n: i64 = v.len();
+    if n == 0 { return; }
+    let mut i: i64 = 0;
+    while i < n - 1 {
+        v[i] = v[i + 1];
+        i = i + 1;
+    }
+    v.pop();
+}
+
+fn verify_collect_and_report(
+    h: i64, f: IrFunction, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>,
+    max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
+    vec_max: i64, string_max: i64, hashmap_max: i64,
+) -> i64 [io] {
+    if h == -1 {
+        // process_start failed (fork/exec error, OOM, rlimit, etc.) — this
+        // is distinct from "no vows", which the caller already filters.
+        // Silently skipping would mis-report an un-verified function as proven.
+        eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR (failed to start ESBMC)")));
+        return 0;
+    }
+    if h == -2 {
+        eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN (cached)")));
+        return 1;
+    }
+    let vr: VerifyResult = verify_collect(h, f);
+    let st: i64 = vr.status;
+    if st == VERIFY_PROVEN() {
+        eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
+        if use_cache {
+            let c_src2: String = emit_c_for_verify(f, ir_mod, vec_max, string_max, hashmap_max);
+            let bv_solver2: String = resolve_auto_bv_solver(solver);
+            let bv_encoding2: String = { if is_auto_encoding(encoding) { String::from("bv") } else { encoding } };
+            let ck2: String = verify_cache_key(c_src2, max_k_step, bv_solver2, bv_encoding2);
+            verify_cache_store(ck2, VERIFY_PROVEN());
+        }
+        return 1;
+    }
+    if st == VERIFY_PROVEN_IR() {
+        eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN (IR)")));
+        return 1;
+    }
+    if st == VERIFY_FAILED() {
+        eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
+        emit_ce_vars(vr);
+        ces.push(build_ce_from_result(f, vr, path));
+        return 0;
+    }
+    if st == VERIFY_TIMEOUT() {
+        // BV timed out; retry with IR before failing (Phase D fallback).
+        let bv_solver: String = resolve_auto_bv_solver(solver);
+        let auto_enc: bool = is_auto_encoding(encoding);
+        if auto_enc && bv_solver != String::from("bitwuzla") {
+            eprintln_str(str3(String::from("  "), f.name, String::from(": BV timeout, retrying with --z3 --ir...")));
+            let vr2: VerifyResult = verify_function_ir_fallback(f, ir_mod, max_k_step, use_cache, timeout_secs, vec_max, string_max, hashmap_max);
+            let st2: i64 = vr2.status;
+            if st2 == VERIFY_PROVEN_IR() {
+                eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN (IR)")));
+                return 1;
+            }
+            if st2 == VERIFY_FAILED() {
+                eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
+                emit_ce_vars(vr2);
+                ces.push(build_ce_from_result(f, vr2, path));
+                return 0;
+            }
+            if st2 == VERIFY_TIMEOUT() {
+                eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT (BV and IR)")));
+                return 0;
+            }
+            if st2 == VERIFY_NOT_FOUND() {
+                eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
+                return 0;
+            }
+            eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
+            return 0;
+        }
+        eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT")));
+        return 0;
+    }
+    if st == VERIFY_NOT_FOUND() {
+        eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
+        return 0;
+    }
+    eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
+    0
 }
 
 fn run_verify(argv: Vec<String>) -> i32 [io] {
@@ -288,6 +407,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     let hashmap_max_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
     let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
     validate_limits(vec_max, string_max, hashmap_max);
+    let jobs: i64 = resolve_verify_jobs(argv);
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     let mut solver: String = get_flag_arg(argv, String::from("--solver"));
     let encoding: String = get_flag_arg(argv, String::from("--encoding"));
@@ -310,7 +430,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     emit_ir_warnings(ir_mod, dctx);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
-    let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
+    let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, jobs);
     let status_str: String = {
         if all_proven == 1 {
             String::from("Verified")
@@ -393,19 +513,37 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     let hashmap_max_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
     let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
     validate_limits(vec_max, string_max, hashmap_max);
+    let jobs: i64 = resolve_verify_jobs(argv);
     let fns: Vec<IrFunction> = ir_mod.functions;
-    let handles: Vec<i64> = Vec::new();
-    let vow_fn_indices: Vec<i64> = Vec::new();
+    let ces: Vec<VerifyCE> = Vec::new();
+    let mut all_proven: i64 = 1;
+    // Bounded pool: ≤ jobs ESBMC processes in flight, FIFO drain. See #175.
+    let in_flight_h: Vec<i64> = Vec::new();
+    let in_flight_fi: Vec<i64> = Vec::new();
     if do_verify {
         let mut fi: i64 = 0;
         while fi < fns.len() {
             let f: IrFunction = fns[fi];
             let vows: Vec<IrVowEntry> = f.vows;
-            if vows.len() > 0 {
-                eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
-                let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
-                handles.push(h);
-                vow_fn_indices.push(fi);
+            // Stop launching new ESBMC jobs once any in-flight verification has failed.
+            if vows.len() > 0 && all_proven == 1 {
+                while in_flight_h.len() >= jobs {
+                    let oldest_h: i64 = in_flight_h[0];
+                    let oldest_fi: i64 = in_flight_fi[0];
+                    let oldest_f: IrFunction = fns[oldest_fi];
+                    vec_i64_remove_front(in_flight_h);
+                    vec_i64_remove_front(in_flight_fi);
+                    let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
+                    if proven == 0 {
+                        all_proven = 0;
+                    }
+                }
+                if all_proven == 1 {
+                    eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
+                    let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
+                    in_flight_h.push(h);
+                    in_flight_fi.push(fi);
+                }
             }
             fi = fi + 1;
         }
@@ -426,74 +564,15 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         diag_emit_build_verify_json(String::from("Unverified"), out, dctx, Vec::new());
         return 0;
     }
-    let ces: Vec<VerifyCE> = Vec::new();
-    let mut all_proven: i64 = 1;
-    let mut hi: i64 = 0;
-    while hi < handles.len() {
-        let fi2: i64 = vow_fn_indices[hi];
-        let f: IrFunction = fns[fi2];
-        let h: i64 = handles[hi];
-        if h == -1 {
-            hi = hi + 1;
-        } else if h == -2 {
-            eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN (cached)")));
-            hi = hi + 1;
-        } else {
-            let vr: VerifyResult = verify_collect(h, f);
-            let st: i64 = vr.status;
-            if st == VERIFY_PROVEN() {
-                eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
-                if use_cache {
-                    // Store under the resolved BV key so the sync `verify`
-                    // path (which also normalizes keys) can hit this entry.
-                    let c_src2: String = emit_c_for_verify(f, ir_mod, vec_max, string_max, hashmap_max);
-                    let bv_solver2: String = resolve_auto_bv_solver(solver);
-                    let bv_encoding2: String = { if is_auto_encoding(encoding) { String::from("bv") } else { encoding } };
-                    let ck2: String = verify_cache_key(c_src2, max_k_step, bv_solver2, bv_encoding2);
-                    verify_cache_store(ck2, VERIFY_PROVEN());
-                }
-            } else if st == VERIFY_FAILED() {
-                all_proven = 0;
-                eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
-                emit_ce_vars(vr);
-                ces.push(build_ce_from_result(f, vr, path));
-            } else if st == VERIFY_TIMEOUT() {
-                // BV timed out; retry with IR before failing (mirrors run_verify_loop and run_with_fallback).
-                let bv_solver: String = resolve_auto_bv_solver(solver);
-                let auto_enc: bool = is_auto_encoding(encoding);
-                if auto_enc && bv_solver != String::from("bitwuzla") {
-                    eprintln_str(str3(String::from("  "), f.name, String::from(": BV timeout, retrying with --z3 --ir...")));
-                    let vr2: VerifyResult = verify_function_ir_fallback(f, ir_mod, max_k_step, use_cache, timeout_secs, vec_max, string_max, hashmap_max);
-                    let st2: i64 = vr2.status;
-                    if st2 == VERIFY_PROVEN_IR() {
-                        eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN (IR)")));
-                    } else if st2 == VERIFY_FAILED() {
-                        all_proven = 0;
-                        eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
-                        emit_ce_vars(vr2);
-                        ces.push(build_ce_from_result(f, vr2, path));
-                    } else if st2 == VERIFY_TIMEOUT() {
-                        all_proven = 0;
-                        eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT (BV and IR)")));
-                    } else if st2 == VERIFY_NOT_FOUND() {
-                        all_proven = 0;
-                        eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
-                    } else {
-                        all_proven = 0;
-                        eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
-                    }
-                } else {
-                    all_proven = 0;
-                    eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT")));
-                }
-            } else if st == VERIFY_NOT_FOUND() {
-                all_proven = 0;
-                eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
-            } else {
-                all_proven = 0;
-                eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
-            }
-            hi = hi + 1;
+    while in_flight_h.len() > 0 {
+        let oldest_h: i64 = in_flight_h[0];
+        let oldest_fi: i64 = in_flight_fi[0];
+        let oldest_f: IrFunction = fns[oldest_fi];
+        vec_i64_remove_front(in_flight_h);
+        vec_i64_remove_front(in_flight_fi);
+        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
+        if proven == 0 {
+            all_proven = 0;
         }
     }
     let status_str: String = {
@@ -583,6 +662,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
     let t_hm_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
     let t_hashmap_max: i64 = { if t_hm_str.len() > 0 { parse_i64(t_hm_str) } else { 64 } };
     validate_limits(t_vec_max, t_string_max, t_hashmap_max);
+    let t_jobs: i64 = resolve_verify_jobs(argv);
 
     // Validate path exists
     if fs_exists(path) == 0 {
@@ -660,32 +740,64 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                 fi = fi + 1;
             }
 
-            // Verify if requested
+            // Verify if requested — bounded pool honoring --verify-jobs.
             let mut skip_exec: bool = false;
             if do_verify {
                 let vfns: Vec<IrFunction> = ir_mod.functions;
-                let mut vfi: i64 = 0;
+                let vin_flight_h: Vec<i64> = Vec::new();
+                let vin_flight_fi: Vec<i64> = Vec::new();
                 let mut verify_failed: bool = false;
+                let mut vfi: i64 = 0;
                 while vfi < vfns.len() {
                     let vf: IrFunction = vfns[vfi];
                     let vows: Vec<IrVowEntry> = vf.vows;
-                    if vows.len() > 0 {
-                        let vh: i64 = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max);
-                        if vh != -1 && vh != -2 {
-                            let vr: VerifyResult = verify_collect(vh, vf);
-                            if vr.status == VERIFY_FAILED() {
+                    // Stop launching new ESBMC jobs after a failure is observed.
+                    if vows.len() > 0 && !verify_failed {
+                        while vin_flight_h.len() >= t_jobs {
+                            let oh: i64 = vin_flight_h[0];
+                            let ofi: i64 = vin_flight_fi[0];
+                            let ovf: IrFunction = vfns[ofi];
+                            vec_i64_remove_front(vin_flight_h);
+                            vec_i64_remove_front(vin_flight_fi);
+                            if oh == -1 {
+                                // process_start failed — treat as verification failure, not silent success.
                                 verify_failed = true;
-                            } else if vr.status == VERIFY_TIMEOUT() {
-                                // BV timed out; retry with IR (no Bitwuzla guard needed — run_test only uses Auto/Boolector).
-                                let vr2: VerifyResult = verify_function_ir_fallback(vf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max);
-                                // Anything other than PROVEN/PROVEN_IR is a test failure, including ERROR and NOT_FOUND.
-                                if vr2.status != VERIFY_PROVEN() && vr2.status != VERIFY_PROVEN_IR() {
+                            } else if oh != -2 {
+                                let ovr: VerifyResult = verify_collect(oh, ovf);
+                                if ovr.status == VERIFY_FAILED() {
                                     verify_failed = true;
+                                } else if ovr.status == VERIFY_TIMEOUT() {
+                                    // BV timed out; retry with IR before failing.
+                                    let ovr2: VerifyResult = verify_function_ir_fallback(ovf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max);
+                                    if ovr2.status != VERIFY_PROVEN() && ovr2.status != VERIFY_PROVEN_IR() {
+                                        verify_failed = true;
+                                    }
                                 }
                             }
                         }
+                        if !verify_failed {
+                            let vh: i64 = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max);
+                            vin_flight_h.push(vh);
+                            vin_flight_fi.push(vfi);
+                        }
                     }
                     vfi = vfi + 1;
+                }
+                while vin_flight_h.len() > 0 {
+                    let oh: i64 = vin_flight_h[0];
+                    let ofi: i64 = vin_flight_fi[0];
+                    let ovf: IrFunction = vfns[ofi];
+                    vec_i64_remove_front(vin_flight_h);
+                    vec_i64_remove_front(vin_flight_fi);
+                    if oh == -1 {
+                        // Spawn failure — critical when t_jobs >= nfns and every handle lands here.
+                        verify_failed = true;
+                    } else if oh != -2 {
+                        let ovr: VerifyResult = verify_collect(oh, ovf);
+                        if ovr.status == VERIFY_FAILED() {
+                            verify_failed = true;
+                        }
+                    }
                 }
                 if verify_failed {
                     let duration: i64 = time_unix_ms() - start_time;
@@ -846,7 +958,8 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
             let use_cache_leg: bool = !has_flag(argv, String::from("--no-cache"));
-            let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache_leg, String::from(""), String::from(""), String::from(""), vec_max_leg, string_max_leg, hashmap_max_leg);
+            let jobs_leg: i64 = resolve_verify_jobs(argv);
+            let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache_leg, String::from(""), String::from(""), String::from(""), vec_max_leg, string_max_leg, hashmap_max_leg, jobs_leg);
             let status_str: String = {
                 if all_proven == 1 {
                     String::from("Verified")
@@ -1074,6 +1187,14 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
     r.push_str(String::from("          \"default\": 64\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--verify-jobs <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max concurrent ESBMC verification jobs (default: num_cpus/2)\",\n"));
+    r.push_str(String::from("          \"long\": \"--verify-jobs\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": \"num_cpus/2\"\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1179,6 +1300,14 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
     r.push_str(String::from("          \"default\": 64\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--verify-jobs <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max concurrent ESBMC verification jobs (default: num_cpus/2)\",\n"));
+    r.push_str(String::from("          \"long\": \"--verify-jobs\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": \"num_cpus/2\"\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1270,6 +1399,14 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
     r.push_str(String::from("          \"default\": 64\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--verify-jobs <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Max concurrent ESBMC verification jobs (with --verify)\",\n"));
+    r.push_str(String::from("          \"long\": \"--verify-jobs\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": \"num_cpus/2\"\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1395,6 +1532,14 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
     r.push_str(String::from("          \"default\": 64\n"));
+    r.push_str(String::from("        },\n"));
+    r.push_str(String::from("        {\n"));
+    r.push_str(String::from("          \"form\": \"--verify-jobs <N>\",\n"));
+    r.push_str(String::from("          \"description\": \"Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)\",\n"));
+    r.push_str(String::from("          \"long\": \"--verify-jobs\",\n"));
+    r.push_str(String::from("          \"value_name\": \"N\",\n"));
+    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
+    r.push_str(String::from("          \"default\": \"num_cpus/2\"\n"));
     r.push_str(String::from("        }\n"));
     r.push_str(String::from("      ],\n"));
     r.push_str(String::from("      \"stdout\": {\n"));
@@ -1420,7 +1565,8 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
     r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
+    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
+    r.push_str(String::from("    \"--verify-jobs <N>\": \"Max concurrent ESBMC verification jobs (default: num_cpus/2)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"verify_options\": {\n"));
     r.push_str(String::from("    \"--no-cache\": \"Disable verification result caching\",\n"));
@@ -1430,7 +1576,8 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
     r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
+    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
+    r.push_str(String::from("    \"--verify-jobs <N>\": \"Max concurrent ESBMC verification jobs (default: num_cpus/2)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"test_options\": {\n"));
     r.push_str(String::from("    \"--verify\": \"Run ESBMC verification on test files\",\n"));
@@ -1440,7 +1587,8 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (with --verify)\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
     r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
+    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
+    r.push_str(String::from("    \"--verify-jobs <N>\": \"Max concurrent ESBMC verification jobs (with --verify)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"decl_options\": {\n"));
     r.push_str(String::from("    \"-o, --output <path>\": \"Output declaration file path (default: <source>.vow.d)\"\n"));
@@ -1453,7 +1601,8 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode (with --verify); ir requires z3 (default: auto)\",\n"));
     r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
     r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\"\n"));
+    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
+    r.push_str(String::from("    \"--verify-jobs <N>\": \"Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"global_options\": {\n"));
     r.push_str(String::from("    \"--help\": \"Emit versioned JSON tool-help data\",\n"));
@@ -1591,6 +1740,7 @@ fn skill_json() -> String {
     r.push_str(String::from("      \"vec_sort\": \"fn(v: Vec<i64>) -> Vec<i64> []\",\n"));
     r.push_str(String::from("      \"time_unix\": \"fn() -> i64 [io]\",\n"));
     r.push_str(String::from("      \"time_unix_ms\": \"fn() -> i64 [io]\",\n"));
+    r.push_str(String::from("      \"num_cpus\": \"fn() -> i64 [io]\",\n"));
     r.push_str(String::from("      \"hex_encode\": \"fn(data: Vec<u8>) -> String []\",\n"));
     r.push_str(String::from("      \"hex_decode\": \"fn(s: String) -> Vec<u8> []\",\n"));
     r.push_str(String::from("      \"args\": \"fn() -> Vec<String> [read]\",\n"));
@@ -1805,6 +1955,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
     r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
     r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
+    r.push_str(String::from("  --verify-jobs <N>       Max concurrent ESBMC verification jobs (default: num_cpus/2)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("VERIFY OPTIONS\n"));
     r.push_str(String::from("  --no-cache              Disable verification result caching\n"));
@@ -1815,6 +1966,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
     r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
     r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
+    r.push_str(String::from("  --verify-jobs <N>       Max concurrent ESBMC verification jobs (default: num_cpus/2)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("TEST OPTIONS\n"));
     r.push_str(String::from("  --verify                Run ESBMC verification on test files\n"));
@@ -1825,6 +1977,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
     r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
     r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
+    r.push_str(String::from("  --verify-jobs <N>       Max concurrent ESBMC verification jobs (with --verify)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("CONTRACTS OPTIONS\n"));
     r.push_str(String::from("  --verify                Run ESBMC verification and report per-contract status\n"));
@@ -1835,6 +1988,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
     r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
     r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
+    r.push_str(String::from("  --verify-jobs <N>       Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("DECL OPTIONS\n"));
     r.push_str(String::from("  -o, --output <path>     Output declaration file path (default: <source>.vow.d)\n"));
@@ -1882,7 +2036,7 @@ fn skill_human() -> String {
     r.push_str(String::from("TYPES     : i32  i64  u8  u64  f32  f64  bool  ()  !  Vec<T>  Option<T>  Result<T, E>  String  HashMap<K, V>\n"));
     r.push_str(String::from("EFFECTS   : io  read  write  panic  unsafe\n"));
     r.push_str(String::from("BUILTINS  : print_str: fn(s: String) -> () [io]   print_i64: fn(v: i64) -> () [io]   print_u64: fn(v: u64) -> () [io]\n"));
-    r.push_str(String::from("            eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]\n"));
+    r.push_str(String::from("            eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   num_cpus: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]\n"));
     r.push_str(String::from("METHODS   : Vec: Vec::new/push/pop/len/clear/truncate/v[i]/v[i] = val   String: String::from/String::new/len/byte_at/push_byte/push_str/clear/contains/eq/substring/parse_i64/parse_u64\n"));
     r.push_str(String::from("            HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap\n"));
     r.push_str(String::from("OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?\n"));
@@ -2681,6 +2835,14 @@ fn skill_full() -> String {
     r.push_str(String::from("| `time_unix`      | `fn() -> i64`                              | `[io]`     |\n"));
     r.push_str(String::from("| `time_unix_ms`   | `fn() -> i64`                              | `[io]`     |\n"));
     r.push_str(String::from("\n"));
+    r.push_str(String::from("#### System\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("| Function         | Signature                                  | Effects    |\n"));
+    r.push_str(String::from("|------------------|--------------------------------------------|------------|\n"));
+    r.push_str(String::from("| `num_cpus`       | `fn() -> i64`                              | `[io]`     |\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("`num_cpus()` returns the number of available logical CPUs (from `std::thread::available_parallelism`), or `1` if the query fails. Used to size worker pools (e.g. the default `--verify-jobs` value).\n"));
+    r.push_str(String::from("\n"));
     r.push_str(String::from("#### Encoding\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("| Function         | Signature                                  | Effects    |\n"));
@@ -2785,6 +2947,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |\n"));
     r.push_str(String::from("| `--string-max <N>` | `256`    | Max String capacity for verification model   |\n"));
     r.push_str(String::from("| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |\n"));
+    r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow verify`\n"));
     r.push_str(String::from("\n"));
@@ -2806,6 +2969,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
     r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
     r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
+    r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow contracts`\n"));
     r.push_str(String::from("\n"));
@@ -2827,6 +2991,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
     r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
     r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
+    r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow skill`\n"));
     r.push_str(String::from("\n"));
@@ -2864,6 +3029,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
     r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
     r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
+    r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs (with --verify) |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.\n"));
     r.push_str(String::from("\n"));
@@ -4714,6 +4880,9 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let string_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--string-max")); if s.len() > 0 { parse_i64(s) } else { 256 } };
     let hashmap_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--hashmap-max")); if s.len() > 0 { parse_i64(s) } else { 64 } };
     validate_limits(vec_max_c, string_max_c, hashmap_max_c);
+    // Accepted for CLI parity with build/verify/test; validates a 0 rejection
+    // uniformly, then is discarded because the contracts verify loop is serial.
+    let _cjobs: i64 = resolve_verify_jobs(argv);
 
     // Collect per-contract entries into parallel arrays
     let e_vow_ids: Vec<i64> = Vec::new();

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -28,6 +28,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
 | `--string-max <N>` | `256`    | Max String capacity for verification model   |
 | `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
+| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 ### `vow verify`
 
@@ -49,6 +50,7 @@ vow verify [OPTIONS] <source.vow>
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
+| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 ### `vow contracts`
 
@@ -70,6 +72,7 @@ vow contracts [OPTIONS] <source.vow>
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
+| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
 ### `vow skill`
 
@@ -107,6 +110,7 @@ vow test [OPTIONS] [<path>]
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
+| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs (with --verify) |
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.
 

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -713,6 +713,14 @@ Contract expressions (`requires`, `ensures`, `invariant`) must be pure — they 
 | `time_unix`      | `fn() -> i64`                              | `[io]`     |
 | `time_unix_ms`   | `fn() -> i64`                              | `[io]`     |
 
+#### System
+
+| Function         | Signature                                  | Effects    |
+|------------------|--------------------------------------------|------------|
+| `num_cpus`       | `fn() -> i64`                              | `[io]`     |
+
+`num_cpus()` returns the number of available logical CPUs (from `std::thread::available_parallelism`), or `1` if the query fails. Used to size worker pools (e.g. the default `--verify-jobs` value).
+
 #### Encoding
 
 | Function         | Signature                                  | Effects    |

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -81,9 +81,12 @@ fi
 
 # ─── Stage 1: Rust compiler -> build/vowc ────────────────────────────
 
+# --verify-jobs 1 keeps bootstrap memory bounded: at most one ESBMC process
+# runs at a time across the ~45 vowed compiler functions, so peak RSS is
+# codegen + one ESBMC instead of codegen + N-fold ESBMC fan-out. See #175.
 printf "${BOLD}Stage 1:${RESET} Rust compiler -> build/vowc\n"
 t0=$(date +%s)
-if ! run_logged "./target/release/vow build compiler/main.vow -o build/vowc"; then
+if ! run_logged "./target/release/vow build --verify-jobs 1 compiler/main.vow -o build/vowc"; then
     printf "  ${RED}FAILED${RESET}\n"
     exit 1
 fi
@@ -94,7 +97,7 @@ printf "  done in %ds\n" $((t1 - t0))
 
 printf "${BOLD}Stage 2:${RESET} build/vowc -> build/vowc2\n"
 t0=$(date +%s)
-if ! run_stage_cmd "build/vowc build compiler/main.vow -o build/vowc2"; then
+if ! run_stage_cmd "build/vowc build --verify-jobs 1 compiler/main.vow -o build/vowc2"; then
     printf "  ${RED}FAILED${RESET}\n"
     if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
         printf "  Hint: rerun with a higher VOW_BOOTSTRAP_VMEM_KB or unset it for no cap.\n"
@@ -108,7 +111,7 @@ printf "  done in %ds\n" $((t1 - t0))
 
 printf "${BOLD}Stage 3:${RESET} build/vowc2 -> build/vowc3\n"
 t0=$(date +%s)
-if ! run_stage_cmd "build/vowc2 build compiler/main.vow -o build/vowc3"; then
+if ! run_stage_cmd "build/vowc2 build --verify-jobs 1 compiler/main.vow -o build/vowc3"; then
     printf "  ${RED}FAILED${RESET}\n"
     if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
         printf "  Hint: rerun with a higher VOW_BOOTSTRAP_VMEM_KB or unset it for no cap.\n"

--- a/tests/verify/verify_jobs_pool.vow
+++ b/tests/verify/verify_jobs_pool.vow
@@ -1,0 +1,44 @@
+module VerifyJobsPool
+
+fn abs_safe(x: i64) -> i64 vow {
+  requires: x > -9223372036854775807,
+  ensures: result >= 0
+} {
+  if x < 0 { -x } else { x }
+}
+
+fn max3(a: i64, b: i64, c: i64) -> i64 vow {
+  ensures: result == a || result == b || result == c,
+  ensures: result >= a,
+  ensures: result >= b,
+  ensures: result >= c
+} {
+  let ab: i64 = if a > b { a } else { b };
+  if ab > c { ab } else { c }
+}
+
+fn clamp_nonneg(x: i64, hi: i64) -> i64 vow {
+  requires: hi >= 0,
+  ensures: result >= 0,
+  ensures: result <= hi
+} {
+  if x < 0 { 0 } else { if x > hi { hi } else { x } }
+}
+
+fn add_nonneg(a: i64, b: i64) -> i64 vow {
+  requires: a >= 0,
+  requires: b >= 0,
+  requires: a <= 4611686018427387903,
+  requires: b <= 4611686018427387903,
+  ensures: result == a + b
+} {
+  a + b
+}
+
+fn main() -> i32 [io] {
+  print_i64(abs_safe(-5));
+  print_i64(max3(1, 7, 4));
+  print_i64(clamp_nonneg(150, 100));
+  print_i64(add_nonneg(3, 4));
+  0
+}

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2138,6 +2138,9 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_time_unix_ms" => {
             sig.returns.push(AbiParam::new(types::I64));
         }
+        "__vow_num_cpus" => {
+            sig.returns.push(AbiParam::new(types::I64));
+        }
         "__vow_hex_encode" => {
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -1612,6 +1612,9 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_time_unix_ms" => {
             sig.returns.push(AbiParam::new(types::I64)); // unix timestamp ms
         }
+        "__vow_num_cpus" => {
+            sig.returns.push(AbiParam::new(types::I64)); // available CPU count
+        }
         "__vow_hex_encode" => {
             sig.params.push(AbiParam::new(types::I64)); // vec ptr
             sig.returns.push(AbiParam::new(types::I64)); // string ptr

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -77,6 +77,7 @@ fn vow_builtin_to_runtime(name: &str) -> Option<(&'static str, Ty)> {
         "vec_sort" => Some(("__vow_vec_sort", Ty::Ptr)),
         "time_unix" => Some(("__vow_time_unix", Ty::I64)),
         "time_unix_ms" => Some(("__vow_time_unix_ms", Ty::I64)),
+        "num_cpus" => Some(("__vow_num_cpus", Ty::I64)),
         "hex_encode" => Some(("__vow_hex_encode", Ty::Ptr)),
         "hex_decode" => Some(("__vow_hex_decode", Ty::Ptr)),
         "args" => Some(("__vow_args", Ty::Ptr)),

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -1421,6 +1421,13 @@ pub extern "C" fn __vow_time_unix_ms() -> i64 {
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn __vow_num_cpus() -> i64 {
+    std::thread::available_parallelism()
+        .map(|n| n.get() as i64)
+        .unwrap_or(1)
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_hex_encode(vec: *const u8) -> *mut u8 {
     if vec.is_null() {
         return __vow_vec_new(1, 1);

--- a/vow-types/src/env.rs
+++ b/vow-types/src/env.rs
@@ -306,6 +306,14 @@ impl TypeEnv {
             },
         );
         env.define_fn(
+            "num_cpus",
+            FnSig {
+                params: vec![],
+                return_ty: Ty::I64,
+                effects: [Effect::IO].into_iter().collect(),
+            },
+        );
+        env.define_fn(
             "hex_encode",
             FnSig {
                 params: vec![Ty::Applied(

--- a/vow-verify/src/lib.rs
+++ b/vow-verify/src/lib.rs
@@ -2,7 +2,7 @@ pub mod c_emitter;
 pub mod esbmc;
 pub mod solver_strategy;
 
-pub use c_emitter::{VerifyLimits, detect_constant_functions};
+pub use c_emitter::{ConstantValue, VerifyLimits, detect_constant_functions};
 pub use esbmc::{
     Counterexample, DEFAULT_MAX_K_STEP, VerificationResult, emit_verify_c_source, find_esbmc,
     parse_esbmc_output, run_esbmc_k_induction, run_esbmc_with_max_k_step, verify_function,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -4,6 +4,8 @@ mod module_loader;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread;
 
 use std::collections::BTreeMap;
@@ -15,9 +17,9 @@ use vow_codegen::linker::{find_runtime_lib, find_shim_lib, link};
 use vow_codegen::{Backend, BuildMode, TraceMode};
 use vow_diag::{Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
 use vow_verify::{
-    Counterexample, DEFAULT_MAX_K_STEP, Encoding, Solver, SolverConfig, VerificationResult,
-    VerifyLimits, detect_constant_functions, emit_verify_c_source, find_esbmc, run_with_fallback,
-    verify_function_with_module_and_const_fns_configured,
+    ConstantValue, Counterexample, DEFAULT_MAX_K_STEP, Encoding, Solver, SolverConfig,
+    VerificationResult, VerifyLimits, detect_constant_functions, emit_verify_c_source, find_esbmc,
+    run_with_fallback, verify_function_with_module_and_const_fns_configured,
 };
 
 use cache::{CachedVerifyResult, VerifyCache};
@@ -124,6 +126,8 @@ struct Args {
     #[arg(long)]
     timeout: Option<u32>,
     #[arg(long)]
+    verify_jobs: Option<u32>,
+    #[arg(long)]
     help: bool,
     #[arg(long)]
     human: bool,
@@ -176,6 +180,8 @@ struct BuildArgs {
     #[arg(long)]
     timeout: Option<u32>,
     #[arg(long)]
+    verify_jobs: Option<u32>,
+    #[arg(long)]
     help: bool,
     #[arg(long)]
     human: bool,
@@ -205,6 +211,8 @@ struct VerifyArgs {
     encoding: EncodingArg,
     #[arg(long)]
     timeout: Option<u32>,
+    #[arg(long)]
+    verify_jobs: Option<u32>,
 }
 
 #[derive(clap::Args, Debug)]
@@ -233,6 +241,8 @@ struct TestArgs {
     string_max: usize,
     #[arg(long, default_value = "64")]
     hashmap_max: usize,
+    #[arg(long)]
+    verify_jobs: Option<u32>,
     #[arg(long)]
     help: bool,
     #[arg(long)]
@@ -273,6 +283,10 @@ struct ContractsArgs {
     encoding: EncodingArg,
     #[arg(long)]
     timeout: Option<u32>,
+    /// Accepted for CLI parity with build/verify/test; ignored because
+    /// `update_contract_statuses` has no pool wiring yet (see #175 follow-ups).
+    #[arg(long)]
+    verify_jobs: Option<u32>,
     #[arg(long)]
     help: bool,
     #[arg(long)]
@@ -479,6 +493,14 @@ fn skill_json() -> String {
           "value_name": "N",
           "value_kind": "integer",
           "default": 64
+        },
+        {
+          "form": "--verify-jobs <N>",
+          "description": "Max concurrent ESBMC verification jobs (default: num_cpus/2)",
+          "long": "--verify-jobs",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": "num_cpus/2"
         }
       ],
       "stdout": {
@@ -584,6 +606,14 @@ fn skill_json() -> String {
           "value_name": "N",
           "value_kind": "integer",
           "default": 64
+        },
+        {
+          "form": "--verify-jobs <N>",
+          "description": "Max concurrent ESBMC verification jobs (default: num_cpus/2)",
+          "long": "--verify-jobs",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": "num_cpus/2"
         }
       ],
       "stdout": {
@@ -675,6 +705,14 @@ fn skill_json() -> String {
           "value_name": "N",
           "value_kind": "integer",
           "default": 64
+        },
+        {
+          "form": "--verify-jobs <N>",
+          "description": "Max concurrent ESBMC verification jobs (with --verify)",
+          "long": "--verify-jobs",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": "num_cpus/2"
         }
       ],
       "stdout": {
@@ -800,6 +838,14 @@ fn skill_json() -> String {
           "value_name": "N",
           "value_kind": "integer",
           "default": 64
+        },
+        {
+          "form": "--verify-jobs <N>",
+          "description": "Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)",
+          "long": "--verify-jobs",
+          "value_name": "N",
+          "value_kind": "integer",
+          "default": "num_cpus/2"
         }
       ],
       "stdout": {
@@ -825,7 +871,8 @@ fn skill_json() -> String {
     "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
+    "--verify-jobs <N>": "Max concurrent ESBMC verification jobs (default: num_cpus/2)"
   },
   "verify_options": {
     "--no-cache": "Disable verification result caching",
@@ -835,7 +882,8 @@ fn skill_json() -> String {
     "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long (default: (none; 30 when encoding is auto))",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
+    "--verify-jobs <N>": "Max concurrent ESBMC verification jobs (default: num_cpus/2)"
   },
   "test_options": {
     "--verify": "Run ESBMC verification on test files",
@@ -845,7 +893,8 @@ fn skill_json() -> String {
     "--max-k-step <N>": "ESBMC incremental BMC max iterations (with --verify)",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
+    "--verify-jobs <N>": "Max concurrent ESBMC verification jobs (with --verify)"
   },
   "decl_options": {
     "-o, --output <path>": "Output declaration file path (default: <source>.vow.d)"
@@ -858,7 +907,8 @@ fn skill_json() -> String {
     "--encoding <bv|ir|auto>": "ESBMC encoding mode (with --verify); ir requires z3 (default: auto)",
     "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
     "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)"
+    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
+    "--verify-jobs <N>": "Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)"
   },
   "global_options": {
     "--help": "Emit versioned JSON tool-help data",
@@ -996,6 +1046,7 @@ fn skill_json() -> String {
       "vec_sort": "fn(v: Vec<i64>) -> Vec<i64> []",
       "time_unix": "fn() -> i64 [io]",
       "time_unix_ms": "fn() -> i64 [io]",
+      "num_cpus": "fn() -> i64 [io]",
       "hex_encode": "fn(data: Vec<u8>) -> String []",
       "hex_decode": "fn(s: String) -> Vec<u8> []",
       "args": "fn() -> Vec<String> [read]",
@@ -1210,6 +1261,7 @@ BUILD OPTIONS
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
+  --verify-jobs <N>       Max concurrent ESBMC verification jobs (default: num_cpus/2)
 
 VERIFY OPTIONS
   --no-cache              Disable verification result caching
@@ -1220,6 +1272,7 @@ VERIFY OPTIONS
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
+  --verify-jobs <N>       Max concurrent ESBMC verification jobs (default: num_cpus/2)
 
 TEST OPTIONS
   --verify                Run ESBMC verification on test files
@@ -1230,6 +1283,7 @@ TEST OPTIONS
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
+  --verify-jobs <N>       Max concurrent ESBMC verification jobs (with --verify)
 
 CONTRACTS OPTIONS
   --verify                Run ESBMC verification and report per-contract status
@@ -1240,6 +1294,7 @@ CONTRACTS OPTIONS
   --vec-max <N>           Max Vec capacity for verification model (default: 128)
   --string-max <N>        Max String capacity for verification model (default: 256)
   --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
+  --verify-jobs <N>       Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)
 
 DECL OPTIONS
   -o, --output <path>     Output declaration file path (default: <source>.vow.d)
@@ -1287,7 +1342,7 @@ LANGUAGE SUMMARY
 TYPES     : i32  i64  u8  u64  f32  f64  bool  ()  !  Vec<T>  Option<T>  Result<T, E>  String  HashMap<K, V>
 EFFECTS   : io  read  write  panic  unsafe
 BUILTINS  : print_str: fn(s: String) -> () [io]   print_i64: fn(v: i64) -> () [io]   print_u64: fn(v: u64) -> () [io]
-            eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]
+            eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   num_cpus: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]
 METHODS   : Vec: Vec::new/push/pop/len/clear/truncate/v[i]/v[i] = val   String: String::from/String::new/len/byte_at/push_byte/push_str/clear/contains/eq/substring/parse_i64/parse_u64
             HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap
 OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?
@@ -2086,6 +2141,14 @@ Contract expressions (`requires`, `ensures`, `invariant`) must be pure — they 
 | `time_unix`      | `fn() -> i64`                              | `[io]`     |
 | `time_unix_ms`   | `fn() -> i64`                              | `[io]`     |
 
+#### System
+
+| Function         | Signature                                  | Effects    |
+|------------------|--------------------------------------------|------------|
+| `num_cpus`       | `fn() -> i64`                              | `[io]`     |
+
+`num_cpus()` returns the number of available logical CPUs (from `std::thread::available_parallelism`), or `1` if the query fails. Used to size worker pools (e.g. the default `--verify-jobs` value).
+
 #### Encoding
 
 | Function         | Signature                                  | Effects    |
@@ -2190,6 +2253,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
 | `--string-max <N>` | `256`    | Max String capacity for verification model   |
 | `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
+| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 ### `vow verify`
 
@@ -2211,6 +2275,7 @@ vow verify [OPTIONS] <source.vow>
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
+| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 ### `vow contracts`
 
@@ -2232,6 +2297,7 @@ vow contracts [OPTIONS] <source.vow>
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
+| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
 ### `vow skill`
 
@@ -2269,6 +2335,7 @@ vow test [OPTIONS] [<path>]
 | `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
 | `--string-max <N>`| `256`       | Max String capacity for verification model |
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
+| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs (with --verify) |
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` in the given directory, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.
 
@@ -4783,141 +4850,229 @@ fn compile_frontend(source: &Path) -> Result<FrontendBundle, Box<BuildOutput>> {
 // Verification (synchronous)
 // ---------------------------------------------------------------------------
 
+/// Thread-safe: `verify_cache` writes are content-addressed.
+#[allow(clippy::too_many_arguments)]
+fn verify_one_function(
+    func: &vow_ir::Function,
+    ir_module: &vow_ir::Module,
+    const_fns: &std::collections::HashMap<vow_ir::FuncId, ConstantValue>,
+    file: &str,
+    call_site_index: &std::collections::HashMap<String, Vec<CallSiteInfo>>,
+    verify_cache: Option<&VerifyCache>,
+    limits: &VerifyLimits,
+    config: &SolverConfig,
+) -> Option<VerifyOutcome> {
+    // Resolve Auto solver via heuristic (Phase B).
+    // Skip heuristic when encoding is Ir — that forces Z3 via resolve().
+    let func_config = if config.solver == Solver::Auto && config.encoding != Encoding::Ir {
+        let heuristic = vow_verify::classify_function(func);
+        SolverConfig {
+            solver: heuristic.solver,
+            encoding: config.encoding,
+            timeout_secs: config.timeout_secs,
+        }
+    } else {
+        *config
+    };
+
+    let result = if let Some(vc) = verify_cache {
+        let c_src = emit_verify_c_source(func, ir_module, const_fns, limits);
+        let key = VerifyCache::cache_key(
+            &c_src,
+            limits.max_k_step,
+            func_config.solver_str(),
+            func_config.encoding_str(),
+        );
+
+        let cached_result = vc.lookup(&key).map(|c| match c {
+            CachedVerifyResult::Proven => VerificationResult::Proven,
+            CachedVerifyResult::Failed { .. } => {
+                VerificationResult::Failed(c.to_counterexample().unwrap())
+            }
+        });
+        // Phase D: if BV lookup misses under Auto encoding and BV solver
+        // isn't Bitwuzla, probe the IR fallback key for a prior ProvenIr
+        // result. Only promote Proven hits — IR Failed entries must be
+        // ignored because IR doesn't model overflow.
+        let cached_result = cached_result.or_else(|| {
+            if func_config.encoding != Encoding::Auto
+                || matches!(func_config.solver, Solver::Bitwuzla)
+            {
+                return None;
+            }
+            let ir_key = VerifyCache::cache_key(&c_src, limits.max_k_step, "z3", "ir");
+            vc.lookup(&ir_key).and_then(|c| match c {
+                CachedVerifyResult::Proven => Some(VerificationResult::ProvenIr),
+                CachedVerifyResult::Failed { .. } => None,
+            })
+        });
+
+        if let Some(r) = cached_result {
+            r
+        } else {
+            let esbmc = match find_esbmc() {
+                Some(p) => p,
+                None => return Some(VerifyOutcome::ToolNotFound),
+            };
+            let (res, resolved_config) =
+                run_with_fallback(&esbmc, &c_src, limits.max_k_step, &func.name, &func_config);
+            // Store under the resolved config so ProvenIr results are
+            // keyed by encoding=ir rather than the pre-fallback Auto/Bv.
+            let store_key = VerifyCache::cache_key(
+                &c_src,
+                limits.max_k_step,
+                resolved_config.solver_str(),
+                resolved_config.encoding_str(),
+            );
+            match &res {
+                VerificationResult::Proven | VerificationResult::ProvenIr => {
+                    vc.store(&store_key, &CachedVerifyResult::Proven);
+                }
+                VerificationResult::Failed(ce) => {
+                    vc.store(
+                        &store_key,
+                        &CachedVerifyResult::Failed {
+                            vow_id: ce.vow_id,
+                            description: ce.description.clone(),
+                            values: ce.values.clone(),
+                            block_visits: ce.block_visits.clone(),
+                            raw_output: ce.raw_output.clone(),
+                        },
+                    );
+                }
+                _ => {}
+            }
+            res
+        }
+    } else {
+        verify_function_with_module_and_const_fns_configured(
+            func,
+            ir_module,
+            const_fns,
+            limits.max_k_step,
+            &func_config,
+            limits,
+        )
+    };
+
+    match result {
+        VerificationResult::Failed(ce) => {
+            let sce = build_structured_counterexample(func, &ce, file, call_site_index);
+            Some(VerifyOutcome::Failed {
+                function: func.name.clone(),
+                description: ce.description.clone(),
+                counterexamples: vec![sce],
+            })
+        }
+        VerificationResult::ToolError(e) => Some(VerifyOutcome::Error {
+            function: func.name.clone(),
+            message: e,
+        }),
+        VerificationResult::Timeout => Some(VerifyOutcome::Timeout {
+            function: func.name.clone(),
+        }),
+        VerificationResult::Proven | VerificationResult::ProvenIr => None,
+        VerificationResult::ToolNotFound => Some(VerifyOutcome::ToolNotFound),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn run_verification_sync(
     ir_module: &vow_ir::Module,
     file: &str,
     call_site_index: &std::collections::HashMap<String, Vec<CallSiteInfo>>,
     verify_cache: Option<&VerifyCache>,
     limits: &VerifyLimits,
+    jobs: usize,
     config: &SolverConfig,
 ) -> VerifyOutcome {
     let const_fns = detect_constant_functions(ir_module);
-    for func in &ir_module.functions {
-        if func.vows.is_empty() {
-            continue;
-        }
 
-        // Resolve Auto solver via heuristic (Phase B).
-        // Skip heuristic when encoding is Ir — that forces Z3 via resolve().
-        let func_config = if config.solver == Solver::Auto && config.encoding != Encoding::Ir {
-            let heuristic = vow_verify::classify_function(func);
-            SolverConfig {
-                solver: heuristic.solver,
-                encoding: config.encoding,
-                timeout_secs: config.timeout_secs,
-            }
-        } else {
-            *config
-        };
+    let vowed: Vec<&vow_ir::Function> = ir_module
+        .functions
+        .iter()
+        .filter(|f| !f.vows.is_empty())
+        .collect();
 
-        let result = if let Some(vc) = verify_cache {
-            let c_src = emit_verify_c_source(func, ir_module, &const_fns, limits);
-            let key = VerifyCache::cache_key(
-                &c_src,
-                limits.max_k_step,
-                func_config.solver_str(),
-                func_config.encoding_str(),
-            );
+    if vowed.is_empty() {
+        return VerifyOutcome::Proven;
+    }
 
-            let cached_result = vc.lookup(&key).map(|c| match c {
-                CachedVerifyResult::Proven => VerificationResult::Proven,
-                CachedVerifyResult::Failed { .. } => {
-                    VerificationResult::Failed(c.to_counterexample().unwrap())
-                }
-            });
-            // Phase D: if BV lookup misses under Auto encoding and BV solver
-            // isn't Bitwuzla, probe the IR fallback key for a prior
-            // ProvenIr result. Only promote Proven hits — IR Failed entries
-            // must be ignored because IR doesn't model overflow, so an
-            // IR-only counterexample may be infeasible under BV semantics.
-            let cached_result = cached_result.or_else(|| {
-                if func_config.encoding != Encoding::Auto
-                    || matches!(func_config.solver, Solver::Bitwuzla)
-                {
-                    return None;
-                }
-                let ir_key = VerifyCache::cache_key(&c_src, limits.max_k_step, "z3", "ir");
-                vc.lookup(&ir_key).and_then(|c| match c {
-                    CachedVerifyResult::Proven => Some(VerificationResult::ProvenIr),
-                    CachedVerifyResult::Failed { .. } => None,
-                })
-            });
-
-            if let Some(r) = cached_result {
-                r
-            } else {
-                let esbmc = match find_esbmc() {
-                    Some(p) => p,
-                    None => return VerifyOutcome::ToolNotFound,
-                };
-                let (res, resolved_config) =
-                    run_with_fallback(&esbmc, &c_src, limits.max_k_step, &func.name, &func_config);
-                // Store under the resolved config so ProvenIr results are
-                // keyed by encoding=ir rather than the pre-fallback Auto/Bv.
-                let store_key = VerifyCache::cache_key(
-                    &c_src,
-                    limits.max_k_step,
-                    resolved_config.solver_str(),
-                    resolved_config.encoding_str(),
-                );
-                match &res {
-                    VerificationResult::Proven | VerificationResult::ProvenIr => {
-                        vc.store(&store_key, &CachedVerifyResult::Proven);
-                    }
-                    VerificationResult::Failed(ce) => {
-                        vc.store(
-                            &store_key,
-                            &CachedVerifyResult::Failed {
-                                vow_id: ce.vow_id,
-                                description: ce.description.clone(),
-                                values: ce.values.clone(),
-                                block_visits: ce.block_visits.clone(),
-                                raw_output: ce.raw_output.clone(),
-                            },
-                        );
-                    }
-                    _ => {}
-                }
-                res
-            }
-        } else {
-            verify_function_with_module_and_const_fns_configured(
+    let jobs = jobs.max(1).min(vowed.len());
+    if jobs == 1 {
+        for func in &vowed {
+            if let Some(outcome) = verify_one_function(
                 func,
                 ir_module,
                 &const_fns,
-                limits.max_k_step,
-                &func_config,
+                file,
+                call_site_index,
+                verify_cache,
                 limits,
-            )
-        };
-
-        match result {
-            VerificationResult::Failed(ce) => {
-                let sce = build_structured_counterexample(func, &ce, file, call_site_index);
-                return VerifyOutcome::Failed {
-                    function: func.name.clone(),
-                    description: ce.description.clone(),
-                    counterexamples: vec![sce],
-                };
-            }
-            VerificationResult::ToolError(e) => {
-                return VerifyOutcome::Error {
-                    function: func.name.clone(),
-                    message: e,
-                };
-            }
-            VerificationResult::Timeout => {
-                return VerifyOutcome::Timeout {
-                    function: func.name.clone(),
-                };
-            }
-            VerificationResult::Proven | VerificationResult::ProvenIr => {}
-            VerificationResult::ToolNotFound => {
-                return VerifyOutcome::ToolNotFound;
+                config,
+            ) {
+                return outcome;
             }
         }
+        return VerifyOutcome::Proven;
     }
-    VerifyOutcome::Proven
+
+    // Stop after first failure; return lowest-indexed outcome for deterministic reporting.
+    let next = AtomicUsize::new(0);
+    let stop = AtomicBool::new(false);
+    let outcomes: StdMutex<Vec<Option<VerifyOutcome>>> =
+        StdMutex::new((0..vowed.len()).map(|_| None).collect());
+
+    thread::scope(|scope| {
+        for _ in 0..jobs {
+            let next = &next;
+            let stop = &stop;
+            let outcomes = &outcomes;
+            let vowed = &vowed;
+            let const_fns = &const_fns;
+            scope.spawn(move || {
+                loop {
+                    if stop.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let idx = next.fetch_add(1, Ordering::AcqRel);
+                    if idx >= vowed.len() {
+                        break;
+                    }
+                    // Always finish what we've claimed so `outcomes[idx]` reflects
+                    // its true verdict — otherwise lowest-index failure reporting
+                    // becomes timing-dependent. The pre-check already avoids claims
+                    // in the common post-failure case.
+                    let outcome = verify_one_function(
+                        vowed[idx],
+                        ir_module,
+                        const_fns,
+                        file,
+                        call_site_index,
+                        verify_cache,
+                        limits,
+                        config,
+                    );
+                    if let Some(out) = outcome {
+                        let mut guard = outcomes.lock().expect("verify outcomes mutex poisoned");
+                        guard[idx] = Some(out);
+                        drop(guard);
+                        // Release pairs with sibling threads' stop.load(Acquire) to propagate early-exit.
+                        stop.store(true, Ordering::Release);
+                    }
+                }
+            });
+        }
+    });
+
+    let results = outcomes
+        .into_inner()
+        .expect("verify outcomes mutex poisoned");
+    results
+        .into_iter()
+        .flatten()
+        .next()
+        .unwrap_or(VerifyOutcome::Proven)
 }
 
 fn blame_to_error_code(blame: &str) -> vow_diag::ErrorCode {
@@ -5080,13 +5235,14 @@ fn verify_outcome_to_output(
 
 pub fn run_verify_only(source: &Path) -> BuildOutput {
     let limits = VerifyLimits::default();
-    run_verify_only_inner(source, false, &limits, &SolverConfig::default_config())
+    run_verify_only_inner(source, false, &limits, 1, &SolverConfig::default_config())
 }
 
 fn run_verify_only_inner(
     source: &Path,
     no_cache: bool,
     limits: &VerifyLimits,
+    jobs: usize,
     config: &SolverConfig,
 ) -> BuildOutput {
     let frontend = match compile_frontend(source) {
@@ -5111,6 +5267,7 @@ fn run_verify_only_inner(
         &call_site_index,
         verify_cache.as_ref(),
         limits,
+        jobs,
         config,
     );
     verify_outcome_to_output(outcome, all_diagnostics, None)
@@ -5158,6 +5315,7 @@ pub fn run_pipeline(
         trace,
         false,
         &limits,
+        1,
         &SolverConfig::default_config(),
     )
 }
@@ -5172,6 +5330,7 @@ fn run_pipeline_inner(
     trace: TraceMode,
     no_cache: bool,
     limits: &VerifyLimits,
+    jobs: usize,
     config: &SolverConfig,
 ) -> BuildOutput {
     let frontend = match compile_frontend(source) {
@@ -5180,7 +5339,7 @@ fn run_pipeline_inner(
     };
 
     run_pipeline_from_frontend(
-        frontend, source, output, mode, no_verify, dump_ir, trace, no_cache, limits, config,
+        frontend, source, output, mode, no_verify, dump_ir, trace, no_cache, limits, jobs, config,
     )
 }
 
@@ -5195,6 +5354,7 @@ fn run_pipeline_from_frontend(
     trace: TraceMode,
     no_cache: bool,
     limits: &VerifyLimits,
+    jobs: usize,
     config: &SolverConfig,
 ) -> BuildOutput {
     let all_diagnostics = frontend.diagnostics().to_vec();
@@ -5241,6 +5401,7 @@ fn run_pipeline_from_frontend(
             &call_site_index,
             verify_cache.as_ref(),
             &verify_limits,
+            jobs,
             &verify_config,
         )
     });
@@ -5367,6 +5528,7 @@ fn count_contract_density(ir_module: &vow_ir::Module) -> ContractDensity {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_test_command(
     path: &Path,
     verify: bool,
@@ -5374,6 +5536,7 @@ fn run_test_command(
     mode: BuildMode,
     timeout_ms: u64,
     limits: &VerifyLimits,
+    jobs: usize,
 ) {
     if !path.exists() {
         let result = TestResult {
@@ -5465,6 +5628,7 @@ fn run_test_command(
             TraceMode::Off,
             true,
             limits,
+            jobs,
             &SolverConfig::default_config(),
         );
 
@@ -5666,6 +5830,23 @@ fn validate_limits(limits: &VerifyLimits) {
     }
 }
 
+/// User value verbatim; rejects 0 with a clear error. None → num_cpus/2 clamped to ≥1.
+fn resolve_verify_jobs(opt: Option<u32>) -> usize {
+    match opt {
+        Some(0) => {
+            eprintln!("error: --verify-jobs must be >= 1");
+            std::process::exit(1);
+        }
+        Some(n) => n as usize,
+        None => {
+            let n = std::thread::available_parallelism()
+                .map(|p| p.get())
+                .unwrap_or(1);
+            (n / 2).max(1)
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_build_command(
     source: &Path,
@@ -5676,10 +5857,11 @@ fn run_build_command(
     trace: TraceMode,
     no_cache: bool,
     limits: &VerifyLimits,
+    jobs: usize,
     config: &SolverConfig,
 ) {
     let result = run_pipeline_inner(
-        source, output, mode, no_verify, dump_ir, trace, no_cache, limits, config,
+        source, output, mode, no_verify, dump_ir, trace, no_cache, limits, jobs, config,
     );
     if !dump_ir {
         result.emit_json();
@@ -5727,8 +5909,14 @@ fn run_decl_command(source: &Path, output: Option<&Path>) {
     eprintln!("wrote {}", out_path.display());
 }
 
-fn run_verify_command(source: &Path, no_cache: bool, limits: &VerifyLimits, config: &SolverConfig) {
-    let result = run_verify_only_inner(source, no_cache, limits, config);
+fn run_verify_command(
+    source: &Path,
+    no_cache: bool,
+    limits: &VerifyLimits,
+    jobs: usize,
+    config: &SolverConfig,
+) {
+    let result = run_verify_only_inner(source, no_cache, limits, jobs, config);
     result.emit_json();
     if matches!(
         &result.status,
@@ -6010,6 +6198,7 @@ fn main() {
                 hashmap_max: b.hashmap_max,
             };
             validate_limits(&limits);
+            let jobs = resolve_verify_jobs(b.verify_jobs);
             let bconfig = make_solver_config(b.solver, b.encoding, b.timeout);
             run_build_command(
                 &source,
@@ -6020,6 +6209,7 @@ fn main() {
                 trace,
                 b.no_cache,
                 &limits,
+                jobs,
                 &bconfig,
             );
         }
@@ -6046,8 +6236,9 @@ fn main() {
                 hashmap_max: v.hashmap_max,
             };
             validate_limits(&limits);
+            let jobs = resolve_verify_jobs(v.verify_jobs);
             let config = make_solver_config(v.solver, v.encoding, v.timeout);
-            run_verify_command(&source, v.no_cache, &limits, &config);
+            run_verify_command(&source, v.no_cache, &limits, jobs, &config);
         }
         Some(Command::Test(t)) => {
             if t.help {
@@ -6075,6 +6266,7 @@ fn main() {
                 hashmap_max: t.hashmap_max,
             };
             validate_limits(&limits);
+            let jobs = resolve_verify_jobs(t.verify_jobs);
             run_test_command(
                 &path,
                 t.verify,
@@ -6082,6 +6274,7 @@ fn main() {
                 mode,
                 t.timeout,
                 &limits,
+                jobs,
             );
         }
         Some(Command::Decl(d)) => {
@@ -6125,6 +6318,10 @@ fn main() {
                 hashmap_max: c.hashmap_max,
             };
             validate_limits(&limits);
+            // Accepted for CLI parity; validates a 0 rejection via the same path
+            // as build/verify/test, then is discarded because update_contract_statuses
+            // has no pool wiring today.
+            let _ = resolve_verify_jobs(c.verify_jobs);
             let config = make_solver_config(c.solver, c.encoding, c.timeout);
             run_contracts_command(&source, c.verify, c.no_cache, &limits, &config);
         }
@@ -6183,6 +6380,7 @@ fn main() {
                 hashmap_max: args.hashmap_max,
             };
             validate_limits(&limits);
+            let jobs = resolve_verify_jobs(args.verify_jobs);
             let config = make_solver_config(args.solver, args.encoding, args.timeout);
             run_build_command(
                 &source,
@@ -6193,6 +6391,7 @@ fn main() {
                 trace,
                 args.no_cache,
                 &limits,
+                jobs,
                 &config,
             );
         }
@@ -8241,6 +8440,107 @@ fn main() -> i32 {
             result.status
         );
         assert!(result.executable.is_none());
+    }
+
+    // Exercises `run_verification_sync`'s threaded pool (`jobs > 1`). The public
+    // `run_pipeline` / `run_verify_only` hardcode jobs=1, so without this test
+    // the parallel code path is only covered via the CLI.
+    #[test]
+    fn verify_only_inner_runs_threaded_pool() {
+        let dir = TempDir::new().unwrap();
+        let src = r#"module MultiVow
+fn a() -> i64 vow {
+  ensures: result == 1
+} {
+  1
+}
+fn b() -> i64 vow {
+  ensures: result == 2
+} {
+  2
+}
+fn c() -> i64 vow {
+  ensures: result == 3
+} {
+  3
+}
+fn d() -> i64 vow {
+  ensures: result == 4
+} {
+  4
+}
+fn main() -> i32 {
+  0
+}"#;
+        let source = write_source(&dir, "multi.vow", src);
+        let limits = VerifyLimits::default();
+        // jobs=4 with 4 vowed functions forces the threaded path.
+        let result =
+            run_verify_only_inner(&source, true, &limits, 4, &SolverConfig::default_config());
+        match &result.status {
+            BuildStatus::Verified => {
+                assert!(result.executable.is_none());
+                assert!(result.counterexamples.is_empty());
+            }
+            BuildStatus::Unverified => {
+                eprintln!("SKIP: esbmc not found");
+            }
+            BuildStatus::CompileFailed { message } => {
+                panic!("unexpected compile failure: {message}");
+            }
+            other => panic!("unexpected status: {other:?}"),
+        }
+    }
+
+    // Locks in the lowest-index determinism guarantee on the threaded pool:
+    // two functions are both provably wrong, but `fail_a` appears before
+    // `fail_b` in source order, so it must be reported.
+    #[test]
+    fn verify_only_inner_reports_lowest_index_failure() {
+        let dir = TempDir::new().unwrap();
+        let src = r#"module FailDeterminism
+fn ok_1() -> i64 vow {
+  ensures: result == 1
+} {
+  1
+}
+fn fail_a() -> i64 vow {
+  ensures: result == 99
+} {
+  1
+}
+fn ok_2() -> i64 vow {
+  ensures: result == 2
+} {
+  2
+}
+fn fail_b() -> i64 vow {
+  ensures: result == 99
+} {
+  2
+}
+fn main() -> i32 {
+  0
+}"#;
+        let source = write_source(&dir, "fail_det.vow", src);
+        let limits = VerifyLimits::default();
+        let result =
+            run_verify_only_inner(&source, true, &limits, 4, &SolverConfig::default_config());
+        match &result.status {
+            BuildStatus::VerifyFailed { function, .. } => {
+                assert_eq!(
+                    function, "fail_a",
+                    "expected lowest-index failure fail_a, got {function}"
+                );
+            }
+            BuildStatus::Unverified => {
+                eprintln!("SKIP: esbmc not found");
+            }
+            BuildStatus::CompileFailed { message } => {
+                panic!("unexpected compile failure: {message}");
+            }
+            other => panic!("unexpected status: {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `--verify-jobs <N>` flag to `build`/`verify`/`test`/`contracts` in both compilers. Default `max(1, num_cpus/2)`.
- Rust `run_verification_sync`: serial when jobs=1, else scoped bounded pool (AtomicUsize + AtomicBool + Mutex<Vec<Option<VerifyOutcome>>>), reports lowest-index failure for determinism.
- Self-hosted `run_build`: FIFO bounded pool via blocking `process_wait`; peak in-flight ESBMC ≤ jobs. Codegen runs alongside the tail-end jobs.
- Bootstrap (`scripts/bootstrap.sh`) now passes `--verify-jobs 1` to Stages 1/2/3 so peak RSS stays at codegen + one ESBMC.
- Fixes a pre-existing bug (surfaced by Codex review): self-hosted `verify_collect_and_report` silently treated `-1` handles (process_start failures) as "proven" — now reports the spawn error.

Fixes #175.

## Test plan

- [x] `cargo test --all`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `scripts/bootstrap.sh --skip-cargo` — SHA-256 fixed-point MATCH
- [x] New regression test `tests/verify/verify_jobs_pool.vow` verifies under `--verify-jobs 1` and `--verify-jobs 3`
- [x] `scripts/full_test.sh` sections 1–5c all PASS (section 6's geometry/verify is a pre-existing ESBMC slow path unrelated to the pool — every other verify call exercises the pool)
- [x] `--verify-jobs 0` rejected with clear error in both compilers
- [x] Interleaving log confirms `--verify-jobs 3` actually runs 3 ESBMC processes in parallel