### PR TITLE
[codex] Implement arena Phase 4 lowering cutover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +358,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +513,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,9 +538,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63944c133d03f44e75866bbd160b95af0ec3f6a13d936d69d31c81078cbc5baf"
 dependencies = [
  "crc32fast",
+ "flate2",
  "hashbrown 0.16.1",
  "indexmap",
  "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -687,6 +715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +825,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "unarray"
@@ -843,6 +892,7 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "object",
  "proptest",
  "tempfile",
  "vow-diag",

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -65,7 +65,7 @@ fn clif_compile_function(ctx: i64, func_idx: i64, f: IrFunction) -> i64 [io] {
             let rc_inst: i64 = __vow_clif_fn_inst(
                 ctx, inst.id, inst.op, inst.ty,
                 inst.dk, inst.dv, inst.dv2,
-                inst.ds, args
+                inst.ds, args, inst.rgn
             );
             if rc_inst != 0 {
                 return rc_inst;

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -275,9 +275,6 @@ fn lctx_get_tag(ctx: LowerCtx, inst_id: i64) -> String {
 }
 
 fn lctx_track_alloc(ctx: LowerCtx, id: i64, tag: String, alloc_size: i64) {
-    ctx.alloc_ids.push(id);
-    ctx.alloc_tags.push(tag);
-    ctx.alloc_sizes.push(alloc_size);
 }
 
 fn lctx_push_alloc_scope(ctx: LowerCtx) {
@@ -287,47 +284,6 @@ fn lctx_push_alloc_scope(ctx: LowerCtx) {
 fn lctx_pop_alloc_scope_frees(ctx: LowerCtx, live_out: Vec<i64>) {
     let scope_start: i64 = ctx.alloc_scope_starts[ctx.alloc_scope_starts.len() - 1];
     ctx.alloc_scope_starts.pop();
-    let n: i64 = ctx.alloc_ids.len();
-    let mut i: i64 = scope_start;
-    while i < n {
-        let id: i64 = ctx.alloc_ids[i];
-        let tag: String = ctx.alloc_tags[i];
-        let mut skip: bool = lctx_is_escaped(ctx, id);
-        if !skip {
-            let mut li: i64 = 0;
-            while li < live_out.len() {
-                if live_out[li] == id {
-                    skip = true;
-                }
-                li = li + 1;
-            }
-        }
-        if !skip {
-            if lower_str_starts_with(tag, String::from("region:")) {
-                let size: i64 = ctx.alloc_sizes[i];
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_REGION_FREE(), ITY_UNIT(), free_args, IDATA_ALLOC_SIZE(), size, 8, String::from(""));
-            }
-            if tag == String::from("String") {
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_free"));
-            }
-            if tag == String::from("Vec") {
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_free_val"));
-            }
-            if tag == String::from("HashMap") {
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_map_free"));
-            }
-        }
-        i = i + 1;
-    }
-    // Truncate the alloc arrays back to the scope start.
     while ctx.alloc_ids.len() > scope_start {
         ctx.alloc_ids.pop();
         ctx.alloc_tags.pop();
@@ -346,50 +302,9 @@ fn lctx_discard_alloc_scope(ctx: LowerCtx) {
 }
 
 fn lctx_emit_alloc_frees_to_depth(ctx: LowerCtx, target_depth: i64, live_out: Vec<i64>) {
-    let n: i64 = ctx.alloc_ids.len();
-    let mut i: i64 = target_depth;
-    while i < n {
-        let id: i64 = ctx.alloc_ids[i];
-        let tag: String = ctx.alloc_tags[i];
-        let mut skip: bool = lctx_is_escaped(ctx, id);
-        if !skip {
-            let mut li: i64 = 0;
-            while li < live_out.len() {
-                if live_out[li] == id {
-                    skip = true;
-                }
-                li = li + 1;
-            }
-        }
-        if !skip {
-            if lower_str_starts_with(tag, String::from("region:")) {
-                let size: i64 = ctx.alloc_sizes[i];
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_REGION_FREE(), ITY_UNIT(), free_args, IDATA_ALLOC_SIZE(), size, 8, String::from(""));
-            }
-            if tag == String::from("String") {
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_free"));
-            }
-            if tag == String::from("Vec") {
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_free_val"));
-            }
-            if tag == String::from("HashMap") {
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_map_free"));
-            }
-        }
-        i = i + 1;
-    }
 }
 
 fn lctx_mark_escaped(ctx: LowerCtx, id: i64) {
-    ctx.escaped_ids.push(id);
 }
 
 fn lctx_is_escaped(ctx: LowerCtx, id: i64) -> bool {
@@ -455,47 +370,6 @@ fn lctx_collect_return_sources(ctx: LowerCtx, return_val: i64) -> Vec<i64> {
 }
 
 fn lctx_emit_return_frees(ctx: LowerCtx, return_val: i64) {
-    let sources: Vec<i64> = lctx_collect_return_sources(ctx, return_val);
-    let n: i64 = ctx.alloc_ids.len();
-    let mut i: i64 = 0;
-    while i < n {
-        let id: i64 = ctx.alloc_ids[i];
-        let tag: String = ctx.alloc_tags[i];
-        let mut skip: bool = lctx_is_escaped(ctx, id);
-        if !skip {
-            let mut si: i64 = 0;
-            while si < sources.len() {
-                if sources[si] == id {
-                    skip = true;
-                }
-                si = si + 1;
-            }
-        }
-        if !skip {
-            if lower_str_starts_with(tag, String::from("region:")) {
-                let size: i64 = ctx.alloc_sizes[i];
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_REGION_FREE(), ITY_UNIT(), free_args, IDATA_ALLOC_SIZE(), size, 8, String::from(""));
-            }
-            if tag == String::from("String") {
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_free"));
-            }
-            if tag == String::from("Vec") {
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_free_val"));
-            }
-            if tag == String::from("HashMap") {
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_map_free"));
-            }
-        }
-        i = i + 1;
-    }
 }
 
 fn lctx_is_str_eid(ctx: LowerCtx, eid: i64) -> bool {
@@ -1141,16 +1015,10 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let lhs_tag: i64 = expr_tag(a, lhs_eid);
             if lhs_tag == EXPR_LIT_STR() {
                 lctx_mark_escaped(ctx, lhs_id);
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(lhs_id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_free"));
             }
             let rhs_tag: i64 = expr_tag(a, rhs_eid);
             if rhs_tag == EXPR_LIT_STR() {
                 lctx_mark_escaped(ctx, rhs_id);
-                let free_args: Vec<i64> = Vec::new();
-                free_args.push(rhs_id);
-                lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_free"));
             }
             if op == BINOP_NE() {
                 let not_args: Vec<i64> = Vec::new();
@@ -2477,9 +2345,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     let ae: i64 = list_get(a, args_lid, 0);
                     let ae_tag: i64 = expr_tag(a, ae);
                     if ae_tag == EXPR_LIT_STR() {
-                        let free_args: Vec<i64> = Vec::new();
-                        free_args.push(arg_id);
-                        lctx_emit(ctx, IOP_CALL(), ITY_UNIT(), free_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_free"));
                     }
                 }
                 return contains_result;

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -48,7 +48,6 @@ struct LowerCtx {
     alloc_ids: Vec<i64>,
     alloc_tags: Vec<String>,
     alloc_sizes: Vec<i64>,
-    escaped_ids: Vec<i64>,
     alloc_scope_starts: Vec<i64>,
     loop_alloc_scope_depths: Vec<i64>,
     file: String,
@@ -109,7 +108,6 @@ fn lctx_new(name: String, return_ty: i64, effects: i64, arena: AstArena, str_eid
         alloc_ids: Vec::new(),
         alloc_tags: Vec::new(),
         alloc_sizes: Vec::new(),
-        escaped_ids: Vec::new(),
         alloc_scope_starts: Vec::new(),
         loop_alloc_scope_depths: Vec::new(),
         file: String::from(""),
@@ -281,7 +279,7 @@ fn lctx_push_alloc_scope(ctx: LowerCtx) {
     ctx.alloc_scope_starts.push(ctx.alloc_ids.len());
 }
 
-fn lctx_pop_alloc_scope_frees(ctx: LowerCtx, live_out: Vec<i64>) {
+fn lctx_pop_alloc_scope_frees(ctx: LowerCtx) {
     let scope_start: i64 = ctx.alloc_scope_starts[ctx.alloc_scope_starts.len() - 1];
     ctx.alloc_scope_starts.pop();
     while ctx.alloc_ids.len() > scope_start {
@@ -299,74 +297,6 @@ fn lctx_discard_alloc_scope(ctx: LowerCtx) {
         ctx.alloc_tags.pop();
         ctx.alloc_sizes.pop();
     }
-}
-
-fn lctx_emit_alloc_frees_to_depth(ctx: LowerCtx, target_depth: i64, live_out: Vec<i64>) {
-}
-
-fn lctx_mark_escaped(ctx: LowerCtx, id: i64) {
-}
-
-fn lctx_is_escaped(ctx: LowerCtx, id: i64) -> bool {
-    let n: i64 = ctx.escaped_ids.len();
-    let mut i: i64 = 0;
-    while i < n {
-        if ctx.escaped_ids[i] == id {
-            return true;
-        }
-        i = i + 1;
-    }
-    false
-}
-
-fn lower_str_starts_with(s: String, prefix: String) -> bool {
-    let plen: i64 = prefix.len();
-    if s.len() < plen { return false; }
-    let mut i: i64 = 0;
-    while i < plen {
-        if s.byte_at(i) != prefix.byte_at(i) { return false; }
-        i = i + 1;
-    }
-    true
-}
-
-fn lctx_collect_return_sources(ctx: LowerCtx, return_val: i64) -> Vec<i64> {
-    let mut sources: Vec<i64> = Vec::new();
-    sources.push(return_val);
-    let mut wi: i64 = 0;
-    while wi < sources.len() {
-        let val: i64 = sources[wi];
-        let nb: i64 = ctx.func.blocks.len();
-        let mut bi: i64 = 0;
-        while bi < nb {
-            let blk: IrBlock = ctx.func.blocks[bi];
-            let ni: i64 = blk.insts.len();
-            let mut ii: i64 = 0;
-            while ii < ni {
-                let inst: IrInst = blk.insts[ii];
-                if inst.op == IOP_UPSILON() && inst.dk == IDATA_PHI_TARGET() && inst.dv == val {
-                    if inst.args.len() > 0 {
-                        let src: i64 = inst.args[0];
-                        let mut found: bool = false;
-                        let mut si: i64 = 0;
-                        while si < sources.len() {
-                            if sources[si] == src {
-                                found = true;
-                            }
-                            si = si + 1;
-                        }
-                        if !found {
-                            sources.push(src);
-                        }
-                    }
-                }
-                ii = ii + 1;
-            }
-            bi = bi + 1;
-        }
-        wi = wi + 1;
-    }
-    sources
 }
 
 fn lctx_emit_return_frees(ctx: LowerCtx, return_val: i64) {
@@ -972,9 +902,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             lctx_switch_to_block(ctx, rhs_block);
             lctx_push_alloc_scope(ctx);
             let rhs_id: i64 = lower_expr(ctx, rhs_eid);
-            let rhs_live_out: Vec<i64> = Vec::new();
-            rhs_live_out.push(rhs_id);
-            lctx_pop_alloc_scope_frees(ctx, rhs_live_out);
+            lctx_pop_alloc_scope_frees(ctx);
             let rhs_up_args: Vec<i64> = Vec::new();
             rhs_up_args.push(rhs_id);
             let rhs_up_id: i64 = lctx_emit(ctx, IOP_UPSILON(), ITY_UNIT(), rhs_up_args, IDATA_PHI_TARGET(), 2147483647, 0, String::from(""));
@@ -1012,14 +940,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             call_args.push(lhs_id);
             call_args.push(rhs_id);
             let eq_id: i64 = lctx_emit(ctx, IOP_CALL(), ITY_BOOL(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_eq"));
-            let lhs_tag: i64 = expr_tag(a, lhs_eid);
-            if lhs_tag == EXPR_LIT_STR() {
-                lctx_mark_escaped(ctx, lhs_id);
-            }
-            let rhs_tag: i64 = expr_tag(a, rhs_eid);
-            if rhs_tag == EXPR_LIT_STR() {
-                lctx_mark_escaped(ctx, rhs_id);
-            }
             if op == BINOP_NE() {
                 let not_args: Vec<i64> = Vec::new();
                 not_args.push(eq_id);
@@ -1094,7 +1014,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             while ai < nargs {
                 let arg_eid: i64 = list_get(a, args_lid, ai);
                 let arg_id: i64 = lower_expr(ctx, arg_eid);
-                lctx_mark_escaped(ctx, arg_id);
                 call_args.push(arg_id);
                 ai = ai + 1;
             }
@@ -1137,7 +1056,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             while ai < nargs {
                 let arg_eid: i64 = list_get(a, args_lid, ai);
                 let arg_id: i64 = lower_expr(ctx, arg_eid);
-                lctx_mark_escaped(ctx, arg_id);
                 call_args.push(arg_id);
                 ai = ai + 1;
             }
@@ -1160,7 +1078,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         while ai < nargs {
             let arg_eid: i64 = list_get(a, args_lid, ai);
             let arg_id: i64 = lower_expr(ctx, arg_eid);
-            lctx_mark_escaped(ctx, arg_id);
             call_args.push(arg_id);
             ai = ai + 1;
         }
@@ -1207,28 +1124,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             then_mut_vals.push(lctx_lookup(ctx, mutations[tmi]));
             tmi = tmi + 1;
         }
-        // Free branch temporaries (keep result and transitive sources alive).
         if !then_terminated {
-            let then_live_out: Vec<i64> = Vec::new();
-            let mut loi: i64 = 0;
-            while loi < then_mut_vals.len() {
-                then_live_out.push(then_mut_vals[loi]);
-                let srcs: Vec<i64> = lctx_collect_return_sources(ctx, then_mut_vals[loi]);
-                let mut si: i64 = 0;
-                while si < srcs.len() {
-                    then_live_out.push(srcs[si]);
-                    si = si + 1;
-                }
-                loi = loi + 1;
-            }
-            then_live_out.push(then_result);
-            let rsrcs: Vec<i64> = lctx_collect_return_sources(ctx, then_result);
-            let mut rsi: i64 = 0;
-            while rsi < rsrcs.len() {
-                then_live_out.push(rsrcs[rsi]);
-                rsi = rsi + 1;
-            }
-            lctx_pop_alloc_scope_frees(ctx, then_live_out);
+            lctx_pop_alloc_scope_frees(ctx);
         } else {
             lctx_discard_alloc_scope(ctx);
         }
@@ -1279,28 +1176,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             else_mut_vals.push(lctx_lookup(ctx, mutations[emi]));
             emi = emi + 1;
         }
-        // Free branch temporaries (keep result and transitive sources alive).
         if !else_terminated {
-            let else_live_out: Vec<i64> = Vec::new();
-            let mut eloi: i64 = 0;
-            while eloi < else_mut_vals.len() {
-                else_live_out.push(else_mut_vals[eloi]);
-                let esrcs: Vec<i64> = lctx_collect_return_sources(ctx, else_mut_vals[eloi]);
-                let mut esi: i64 = 0;
-                while esi < esrcs.len() {
-                    else_live_out.push(esrcs[esi]);
-                    esi = esi + 1;
-                }
-                eloi = eloi + 1;
-            }
-            else_live_out.push(else_result);
-            let ersrcs: Vec<i64> = lctx_collect_return_sources(ctx, else_result);
-            let mut ersi: i64 = 0;
-            while ersi < ersrcs.len() {
-                else_live_out.push(ersrcs[ersi]);
-                ersi = ersi + 1;
-            }
-            lctx_pop_alloc_scope_frees(ctx, else_live_out);
+            lctx_pop_alloc_scope_frees(ctx);
         } else {
             lctx_discard_alloc_scope(ctx);
         }
@@ -1490,24 +1367,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_header_blocks.pop();
         ctx.loop_exit_blocks.pop();
 
-        // Free loop-body temporaries before back-edge.
-        // Include transitive sources so Phi/Upsilon aliases aren't freed.
         if !lctx_is_terminated(ctx) {
-            let loop_live_out: Vec<i64> = Vec::new();
-            let mut li: i64 = 0;
-            while li < nassigned {
-                let vname: String = assigned[li];
-                let cur: i64 = lctx_lookup(ctx, vname);
-                loop_live_out.push(cur);
-                let sources: Vec<i64> = lctx_collect_return_sources(ctx, cur);
-                let mut si: i64 = 0;
-                while si < sources.len() {
-                    loop_live_out.push(sources[si]);
-                    si = si + 1;
-                }
-                li = li + 1;
-            }
-            lctx_pop_alloc_scope_frees(ctx, loop_live_out);
+            lctx_pop_alloc_scope_frees(ctx);
         } else {
             lctx_discard_alloc_scope(ctx);
         }
@@ -1650,24 +1511,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         ctx.loop_header_blocks.pop();
         ctx.loop_exit_blocks.pop();
 
-        // Free loop-body temporaries before back-edge.
-        // Include transitive sources so Phi/Upsilon aliases aren't freed.
         if !lctx_is_terminated(ctx) {
-            let loop_live_out2: Vec<i64> = Vec::new();
-            let mut lli: i64 = 0;
-            while lli < nassigned {
-                let vname: String = assigned[lli];
-                let cur: i64 = lctx_lookup(ctx, vname);
-                loop_live_out2.push(cur);
-                let sources: Vec<i64> = lctx_collect_return_sources(ctx, cur);
-                let mut si: i64 = 0;
-                while si < sources.len() {
-                    loop_live_out2.push(sources[si]);
-                    si = si + 1;
-                }
-                lli = lli + 1;
-            }
-            lctx_pop_alloc_scope_frees(ctx, loop_live_out2);
+            lctx_pop_alloc_scope_frees(ctx);
         } else {
             lctx_discard_alloc_scope(ctx);
         }
@@ -1882,24 +1727,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
 
         lctx_pop_scope(ctx);
 
-        // Free loop-body temporaries before back-edge.
-        // Include transitive sources so Phi/Upsilon aliases aren't freed.
         if !lctx_is_terminated(ctx) {
-            let loop_live_out: Vec<i64> = Vec::new();
-            let mut li: i64 = 0;
-            while li < nassigned {
-                let vname: String = assigned[li];
-                let cur: i64 = lctx_lookup(ctx, vname);
-                loop_live_out.push(cur);
-                let sources: Vec<i64> = lctx_collect_return_sources(ctx, cur);
-                let mut si: i64 = 0;
-                while si < sources.len() {
-                    loop_live_out.push(sources[si]);
-                    si = si + 1;
-                }
-                li = li + 1;
-            }
-            lctx_pop_alloc_scope_frees(ctx, loop_live_out);
+            lctx_pop_alloc_scope_frees(ctx);
         } else {
             lctx_discard_alloc_scope(ctx);
         }
@@ -1993,7 +1822,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             }
             let fidx: i64 = lctx_struct_field_index(ctx, recv_tag_str, field_name);
             if fidx != -1 {
-                lctx_mark_escaped(ctx, val_id);
                 let fs_args: Vec<i64> = Vec::new();
                 fs_args.push(recv_id);
                 fs_args.push(val_id);
@@ -2007,7 +1835,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let recv_id: i64 = lower_expr(ctx, recv_eid);
             let idx_id: i64 = lower_expr(ctx, idx_eid);
             let val_id: i64 = lower_expr(ctx, rhs_eid);
-            lctx_mark_escaped(ctx, val_id);
             let set_args: Vec<i64> = Vec::new();
             set_args.push(recv_id);
             set_args.push(idx_id);
@@ -2090,7 +1917,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let fidx: i64 = lctx_struct_field_index(ctx, struct_name, fname);
             let val_id: i64 = lower_expr(ctx, fval_eid);
             if fidx != -1 {
-                lctx_mark_escaped(ctx, val_id);
                 let fs_args: Vec<i64> = Vec::new();
                 fs_args.push(ptr_id);
                 fs_args.push(val_id);
@@ -2188,7 +2014,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         while pi < n_payload {
             let payload_eid: i64 = list_get(a, fields_lid, pi);
             let val_id: i64 = lower_expr(ctx, payload_eid);
-            lctx_mark_escaped(ctx, val_id);
             let pfs_args: Vec<i64> = Vec::new();
             pfs_args.push(ptr_id);
             pfs_args.push(val_id);
@@ -2366,8 +2191,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     let ae: i64 = list_get(a, args_lid, 1);
                     lower_expr(ctx, ae)
                 };
-                lctx_mark_escaped(ctx, k_id);
-                lctx_mark_escaped(ctx, v_id);
                 let call_args: Vec<i64> = Vec::new();
                 call_args.push(recv_id);
                 call_args.push(k_id);
@@ -2422,7 +2245,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     lctx_emit(ctx, IOP_CONST_UNIT(), ITY_UNIT(), u_args, IDATA_NONE(), 0, 0, String::from(""))
                 }
             };
-            lctx_mark_escaped(ctx, elem_id);
             let call_args: Vec<i64> = Vec::new();
             call_args.push(recv_id);
             call_args.push(elem_id);
@@ -2596,28 +2418,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     arm_mut_vals.push(lctx_lookup(ctx, match_muts[ami]));
                     ami = ami + 1;
                 }
-                // Free match arm temporaries (keep result and transitive sources alive).
                 if !arm_terminated {
-                    let arm_live_out: Vec<i64> = Vec::new();
-                    let mut aloi: i64 = 0;
-                    while aloi < arm_mut_vals.len() {
-                        arm_live_out.push(arm_mut_vals[aloi]);
-                        let asrcs: Vec<i64> = lctx_collect_return_sources(ctx, arm_mut_vals[aloi]);
-                        let mut asi: i64 = 0;
-                        while asi < asrcs.len() {
-                            arm_live_out.push(asrcs[asi]);
-                            asi = asi + 1;
-                        }
-                        aloi = aloi + 1;
-                    }
-                    arm_live_out.push(arm_result);
-                    let arsrcs: Vec<i64> = lctx_collect_return_sources(ctx, arm_result);
-                    let mut arsi: i64 = 0;
-                    while arsi < arsrcs.len() {
-                        arm_live_out.push(arsrcs[arsi]);
-                        arsi = arsi + 1;
-                    }
-                    lctx_pop_alloc_scope_frees(ctx, arm_live_out);
+                    lctx_pop_alloc_scope_frees(ctx);
                 } else {
                     lctx_discard_alloc_scope(ctx);
                 }
@@ -2669,28 +2471,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     arm_mut_vals2.push(lctx_lookup(ctx, match_muts[ami2]));
                     ami2 = ami2 + 1;
                 }
-                // Free match arm temporaries (keep result and transitive sources alive).
                 if !arm_terminated2 {
-                    let arm_live_out2: Vec<i64> = Vec::new();
-                    let mut aloi2: i64 = 0;
-                    while aloi2 < arm_mut_vals2.len() {
-                        arm_live_out2.push(arm_mut_vals2[aloi2]);
-                        let asrcs2: Vec<i64> = lctx_collect_return_sources(ctx, arm_mut_vals2[aloi2]);
-                        let mut asi2: i64 = 0;
-                        while asi2 < asrcs2.len() {
-                            arm_live_out2.push(asrcs2[asi2]);
-                            asi2 = asi2 + 1;
-                        }
-                        aloi2 = aloi2 + 1;
-                    }
-                    arm_live_out2.push(arm_result);
-                    let arsrcs2: Vec<i64> = lctx_collect_return_sources(ctx, arm_result);
-                    let mut arsi2: i64 = 0;
-                    while arsi2 < arsrcs2.len() {
-                        arm_live_out2.push(arsrcs2[arsi2]);
-                        arsi2 = arsi2 + 1;
-                    }
-                    lctx_pop_alloc_scope_frees(ctx, arm_live_out2);
+                    lctx_pop_alloc_scope_frees(ctx);
                 } else {
                     lctx_discard_alloc_scope(ctx);
                 }
@@ -2821,10 +2603,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         if nle > 0 {
             let exit_block: i64 = ctx.loop_exit_blocks[nle - 1];
             let val_eid: i64 = expr_a(a, eid);
-            let break_live_out: Vec<i64> = Vec::new();
             if val_eid != -1 {
                 let val_id: i64 = lower_expr(ctx, val_eid);
-                break_live_out.push(val_id);
                 let is_loop_idx: i64 = ctx.loop_is_loop.len() - 1;
                 let is_loop: i64 = ctx.loop_is_loop[is_loop_idx];
                 if is_loop == 1 {
@@ -2864,45 +2644,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 }
             }
 
-            // Free loop body allocations before jumping to exit.
-            // Trace transitive sources of break value and mutation variables
-            // through Phi/Upsilon chains so they aren't freed prematurely.
-            // Resolve mutation vars at loop header scope depth.
-            let nlasd: i64 = ctx.loop_alloc_scope_depths.len();
-            if nlasd > 0 {
-                let depth: i64 = ctx.loop_alloc_scope_depths[nlasd - 1];
-                if break_live_out.len() > 0 {
-                    let bv: i64 = break_live_out[0];
-                    let sources: Vec<i64> = lctx_collect_return_sources(ctx, bv);
-                    let mut si: i64 = 0;
-                    while si < sources.len() {
-                        break_live_out.push(sources[si]);
-                        si = si + 1;
-                    }
-                }
-                // Include mutation variable values so they survive the free.
-                let nep3: i64 = ctx.loop_exit_phi_names.len();
-                if nep3 > 0 {
-                    let mv_names: Vec<String> = ctx.loop_exit_phi_names[nep3 - 1];
-                    let nmv: i64 = mv_names.len();
-                    let mut mvi: i64 = 0;
-                    while mvi < nmv {
-                        let mv_name: String = mv_names[mvi];
-                        let mv_val: i64 = lctx_lookup_at_depth(ctx, mv_name, brk_scope_depth);
-                        if mv_val != -1 {
-                            break_live_out.push(mv_val);
-                            let mv_sources: Vec<i64> = lctx_collect_return_sources(ctx, mv_val);
-                            let mut msi: i64 = 0;
-                            while msi < mv_sources.len() {
-                                break_live_out.push(mv_sources[msi]);
-                                msi = msi + 1;
-                            }
-                        }
-                        mvi = mvi + 1;
-                    }
-                }
-                lctx_emit_alloc_frees_to_depth(ctx, depth, break_live_out);
-            }
             let jmp_args: Vec<i64> = Vec::new();
             return lctx_emit(ctx, IOP_JUMP(), ITY_UNIT(), jmp_args, IDATA_JUMP_TARGET(), exit_block, 0, String::from(""));
         }
@@ -2918,28 +2659,6 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let phi_ids2: Vec<i64> = ctx.loop_continue_phi_ids[nlh - 1];
             let scope_depth: i64 = ctx.loop_continue_scope_depth[nlh - 1];
             let nphis: i64 = phi_names.len();
-
-            // Free loop body allocations before jumping back to header.
-            // Include transitive sources so Phi/Upsilon aliases aren't freed.
-            let nlasd: i64 = ctx.loop_alloc_scope_depths.len();
-            if nlasd > 0 {
-                let depth: i64 = ctx.loop_alloc_scope_depths[nlasd - 1];
-                let cont_live_out: Vec<i64> = Vec::new();
-                let mut cli: i64 = 0;
-                while cli < nphis {
-                    let vname: String = phi_names[cli];
-                    let cval: i64 = lctx_lookup_at_depth(ctx, vname, scope_depth);
-                    cont_live_out.push(cval);
-                    let csources: Vec<i64> = lctx_collect_return_sources(ctx, cval);
-                    let mut csi: i64 = 0;
-                    while csi < csources.len() {
-                        cont_live_out.push(csources[csi]);
-                        csi = csi + 1;
-                    }
-                    cli = cli + 1;
-                }
-                lctx_emit_alloc_frees_to_depth(ctx, depth, cont_live_out);
-            }
 
             let mut pi: i64 = 0;
             while pi < nphis {
@@ -3412,7 +3131,6 @@ fn lower_function_vow(ctx: LowerCtx, fid: i64) -> IrFunction {
     ctx.alloc_ids = Vec::new();
     ctx.alloc_tags = Vec::new();
     ctx.alloc_sizes = Vec::new();
-    ctx.escaped_ids = Vec::new();
     ctx.alloc_scope_starts = Vec::new();
     ctx.loop_alloc_scope_depths = Vec::new();
 

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -886,9 +886,6 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     let root_arena_gv = ctx
         .obj_module
         .declare_data_in_func(root_arena_id, builder.func);
-    let runtime_start_ref = ctx
-        .obj_module
-        .declare_func_in_func(runtime_start_id, builder.func);
     let vow_violation_ref =
         vow_violation_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
     let overflow_ref = overflow_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
@@ -1100,6 +1097,9 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         }
         // Emit stack_guard_init at main entry (all modes)
         if ctx.func_decls[fi].is_main {
+            let runtime_start_ref = ctx
+                .obj_module
+                .declare_func_in_func(runtime_start_id, builder.func);
             builder.ins().call(runtime_start_ref, &[]);
         }
         if let Some(init_ref) = stack_guard_init_ref {

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -719,24 +719,25 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         }
     }
 
-    // Declare runtime allocator functions
-    let mut malloc_sig = ctx.obj_module.make_signature();
-    malloc_sig.params.push(AbiParam::new(types::I64));
-    malloc_sig.params.push(AbiParam::new(types::I64));
-    malloc_sig.returns.push(AbiParam::new(types::I64));
-    let malloc_id = ctx
+    // Declare arena runtime functions.
+    let mut arena_alloc_sig = ctx.obj_module.make_signature();
+    arena_alloc_sig.params.push(AbiParam::new(types::I64)); // *VowArena
+    arena_alloc_sig.params.push(AbiParam::new(types::I64)); // size
+    arena_alloc_sig.params.push(AbiParam::new(types::I64)); // align
+    arena_alloc_sig.returns.push(AbiParam::new(types::I64));
+    let arena_alloc_id = ctx
         .obj_module
-        .declare_function("__vow_malloc", Linkage::Import, &malloc_sig)
-        .expect("declare __vow_malloc");
-
-    let mut free_sig = ctx.obj_module.make_signature();
-    free_sig.params.push(AbiParam::new(types::I64)); // ptr
-    free_sig.params.push(AbiParam::new(types::I64)); // size
-    free_sig.params.push(AbiParam::new(types::I64)); // align
-    let free_id = ctx
+        .declare_function("__vow_arena_alloc", Linkage::Import, &arena_alloc_sig)
+        .expect("declare __vow_arena_alloc");
+    let root_arena_id = ctx
         .obj_module
-        .declare_function("__vow_free", Linkage::Import, &free_sig)
-        .expect("declare __vow_free");
+        .declare_data("__vow_root_arena", Linkage::Import, true, false)
+        .expect("declare __vow_root_arena");
+    let runtime_start_sig = ctx.obj_module.make_signature();
+    let runtime_start_id = ctx
+        .obj_module
+        .declare_function("__vow_runtime_start", Linkage::Import, &runtime_start_sig)
+        .expect("declare __vow_runtime_start");
 
     // Debug-only runtime functions (debug=1 or sanitize=3)
     let vow_violation_id = if ctx.mode == 1 || ctx.mode == 3 {
@@ -879,8 +880,15 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         extern_func_refs.insert(sym.clone(), fref);
     }
 
-    let malloc_ref = ctx.obj_module.declare_func_in_func(malloc_id, builder.func);
-    let free_ref = ctx.obj_module.declare_func_in_func(free_id, builder.func);
+    let arena_alloc_ref = ctx
+        .obj_module
+        .declare_func_in_func(arena_alloc_id, builder.func);
+    let root_arena_gv = ctx
+        .obj_module
+        .declare_data_in_func(root_arena_id, builder.func);
+    let runtime_start_ref = ctx
+        .obj_module
+        .declare_func_in_func(runtime_start_id, builder.func);
     let vow_violation_ref =
         vow_violation_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
     let overflow_ref = overflow_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
@@ -1091,6 +1099,9 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
             builder.ins().stack_store(zero, slot, 0);
         }
         // Emit stack_guard_init at main entry (all modes)
+        if ctx.func_decls[fi].is_main {
+            builder.ins().call(runtime_start_ref, &[]);
+        }
         if let Some(init_ref) = stack_guard_init_ref {
             builder.ins().call(init_ref, &[]);
         }
@@ -1762,31 +1773,16 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                     } else {
                         (0, 8)
                     };
+                    let arena = builder.ins().global_value(types::I64, root_arena_gv);
                     let size_val = builder.ins().iconst(types::I64, size);
                     let align_val = builder.ins().iconst(types::I64, align);
-                    let call_inst = builder.ins().call(malloc_ref, &[size_val, align_val]);
+                    let call_inst = builder
+                        .ins()
+                        .call(arena_alloc_ref, &[arena, size_val, align_val]);
                     let ptr = builder.inst_results(call_inst)[0];
                     set_val!(iid, ptr);
                 }
                 IOP_REGION_FREE => {
-                    if alen > 0 {
-                        let ptr_id = all_args[aoff];
-                        let ptr_val = *value_map.get(&ptr_id).unwrap_or_else(|| {
-                            panic!(
-                                "clif shim: IOP_REGION_FREE value_map miss: inst_id={iid} ptr_id={ptr_id} (block={bi}, inst_idx={ii}, func_idx={func_idx})"
-                            )
-                        });
-                        let (size, align) = if dk == IDATA_ALLOC_SIZE {
-                            (dv, dv2)
-                        } else {
-                            (0, 8)
-                        };
-                        let size_val = builder.ins().iconst(types::I64, size);
-                        let align_val = builder.ins().iconst(types::I64, align);
-                        builder
-                            .ins()
-                            .call(free_ref, &[ptr_val, size_val, align_val]);
-                    }
                     let unit = builder.ins().iconst(types::I32, 0);
                     set_val!(iid, unit);
                 }

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -188,6 +188,14 @@ const IOP_CALL: i64 = 76;
 const IOP_REGION_ALLOC: i64 = 77;
 const IOP_REGION_FREE: i64 = 78;
 
+// Region-kind discriminants. Mirror `compiler/ir.vow::REGION_KIND_*` and
+// `RegionId` in `vow-ir/src/types.rs`. The packed i64 is `val * 4 + kind`
+// (see `region_pack`).
+const REGION_KIND_BLOCK: i64 = 0;
+const REGION_KIND_CALLER: i64 = 1;
+const REGION_KIND_ROOT: i64 = 2;
+const REGION_KIND_RODATA: i64 = 3;
+
 const IOP_LINEAR_CONSUME: i64 = 79;
 const IOP_LINEAR_BORROW: i64 = 80;
 
@@ -311,6 +319,13 @@ struct FnScratch {
     inst_dvs: Vec<i64>,
     inst_dv2s: Vec<i64>,
     inst_ds_ptrs: Vec<i64>, // raw VowVec ptrs — see struct-level doc
+    // Region tag per instruction, packed as (val * 4 + kind) — mirrors
+    // `region_pack` in `compiler/ir.vow` and `RegionId` in `vow-ir`. Today
+    // only the kind byte matters for codegen; the payload is read so
+    // `.vmod`-produced `Caller(idx)` regions carry through for error
+    // reporting when the shim refuses them (see REGION_KIND_ROOT check
+    // in IOP_REGION_ALLOC).
+    inst_rgns: Vec<i64>,
     all_args: Vec<i64>,
     arg_offsets: Vec<i64>,
     arg_lengths: Vec<i64>,
@@ -338,6 +353,7 @@ impl FnScratch {
         self.inst_dvs.clear();
         self.inst_dv2s.clear();
         self.inst_ds_ptrs.clear();
+        self.inst_rgns.clear();
         self.all_args.clear();
         self.arg_offsets.clear();
         self.arg_lengths.clear();
@@ -578,6 +594,7 @@ pub unsafe extern "C" fn __vow_clif_fn_inst(
     dv2: i64,
     ds_vec: i64,
     args_vec: i64,
+    rgn: i64,
 ) -> i64 {
     let ctx = unsafe { &mut *(ctx_ptr as *mut ModuleContext) };
     let args_start;
@@ -602,6 +619,7 @@ pub unsafe extern "C" fn __vow_clif_fn_inst(
         s.inst_dvs.push(dv);
         s.inst_dv2s.push(dv2);
         s.inst_ds_ptrs.push(ds_vec);
+        s.inst_rgns.push(rgn);
         args_start = s.all_args.len() as i64;
     }
     // Copy arg inst IDs into the flat all_args buffer.
@@ -698,6 +716,7 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     let inst_dvs: &[i64] = &ctx.fn_scratch.inst_dvs;
     let inst_dv2s: &[i64] = &ctx.fn_scratch.inst_dv2s;
     let inst_ds_ptrs: &[i64] = &ctx.fn_scratch.inst_ds_ptrs;
+    let inst_rgns: &[i64] = &ctx.fn_scratch.inst_rgns;
     let all_args: &[i64] = &ctx.fn_scratch.all_args;
     let arg_offsets: &[i64] = &ctx.fn_scratch.arg_offsets;
     let arg_lengths: &[i64] = &ctx.fn_scratch.arg_lengths;
@@ -1768,6 +1787,34 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
 
                 // Region / linear
                 IOP_REGION_ALLOC => {
+                    // Region-kind gating. The Rust backend routes
+                    // `RegionId::Caller(idx)` through a hidden arena
+                    // parameter and rejects `Block`/`Rodata`. The shim
+                    // has not yet grown the hidden-arena plumbing, so
+                    // we refuse anything that isn't `Root` rather than
+                    // silently allocating into the root arena — which
+                    // would violate the caller's region lifetime when
+                    // a `.vmod` produced by the Rust compiler is fed
+                    // back through the self-hosted pipeline.
+                    let rgn = inst_rgns[ii];
+                    let kind = rgn & 3;
+                    if kind != REGION_KIND_ROOT {
+                        let label = match kind {
+                            REGION_KIND_BLOCK => "Block",
+                            REGION_KIND_CALLER => "Caller",
+                            REGION_KIND_RODATA => "Rodata",
+                            _ => "Unknown",
+                        };
+                        eprintln!(
+                            "clif_shim: IOP_REGION_ALLOC with region kind {} (payload {}) \
+                             is not supported yet — only Root is wired; \
+                             hidden-arena routing for Caller and block-scoped arenas \
+                             lands in a follow-up",
+                            label,
+                            rgn >> 2,
+                        );
+                        return -1;
+                    }
                     let (size, align) = if dk == IDATA_ALLOC_SIZE {
                         (dv, dv2)
                     } else {
@@ -2479,8 +2526,8 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.returns.push(AbiParam::new(types::I64));
         }
         "__vow_clif_fn_inst" => {
-            // ctx, id, op, ty, dk, dv, dv2, ds_vec, args_vec
-            for _ in 0..9 {
+            // ctx, id, op, ty, dk, dv, dv2, ds_vec, args_vec, rgn
+            for _ in 0..10 {
                 sig.params.push(AbiParam::new(types::I64));
             }
             sig.returns.push(AbiParam::new(types::I64));

--- a/vow-codegen/Cargo.toml
+++ b/vow-codegen/Cargo.toml
@@ -18,3 +18,4 @@ vow-types = { path = "../vow-types" }
 vow-diag = { path = "../vow-diag" }
 proptest = "1"
 tempfile = "3"
+object = "0.39"

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use vow_ir::{
     BlockId, FuncId as IrFuncId, Function as IrFunction, Inst, InstData, InstId,
-    Module as IrModule, Opcode, Ty as IrTy,
+    Module as IrModule, Opcode, RegionConstraint, RegionId, Ty as IrTy,
 };
 
 use crate::{Backend, BuildMode, CodegenError, CompiledObject, TraceMode};
@@ -176,10 +176,36 @@ fn build_signature(ir_func: &IrFunction, call_conv: cranelift_codegen::isa::Call
             sig.params.push(AbiParam::new(cl_ty));
         }
     }
+    for _ in 0..hidden_region_param_count(ir_func) {
+        sig.params.push(AbiParam::new(types::I64));
+    }
     if let Some(cl_ty) = ir_ty_to_cranelift(ir_func.return_ty) {
         sig.returns.push(AbiParam::new(cl_ty));
     }
     sig
+}
+
+fn hidden_region_store_targets(ir_func: &IrFunction) -> Vec<u32> {
+    let mut targets: Vec<u32> = ir_func
+        .summary
+        .store_effects
+        .iter()
+        .map(|effect| effect.target)
+        .collect();
+    targets.sort_unstable();
+    targets.dedup();
+    targets
+}
+
+fn hidden_region_param_count(ir_func: &IrFunction) -> usize {
+    if ir_func.name == "main" {
+        return 0;
+    }
+    let mut count = 0;
+    if ir_func.summary.return_region == RegionConstraint::FreshInCaller {
+        count += 1;
+    }
+    count + hidden_region_store_targets(ir_func).len()
 }
 
 fn coerce_return_value(builder: &mut FunctionBuilder<'_>, val: Value, return_ty: IrTy) -> Value {
@@ -200,12 +226,12 @@ struct LowerCtx<'a> {
     block_map: &'a HashMap<BlockId, Block>,
     phi_data: &'a PhiUpsilonData,
     arg_values: &'a HashMap<u32, Value>,
+    hidden_region_values: &'a [Value],
     return_ty: IrTy,
     ir_func_id_to_ref: &'a HashMap<IrFuncId, FuncRef>,
     vow_violation_ref: Option<FuncRef>,
     overflow_ref: Option<FuncRef>,
-    malloc_ref: FuncRef,
-    free_ref: FuncRef,
+    arena_alloc_ref: FuncRef,
     mode: BuildMode,
     trace: TraceMode,
     current_ir_block: BlockId,
@@ -220,6 +246,7 @@ struct LowerCtx<'a> {
     trace_vow_ref: Option<FuncRef>,
     fn_name_gv: Option<GlobalValue>,
     stack_exit_ref: Option<FuncRef>,
+    root_arena_gv: GlobalValue,
 }
 
 fn lower_inst(
@@ -776,8 +803,10 @@ fn lower_inst(
         // Function calls
         // ------------------------------------------------------------------
         Opcode::Call => {
+            let mut internal_call = false;
             let func_ref = match &inst.data {
                 InstData::CallTarget(f) => {
+                    internal_call = true;
                     let Some(&fr) = ctx.ir_func_id_to_ref.get(f) else {
                         return Err(CodegenError::UnsupportedOpcode(format!(
                             "unknown call target FuncId({:?})",
@@ -806,7 +835,7 @@ fn lower_inst(
                 .iter()
                 .map(|p| p.value_type)
                 .collect();
-            let call_args: Vec<Value> = inst
+            let mut call_args: Vec<Value> = inst
                 .args
                 .iter()
                 .enumerate()
@@ -829,6 +858,11 @@ fn lower_inst(
                     v
                 })
                 .collect();
+            if internal_call {
+                while call_args.len() < expected_types.len() {
+                    call_args.push(builder.ins().global_value(types::I64, ctx.root_arena_gv));
+                }
+            }
             let call_inst = builder.ins().call(func_ref, &call_args);
             let results = builder.inst_results(call_inst);
             if results.is_empty() {
@@ -855,30 +889,38 @@ fn lower_inst(
             } else {
                 (0, 8)
             };
+            let arena = match inst.region {
+                RegionId::Root => builder.ins().global_value(types::I64, ctx.root_arena_gv),
+                RegionId::Caller(idx) => {
+                    let Some(&arena) = ctx.hidden_region_values.get(idx.0 as usize) else {
+                        return Err(CodegenError::UnsupportedOpcode(format!(
+                            "missing hidden arena parameter {:?} for RegionAlloc",
+                            idx
+                        )));
+                    };
+                    arena
+                }
+                RegionId::Block(_) => {
+                    return Err(CodegenError::UnsupportedOpcode(format!(
+                        "RegionAlloc with {:?} is not wired until block arena routing lands",
+                        inst.region
+                    )));
+                }
+                RegionId::Rodata => {
+                    return Err(CodegenError::UnsupportedOpcode(
+                        "RegionAlloc cannot target rodata".to_string(),
+                    ));
+                }
+            };
             let size_val = builder.ins().iconst(types::I64, size);
             let align_val = builder.ins().iconst(types::I64, align);
-            let call_inst = builder.ins().call(ctx.malloc_ref, &[size_val, align_val]);
+            let call_inst = builder
+                .ins()
+                .call(ctx.arena_alloc_ref, &[arena, size_val, align_val]);
             let ptr = builder.inst_results(call_inst)[0];
             ctx.value_map.insert(inst.id, ptr);
         }
         Opcode::RegionFree => {
-            let ptr_id = *inst.args.first().expect("RegionFree missing arg");
-            let ptr_val = *ctx.value_map.get(&ptr_id).unwrap_or_else(|| {
-                panic!(
-                    "cranelift backend: RegionFree value_map miss for {:?}",
-                    inst.id
-                )
-            });
-            let (size, align) = if let InstData::AllocSize { size, align } = inst.data {
-                (size as i64, align as i64)
-            } else {
-                (0, 8)
-            };
-            let size_val = builder.ins().iconst(types::I64, size);
-            let align_val = builder.ins().iconst(types::I64, align);
-            builder
-                .ins()
-                .call(ctx.free_ref, &[ptr_val, size_val, align_val]);
             let unit = builder.ins().iconst(types::I32, 0);
             ctx.value_map.insert(inst.id, unit);
         }
@@ -1130,8 +1172,9 @@ fn emit_vow_violation_body(
 struct RuntimeIds {
     vow_violation_id: Option<CraneliftFuncId>,
     overflow_id: Option<CraneliftFuncId>,
-    malloc_id: CraneliftFuncId,
-    free_id: CraneliftFuncId,
+    arena_alloc_id: CraneliftFuncId,
+    runtime_start_id: CraneliftFuncId,
+    root_arena_id: DataId,
     trace_enter_id: Option<CraneliftFuncId>,
     trace_exit_id: Option<CraneliftFuncId>,
     trace_vow_id: Option<CraneliftFuncId>,
@@ -1192,8 +1235,9 @@ fn compile_ir_function(
     let vow_violation_ref =
         vow_violation_id.map(|id| obj_module.declare_func_in_func(id, builder.func));
     let overflow_ref = overflow_id.map(|id| obj_module.declare_func_in_func(id, builder.func));
-    let malloc_ref = obj_module.declare_func_in_func(runtime.malloc_id, builder.func);
-    let free_ref = obj_module.declare_func_in_func(runtime.free_id, builder.func);
+    let arena_alloc_ref = obj_module.declare_func_in_func(runtime.arena_alloc_id, builder.func);
+    let runtime_start_ref = obj_module.declare_func_in_func(runtime.runtime_start_id, builder.func);
+    let root_arena_gv = obj_module.declare_data_in_func(runtime.root_arena_id, builder.func);
 
     let mut ir_func_id_to_ref: HashMap<IrFuncId, FuncRef> = HashMap::new();
     for &(ir_id, cl_id) in ir_to_cl {
@@ -1314,6 +1358,7 @@ fn compile_ir_function(
 
     // Collect entry block arg Values → ArgIndex map
     let mut arg_values: HashMap<u32, Value> = HashMap::new();
+    let mut hidden_region_values: Vec<Value> = Vec::new();
     if let Some(first) = ir_func.blocks.first() {
         let entry_cl = block_map[&first.id];
         builder.switch_to_block(entry_cl);
@@ -1325,7 +1370,9 @@ fn compile_ir_function(
                 cl_idx += 1;
             }
         }
+        hidden_region_values.extend(entry_params[cl_idx..].iter().copied());
         if ir_func.name == "main" {
+            builder.ins().call(runtime_start_ref, &[]);
             let guard_ref =
                 obj_module.declare_func_in_func(runtime.stack_guard_init_id, builder.func);
             builder.ins().call(guard_ref, &[]);
@@ -1383,12 +1430,12 @@ fn compile_ir_function(
             block_map: &block_map,
             phi_data: &phi_data,
             arg_values: &arg_values,
+            hidden_region_values: &hidden_region_values,
             return_ty: ir_func.return_ty,
             ir_func_id_to_ref: &ir_func_id_to_ref,
             vow_violation_ref,
             overflow_ref,
-            malloc_ref,
-            free_ref,
+            arena_alloc_ref,
             mode,
             trace,
             current_ir_block: ir_block.id,
@@ -1403,6 +1450,7 @@ fn compile_ir_function(
             trace_vow_ref,
             fn_name_gv,
             stack_exit_ref,
+            root_arena_gv,
         };
 
         for inst in &ir_block.insts {
@@ -1877,21 +1925,23 @@ impl Backend for CraneliftBackend {
             ir_to_cl.push((ir_func.id, cl_id));
         }
 
-        // Declare arena runtime functions (always needed)
-        let mut malloc_sig = obj_module.make_signature();
-        malloc_sig.params.push(AbiParam::new(types::I64)); // size
-        malloc_sig.params.push(AbiParam::new(types::I64)); // align
-        malloc_sig.returns.push(AbiParam::new(types::I64)); // *mut u8
-        let malloc_id = obj_module
-            .declare_function("__vow_malloc", Linkage::Import, &malloc_sig)
+        // Declare arena runtime functions (always needed by RegionAlloc and main startup).
+        let mut arena_alloc_sig = obj_module.make_signature();
+        arena_alloc_sig.params.push(AbiParam::new(types::I64)); // *VowArena
+        arena_alloc_sig.params.push(AbiParam::new(types::I64)); // size
+        arena_alloc_sig.params.push(AbiParam::new(types::I64)); // align
+        arena_alloc_sig.returns.push(AbiParam::new(types::I64)); // *mut u8
+        let arena_alloc_id = obj_module
+            .declare_function("__vow_arena_alloc", Linkage::Import, &arena_alloc_sig)
             .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
 
-        let mut free_sig = obj_module.make_signature();
-        free_sig.params.push(AbiParam::new(types::I64)); // *mut u8
-        free_sig.params.push(AbiParam::new(types::I64)); // size
-        free_sig.params.push(AbiParam::new(types::I64)); // align
-        let free_id = obj_module
-            .declare_function("__vow_free", Linkage::Import, &free_sig)
+        let runtime_start_sig = obj_module.make_signature();
+        let runtime_start_id = obj_module
+            .declare_function("__vow_runtime_start", Linkage::Import, &runtime_start_sig)
+            .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
+
+        let root_arena_id = obj_module
+            .declare_data("__vow_root_arena", Linkage::Import, true, false)
             .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
 
         // Declare external runtime functions (debug/sanitize mode only)
@@ -2009,8 +2059,9 @@ impl Backend for CraneliftBackend {
                 &RuntimeIds {
                     vow_violation_id,
                     overflow_id,
-                    malloc_id,
-                    free_id,
+                    arena_alloc_id,
+                    runtime_start_id,
+                    root_arena_id,
                     trace_enter_id,
                     trace_exit_id,
                     trace_vow_id,
@@ -2051,8 +2102,8 @@ impl Backend for CraneliftBackend {
 mod tests {
     use super::*;
     use vow_ir::{
-        BasicBlock, BlockId, FuncId, Function, InstData, InstId, Module, Opcode, RegionId,
-        RegionSummary, Ty, VowEntry, VowId,
+        BasicBlock, BlockId, FuncId, Function, InstData, InstId, Module, Opcode, RegionConstraint,
+        RegionId, RegionSummary, StoreEffect, Ty, VowEntry, VowId,
     };
     use vow_syntax::span::Span;
 
@@ -2321,6 +2372,74 @@ mod tests {
         assert_eq!(sig.returns.len(), 1);
         assert_eq!(sig.params[0].value_type, types::I64);
         assert_eq!(sig.returns[0].value_type, types::I64);
+    }
+
+    #[test]
+    fn signature_projects_hidden_regions_from_full_summary() {
+        use cranelift_codegen::isa::CallConv;
+        let ir_func = Function {
+            id: FuncId(0),
+            name: "mutating_builder".to_string(),
+            params: vec![Ty::Ptr, Ty::I64],
+            param_names: vec![],
+            return_ty: Ty::Ptr,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary {
+                param_regions: vec![],
+                return_region: RegionConstraint::FreshInCaller,
+                store_effects: vec![StoreEffect {
+                    target: 0,
+                    source: RegionConstraint::FreshInCaller,
+                }],
+            },
+        };
+
+        let sig = build_signature(&ir_func, CallConv::SystemV);
+
+        assert_eq!(
+            sig.params.len(),
+            4,
+            "two user params plus target_region and one store-target hidden region"
+        );
+        assert_eq!(sig.params[2].value_type, types::I64);
+        assert_eq!(sig.params[3].value_type, types::I64);
+        assert_eq!(sig.returns.len(), 1);
+    }
+
+    #[test]
+    fn signature_omits_hidden_regions_for_exported_main() {
+        use cranelift_codegen::isa::CallConv;
+        let ir_func = Function {
+            id: FuncId(0),
+            name: "main".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I32,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary {
+                param_regions: vec![],
+                return_region: RegionConstraint::FreshInCaller,
+                store_effects: vec![StoreEffect {
+                    target: 0,
+                    source: RegionConstraint::FreshInCaller,
+                }],
+            },
+        };
+
+        let sig = build_signature(&ir_func, CallConv::SystemV);
+
+        assert_eq!(
+            sig.params.len(),
+            0,
+            "C ABI main must not take hidden regions"
+        );
+        assert_eq!(sig.returns.len(), 1);
     }
 
     #[test]
@@ -3231,6 +3350,21 @@ mod tests {
         let result =
             CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
         assert!(result.is_ok(), "{:?}", result.err());
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(
+            symbols.contains("__vow_arena_alloc"),
+            "RegionAlloc must lower through __vow_arena_alloc"
+        );
+        assert!(
+            !symbols.contains("__vow_malloc"),
+            "RegionAlloc must not import the legacy __vow_malloc shim"
+        );
     }
 
     #[test]

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -859,6 +859,15 @@ fn lower_inst(
                 })
                 .collect();
             if internal_call {
+                // Pad missing hidden-region parameters with the root arena. This is sound
+                // today because every callee has `RegionSummary::default()` (see
+                // `LowerCtx::finalize` in `vow-ir/src/lower/mod.rs`), so the callee expects
+                // zero hidden region arguments and this loop body is never executed.
+                // TODO(arena-phase3): once region inference produces `FreshInCaller` /
+                // `AliasOf` constraints, the caller must forward `ctx.hidden_region_values`
+                // (or a specific parameter's arena) per the callee's `RegionSummary`
+                // instead of hardcoding root, otherwise callee allocations will escape
+                // the caller's region lifetime.
                 while call_args.len() < expected_types.len() {
                     call_args.push(builder.ins().global_value(types::I64, ctx.root_arena_gv));
                 }
@@ -1236,7 +1245,6 @@ fn compile_ir_function(
         vow_violation_id.map(|id| obj_module.declare_func_in_func(id, builder.func));
     let overflow_ref = overflow_id.map(|id| obj_module.declare_func_in_func(id, builder.func));
     let arena_alloc_ref = obj_module.declare_func_in_func(runtime.arena_alloc_id, builder.func);
-    let runtime_start_ref = obj_module.declare_func_in_func(runtime.runtime_start_id, builder.func);
     let root_arena_gv = obj_module.declare_data_in_func(runtime.root_arena_id, builder.func);
 
     let mut ir_func_id_to_ref: HashMap<IrFuncId, FuncRef> = HashMap::new();
@@ -1372,6 +1380,8 @@ fn compile_ir_function(
         }
         hidden_region_values.extend(entry_params[cl_idx..].iter().copied());
         if ir_func.name == "main" {
+            let runtime_start_ref =
+                obj_module.declare_func_in_func(runtime.runtime_start_id, builder.func);
             builder.ins().call(runtime_start_ref, &[]);
             let guard_ref =
                 obj_module.declare_func_in_func(runtime.stack_guard_init_id, builder.func);

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -1809,7 +1809,7 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.returns.push(AbiParam::new(types::I64));
         }
         "__vow_clif_fn_inst" => {
-            for _ in 0..9 {
+            for _ in 0..10 {
                 sig.params.push(AbiParam::new(types::I64));
             }
             sig.returns.push(AbiParam::new(types::I64));

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -821,7 +821,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             };
             let call_info = ctx.func_index.get(&callee_name).cloned();
             if let Some(call_info) = call_info {
-let result = ctx.emit(
+                let result = ctx.emit(
                     Opcode::Call,
                     call_info.ret_ty,
                     arg_ids,
@@ -845,7 +845,7 @@ let result = ctx.emit(
                     span,
                 )
             } else if let Some((sym, ret_ty)) = vow_builtin_to_runtime(&callee_name) {
-let result = ctx.emit(
+                let result = ctx.emit(
                     Opcode::Call,
                     ret_ty,
                     arg_ids,
@@ -860,7 +860,7 @@ let result = ctx.emit(
                 }
                 result
             } else {
-ctx.emit(
+                ctx.emit(
                     Opcode::Call,
                     Ty::Unit,
                     arg_ids,

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -301,53 +301,12 @@ impl LowerCtx {
         let _ = (id, tag);
     }
 
-    pub(super) fn mark_escaped(&mut self, id: InstId) {
-        let _ = id;
-    }
-
     pub(super) fn push_alloc_scope(&mut self) {
         self.alloc_scopes.push(Vec::new());
     }
 
-    /// Pop the current alloc scope and emit frees for non-escaped allocations.
-    /// `live_out` contains InstIds that flow out of this scope (e.g. via Upsilon)
-    /// and must not be freed.
-    pub(super) fn pop_alloc_scope_frees(&mut self, live_out: &[InstId], span: Span) {
-        let _ = (live_out, span);
+    pub(super) fn pop_alloc_scope_frees(&mut self) {
         self.alloc_scopes.pop().expect("alloc_scopes underflow");
-    }
-
-    /// Emit frees for allocations from the innermost scope down to (and including)
-    /// the scope at `target_depth`. Does NOT pop any scopes.
-    /// Used by break/continue to free loop body temporaries before jumping.
-    pub(super) fn emit_alloc_frees_to_depth(
-        &mut self,
-        target_depth: usize,
-        live_out: &[InstId],
-        span: Span,
-    ) {
-        let _ = (target_depth, live_out, span);
-    }
-
-    fn collect_return_sources(&self, return_val: InstId) -> HashSet<InstId> {
-        let mut sources = HashSet::new();
-        sources.insert(return_val);
-        let mut worklist = vec![return_val];
-        while let Some(val) = worklist.pop() {
-            for block in &self.func.blocks {
-                for inst in &block.insts {
-                    if inst.opcode == Opcode::Upsilon
-                        && let InstData::PhiTarget(target) = inst.data
-                        && target == val
-                        && let Some(&src) = inst.args.first()
-                        && sources.insert(src)
-                    {
-                        worklist.push(src);
-                    }
-                }
-            }
-        }
-        sources
     }
 
     pub(super) fn emit_return_frees(&mut self, return_val: InstId, span: Span) {
@@ -737,7 +696,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 ctx.switch_to_block(rhs_block);
                 ctx.push_alloc_scope();
                 let rhs_id = lower_expr(ctx, rhs);
-                ctx.pop_alloc_scope_frees(&[rhs_id], span);
+                ctx.pop_alloc_scope_frees();
                 let rhs_upsilon = ctx.emit(
                     Opcode::Upsilon,
                     Ty::Unit,
@@ -862,10 +821,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             };
             let call_info = ctx.func_index.get(&callee_name).cloned();
             if let Some(call_info) = call_info {
-                for &aid in &arg_ids {
-                    ctx.mark_escaped(aid);
-                }
-                let result = ctx.emit(
+let result = ctx.emit(
                     Opcode::Call,
                     call_info.ret_ty,
                     arg_ids,
@@ -889,10 +845,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     span,
                 )
             } else if let Some((sym, ret_ty)) = vow_builtin_to_runtime(&callee_name) {
-                for &aid in &arg_ids {
-                    ctx.mark_escaped(aid);
-                }
-                let result = ctx.emit(
+let result = ctx.emit(
                     Opcode::Call,
                     ret_ty,
                     arg_ids,
@@ -907,10 +860,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 }
                 result
             } else {
-                for &aid in &arg_ids {
-                    ctx.mark_escaped(aid);
-                }
-                ctx.emit(
+ctx.emit(
                     Opcode::Call,
                     Ty::Unit,
                     arg_ids,
@@ -958,19 +908,8 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .iter()
                 .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                 .collect();
-            // Free branch temporaries (keep result and transitive sources alive).
             if !then_terminated {
-                let mut live_out: Vec<InstId> = then_mut_vals.clone();
-                live_out.push(then_val);
-                for src in ctx.collect_return_sources(then_val) {
-                    live_out.push(src);
-                }
-                for mv in &then_mut_vals {
-                    for src in ctx.collect_return_sources(*mv) {
-                        live_out.push(src);
-                    }
-                }
-                ctx.pop_alloc_scope_frees(&live_out, span);
+                ctx.pop_alloc_scope_frees();
             } else {
                 ctx.alloc_scopes.pop();
             }
@@ -1011,19 +950,8 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .iter()
                 .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                 .collect();
-            // Free branch temporaries (keep result and transitive sources alive).
             if !else_terminated {
-                let mut live_out: Vec<InstId> = else_mut_vals.clone();
-                live_out.push(else_val);
-                for src in ctx.collect_return_sources(else_val) {
-                    live_out.push(src);
-                }
-                for mv in &else_mut_vals {
-                    for src in ctx.collect_return_sources(*mv) {
-                        live_out.push(src);
-                    }
-                }
-                ctx.pop_alloc_scope_frees(&live_out, span);
+                ctx.pop_alloc_scope_frees();
             } else {
                 ctx.alloc_scopes.pop();
             }
@@ -1180,7 +1108,6 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         FIELD_IDX_SENTINEL
                     } as u32;
                     if field_idx != FIELD_IDX_SENTINEL as u32 {
-                        ctx.mark_escaped(new_val);
                         ctx.emit(
                             Opcode::FieldSet,
                             Ty::Unit,
@@ -1193,7 +1120,6 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 ExprKind::Index { base, index } => {
                     let vec_ptr = lower_expr(ctx, base);
                     let idx_id = lower_expr(ctx, index);
-                    ctx.mark_escaped(new_val);
                     ctx.emit(
                         Opcode::Call,
                         Ty::Unit,
@@ -1330,18 +1256,8 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_header_blocks.pop();
             ctx.loop_exit_blocks.pop();
 
-            // Free loop-body temporaries before back-edge.
-            // Include transitive sources so Phi/Upsilon aliases aren't freed.
             if !ctx.is_terminated() {
-                let mut loop_live_out: Vec<InstId> = Vec::new();
-                for (name, _) in &phi_ids {
-                    if let Some(val) = ctx.lookup(name) {
-                        for src in ctx.collect_return_sources(val) {
-                            loop_live_out.push(src);
-                        }
-                    }
-                }
-                ctx.pop_alloc_scope_frees(&loop_live_out, span);
+                ctx.pop_alloc_scope_frees();
             } else {
                 ctx.alloc_scopes.pop();
             }
@@ -1558,18 +1474,8 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
 
             ctx.pop_scope();
 
-            // Free loop-body temporaries before back-edge.
-            // Include transitive sources so Phi/Upsilon aliases aren't freed.
             if !ctx.is_terminated() {
-                let mut loop_live_out: Vec<InstId> = Vec::new();
-                for (name, _) in &phi_ids {
-                    if let Some(val) = ctx.lookup(name) {
-                        for src in ctx.collect_return_sources(val) {
-                            loop_live_out.push(src);
-                        }
-                    }
-                }
-                ctx.pop_alloc_scope_frees(&loop_live_out, span);
+                ctx.pop_alloc_scope_frees();
             } else {
                 ctx.alloc_scopes.pop();
             }
@@ -1709,13 +1615,8 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             ctx.loop_header_blocks.pop();
             ctx.loop_exit_blocks.pop();
 
-            // Free loop-body temporaries before back-edge.
             if !ctx.is_terminated() {
-                let loop_live_out: Vec<InstId> = phi_ids
-                    .iter()
-                    .filter_map(|(name, _)| ctx.lookup(name))
-                    .collect();
-                ctx.pop_alloc_scope_frees(&loop_live_out, span);
+                ctx.pop_alloc_scope_frees();
             } else {
                 ctx.alloc_scopes.pop();
             }
@@ -1772,7 +1673,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .copied()
                 .expect("break outside of loop");
 
-            let break_val = if let Some(val_expr) = value {
+            if let Some(val_expr) = value {
                 let val_id = lower_expr(ctx, val_expr);
                 // If inside a `loop` (Some), emit Upsilon for the break-value Phi.
                 let is_loop = matches!(ctx.loop_break_upsilons.last(), Some(Some(_)));
@@ -1790,10 +1691,7 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         ups.push((block, up_id, val_ty));
                     }
                 }
-                Some(val_id)
-            } else {
-                None
-            };
+            }
 
             // Emit Upsilons for loop mutation variables targeting the
             // exit-block Phis so the exit block receives updated values.
@@ -1811,24 +1709,6 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                         span,
                     );
                 }
-            }
-
-            // Free loop body allocations before jumping to exit.
-            // Use collect_return_sources to trace through Phi/Upsilon chains —
-            // break_val and mutation variables may alias heap allocations.
-            // Resolve mutation vars at loop header scope depth.
-            if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
-                let mut live_out: Vec<InstId> = if let Some(bv) = break_val {
-                    ctx.collect_return_sources(bv).into_iter().collect()
-                } else {
-                    vec![]
-                };
-                for (name, _) in &exit_phis {
-                    if let Some(cur_val) = ctx.lookup_at_depth(name, scope_depth) {
-                        live_out.extend(ctx.collect_return_sources(cur_val));
-                    }
-                }
-                ctx.emit_alloc_frees_to_depth(depth, &live_out, span);
             }
 
             ctx.emit(
@@ -1852,20 +1732,6 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 .last()
                 .copied()
                 .expect("continue outside of loop");
-
-            // Free loop body allocations before jumping back to header.
-            // Include transitive sources so Phi/Upsilon aliases aren't freed.
-            if let Some(&depth) = ctx.loop_alloc_scope_depth.last() {
-                let mut live_out: Vec<InstId> = Vec::new();
-                for (name, _) in &phis {
-                    if let Some(val) = ctx.lookup_at_depth(name, scope_depth) {
-                        for src in ctx.collect_return_sources(val) {
-                            live_out.push(src);
-                        }
-                    }
-                }
-                ctx.emit_alloc_frees_to_depth(depth, &live_out, span);
-            }
 
             // Emit back-edge Upsilons for mutation variables.
             // Use lookup_at_depth to resolve from the loop header scope, not the
@@ -2033,7 +1899,6 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 } as u32;
                 let val_id = lower_expr(ctx, field_expr);
                 if idx != FIELD_IDX_SENTINEL as u32 {
-                    ctx.mark_escaped(val_id);
                     ctx.emit(
                         Opcode::FieldSet,
                         Ty::Unit,
@@ -2155,7 +2020,6 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
             );
             for (i, field_expr) in fields.iter().enumerate() {
                 let val_id = lower_expr(ctx, field_expr);
-                ctx.mark_escaped(val_id);
                 ctx.emit(
                     Opcode::FieldSet,
                     Ty::Unit,
@@ -2262,19 +2126,8 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                             .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                             .collect();
 
-                        // Free match arm temporaries (keep transitive sources alive).
                         if !arm_terminated {
-                            let mut live_out: Vec<InstId> = arm_mut_vals.clone();
-                            live_out.push(arm_result);
-                            for src in ctx.collect_return_sources(arm_result) {
-                                live_out.push(src);
-                            }
-                            for mv in &arm_mut_vals {
-                                for src in ctx.collect_return_sources(*mv) {
-                                    live_out.push(src);
-                                }
-                            }
-                            ctx.pop_alloc_scope_frees(&live_out, span);
+                            ctx.pop_alloc_scope_frees();
                         } else {
                             ctx.alloc_scopes.pop();
                         }
@@ -2321,19 +2174,8 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                             .map(|(name, pre_id)| ctx.lookup(name).unwrap_or(*pre_id))
                             .collect();
 
-                        // Free match arm temporaries (keep transitive sources alive).
                         if !arm_terminated {
-                            let mut live_out: Vec<InstId> = arm_mut_vals.clone();
-                            live_out.push(arm_result);
-                            for src in ctx.collect_return_sources(arm_result) {
-                                live_out.push(src);
-                            }
-                            for mv in &arm_mut_vals {
-                                for src in ctx.collect_return_sources(*mv) {
-                                    live_out.push(src);
-                                }
-                            }
-                            ctx.pop_alloc_scope_frees(&live_out, span);
+                            ctx.pop_alloc_scope_frees();
                         } else {
                             ctx.alloc_scopes.pop();
                         }
@@ -2581,8 +2423,6 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     let v_id = args.get(1).map(|e| lower_expr(ctx, e)).unwrap_or_else(|| {
                         ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
                     });
-                    ctx.mark_escaped(k_id);
-                    ctx.mark_escaped(v_id);
                     ctx.emit(
                         Opcode::Call,
                         Ty::Unit,
@@ -2638,7 +2478,6 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     let elem_id = args.first().map(|e| lower_expr(ctx, e)).unwrap_or_else(|| {
                         ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span)
                     });
-                    ctx.mark_escaped(elem_id);
                     ctx.emit(
                         Opcode::Call,
                         Ty::Unit,

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -222,7 +222,6 @@ pub(crate) struct LowerCtx {
     // Scope-based deallocation: stack of alloc scopes, each tracking (InstId, tag).
     // Push on entering a branch/loop/match arm, pop (with frees) on exit.
     alloc_scopes: Vec<Vec<(InstId, String)>>,
-    escaped_allocs: HashSet<InstId>,
     // Alloc scope depth at each loop body entry (for break/continue frees).
     loop_alloc_scope_depth: Vec<usize>,
 }
@@ -294,20 +293,16 @@ impl LowerCtx {
             struct_field_vec_elems,
             warnings: Vec::new(),
             alloc_scopes: vec![Vec::new()],
-            escaped_allocs: HashSet::new(),
             loop_alloc_scope_depth: Vec::new(),
         }
     }
 
     pub(super) fn track_heap_alloc(&mut self, id: InstId, tag: &str) {
-        self.alloc_scopes
-            .last_mut()
-            .expect("alloc_scopes must have at least one scope")
-            .push((id, tag.to_string()));
+        let _ = (id, tag);
     }
 
     pub(super) fn mark_escaped(&mut self, id: InstId) {
-        self.escaped_allocs.insert(id);
+        let _ = id;
     }
 
     pub(super) fn push_alloc_scope(&mut self) {
@@ -318,36 +313,8 @@ impl LowerCtx {
     /// `live_out` contains InstIds that flow out of this scope (e.g. via Upsilon)
     /// and must not be freed.
     pub(super) fn pop_alloc_scope_frees(&mut self, live_out: &[InstId], span: Span) {
-        let scope = self.alloc_scopes.pop().expect("alloc_scopes underflow");
-        for (id, tag) in &scope {
-            if self.escaped_allocs.contains(id) || live_out.contains(id) {
-                continue;
-            }
-            if let Some(size_str) = tag.strip_prefix("region:") {
-                let size: u32 = size_str.parse().unwrap_or(0);
-                self.emit(
-                    Opcode::RegionFree,
-                    Ty::Unit,
-                    vec![*id],
-                    InstData::AllocSize { size, align: 8 },
-                    span,
-                );
-                continue;
-            }
-            let sym = match tag.as_str() {
-                "String" => "__vow_string_free",
-                "Vec" => "__vow_vec_free_val",
-                "HashMap" => "__vow_map_free",
-                _ => continue,
-            };
-            self.emit(
-                Opcode::Call,
-                Ty::Unit,
-                vec![*id],
-                InstData::CallExtern(sym.to_string()),
-                span,
-            );
-        }
+        let _ = (live_out, span);
+        self.alloc_scopes.pop().expect("alloc_scopes underflow");
     }
 
     /// Emit frees for allocations from the innermost scope down to (and including)
@@ -359,39 +326,7 @@ impl LowerCtx {
         live_out: &[InstId],
         span: Span,
     ) {
-        let allocs: Vec<(InstId, String)> = self.alloc_scopes[target_depth..]
-            .iter()
-            .flat_map(|scope| scope.iter().cloned())
-            .collect();
-        for (id, tag) in allocs {
-            if self.escaped_allocs.contains(&id) || live_out.contains(&id) {
-                continue;
-            }
-            if let Some(size_str) = tag.strip_prefix("region:") {
-                let size: u32 = size_str.parse().unwrap_or(0);
-                self.emit(
-                    Opcode::RegionFree,
-                    Ty::Unit,
-                    vec![id],
-                    InstData::AllocSize { size, align: 8 },
-                    span,
-                );
-                continue;
-            }
-            let sym = match tag.as_str() {
-                "String" => "__vow_string_free",
-                "Vec" => "__vow_vec_free_val",
-                "HashMap" => "__vow_map_free",
-                _ => continue,
-            };
-            self.emit(
-                Opcode::Call,
-                Ty::Unit,
-                vec![id],
-                InstData::CallExtern(sym.to_string()),
-                span,
-            );
-        }
+        let _ = (target_depth, live_out, span);
     }
 
     fn collect_return_sources(&self, return_val: InstId) -> HashSet<InstId> {
@@ -416,41 +351,7 @@ impl LowerCtx {
     }
 
     pub(super) fn emit_return_frees(&mut self, return_val: InstId, span: Span) {
-        let return_sources = self.collect_return_sources(return_val);
-        let all_allocs: Vec<(InstId, String)> = self
-            .alloc_scopes
-            .iter()
-            .flat_map(|scope| scope.iter().cloned())
-            .collect();
-        for (id, tag) in all_allocs {
-            if self.escaped_allocs.contains(&id) || return_sources.contains(&id) {
-                continue;
-            }
-            if let Some(size_str) = tag.strip_prefix("region:") {
-                let size: u32 = size_str.parse().unwrap_or(0);
-                self.emit(
-                    Opcode::RegionFree,
-                    Ty::Unit,
-                    vec![id],
-                    InstData::AllocSize { size, align: 8 },
-                    span,
-                );
-                continue;
-            }
-            let sym = match tag.as_str() {
-                "String" => "__vow_string_free",
-                "Vec" => "__vow_vec_free_val",
-                "HashMap" => "__vow_map_free",
-                _ => continue,
-            };
-            self.emit(
-                Opcode::Call,
-                Ty::Unit,
-                vec![id],
-                InstData::CallExtern(sym.to_string()),
-                span,
-            );
-        }
+        let _ = (return_val, span);
     }
 
     pub(super) fn intern_str(&mut self, s: &str) -> u32 {
@@ -472,14 +373,7 @@ impl LowerCtx {
     }
 
     pub(super) fn emit_string_free(&mut self, id: InstId, span: Span) {
-        self.escaped_allocs.insert(id);
-        self.emit(
-            Opcode::Call,
-            Ty::Unit,
-            vec![id],
-            InstData::CallExtern("__vow_string_free".to_string()),
-            span,
-        );
+        let _ = (id, span);
     }
 
     pub(super) fn define(&mut self, name: String, id: InstId) {
@@ -4482,7 +4376,7 @@ mod tests {
     }
 
     #[test]
-    fn region_free_emitted_for_unused_struct() {
+    fn no_region_free_for_unused_struct_after_arena_cutover() {
         // fn f() -> i64 { let p = Pair{a:1, b:2}; 42 }
         let body = Block {
             stmts: vec![let_stmt("p", Some(pair_ty()), pair_literal(1, 2))],
@@ -4497,7 +4391,10 @@ mod tests {
             .iter()
             .flat_map(|b| b.insts.iter())
             .any(|i| i.opcode == Opcode::RegionFree);
-        assert!(has_region_free, "expected RegionFree for unused struct");
+        assert!(
+            !has_region_free,
+            "arena lowering must not emit per-value RegionFree for unused structs"
+        );
     }
 
     #[test]
@@ -4606,7 +4503,7 @@ mod tests {
     }
 
     #[test]
-    fn string_free_emitted_for_unused_string() {
+    fn no_string_free_for_unused_string_after_arena_cutover() {
         // fn f() -> i64 { let s = String::from("hello"); 42 }
         let body = Block {
             stmts: vec![let_stmt(
@@ -4647,14 +4544,14 @@ mod tests {
                 && i.data == InstData::CallExtern("__vow_string_free".to_string())
         });
         assert!(
-            has_string_free,
-            "expected __vow_string_free for unused string"
+            !has_string_free,
+            "arena lowering must not emit per-value __vow_string_free for unused strings"
         );
     }
 
     #[test]
-    fn region_free_has_correct_size() {
-        // Verify RegionFree carries the same AllocSize as RegionAlloc
+    fn region_allocs_do_not_get_matching_region_frees() {
+        // Arena close, not per-object free, owns reclamation after the cutover.
         let body = Block {
             stmts: vec![let_stmt("p", Some(pair_ty()), pair_literal(1, 2))],
             trailing_expr: Some(Box::new(int_expr(0))),
@@ -4670,16 +4567,13 @@ mod tests {
             .find(|i| i.opcode == Opcode::RegionAlloc)
             .map(|i| i.data.clone())
             .expect("expected RegionAlloc");
-        let free_data = func
-            .blocks
-            .iter()
-            .flat_map(|b| b.insts.iter())
-            .find(|i| i.opcode == Opcode::RegionFree)
-            .map(|i| i.data.clone())
-            .expect("expected RegionFree");
-        assert_eq!(
-            alloc_data, free_data,
-            "RegionFree size must match RegionAlloc size"
+        assert!(
+            func.blocks
+                .iter()
+                .flat_map(|b| b.insts.iter())
+                .all(|i| i.opcode != Opcode::RegionFree),
+            "arena lowering must not emit RegionFree after allocation {:?}",
+            alloc_data
         );
     }
 
@@ -4737,7 +4631,7 @@ mod tests {
     }
 
     #[test]
-    fn receiver_method_does_not_prevent_free() {
+    fn receiver_method_does_not_emit_free_after_arena_cutover() {
         // fn f() -> i64 { let s = String::from("x"); s.len() }
         // s.len() is read-only — s must still be freed (#71)
         let body = Block {
@@ -4786,8 +4680,8 @@ mod tests {
                 && i.data == InstData::CallExtern("__vow_string_free".to_string())
         });
         assert!(
-            has_string_free,
-            "method call on receiver must not prevent deallocation (#71)"
+            !has_string_free,
+            "arena lowering must not emit __vow_string_free after receiver method calls"
         );
     }
 
@@ -4867,9 +4761,9 @@ mod tests {
     }
 
     #[test]
-    fn string_freed_after_method_call() {
+    fn string_method_call_emits_no_string_free_after_arena_cutover() {
         // fn f() -> i64 { let s: String = String::from("hello"); s.len() }
-        // s.len() is read-only — s must still be freed
+        // s.len() is read-only, but arena close owns reclamation after cutover.
         let string_from = Expr {
             kind: ExprKind::EnumConstruct {
                 path: vec!["String".to_string(), "from".to_string()],
@@ -4918,15 +4812,15 @@ mod tests {
                 && i.data == InstData::CallExtern("__vow_string_free".to_string())
         });
         assert!(
-            has_string_free,
-            "String used via .len() must still be freed at function exit"
+            !has_string_free,
+            "String used via .len() must not emit per-value free after arena cutover"
         );
     }
 
     #[test]
-    fn vec_freed_after_method_call() {
+    fn vec_method_call_emits_no_vec_free_after_arena_cutover() {
         // fn f() -> i64 { let v: Vec<i64> = Vec::new(); v.len() }
-        // v.len() is read-only — v must still be freed
+        // v.len() is read-only, but arena close owns reclamation after cutover.
         let vec_new = Expr {
             kind: ExprKind::EnumConstruct {
                 path: vec!["Vec".to_string(), "new".to_string()],
@@ -4972,15 +4866,15 @@ mod tests {
                 && i.data == InstData::CallExtern("__vow_vec_free_val".to_string())
         });
         assert!(
-            has_vec_free,
-            "Vec used via .len() must still be freed at function exit"
+            !has_vec_free,
+            "Vec used via .len() must not emit per-value free after arena cutover"
         );
     }
 
     #[test]
-    fn hashmap_freed_after_method_call() {
+    fn hashmap_method_call_emits_no_map_free_after_arena_cutover() {
         // fn f() -> i64 { let m: HashMap = HashMap::new(); m.len() }
-        // m.len() is read-only — m must still be freed
+        // m.len() is read-only, but arena close owns reclamation after cutover.
         let map_new = Expr {
             kind: ExprKind::EnumConstruct {
                 path: vec!["HashMap".to_string(), "new".to_string()],
@@ -5025,8 +4919,8 @@ mod tests {
             i.opcode == Opcode::Call && i.data == InstData::CallExtern("__vow_map_free".to_string())
         });
         assert!(
-            has_map_free,
-            "HashMap used via .len() must still be freed at function exit"
+            !has_map_free,
+            "HashMap used via .len() must not emit per-value free after arena cutover"
         );
     }
 }

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -761,9 +761,61 @@ pub static mut __vow_root_arena: VowArena = VowArena {
     last_alloc_size: 0,
 };
 
+static ROOT_ARENA_INITIALIZED: AtomicBool = AtomicBool::new(false);
+static ROOT_ARENA_LOCK: Mutex<()> = Mutex::new(());
+
+unsafe fn ensure_root_arena() {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+}
+
+unsafe fn ensure_root_arena_locked() {
+    if !ROOT_ARENA_INITIALIZED.load(Ordering::SeqCst) {
+        unsafe { __vow_arena_open(&raw mut __vow_root_arena) };
+        ROOT_ARENA_INITIALIZED.store(true, Ordering::SeqCst);
+    }
+}
+
+unsafe fn root_arena_alloc(bytes: usize, align: usize) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_arena_alloc(&raw mut __vow_root_arena, bytes, align) }
+}
+
+unsafe fn root_arena_alloc_zeroed(bytes: usize, align: usize) -> *mut u8 {
+    let ptr = unsafe { root_arena_alloc(bytes, align) };
+    unsafe { std::ptr::write_bytes(ptr, 0, bytes) };
+    ptr
+}
+
+unsafe fn root_arena_grow_backing(
+    ptr: *mut u8,
+    old_size: usize,
+    new_size: usize,
+    align: usize,
+) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    if old_size > 0
+        && unsafe {
+            __vow_arena_try_extend(&raw mut __vow_root_arena, ptr, old_size, new_size) != 0
+        }
+    {
+        unsafe { std::ptr::write_bytes(ptr.add(old_size), 0, new_size - old_size) };
+        return ptr;
+    }
+
+    let new_ptr = unsafe { __vow_arena_alloc(&raw mut __vow_root_arena, new_size, align) };
+    if old_size > 0 {
+        unsafe { std::ptr::copy_nonoverlapping(ptr, new_ptr, old_size) };
+    }
+    unsafe { std::ptr::write_bytes(new_ptr.add(old_size), 0, new_size - old_size) };
+    new_ptr
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_runtime_start() {
-    unsafe { __vow_arena_open(&raw mut __vow_root_arena) };
+    unsafe { ensure_root_arena() };
 }
 
 #[repr(C)]
@@ -778,11 +830,7 @@ const VEC_INITIAL_CAP: usize = 8;
 #[unsafe(no_mangle)]
 pub extern "C" fn __vow_vec_new(elem_size: usize, align: usize) -> *mut u8 {
     let _ = elem_size;
-    let header_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(24, 8) };
-    let header_ptr = unsafe { std::alloc::alloc_zeroed(header_layout) } as *mut VowVec;
-    if header_ptr.is_null() {
-        std::process::abort();
-    }
+    let header_ptr = unsafe { root_arena_alloc_zeroed(24, 8) } as *mut VowVec;
     // Lazy allocation: don't allocate buffer until first push.
     // Use a dangling aligned pointer so from_raw_parts with len=0 is safe.
     unsafe {
@@ -814,17 +862,7 @@ unsafe fn __vow_vec_reserve(vec: *mut u8, additional: usize, elem_size: usize, e
     }
     let old_size = v.cap * elem_size;
     let new_size = new_cap * elem_size;
-    let new_ptr = if old_size == 0 {
-        let layout = unsafe { std::alloc::Layout::from_size_align_unchecked(new_size, elem_align) };
-        unsafe { std::alloc::alloc_zeroed(layout) }
-    } else {
-        let old_layout =
-            unsafe { std::alloc::Layout::from_size_align_unchecked(old_size, elem_align) };
-        unsafe { std::alloc::realloc(v.ptr, old_layout, new_size) }
-    };
-    if new_ptr.is_null() {
-        std::process::abort();
-    }
+    let new_ptr = unsafe { root_arena_grow_backing(v.ptr, old_size, new_size, elem_align) };
     v.ptr = new_ptr;
     v.cap = new_cap;
 }
@@ -901,8 +939,8 @@ pub unsafe extern "C" fn __vow_vec_pop(vec: *mut u8) {
     }
 }
 
-/// Frees the data buffer and resets the Vec to an empty state (len=0, cap=0).
-/// The Vec header itself remains valid and can be reused with push().
+/// Resets the Vec to an empty state. Arena-backed buffers are retained until
+/// the region closes; the header remains valid and can be reused with push().
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_clear(vec: *mut u8) {
     sanitize_on_clear(vec as usize);
@@ -910,17 +948,11 @@ pub unsafe extern "C" fn __vow_vec_clear(vec: *mut u8) {
     if v.cap == VOW_CAP_RODATA {
         region_literal_mutation_trap("Vec::clear");
     }
-    if v.cap > 0 && !v.ptr.is_null() {
-        let buf_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(v.cap * 8, 8) };
-        unsafe { std::alloc::dealloc(v.ptr, buf_layout) };
-    }
-    v.ptr = std::ptr::dangling_mut::<u64>() as *mut u8;
     v.len = 0;
-    v.cap = 0;
 }
 
-/// Truncates the Vec to `new_len` elements and shrinks the buffer to fit.
-/// If `new_len >= len`, this is a no-op. If `new_len == 0`, equivalent to clear().
+/// Truncates the Vec to `new_len` elements. Arena-backed buffers are not
+/// shrunk; their storage is reclaimed when the containing region closes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_truncate(vec: *mut u8, new_len: usize) {
     sanitize_on_truncate(vec as usize, new_len);
@@ -931,22 +963,7 @@ pub unsafe extern "C" fn __vow_vec_truncate(vec: *mut u8, new_len: usize) {
     if new_len >= v.len {
         return;
     }
-    if new_len == 0 {
-        unsafe { __vow_vec_clear(vec) };
-        return;
-    }
     v.len = new_len;
-    // Shrink buffer: reallocate to exactly new_len capacity (rounded up to next power of 2)
-    let new_cap = new_len.next_power_of_two().max(VEC_INITIAL_CAP);
-    if new_cap < v.cap {
-        let old_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(v.cap * 8, 8) };
-        let new_ptr = unsafe { std::alloc::realloc(v.ptr, old_layout, new_cap * 8) };
-        if new_ptr.is_null() {
-            std::process::abort();
-        }
-        v.ptr = new_ptr;
-        v.cap = new_cap;
-    }
 }
 
 #[unsafe(no_mangle)]
@@ -1014,8 +1031,8 @@ pub unsafe extern "C" fn __vow_string_len(s: *const u8) -> usize {
     unsafe { __vow_vec_len(s) }
 }
 
-/// Frees the String's byte buffer and resets to empty (len=0, cap=0).
-/// The String header remains valid and can be reused with push_byte/push_str.
+/// Resets the String to empty. Arena-backed storage is retained until the
+/// region closes; the header remains valid and can be reused.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_string_clear(s: *mut u8) {
     sanitize_on_read(s as usize, 0);
@@ -1023,13 +1040,7 @@ pub unsafe extern "C" fn __vow_string_clear(s: *mut u8) {
     if v.cap == VOW_CAP_RODATA {
         region_literal_mutation_trap("String::clear");
     }
-    if v.cap > 0 && !v.ptr.is_null() {
-        let buf_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(v.cap, 1) };
-        unsafe { std::alloc::dealloc(v.ptr, buf_layout) };
-    }
-    v.ptr = std::ptr::dangling_mut::<u8>();
     v.len = 0;
-    v.cap = 0;
 }
 
 #[unsafe(no_mangle)]
@@ -1997,17 +2008,9 @@ const MAP_INITIAL_CAP: usize = 8;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __vow_map_new() -> *mut u8 {
-    let header_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(24, 8) };
-    let header_ptr = unsafe { std::alloc::alloc_zeroed(header_layout) } as *mut VowMap;
-    if header_ptr.is_null() {
-        std::process::abort();
-    }
+    let header_ptr = unsafe { root_arena_alloc_zeroed(24, 8) } as *mut VowMap;
     let buf_size = MAP_INITIAL_CAP * MAP_ENTRY_BYTES;
-    let buf_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(buf_size, 8) };
-    let buf_ptr = unsafe { std::alloc::alloc_zeroed(buf_layout) };
-    if buf_ptr.is_null() {
-        std::process::abort();
-    }
+    let buf_ptr = unsafe { root_arena_alloc_zeroed(buf_size, 8) };
     unsafe {
         (*header_ptr).ptr = buf_ptr;
         (*header_ptr).len = 0;
@@ -2033,17 +2036,9 @@ pub unsafe extern "C" fn __vow_map_insert(map: *mut u8, key: i64, val: i64) {
         let old_size = m.cap * MAP_ENTRY_BYTES;
         let new_cap = m.cap * 2;
         let new_size = new_cap * MAP_ENTRY_BYTES;
-        let old_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(old_size, 8) };
-        let new_ptr = unsafe { std::alloc::realloc(m.ptr, old_layout, new_size) };
-        if new_ptr.is_null() {
-            std::process::abort();
-        }
+        let new_ptr = unsafe { root_arena_grow_backing(m.ptr, old_size, new_size, 8) };
         m.ptr = new_ptr;
         m.cap = new_cap;
-        unsafe {
-            let extra = new_ptr.add(old_size);
-            std::ptr::write_bytes(extra, 0, new_size - old_size);
-        }
     }
     let entries = unsafe { std::slice::from_raw_parts_mut(m.ptr as *mut i64, (m.len + 1) * 2) };
     entries[m.len * 2] = key;
@@ -2107,49 +2102,17 @@ pub unsafe extern "C" fn __vow_map_len(map: *const u8) -> usize {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_string_free(s: *mut u8) {
-    if s.is_null() {
-        return;
-    }
-    sanitize_on_free(s as usize);
-    let v = unsafe { &*(s as *const VowVec) };
-    // Rodata-backed: buffer lives in .rodata; never free it. Header is still
-    // a heap allocation that must be released.
-    if v.cap != VOW_CAP_RODATA && v.cap > 0 && !v.ptr.is_null() {
-        let buf_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(v.cap, 1) };
-        unsafe { std::alloc::dealloc(v.ptr, buf_layout) };
-    }
-    let header_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(24, 8) };
-    unsafe { std::alloc::dealloc(s, header_layout) };
+    let _ = s;
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_free_val(v: *mut u8) {
-    if v.is_null() {
-        return;
-    }
-    sanitize_on_free(v as usize);
-    let vec = unsafe { &*(v as *const VowVec) };
-    if vec.cap != VOW_CAP_RODATA && vec.cap > 0 && !vec.ptr.is_null() {
-        let buf_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(vec.cap * 8, 8) };
-        unsafe { std::alloc::dealloc(vec.ptr, buf_layout) };
-    }
-    let header_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(24, 8) };
-    unsafe { std::alloc::dealloc(v, header_layout) };
+    let _ = v;
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_map_free(m: *mut u8) {
-    if m.is_null() {
-        return;
-    }
-    let map = unsafe { &*(m as *const VowMap) };
-    if map.cap != VOW_CAP_RODATA && map.cap > 0 && !map.ptr.is_null() {
-        let buf_layout =
-            unsafe { std::alloc::Layout::from_size_align_unchecked(map.cap * MAP_ENTRY_BYTES, 8) };
-        unsafe { std::alloc::dealloc(map.ptr, buf_layout) };
-    }
-    let header_layout = unsafe { std::alloc::Layout::from_size_align_unchecked(24, 8) };
-    unsafe { std::alloc::dealloc(m, header_layout) };
+    let _ = m;
 }
 
 // ---------------------------------------------------------------------------
@@ -2273,30 +2236,6 @@ fn sanitize_on_clear(vec_addr: usize) {
             );
         }
         shadow.generations.clear();
-    }
-}
-
-fn sanitize_on_free(vec_addr: usize) {
-    if !sanitize_is_enabled() {
-        return;
-    }
-    let already_freed = {
-        let mut table = SHADOW_TABLE.lock().unwrap();
-        let map = shadow_table_get_or_init(&mut table);
-        if let Some(shadow) = map.get_mut(&vec_addr) {
-            if shadow.freed {
-                true
-            } else {
-                shadow.freed = true;
-                shadow.generations.clear();
-                false
-            }
-        } else {
-            false
-        }
-    };
-    if already_freed {
-        sanitize_emit_error("DoubleFree", &format!("\"vec\":\"0x{vec_addr:x}\""));
     }
 }
 
@@ -2770,6 +2709,40 @@ mod tests {
         // If close fails to walk the chain, leak detectors (ASan/Miri) will flag;
         // functional success is that close completes without UB.
         unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
+    fn legacy_typed_free_noop_worker() {
+        if std::env::var("VOW_LEGACY_FREE_NOOP_WORKER").is_err() {
+            return;
+        }
+        __vow_sanitize_init();
+        let v = __vow_vec_new_val();
+        unsafe { __vow_vec_push_val(v, 1) };
+        unsafe { __vow_vec_free_val(v) };
+        unsafe { __vow_vec_free_val(v) };
+        unsafe { __vow_vec_push_val(v, 2) };
+        assert_eq!(unsafe { __vow_vec_len(v) }, 2);
+    }
+
+    #[test]
+    fn legacy_typed_free_symbols_are_noops() {
+        let exe = std::env::current_exe().expect("current test exe");
+        let output = std::process::Command::new(exe)
+            .env("VOW_LEGACY_FREE_NOOP_WORKER", "1")
+            .args([
+                "tests::legacy_typed_free_noop_worker",
+                "--exact",
+                "--nocapture",
+            ])
+            .output()
+            .expect("spawn legacy free worker");
+        assert!(
+            output.status.success(),
+            "legacy free worker failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/vow-types/src/env.rs
+++ b/vow-types/src/env.rs
@@ -540,6 +540,7 @@ impl TypeEnv {
                     Ty::I64,
                     Ty::Str,
                     Ty::Applied(Box::new(Ty::Struct("Vec".to_string())), vec![Ty::I64]),
+                    Ty::I64,
                 ],
                 return_ty: Ty::I64,
                 effects: [Effect::IO].into_iter().collect(),

--- a/vow/src/cache.rs
+++ b/vow/src/cache.rs
@@ -7,6 +7,11 @@ use vow_verify::Counterexample;
 
 use crate::frontend::DependencyManifest;
 
+// Bump this whenever generated object files are no longer ABI-compatible with
+// existing cached artifacts. Phase 4 adds the root-arena argument to
+// __vow_arena_alloc, so pre-cutover objects must not be reused.
+const COMPILE_CACHE_ABI_VERSION: &str = "arena-phase4-region-alloc-v1";
+
 pub struct CompileCache {
     dir: PathBuf,
 }
@@ -25,7 +30,17 @@ impl CompileCache {
     }
 
     pub fn cache_key(deps: &DependencyManifest, mode: &str, trace: &str) -> String {
+        Self::cache_key_with_abi_seed(deps, mode, trace, COMPILE_CACHE_ABI_VERSION)
+    }
+
+    fn cache_key_with_abi_seed(
+        deps: &DependencyManifest,
+        mode: &str,
+        trace: &str,
+        abi_seed: &str,
+    ) -> String {
         let mut hasher = DefaultHasher::new();
+        abi_seed.hash(&mut hasher);
         let mut entries: Vec<(String, u64)> = deps
             .paths()
             .iter()
@@ -328,5 +343,19 @@ mod tests {
         let k2 = CompileCache::cache_key(&deps_ab, "Release", "Off");
 
         assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn compile_cache_key_includes_codegen_abi_seed() {
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.vow");
+        std::fs::write(&a, "module A").unwrap();
+
+        let deps = DependencyManifest::from_paths(vec![a]);
+
+        let old_key = CompileCache::cache_key_with_abi_seed(&deps, "Release", "Off", "old-abi");
+        let new_key = CompileCache::cache_key_with_abi_seed(&deps, "Release", "Off", "new-abi");
+
+        assert_ne!(old_key, new_key);
     }
 }


### PR DESCRIPTION
## Summary

Refs #198 and the PRD in #195.

This PR cuts the lowering/runtime/codegen paths over to the arena-backed model for the current Phase 4 surface:

- removes explicit per-value free emission from the Rust and self-hosted lowerers
- routes `RegionAlloc` through `__vow_arena_alloc(region, size, align)` in Rust codegen and the self-hosted Cranelift shim
- initializes and uses the root arena for process-lifetime allocation paths
- moves Vec/String/HashMap runtime allocation and growth onto arena storage, including the `__vow_arena_try_extend` fast path
- turns legacy typed free entry points into no-ops
- projects hidden region parameters from function summaries while preserving the exported `main` ABI exception
- adds a compile-cache ABI seed so stale pre-cutover object files cannot be reused with the new arena ABI

## Root Cause / Impact

The old lowering path tracked heap allocations and emitted explicit frees for scoped values. That conflicts with the arena model from #195, where reclamation is handled by region close and legacy typed frees must not reclaim individual backings. During validation, stale cached objects also reused the old two-argument arena allocation ABI and crashed when linked with the new runtime, so the compile-cache key now includes a codegen ABI seed.

## Validation

- `git diff --check`
- `cargo test --all` passes
- `cargo clippy --all -- -D warnings` passes
- `scripts/full_test.sh` currently reports `288 passed, 8 failed, 1 skipped`

Remaining `scripts/full_test.sh` failures after the allocator crash cluster was fixed:

- `search/verify`, `sum_range/verify`, `vec_fill/verify`, `bignum/verify`: harness hits `/usr/bin/python3: Argument list too long`
- `cmdloop/test-expected`: expected stdin-driven output but the expectation runner invokes the binary with `/dev/null`
- `string_parse/test-exit`: expected exit `128`, observed `224`
- `gc/verify`, `math/verify`: both Rust and self-hosted report `VerifyFailed` without counterexamples

The arena-related runtime segfault cluster from stale/two-argument `__vow_arena_alloc` objects is gone in the final full-test run.