### PR TITLE
feat: arenas Phase 4 — lowering cutover (#198)

### DIFF
--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1160,8 +1160,11 @@ fn tarjan_sccs(cg: Vec<Vec<i64>>, n: i64) -> Vec<Vec<i64>> {
 //      `Root` until full hidden-region plumbing lands.
 //
 // `frontend.vow` therefore does NOT call this function in Phase 4. The
-// scaffolding below is exercised by `compile_test` in CI but not by the
-// production pipeline.
+// body below is unreachable (the early `return m;` short-circuits it) and
+// remains only as Phase 9 scaffolding — it is NOT exercised by any test
+// today. When Phase 9 lifts the `Block(_)` deferral in `region.rs`, drop
+// the early return here, wire the call from `frontend.vow`, and add a
+// differential test against the Rust pass.
 // ---------------------------------------------------------------------------
 
 fn insert_region_markers_module(m: IrModule) -> IrModule {

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1139,3 +1139,153 @@ fn tarjan_sccs(cg: Vec<Vec<i64>>, n: i64) -> Vec<Vec<i64>> {
     }
     sccs
 }
+
+// ---------------------------------------------------------------------------
+// Block-region marker insertion (mirror of vow-ir/src/region.rs
+// `insert_region_markers`). Tags every non-escaping `IOP_REGION_ALLOC` with
+// `Block(defining_block)` and brackets the containing block with
+// `IOP_REGION_OPEN` / `IOP_REGION_CLOSE` markers per spec §3.5 criterion 1.
+//
+// Phase 4 status: this function is a NO-OP (the body returns the module
+// unchanged) because:
+//   1. The Rust pass equivalent (`vow-ir/src/region.rs::lub_to_region_id`)
+//      defers `Block(_)` emission to Phase 9 (#204) until `must_outlive`
+//      tracks every use of a heap-typed value (regular `FieldGet`/`Load`,
+//      non-store-effect call args, Phi-merged values).
+//   2. To stay aligned with the Rust pass, the self-hosted equivalent must
+//      defer the same way. The implementation below remains as scaffolding
+//      so Phase 9 can flip a single switch.
+//   3. The shim rejects `REGION_KIND_CALLER` with `k > 0` (S1
+//      vow-clif-shim/src/lib.rs); escaping allocs continue to route to
+//      `Root` until full hidden-region plumbing lands.
+//
+// `frontend.vow` therefore does NOT call this function in Phase 4. The
+// scaffolding below is exercised by `compile_test` in CI but not by the
+// production pipeline.
+// ---------------------------------------------------------------------------
+
+fn insert_region_markers_module(m: IrModule) -> IrModule {
+    // No-op for Phase 4 — see header comment for rationale.
+    return m;
+    let n_funcs: i64 = m.functions.len();
+    let mut fi: i64 = 0;
+    while fi < n_funcs {
+        let f: IrFunction = m.functions[fi];
+        let escaping_ids: Vec<i64> = collect_escaping_allocs(m, f);
+
+        // Find the largest existing inst id so we can mint fresh ones.
+        let mut max_id: i64 = 0;
+        let mut bi: i64 = 0;
+        while bi < f.blocks.len() {
+            let blk_scan: IrBlock = f.blocks[bi];
+            let mut ii: i64 = 0;
+            while ii < blk_scan.insts.len() {
+                if blk_scan.insts[ii].id > max_id {
+                    max_id = blk_scan.insts[ii].id;
+                }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        let mut next_id: i64 = max_id + 1;
+
+        // Pass 1: tag non-escaping RegionAlloc insts with Block(defining_block).
+        let mut bi2: i64 = 0;
+        while bi2 < f.blocks.len() {
+            let blk: IrBlock = f.blocks[bi2];
+            let mut ii2: i64 = 0;
+            while ii2 < blk.insts.len() {
+                let inst: IrInst = blk.insts[ii2];
+                if inst.op == IOP_REGION_ALLOC()
+                    && !region_vec_contains_i64(escaping_ids, inst.id)
+                {
+                    let block_region: i64 = region_pack(REGION_KIND_BLOCK(), blk.id);
+                    blk.insts[ii2] = ir_inst_set_region(inst, block_region);
+                }
+                ii2 = ii2 + 1;
+            }
+            f.blocks[bi2] = blk;
+            bi2 = bi2 + 1;
+        }
+
+        // Pass 2: collect blocks that now contain a Block-tagged alloc.
+        let block_regions: Vec<i64> = Vec::new();
+        let mut bi3: i64 = 0;
+        while bi3 < f.blocks.len() {
+            let blk2: IrBlock = f.blocks[bi3];
+            let mut ii3: i64 = 0;
+            let mut found: bool = false;
+            while ii3 < blk2.insts.len() {
+                let inst3: IrInst = blk2.insts[ii3];
+                if region_kind(inst3.rgn) == REGION_KIND_BLOCK() {
+                    found = true;
+                }
+                ii3 = ii3 + 1;
+            }
+            if found {
+                block_regions.push(blk2.id);
+            }
+            bi3 = bi3 + 1;
+        }
+
+        // Pass 3: insert RegionOpen at start of marked blocks and
+        // RegionClose just before the terminator.
+        let mut bi4: i64 = 0;
+        while bi4 < f.blocks.len() {
+            let blk3: IrBlock = f.blocks[bi4];
+            if region_vec_contains_i64(block_regions, blk3.id) {
+                let block_rgn: i64 = region_pack(REGION_KIND_BLOCK(), blk3.id);
+
+                let mut open_inst: IrInst = ir_inst_new(
+                    next_id, IOP_REGION_OPEN(), ITY_UNIT(),
+                    Vec::new(), 0, 0, 0, String::from(""),
+                );
+                open_inst = ir_inst_set_region(open_inst, block_rgn);
+                next_id = next_id + 1;
+
+                let mut close_inst: IrInst = ir_inst_new(
+                    next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
+                    Vec::new(), 0, 0, 0, String::from(""),
+                );
+                close_inst = ir_inst_set_region(close_inst, block_rgn);
+                next_id = next_id + 1;
+
+                // Find terminator position. The block always has one terminal
+                // inst at the tail; defensive scan covers a missing terminator.
+                let mut term_pos: i64 = blk3.insts.len();
+                let mut k: i64 = 0;
+                while k < blk3.insts.len() {
+                    if iop_is_terminal(blk3.insts[k].op) {
+                        term_pos = k;
+                        k = blk3.insts.len();
+                    } else {
+                        k = k + 1;
+                    }
+                }
+
+                // Splice: insert close before terminator first (so the open
+                // insertion at index 0 doesn't shift term_pos).
+                let mut new_insts: Vec<IrInst> = Vec::new();
+                new_insts.push(open_inst);
+                let mut copy_i: i64 = 0;
+                while copy_i < blk3.insts.len() {
+                    if copy_i == term_pos {
+                        new_insts.push(close_inst);
+                    }
+                    new_insts.push(blk3.insts[copy_i]);
+                    copy_i = copy_i + 1;
+                }
+                if term_pos == blk3.insts.len() {
+                    new_insts.push(close_inst);
+                }
+                blk3.insts = new_insts;
+                f.blocks[bi4] = blk3;
+            }
+            bi4 = bi4 + 1;
+        }
+
+        m.functions[fi] = f;
+        fi = fi + 1;
+    }
+    m
+}

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -748,6 +748,18 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         .obj_module
         .declare_function("__vow_arena_alloc", Linkage::Import, &arena_alloc_sig)
         .expect("declare __vow_arena_alloc");
+
+    let mut arena_open_close_sig = ctx.obj_module.make_signature();
+    arena_open_close_sig.params.push(AbiParam::new(types::I64)); // *VowArena
+    let arena_open_id = ctx
+        .obj_module
+        .declare_function("__vow_arena_open", Linkage::Import, &arena_open_close_sig)
+        .expect("declare __vow_arena_open");
+    let arena_close_id = ctx
+        .obj_module
+        .declare_function("__vow_arena_close", Linkage::Import, &arena_open_close_sig)
+        .expect("declare __vow_arena_close");
+
     let root_arena_id = ctx
         .obj_module
         .declare_data("__vow_root_arena", Linkage::Import, true, false)
@@ -902,9 +914,21 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     let arena_alloc_ref = ctx
         .obj_module
         .declare_func_in_func(arena_alloc_id, builder.func);
+    let arena_open_ref = ctx
+        .obj_module
+        .declare_func_in_func(arena_open_id, builder.func);
+    let arena_close_ref = ctx
+        .obj_module
+        .declare_func_in_func(arena_close_id, builder.func);
     let root_arena_gv = ctx
         .obj_module
         .declare_data_in_func(root_arena_id, builder.func);
+    // Per-block VowArena stack-slot map. Lazily populated on first use of
+    // a given BlockId by `IOP_REGION_OPEN` / `IOP_REGION_CLOSE` /
+    // `IOP_REGION_ALLOC` with `REGION_KIND_BLOCK`. `VowArena` is 48 bytes,
+    // 8-byte aligned (asserted in `vow-runtime/src/lib.rs`).
+    let mut block_arena_slots: std::collections::HashMap<i64, StackSlot> =
+        std::collections::HashMap::new();
     let vow_violation_ref =
         vow_violation_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
     let overflow_ref = overflow_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
@@ -1787,40 +1811,60 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
 
                 // Region / linear
                 IOP_REGION_ALLOC => {
-                    // Region-kind gating. The Rust backend routes
-                    // `RegionId::Caller(idx)` through a hidden arena
-                    // parameter and rejects `Block`/`Rodata`. The shim
-                    // has not yet grown the hidden-arena plumbing, so
-                    // we refuse anything that isn't `Root` rather than
-                    // silently allocating into the root arena — which
-                    // would violate the caller's region lifetime when
-                    // a `.vmod` produced by the Rust compiler is fed
-                    // back through the self-hosted pipeline.
                     let rgn = inst_rgns[ii];
                     let kind = rgn & 3;
-                    if kind != REGION_KIND_ROOT {
-                        let label = match kind {
-                            REGION_KIND_BLOCK => "Block",
-                            REGION_KIND_CALLER => "Caller",
-                            REGION_KIND_RODATA => "Rodata",
-                            _ => "Unknown",
-                        };
-                        eprintln!(
-                            "clif_shim: IOP_REGION_ALLOC with region kind {} (payload {}) \
-                             is not supported yet — only Root is wired; \
-                             hidden-arena routing for Caller and block-scoped arenas \
-                             lands in a follow-up",
-                            label,
-                            rgn >> 2,
-                        );
-                        return -1;
-                    }
+                    let payload = rgn >> 2;
                     let (size, align) = if dk == IDATA_ALLOC_SIZE {
                         (dv, dv2)
                     } else {
                         (0, 8)
                     };
-                    let arena = builder.ins().global_value(types::I64, root_arena_gv);
+                    let arena = match kind {
+                        REGION_KIND_ROOT => builder.ins().global_value(types::I64, root_arena_gv),
+                        REGION_KIND_BLOCK => {
+                            let slot = *block_arena_slots.entry(payload).or_insert_with(|| {
+                                builder.create_sized_stack_slot(StackSlotData::new(
+                                    StackSlotKind::ExplicitSlot,
+                                    48, // sizeof VowArena
+                                    3,  // log2(8)
+                                ))
+                            });
+                            builder.ins().stack_addr(types::I64, slot, 0)
+                        }
+                        REGION_KIND_CALLER => {
+                            // Hidden region parameters are appended to the
+                            // function's signature after the user-visible
+                            // params (spec §5.2). Threading `Caller(k)` for
+                            // `k > 0` requires the self-hosted compiler to
+                            // declare the right hidden-param count when
+                            // emitting the function — currently the shim
+                            // expects only user params, so we reject
+                            // anything beyond `Caller(0)` for now and use
+                            // the first hidden value when `k == 0`.
+                            eprintln!(
+                                "clif_shim: IOP_REGION_ALLOC with REGION_KIND_CALLER \
+                                 (k={}) is not yet wired — self-hosted compiler must \
+                                 not emit Caller-routed allocations until hidden-param \
+                                 plumbing lands",
+                                payload,
+                            );
+                            return -1;
+                        }
+                        REGION_KIND_RODATA => {
+                            eprintln!(
+                                "clif_shim: IOP_REGION_ALLOC with REGION_KIND_RODATA \
+                                 is invalid — rodata-backed values are static, not \
+                                 allocated"
+                            );
+                            return -1;
+                        }
+                        _ => {
+                            eprintln!(
+                                "clif_shim: IOP_REGION_ALLOC with unknown region kind {kind}"
+                            );
+                            return -1;
+                        }
+                    };
                     let size_val = builder.ins().iconst(types::I64, size);
                     let align_val = builder.ins().iconst(types::I64, align);
                     let call_inst = builder
@@ -1838,13 +1882,39 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                     set_val!(iid, unit);
                 }
 
-                // Phase 2: RegionOpen / RegionClose are declared but never
-                // emitted. Trap at runtime so an accidental Phase-3 slip
-                // fails loudly (symmetric with `vow-codegen`'s
-                // `unreachable!("not emitted in Phase 2")`). User trap code
-                // `3` is reserved for "unimplemented region opcode".
+                // RegionOpen / RegionClose: bracket a block-region's lifetime
+                // by calling `__vow_arena_open` / `__vow_arena_close` on the
+                // BlockId-keyed stack slot. The region payload (encoded in
+                // `inst_rgns[ii]`) names the block being opened/closed, which
+                // need not match the containing IR block — opens/closes can
+                // straddle basic-block boundaries.
                 IOP_REGION_OPEN | IOP_REGION_CLOSE => {
-                    builder.ins().trap(TrapCode::unwrap_user(3));
+                    let rgn = inst_rgns[ii];
+                    let kind = rgn & 3;
+                    if kind != REGION_KIND_BLOCK {
+                        eprintln!(
+                            "clif_shim: IOP_REGION_{{OPEN,CLOSE}} requires \
+                             REGION_KIND_BLOCK, got kind {kind}"
+                        );
+                        return -1;
+                    }
+                    let payload = rgn >> 2;
+                    let slot = *block_arena_slots.entry(payload).or_insert_with(|| {
+                        builder.create_sized_stack_slot(StackSlotData::new(
+                            StackSlotKind::ExplicitSlot,
+                            48,
+                            3,
+                        ))
+                    });
+                    let arena_addr = builder.ins().stack_addr(types::I64, slot, 0);
+                    let func_ref = if op == IOP_REGION_OPEN {
+                        arena_open_ref
+                    } else {
+                        arena_close_ref
+                    };
+                    builder.ins().call(func_ref, &[arena_addr]);
+                    let unit = builder.ins().iconst(types::I32, 0);
+                    set_val!(iid, unit);
                 }
 
                 // Struct / enum field access

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -196,6 +196,15 @@ const REGION_KIND_CALLER: i64 = 1;
 const REGION_KIND_ROOT: i64 = 2;
 const REGION_KIND_RODATA: i64 = 3;
 
+/// Size of `vow_runtime::VowArena` in bytes — asserted in
+/// `vow-runtime/src/lib.rs` (`assert!(size_of::<VowArena>() == 48)`).
+/// Mirrors the same constant in `vow-codegen/src/cranelift_backend.rs`
+/// so a future `VowArena` resize updates both backends in lockstep.
+const VOW_ARENA_HEADER_SIZE: u32 = 48;
+/// Log₂ of the `VowArena` header alignment (8 bytes — contains
+/// pointers). Mirrors `vow-codegen`.
+const VOW_ARENA_HEADER_ALIGN_LOG2: u8 = 3;
+
 const IOP_LINEAR_CONSUME: i64 = 79;
 const IOP_LINEAR_BORROW: i64 = 80;
 
@@ -1832,8 +1841,8 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                             let slot = *block_arena_slots.entry(payload).or_insert_with(|| {
                                 builder.create_sized_stack_slot(StackSlotData::new(
                                     StackSlotKind::ExplicitSlot,
-                                    48, // sizeof VowArena
-                                    3,  // log2(8)
+                                    VOW_ARENA_HEADER_SIZE,
+                                    VOW_ARENA_HEADER_ALIGN_LOG2,
                                 ))
                             });
                             builder.ins().stack_addr(types::I64, slot, 0)
@@ -1908,8 +1917,8 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                     let slot = *block_arena_slots.entry(payload).or_insert_with(|| {
                         builder.create_sized_stack_slot(StackSlotData::new(
                             StackSlotKind::ExplicitSlot,
-                            48,
-                            3,
+                            VOW_ARENA_HEADER_SIZE,
+                            VOW_ARENA_HEADER_ALIGN_LOG2,
                         ))
                     });
                     let arena_addr = builder.ins().stack_addr(types::I64, slot, 0);

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -927,8 +927,15 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     // a given BlockId by `IOP_REGION_OPEN` / `IOP_REGION_CLOSE` /
     // `IOP_REGION_ALLOC` with `REGION_KIND_BLOCK`. `VowArena` is 48 bytes,
     // 8-byte aligned (asserted in `vow-runtime/src/lib.rs`).
-    let mut block_arena_slots: std::collections::HashMap<i64, StackSlot> =
-        std::collections::HashMap::new();
+    //
+    // BTreeMap (not HashMap) for the same reason `slot_map` below uses one
+    // (CLAUDE.md): deterministic iteration order is required for binary
+    // fixed-point reproducibility under the bootstrap triple. Today the
+    // map is only accessed via `.entry()` so the codegen order is
+    // incidentally deterministic, but any future iteration over it
+    // (diagnostics, init pass) MUST preserve that property by default.
+    let mut block_arena_slots: std::collections::BTreeMap<i64, StackSlot> =
+        std::collections::BTreeMap::new();
     let vow_violation_ref =
         vow_violation_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
     let overflow_ref = overflow_id.map(|id| ctx.obj_module.declare_func_in_func(id, builder.func));
@@ -1832,15 +1839,14 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                             builder.ins().stack_addr(types::I64, slot, 0)
                         }
                         REGION_KIND_CALLER => {
-                            // Hidden region parameters are appended to the
-                            // function's signature after the user-visible
-                            // params (spec §5.2). Threading `Caller(k)` for
-                            // `k > 0` requires the self-hosted compiler to
-                            // declare the right hidden-param count when
-                            // emitting the function — currently the shim
-                            // expects only user params, so we reject
-                            // anything beyond `Caller(0)` for now and use
-                            // the first hidden value when `k == 0`.
+                            // Hidden-region plumbing (spec §5.2) is not yet
+                            // wired in the shim — `__vow_clif_declare_function`
+                            // does not accept a hidden-param count, so the
+                            // self-hosted compiler cannot emit any
+                            // `Caller`-routed allocation regardless of `k`.
+                            // Reject all `k` values rather than silently
+                            // routing into the root arena. Phase 5 (#200)
+                            // extends the declare API and lifts this reject.
                             eprintln!(
                                 "clif_shim: IOP_REGION_ALLOC with REGION_KIND_CALLER \
                                  (k={}) is not yet wired — self-hosted compiler must \

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -427,8 +427,21 @@ fn return_source_needs_materialization(
             Opcode::Phi => {
                 // Walk every Upsilon arm that targets this Phi. Upsilons
                 // can live in any block, so we iterate the whole function
-                // here (O(n) rather than O(n²) thanks to the index above
-                // — the loop body is constant-time per inst).
+                // looking for matching `PhiTarget(id)` writes.
+                //
+                // Complexity: O(n_insts) per visited Phi. `inst_index`
+                // doesn't help (it's keyed by InstId, not by PhiTarget),
+                // and the existing `PhiUpsilonData` pre-pass indexes
+                // Upsilons by source block, not by Phi ID, so it can't
+                // be reused either. Phase 7 / #202 — when materialisation
+                // becomes load-bearing on synthesised functions with
+                // deeper Phi chains — should add a `phi_id → [arm_ids]`
+                // inverted index (either inside `PhiUpsilonData` or as a
+                // standalone helper) to bring this to O(k_arms) per Phi.
+                // For Phase 4 this scan rarely fires (materialisation
+                // requires a `FreshInCaller` summary AND a
+                // `__vow_string_from_cstr` leaf, which only String-literal
+                // returns produce).
                 for block in &func.blocks {
                     for inst in &block.insts {
                         if inst.opcode == Opcode::Upsilon

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -370,34 +370,35 @@ fn build_inst_index(func: &IrFunction) -> HashMap<InstId, &Inst> {
 /// deep-copied into `target_region` to satisfy the §5.1 representation
 /// promise.
 ///
-/// Walks the value's source transitively through `Phi` (via `Upsilon` arms).
-/// Returns true iff:
-///   - At least one reachable leaf is a `.rodata` literal (`ConstStr`)
-///     that needs copying into `target_region`, AND
-///   - **EVERY** reachable leaf is `ConstStr` (so the runtime clone
-///     primitive will see a `VowString` / `Vec<u8>` descriptor on every
-///     execution path).
+/// Walks the value's source transitively through `Phi` (via `Upsilon`
+/// arms). Returns true iff at least one reachable leaf is a
+/// `__vow_string_from_cstr(literal)` call AND every reachable leaf is
+/// the same shape (a known-safe `VowString` / `Vec<u8>` descriptor
+/// producer).
 ///
-/// The "every leaf is `ConstStr`" condition is the safety guard:
-/// `__vow_string_clone_into_arena` is type-specialised for the
-/// VowString / `Vec<u8>` descriptor layout. Firing it on an arbitrary
-/// heap pointer (a struct, a `Vec<T>` for `T != u8`, a `HashMap`, …)
-/// would reinterpret 24 bytes of unrelated data as `{ptr, len, cap}`
-/// and copy `len` arbitrary bytes — corrupting memory. So if a Phi
-/// mixes `ConstStr` arms with `RegionAlloc` / `GetArg` / `Call` arms
-/// of unknown layout, we cannot safely emit a clone — return `false`
-/// and let the value escape un-cloned. (The escape-without-clone
-/// case is itself non-§5.1-compliant for the literal arm, but it's
-/// strictly safer than memory corruption; a generic deep-clone
-/// intrinsic in Phase 7 / #202 lifts this restriction.)
+/// **Why `__vow_string_from_cstr`, not `ConstStr` directly.**
+/// `ConstStr` lowers to a pointer to a NUL-terminated byte blob in a
+/// `.rodata` data section — it is *not* a `VowVec` descriptor.
+/// `__vow_string_clone_into_arena` reads `(ptr, len, cap)` from its
+/// source and copies `len` bytes; firing it on a raw `ConstStr` would
+/// reinterpret arbitrary literal bytes as `{ptr, len, cap}` and corrupt
+/// memory. The Vow lowerer wraps every `String` literal in
+/// `Call __vow_string_from_cstr(ConstStr)` (`vow-ir/src/lower/mod.rs`
+/// `Lit::String`), and that Call's *result* is the actual `VowVec`
+/// descriptor — that's the shape we recognise here.
 ///
-/// `GetArg` of a `Ptr` param is intentionally **excluded** for the
-/// same layout-safety reason. `RegionAlloc` (placed in `Caller(0)` by
-/// the region pass) and `Call` results from `FreshInCaller` callees
-/// (placed in our `target_region` by the S4 projection) are already
-/// in `target_region` and need no copy — but their layout isn't
-/// `VowString`-shaped, so they also disqualify a Phi from
-/// materialisation.
+/// **Why the all-leaves rule still applies.** A Phi mixing a
+/// `__vow_string_from_cstr` arm with any other leaf shape (a
+/// `RegionAlloc`, a `GetArg` of a heap-typed param, a generic call,
+/// …) cannot be safely cloned via the `VowString`-typed primitive: at
+/// runtime the Phi-selected value might not have descriptor layout.
+/// Mixed Phis fall back to no-clone; correctness over §5.1
+/// compliance for those paths. A generic deep-clone intrinsic in
+/// Phase 7 / #202 lifts the restriction.
+///
+/// `GetArg`, `RegionAlloc`, plain `Call`s, and other leaves disqualify
+/// the walk for the same reason — their layout isn't statically
+/// known to be `VowString`-shaped.
 fn return_source_needs_materialization(
     func: &IrFunction,
     inst_index: &HashMap<InstId, &Inst>,
@@ -405,19 +406,23 @@ fn return_source_needs_materialization(
 ) -> bool {
     let mut visited: HashSet<InstId> = HashSet::new();
     let mut stack: Vec<InstId> = vec![return_val];
-    let mut saw_const_str = false;
+    let mut saw_safe_leaf = false;
     while let Some(id) = stack.pop() {
         if !visited.insert(id) {
             continue;
         }
         let Some(&src) = inst_index.get(&id) else {
-            // Unknown source — be conservative: treat as a non-`ConstStr`
-            // leaf, which disqualifies materialisation.
+            // Unknown source — be conservative.
             return false;
         };
         match src.opcode {
-            Opcode::ConstStr => {
-                saw_const_str = true;
+            Opcode::Call
+                if matches!(
+                    &src.data,
+                    InstData::CallExtern(sym) if sym == "__vow_string_from_cstr"
+                ) =>
+            {
+                saw_safe_leaf = true;
             }
             Opcode::Phi => {
                 // Walk every Upsilon arm that targets this Phi. Upsilons
@@ -436,13 +441,14 @@ fn return_source_needs_materialization(
                     }
                 }
             }
-            // Any non-Phi, non-ConstStr leaf disqualifies the whole
-            // walk: we cannot safely clone via the VowString-typed
-            // primitive when one path produces a non-VowString value.
+            // Any other leaf shape disqualifies the walk. This includes
+            // raw `ConstStr` (a `.rodata` byte blob, NOT a `VowVec`
+            // descriptor — running the clone runtime on it would
+            // corrupt memory).
             _ => return false,
         }
     }
-    saw_const_str
+    saw_safe_leaf
 }
 
 fn lower_inst(
@@ -4431,13 +4437,47 @@ mod tests {
     }
 
     /// Build a 4-block FreshInCaller function whose return is a Phi
-    /// merging the two given arm sources. Helper for the two
-    /// Phi-materialisation tests below.
-    fn fresh_in_caller_phi_function(arm_a: Inst, arm_b: Inst) -> Function {
-        // block 0:                   selector + Branch
-        // block 1: arm_a + Upsilon → Phi
-        // block 2: arm_b + Upsilon → Phi
-        // block 3: Phi + Return
+    /// merging two arm sources. Each arm is a `Vec<Inst>` (so multi-step
+    /// arms like `ConstStr → Call __vow_string_from_cstr(cstr)` can be
+    /// modelled); the source value fed into the Upsilon is the LAST
+    /// inst's id.
+    fn fresh_in_caller_phi_function(arm_a: Vec<Inst>, arm_b: Vec<Inst>) -> Function {
+        let arm_a_src = arm_a.last().unwrap().id.0;
+        let arm_b_src = arm_b.last().unwrap().id.0;
+        let mut block1 = arm_a;
+        block1.extend([
+            inst(
+                100,
+                Opcode::Upsilon,
+                Ty::Unit,
+                vec![arm_a_src],
+                InstData::PhiTarget(InstId(3)),
+            ),
+            inst(
+                101,
+                Opcode::Jump,
+                Ty::Unit,
+                vec![],
+                InstData::JumpTarget(BlockId(3)),
+            ),
+        ]);
+        let mut block2 = arm_b;
+        block2.extend([
+            inst(
+                102,
+                Opcode::Upsilon,
+                Ty::Unit,
+                vec![arm_b_src],
+                InstData::PhiTarget(InstId(3)),
+            ),
+            inst(
+                103,
+                Opcode::Jump,
+                Ty::Unit,
+                vec![],
+                InstData::JumpTarget(BlockId(3)),
+            ),
+        ]);
         Function {
             id: FuncId(0),
             name: "phi_test".to_string(),
@@ -4465,43 +4505,11 @@ mod tests {
                 },
                 BasicBlock {
                     id: BlockId(1),
-                    insts: vec![
-                        arm_a.clone(),
-                        inst(
-                            2,
-                            Opcode::Upsilon,
-                            Ty::Unit,
-                            vec![arm_a.id.0],
-                            InstData::PhiTarget(InstId(3)),
-                        ),
-                        inst(
-                            11,
-                            Opcode::Jump,
-                            Ty::Unit,
-                            vec![],
-                            InstData::JumpTarget(BlockId(3)),
-                        ),
-                    ],
+                    insts: block1,
                 },
                 BasicBlock {
                     id: BlockId(2),
-                    insts: vec![
-                        arm_b.clone(),
-                        inst(
-                            5,
-                            Opcode::Upsilon,
-                            Ty::Unit,
-                            vec![arm_b.id.0],
-                            InstData::PhiTarget(InstId(3)),
-                        ),
-                        inst(
-                            12,
-                            Opcode::Jump,
-                            Ty::Unit,
-                            vec![],
-                            InstData::JumpTarget(BlockId(3)),
-                        ),
-                    ],
+                    insts: block2,
                 },
                 BasicBlock {
                     id: BlockId(3),
@@ -4520,6 +4528,29 @@ mod tests {
         }
     }
 
+    /// Build a `__vow_string_from_cstr(ConstStr)` arm — the actual shape
+    /// the Vow lowerer produces for a String literal (see
+    /// `vow-ir/src/lower/mod.rs` `Lit::String`). The Call's result is a
+    /// `VowVec` descriptor and is the only kind of leaf the
+    /// materialisation analysis treats as clone-safe.
+    fn string_literal_arm(base_id: u32) -> Vec<Inst> {
+        let cstr = inst(
+            base_id,
+            Opcode::ConstStr,
+            Ty::Ptr,
+            vec![],
+            InstData::ConstStr(0),
+        );
+        let call = inst(
+            base_id + 1,
+            Opcode::Call,
+            Ty::Ptr,
+            vec![base_id],
+            InstData::CallExtern("__vow_string_from_cstr".to_string()),
+        );
+        vec![cstr, call]
+    }
+
     fn module_imports_string_clone(bytes: &[u8]) -> bool {
         use object::{Object, ObjectSymbol};
         let object = object::File::parse(bytes).expect("compiled object should parse");
@@ -4530,27 +4561,27 @@ mod tests {
     }
 
     /// Acceptance test 2 from issue #198 (safe variant): a Phi whose
-    /// arms are both `.rodata` literals (`ConstStr`) is fully
-    /// `VowString`-shaped, so materialising via
-    /// `__vow_string_clone_into_arena` is sound. The clone runtime is
-    /// imported and called.
+    /// arms are both `__vow_string_from_cstr(literal)` — the actual
+    /// lowered shape of a Vow String literal — produces `VowVec`
+    /// descriptors on every path. Materialising via
+    /// `__vow_string_clone_into_arena` is sound; the clone runtime is
+    /// imported.
     #[test]
-    fn fresh_in_caller_phi_all_const_str_arms_materialises() {
-        let arm_a = inst(1, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0));
-        let arm_b = inst(4, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0));
-        let func = fresh_in_caller_phi_function(arm_a, arm_b);
-        let module = make_module("test", vec![func]);
+    fn fresh_in_caller_phi_all_string_literal_arms_materialises() {
+        let func = fresh_in_caller_phi_function(string_literal_arm(20), string_literal_arm(40));
+        let mut module = make_module("test", vec![func]);
+        module.strings.push("hello".to_string());
         let result =
             CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
         assert!(result.is_ok(), "{:?}", result.err());
         assert!(
             module_imports_string_clone(&result.unwrap().bytes),
-            "Phi with all-ConstStr arms must materialise"
+            "Phi with all `__vow_string_from_cstr` arms must materialise"
         );
     }
 
     /// Defense-in-depth (codex P1 from PR #230 round-2 review): a Phi
-    /// mixing a `.rodata` literal arm with a `RegionAlloc` arm has at
+    /// mixing a string-literal arm with a `RegionAlloc` arm has at
     /// least one path producing a non-`VowString` descriptor. The clone
     /// runtime is type-specialised for `VowString` / `Vec<u8>`, so
     /// firing it on the `RegionAlloc` arm at runtime would reinterpret
@@ -4564,38 +4595,68 @@ mod tests {
     /// lifts this restriction.)
     #[test]
     fn fresh_in_caller_phi_mixed_arms_skips_materialisation() {
-        let arm_a = inst(1, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0));
         let mut arm_b = inst(
-            4,
+            40,
             Opcode::RegionAlloc,
             Ty::Ptr,
             vec![],
             InstData::AllocSize { size: 16, align: 8 },
         );
         arm_b.region = RegionId::Caller(HiddenRegionIdx(0));
-        let func = fresh_in_caller_phi_function(arm_a, arm_b);
-        let module = make_module("test", vec![func]);
+        let func = fresh_in_caller_phi_function(string_literal_arm(20), vec![arm_b]);
+        let mut module = make_module("test", vec![func]);
+        module.strings.push("hello".to_string());
         let result =
             CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
         assert!(result.is_ok(), "{:?}", result.err());
         assert!(
             !module_imports_string_clone(&result.unwrap().bytes),
-            "Phi mixing ConstStr with non-string-layout arms must NOT \
-             trigger materialisation — the clone primitive only handles \
-             VowString descriptors and would corrupt memory on the \
-             non-string arm"
+            "Phi mixing string literal with non-string-layout arms must \
+             NOT trigger materialisation — the clone primitive only \
+             handles VowString descriptors and would corrupt memory on \
+             the non-string arm"
+        );
+    }
+
+    /// Defense-in-depth (codex P1 from PR #230 round-3 review): a Phi
+    /// arm that is a *raw* `ConstStr` (not wrapped in
+    /// `__vow_string_from_cstr`) is a c-string pointer, not a `VowVec`
+    /// descriptor. Treating it as clone-safe would corrupt memory.
+    /// The well-formed Vow lowerer never produces this shape — every
+    /// String literal is wrapped in the `from_cstr` Call — but the
+    /// analysis must reject it under any IR a future pass might
+    /// synthesise.
+    #[test]
+    fn fresh_in_caller_raw_const_str_arm_skips_materialisation() {
+        let cstr_arm = vec![inst(
+            20,
+            Opcode::ConstStr,
+            Ty::Ptr,
+            vec![],
+            InstData::ConstStr(0),
+        )];
+        let func = fresh_in_caller_phi_function(cstr_arm, string_literal_arm(40));
+        let mut module = make_module("test", vec![func]);
+        module.strings.push("hello".to_string());
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert!(
+            !module_imports_string_clone(&result.unwrap().bytes),
+            "Raw ConstStr arm (c-string, not VowVec descriptor) must NOT \
+             trigger materialisation"
         );
     }
 
     #[test]
-    fn fresh_in_caller_const_str_return_materialises_via_clone() {
-        // Phase 4 / S5: a `FreshInCaller` function whose return path reaches
-        // a `.rodata` `ConstStr` MUST clone the descriptor into
-        // `target_region` before returning (spec §5.1). The produced object
-        // must import `__vow_string_clone_into_arena`; the regular
-        // FreshInCaller-into-RegionAlloc test below confirms the symbol is
-        // *not* imported when the path doesn't need materialisation.
-        let module = make_module(
+    fn fresh_in_caller_string_literal_return_materialises_via_clone() {
+        // Phase 4 / S5: a `FreshInCaller` function whose return path is the
+        // lowered shape of a Vow String literal —
+        // `Call __vow_string_from_cstr(ConstStr)` — produces a `VowVec`
+        // descriptor that must be cloned into `target_region` to satisfy
+        // §5.1. The produced object must import
+        // `__vow_string_clone_into_arena`.
+        let mut module = make_module(
             "test",
             vec![Function {
                 id: FuncId(0),
@@ -4609,7 +4670,14 @@ mod tests {
                     id: BlockId(0),
                     insts: vec![
                         inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
-                        inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                        inst(
+                            1,
+                            Opcode::Call,
+                            Ty::Ptr,
+                            vec![0],
+                            InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                        ),
+                        inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
                     ],
                 }],
                 local_names: std::collections::HashMap::new(),
@@ -4620,19 +4688,13 @@ mod tests {
                 },
             }],
         );
+        module.strings.push("hello".to_string());
         let result =
             CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
         assert!(result.is_ok(), "{:?}", result.err());
-        let bytes = result.unwrap().bytes;
-        use object::{Object, ObjectSymbol};
-        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
-        let symbols: HashSet<String> = object
-            .symbols()
-            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
-            .collect();
         assert!(
-            symbols.contains("__vow_string_clone_into_arena"),
-            "FreshInCaller .rodata return path must import __vow_string_clone_into_arena"
+            module_imports_string_clone(&result.unwrap().bytes),
+            "FreshInCaller String-literal return path must import __vow_string_clone_into_arena"
         );
     }
 

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use vow_ir::{
     BlockId, FuncId as IrFuncId, Function as IrFunction, Inst, InstData, InstId,
-    Module as IrModule, Opcode, RegionConstraint, RegionId, Ty as IrTy,
+    Module as IrModule, Opcode, RegionConstraint, RegionId, RegionSummary, Ty as IrTy,
 };
 
 use crate::{Backend, BuildMode, CodegenError, CompiledObject, TraceMode};
@@ -232,6 +232,17 @@ struct LowerCtx<'a> {
     vow_violation_ref: Option<FuncRef>,
     overflow_ref: Option<FuncRef>,
     arena_alloc_ref: FuncRef,
+    arena_open_ref: FuncRef,
+    arena_close_ref: FuncRef,
+    string_clone_ref: Option<FuncRef>,
+    /// Stack slots holding the `VowArena` header for each block whose region
+    /// is non-empty (spec §3.5). Lazily populated on first use of a given
+    /// `BlockId` by `RegionOpen` / `RegionClose` / `RegionAlloc{Block}`.
+    block_arena_slots: &'a mut HashMap<BlockId, StackSlot>,
+    /// Per-callable region summaries, indexed by IR `FuncId`. Read by the
+    /// `Opcode::Call` lowering to project hidden region parameters from the
+    /// caller's frame (spec §5.2).
+    func_summaries: &'a HashMap<IrFuncId, RegionSummary>,
     mode: BuildMode,
     trace: TraceMode,
     current_ir_block: BlockId,
@@ -247,6 +258,142 @@ struct LowerCtx<'a> {
     fn_name_gv: Option<GlobalValue>,
     stack_exit_ref: Option<FuncRef>,
     root_arena_gv: GlobalValue,
+}
+
+/// Size of `vow_runtime::VowArena` in bytes — asserted in
+/// `vow-runtime/src/lib.rs` (`assert!(size_of::<VowArena>() == 48)`).
+const VOW_ARENA_HEADER_SIZE: u32 = 48;
+/// Alignment for the `VowArena` header (contains pointers).
+const VOW_ARENA_HEADER_ALIGN_LOG2: u8 = 3;
+
+/// Look up or allocate the stack slot holding the `VowArena` header for
+/// `block_id`. Slots are reused across `RegionOpen` / `RegionAlloc{Block}`
+/// / `RegionClose` references to the same block within a single function.
+fn block_arena_slot(
+    builder: &mut FunctionBuilder,
+    slots: &mut HashMap<BlockId, StackSlot>,
+    block_id: BlockId,
+) -> StackSlot {
+    *slots.entry(block_id).or_insert_with(|| {
+        builder.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            VOW_ARENA_HEADER_SIZE,
+            VOW_ARENA_HEADER_ALIGN_LOG2,
+        ))
+    })
+}
+
+/// Materialise the Cranelift `Value` (`*VowArena`) representing `region` in
+/// the current function's frame. Used by:
+/// - `Opcode::RegionAlloc` lowering (§5.3) to pick the arena to allocate
+///   into.
+/// - `Opcode::Call` lowering (§5.2) to project hidden region parameters
+///   for an internal callee.
+fn region_to_arena_value(
+    builder: &mut FunctionBuilder,
+    region: RegionId,
+    hidden_region_values: &[Value],
+    block_arena_slots: &mut HashMap<BlockId, StackSlot>,
+    root_arena_gv: GlobalValue,
+) -> Result<Value, CodegenError> {
+    match region {
+        RegionId::Root => Ok(builder.ins().global_value(types::I64, root_arena_gv)),
+        RegionId::Caller(idx) => {
+            let Some(&arena) = hidden_region_values.get(idx.0 as usize) else {
+                return Err(CodegenError::UnsupportedOpcode(format!(
+                    "missing hidden arena parameter {:?}",
+                    idx
+                )));
+            };
+            Ok(arena)
+        }
+        RegionId::Block(block_id) => {
+            let slot = block_arena_slot(builder, block_arena_slots, block_id);
+            Ok(builder.ins().stack_addr(types::I64, slot, 0))
+        }
+        RegionId::Rodata => Err(CodegenError::UnsupportedOpcode(
+            "cannot derive arena pointer for Rodata region".to_string(),
+        )),
+    }
+}
+
+/// True when the function may emit a return-materialisation clone call —
+/// i.e. it has `return_region == FreshInCaller` and at least one `Return`
+/// inst whose source path reaches a `.rodata` literal or a heap-typed
+/// parameter alias. Used at module-load time to decide whether to import
+/// `__vow_string_clone_into_arena`.
+fn module_uses_return_materialization(func: &IrFunction) -> bool {
+    if func.summary.return_region != RegionConstraint::FreshInCaller {
+        return false;
+    }
+    if func.return_ty != IrTy::Ptr {
+        return false;
+    }
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if inst.opcode == Opcode::Return
+                && let Some(&val_id) = inst.args.first()
+                && return_source_needs_materialization(func, val_id)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Decide whether a `FreshInCaller` function's return value needs to be
+/// deep-copied into `target_region` to satisfy the §5.1 representation
+/// promise.
+///
+/// Walks the value's source transitively through `Phi` (via `Upsilon` arms).
+/// Returns true if any reachable leaf is a `.rodata` literal (`ConstStr`) or
+/// a heap-typed parameter alias (`GetArg` of a `Ptr` param). Other leaves —
+/// `RegionAlloc` (placed in `Caller(0)` by the region pass) and `Call`
+/// results from `FreshInCaller` callees (placed in our `target_region` by
+/// the S4 projection) — are already in `target_region` and need no copy.
+fn return_source_needs_materialization(func: &IrFunction, return_val: InstId) -> bool {
+    let mut visited: HashSet<InstId> = HashSet::new();
+    let mut stack: Vec<InstId> = vec![return_val];
+    while let Some(id) = stack.pop() {
+        if !visited.insert(id) {
+            continue;
+        }
+        let Some(src) = func
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .find(|i| i.id == id)
+        else {
+            continue;
+        };
+        match src.opcode {
+            // `__vow_string_clone_into_arena` is type-specialised for the
+            // VowString / Vec<u8> descriptor layout. Firing it on a Vec<T>
+            // or struct pointer would reinterpret the first 24 bytes as
+            // `{ptr,len,cap}` and copy `len` arbitrary bytes — corrupting
+            // memory. Until a generic deep-clone intrinsic lands (Phase 7
+            // FFI-wrapper stdlib, #202), only the `.rodata` literal case
+            // is safe — every literal is a UTF-8 string today.
+            Opcode::ConstStr => return true,
+            Opcode::Phi => {
+                // Walk every Upsilon arm that targets this Phi.
+                for block in &func.blocks {
+                    for inst in &block.insts {
+                        if inst.opcode == Opcode::Upsilon
+                            && let InstData::PhiTarget(target) = inst.data
+                            && target == id
+                            && let Some(&arm_id) = inst.args.first()
+                        {
+                            stack.push(arm_id);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 fn lower_inst(
@@ -676,8 +823,38 @@ fn lower_inst(
                 builder.ins().return_(&[]);
             } else if let Some(&val_id) = inst.args.first() {
                 if let Some(&val) = ctx.value_map.get(&val_id) {
-                    let val = coerce_return_value(builder, val, ctx.return_ty);
-                    builder.ins().return_(&[val]);
+                    // Phase 4 / S5 return materialization (spec §5.1).
+                    // For a `FreshInCaller` function, the returned heap-typed
+                    // value MUST be in `target_region` at the return edge. If
+                    // the value's source path includes a `.rodata` literal or
+                    // a parameter alias, deep-copy it into `target_region`
+                    // (slot 0 of `hidden_region_values`).
+                    let needs_clone = ctx.return_ty == IrTy::Ptr
+                        && ctx.ir_func.summary.return_region == RegionConstraint::FreshInCaller
+                        && return_source_needs_materialization(ctx.ir_func, val_id);
+                    let materialized = if needs_clone {
+                        let target_region =
+                            ctx.hidden_region_values.first().copied().ok_or_else(|| {
+                                CodegenError::UnsupportedOpcode(
+                                    "FreshInCaller function missing target_region hidden param"
+                                        .to_string(),
+                                )
+                            })?;
+                        let clone_ref = ctx.string_clone_ref.ok_or_else(|| {
+                            CodegenError::UnsupportedOpcode(
+                                "return materialisation needed but \
+                                 __vow_string_clone_into_arena import missing — \
+                                 module-level scan in compile_module is out of sync"
+                                    .to_string(),
+                            )
+                        })?;
+                        let call_inst = builder.ins().call(clone_ref, &[target_region, val]);
+                        builder.inst_results(call_inst)[0]
+                    } else {
+                        val
+                    };
+                    let materialized = coerce_return_value(builder, materialized, ctx.return_ty);
+                    builder.ins().return_(&[materialized]);
                 } else {
                     builder.ins().return_(&[]);
                 }
@@ -859,25 +1036,75 @@ fn lower_inst(
                 })
                 .collect();
             if internal_call {
-                // Pad missing hidden-region parameters with the root arena.
-                //
-                // KNOWN GAP (Phase 4/5): now that the region pass produces
-                // non-default summaries (see `vow-ir/src/region.rs`), callees
-                // with `FreshInCaller` / store-effect-driven `AliasOf` summaries
-                // expect a real caller arena, not the root arena. Padding with
-                // root means escaping allocations from such callees fall back
-                // to process-lifetime storage instead of being routed through
-                // the caller's region. Forwarding `ctx.hidden_region_values`
-                // (or a per-parameter arena selected by the callee summary) is
-                // the right fix; it's left for the same Phase 4/5 work that
-                // wires `RegionId::Caller(idx)` end-to-end through the shim
-                // (issue #200, plus the call-site projection that will follow).
-                // No existing example or `tests/run/*.vow` triggers this path
-                // today — examples build clean post-Phase-3 — so the gap is
-                // latent until a program actually constructs and returns a
-                // fresh allocation through a multi-frame call chain.
-                while call_args.len() < expected_types.len() {
-                    call_args.push(builder.ins().global_value(types::I64, ctx.root_arena_gv));
+                // Project the callee's hidden region parameters from the
+                // caller's frame (spec §5.2). The order MUST match
+                // `build_signature` / `hidden_region_param_count`:
+                //   1. `target_region` first iff callee has
+                //      `return_region == FreshInCaller`. Sourced from the
+                //      Call's `inst.region` — the caller's view of where
+                //      the result must live.
+                //   2. One `*VowArena` per distinct `StoreEffect.target` in
+                //      ascending callee-param-index order. Sourced from the
+                //      region of the matching Vow argument.
+                let callee_id = match &inst.data {
+                    InstData::CallTarget(f) => *f,
+                    _ => unreachable!("internal_call is true only for CallTarget"),
+                };
+                let callee_summary = ctx.func_summaries.get(&callee_id).ok_or_else(|| {
+                    CodegenError::UnsupportedOpcode(format!(
+                        "missing region summary for callee FuncId({:?})",
+                        callee_id
+                    ))
+                })?;
+
+                if callee_summary.return_region == RegionConstraint::FreshInCaller {
+                    let target_region = region_to_arena_value(
+                        builder,
+                        inst.region,
+                        ctx.hidden_region_values,
+                        ctx.block_arena_slots,
+                        ctx.root_arena_gv,
+                    )?;
+                    call_args.push(target_region);
+                }
+
+                let mut store_targets: Vec<u32> = callee_summary
+                    .store_effects
+                    .iter()
+                    .map(|e| e.target)
+                    .collect();
+                store_targets.sort_unstable();
+                store_targets.dedup();
+                for target_idx in store_targets {
+                    // The arena to thread is the region of the Vow
+                    // argument at `target_idx` in this call. For
+                    // `RegionAlloc`-derived arguments the region pass set
+                    // `inst.region` precisely; for other heap-typed
+                    // arguments (`GetArg`, `Phi`, `FieldGet`, ...) the
+                    // region currently defaults to `Root`. That fallback
+                    // matches today's external behavior and is the same
+                    // gap S5 / future work tightens via per-value region
+                    // tracking.
+                    let arg_region = inst
+                        .args
+                        .get(target_idx as usize)
+                        .and_then(|arg_id| {
+                            ctx.ir_func
+                                .blocks
+                                .iter()
+                                .flat_map(|b| b.insts.iter())
+                                .find(|i| i.id == *arg_id)
+                        })
+                        .map(|src_inst| src_inst.region)
+                        .unwrap_or(RegionId::Root);
+                    let arena = region_to_arena_value(
+                        builder,
+                        arg_region,
+                        ctx.hidden_region_values,
+                        ctx.block_arena_slots,
+                        ctx.root_arena_gv,
+                    )?;
+                    call_args.push(arena);
                 }
             }
             let call_inst = builder.ins().call(func_ref, &call_args);
@@ -906,29 +1133,13 @@ fn lower_inst(
             } else {
                 (0, 8)
             };
-            let arena = match inst.region {
-                RegionId::Root => builder.ins().global_value(types::I64, ctx.root_arena_gv),
-                RegionId::Caller(idx) => {
-                    let Some(&arena) = ctx.hidden_region_values.get(idx.0 as usize) else {
-                        return Err(CodegenError::UnsupportedOpcode(format!(
-                            "missing hidden arena parameter {:?} for RegionAlloc",
-                            idx
-                        )));
-                    };
-                    arena
-                }
-                RegionId::Block(_) => {
-                    return Err(CodegenError::UnsupportedOpcode(format!(
-                        "RegionAlloc with {:?} is not wired until block arena routing lands",
-                        inst.region
-                    )));
-                }
-                RegionId::Rodata => {
-                    return Err(CodegenError::UnsupportedOpcode(
-                        "RegionAlloc cannot target rodata".to_string(),
-                    ));
-                }
-            };
+            let arena = region_to_arena_value(
+                builder,
+                inst.region,
+                ctx.hidden_region_values,
+                ctx.block_arena_slots,
+                ctx.root_arena_gv,
+            )?;
             let size_val = builder.ins().iconst(types::I64, size);
             let align_val = builder.ins().iconst(types::I64, align);
             let call_inst = builder
@@ -947,9 +1158,22 @@ fn lower_inst(
         }
 
         Opcode::RegionOpen | Opcode::RegionClose => {
-            // Phase 2: these opcodes are declared but never emitted by the
-            // lowerer. Phase 4 wires them to __vow_arena_open / _close calls.
-            unreachable!("RegionOpen / RegionClose not emitted in Phase 2");
+            let RegionId::Block(block_id) = inst.region else {
+                return Err(CodegenError::UnsupportedOpcode(format!(
+                    "{:?} requires region = Block(_), got {:?}",
+                    inst.opcode, inst.region
+                )));
+            };
+            let slot = block_arena_slot(builder, ctx.block_arena_slots, block_id);
+            let arena_addr = builder.ins().stack_addr(types::I64, slot, 0);
+            let func_ref = if inst.opcode == Opcode::RegionOpen {
+                ctx.arena_open_ref
+            } else {
+                ctx.arena_close_ref
+            };
+            builder.ins().call(func_ref, &[arena_addr]);
+            let unit = builder.ins().iconst(types::I32, 0);
+            ctx.value_map.insert(inst.id, unit);
         }
 
         // ------------------------------------------------------------------
@@ -1190,6 +1414,9 @@ struct RuntimeIds {
     vow_violation_id: Option<CraneliftFuncId>,
     overflow_id: Option<CraneliftFuncId>,
     arena_alloc_id: CraneliftFuncId,
+    arena_open_id: CraneliftFuncId,
+    arena_close_id: CraneliftFuncId,
+    string_clone_id: Option<CraneliftFuncId>,
     runtime_start_id: CraneliftFuncId,
     root_arena_id: DataId,
     trace_enter_id: Option<CraneliftFuncId>,
@@ -1215,6 +1442,7 @@ fn compile_ir_function(
     runtime: &RuntimeIds,
     string_data_ids: &[DataId],
     extern_func_ids: &HashMap<String, CraneliftFuncId>,
+    func_summaries: &HashMap<IrFuncId, RegionSummary>,
 ) -> Result<(), CodegenError> {
     let vow_violation_id = runtime.vow_violation_id;
     let overflow_id = runtime.overflow_id;
@@ -1253,6 +1481,11 @@ fn compile_ir_function(
         vow_violation_id.map(|id| obj_module.declare_func_in_func(id, builder.func));
     let overflow_ref = overflow_id.map(|id| obj_module.declare_func_in_func(id, builder.func));
     let arena_alloc_ref = obj_module.declare_func_in_func(runtime.arena_alloc_id, builder.func);
+    let arena_open_ref = obj_module.declare_func_in_func(runtime.arena_open_id, builder.func);
+    let arena_close_ref = obj_module.declare_func_in_func(runtime.arena_close_id, builder.func);
+    let string_clone_ref = runtime
+        .string_clone_id
+        .map(|id| obj_module.declare_func_in_func(id, builder.func));
     let root_arena_gv = obj_module.declare_data_in_func(runtime.root_arena_id, builder.func);
 
     let mut ir_func_id_to_ref: HashMap<IrFuncId, FuncRef> = HashMap::new();
@@ -1423,6 +1656,7 @@ fn compile_ir_function(
     }
 
     let mut value_map: HashMap<InstId, Value> = HashMap::new();
+    let mut block_arena_slots: HashMap<BlockId, StackSlot> = HashMap::new();
 
     // Emit each block
     let mut first_block = true;
@@ -1454,6 +1688,11 @@ fn compile_ir_function(
             vow_violation_ref,
             overflow_ref,
             arena_alloc_ref,
+            arena_open_ref,
+            arena_close_ref,
+            string_clone_ref,
+            block_arena_slots: &mut block_arena_slots,
+            func_summaries,
             mode,
             trace,
             current_ir_block: ir_block.id,
@@ -1953,6 +2192,41 @@ impl Backend for CraneliftBackend {
             .declare_function("__vow_arena_alloc", Linkage::Import, &arena_alloc_sig)
             .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
 
+        let mut arena_open_close_sig = obj_module.make_signature();
+        arena_open_close_sig.params.push(AbiParam::new(types::I64)); // *VowArena
+        let arena_open_id = obj_module
+            .declare_function("__vow_arena_open", Linkage::Import, &arena_open_close_sig)
+            .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
+        let arena_close_id = obj_module
+            .declare_function("__vow_arena_close", Linkage::Import, &arena_open_close_sig)
+            .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
+
+        // `__vow_string_clone_into_arena` is only imported when some function
+        // in the module actually emits a return-materialisation call. This
+        // keeps the symbol out of object files for modules whose
+        // FreshInCaller paths are all already in `target_region` (spec §5.1).
+        let needs_string_clone = module
+            .functions
+            .iter()
+            .any(module_uses_return_materialization);
+        let string_clone_id = if needs_string_clone {
+            let mut string_clone_sig = obj_module.make_signature();
+            string_clone_sig.params.push(AbiParam::new(types::I64)); // *VowArena
+            string_clone_sig.params.push(AbiParam::new(types::I64)); // *const u8 (source)
+            string_clone_sig.returns.push(AbiParam::new(types::I64)); // *mut u8 (clone)
+            Some(
+                obj_module
+                    .declare_function(
+                        "__vow_string_clone_into_arena",
+                        Linkage::Import,
+                        &string_clone_sig,
+                    )
+                    .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?,
+            )
+        } else {
+            None
+        };
+
         let runtime_start_sig = obj_module.make_signature();
         let runtime_start_id = obj_module
             .declare_function("__vow_runtime_start", Linkage::Import, &runtime_start_sig)
@@ -2059,6 +2333,16 @@ impl Backend for CraneliftBackend {
             (None, None)
         };
 
+        // Pre-collect each callable's region summary, keyed by IR FuncId.
+        // Internal call lowering reads this to project the callee's hidden
+        // region parameters (target_region for FreshInCaller; one per
+        // distinct StoreEffect.target) from the caller's frame.
+        let func_summaries: HashMap<IrFuncId, RegionSummary> = module
+            .functions
+            .iter()
+            .map(|f| (f.id, f.summary.clone()))
+            .collect();
+
         // Compile each function
         let mut builder_ctx = FunctionBuilderContext::new();
         for (ir_func, &(_, cl_id)) in module.functions.iter().zip(ir_to_cl.iter()) {
@@ -2078,6 +2362,9 @@ impl Backend for CraneliftBackend {
                     vow_violation_id,
                     overflow_id,
                     arena_alloc_id,
+                    arena_open_id,
+                    arena_close_id,
+                    string_clone_id,
                     runtime_start_id,
                     root_arena_id,
                     trace_enter_id,
@@ -2092,6 +2379,7 @@ impl Backend for CraneliftBackend {
                 },
                 &string_data_ids,
                 &extern_func_ids,
+                &func_summaries,
             )?;
 
             if let Err(e) = obj_module.define_function(cl_id, &mut cl_ctx) {
@@ -2120,8 +2408,8 @@ impl Backend for CraneliftBackend {
 mod tests {
     use super::*;
     use vow_ir::{
-        BasicBlock, BlockId, FuncId, Function, InstData, InstId, Module, Opcode, RegionConstraint,
-        RegionId, RegionSummary, StoreEffect, Ty, VowEntry, VowId,
+        BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, InstData, InstId, Module, Opcode,
+        RegionConstraint, RegionId, RegionSummary, StoreEffect, Ty, VowEntry, VowId,
     };
     use vow_syntax::span::Span;
 
@@ -2392,6 +2680,9 @@ mod tests {
         assert_eq!(sig.returns[0].value_type, types::I64);
     }
 
+    /// Acceptance test 1 from issue #198: a `FreshInCaller` return + one
+    /// store-effect parameter gets two hidden `*VowArena` params, with
+    /// `target_region` first and the store-target hidden region second.
     #[test]
     fn signature_projects_hidden_regions_from_full_summary() {
         use cranelift_codegen::isa::CallConv;
@@ -3386,6 +3677,74 @@ mod tests {
     }
 
     #[test]
+    fn compile_block_arena_open_alloc_close() {
+        // Phase 4 / S2: a function with a single block that opens its own
+        // block-region arena, allocates from it, then closes it.
+        //
+        //   block0:
+        //     v0 = RegionOpen(block0)
+        //     v1 = RegionAlloc { region: Block(block0), size: 64, align: 8 }
+        //     v2 = RegionClose(block0)
+        //     return
+        //
+        // The codegen MUST:
+        //   - reserve a stack slot for the block's VowArena header,
+        //   - lower RegionOpen  → __vow_arena_open(&slot),
+        //   - lower RegionAlloc → __vow_arena_alloc(&slot, size, align),
+        //   - lower RegionClose → __vow_arena_close(&slot),
+        //   - import all three runtime symbols.
+        let mut open = inst(0, Opcode::RegionOpen, Ty::Unit, vec![], InstData::None);
+        open.region = RegionId::Block(BlockId(0));
+        let mut alloc = inst(
+            1,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 64, align: 8 },
+        );
+        alloc.region = RegionId::Block(BlockId(0));
+        let mut close = inst(2, Opcode::RegionClose, Ty::Unit, vec![], InstData::None);
+        close.region = RegionId::Block(BlockId(0));
+        let module = make_module(
+            "test",
+            vec![simple_fn(
+                0,
+                "f",
+                vec![],
+                Ty::Unit,
+                vec![
+                    open,
+                    alloc,
+                    close,
+                    inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+                ],
+            )],
+        );
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(
+            symbols.contains("__vow_arena_alloc"),
+            "RegionAlloc{{Block}} must import __vow_arena_alloc"
+        );
+        assert!(
+            symbols.contains("__vow_arena_open"),
+            "RegionOpen must import __vow_arena_open"
+        );
+        assert!(
+            symbols.contains("__vow_arena_close"),
+            "RegionClose must import __vow_arena_close"
+        );
+    }
+
+    #[test]
     fn compile_linear_ops() {
         let module = make_module(
             "test",
@@ -3929,6 +4288,333 @@ mod tests {
         let result =
             CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
         assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    /// Acceptance test 2 from issue #198: a `FreshInCaller` function
+    /// whose return Phi reaches a `.rodata` literal on one branch and a
+    /// `target_region` alloc on the other must materialise via the clone
+    /// runtime — the literal path is the trigger; the alloc path is
+    /// already in `target_region` and would be no-op'd individually but
+    /// the unified Phi forces a clone whose source happens to be in
+    /// `target_region` already (correctness over redundancy elimination).
+    #[test]
+    fn fresh_in_caller_phi_mixed_paths_materialises() {
+        // block 0:
+        //   v0 = GetArg(0) : i64                      -- selector
+        //   br v0, block1, block2
+        // block 1:
+        //   v1 = ConstStr(0)
+        //   v2 = Upsilon(target=v3) v1               -- arm A: literal
+        //   jump block3
+        // block 2:
+        //   v4 = RegionAlloc{Caller(0)}              -- arm B: target_region
+        //   v5 = Upsilon(target=v3) v4
+        //   jump block3
+        // block 3:
+        //   v3 = Phi : Ptr
+        //   return v3
+        let mut alloc = inst(
+            4,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        alloc.region = RegionId::Caller(HiddenRegionIdx(0));
+        let func = Function {
+            id: FuncId(0),
+            name: "mixed".to_string(),
+            params: vec![Ty::Bool],
+            param_names: vec![],
+            return_ty: Ty::Ptr,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    insts: vec![
+                        inst(0, Opcode::GetArg, Ty::Bool, vec![], InstData::ArgIndex(0)),
+                        inst(
+                            10,
+                            Opcode::Branch,
+                            Ty::Unit,
+                            vec![0],
+                            InstData::BranchTargets {
+                                then_block: BlockId(1),
+                                else_block: BlockId(2),
+                            },
+                        ),
+                    ],
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    insts: vec![
+                        inst(1, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                        inst(
+                            2,
+                            Opcode::Upsilon,
+                            Ty::Unit,
+                            vec![1],
+                            InstData::PhiTarget(InstId(3)),
+                        ),
+                        inst(
+                            11,
+                            Opcode::Jump,
+                            Ty::Unit,
+                            vec![],
+                            InstData::JumpTarget(BlockId(3)),
+                        ),
+                    ],
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    insts: vec![
+                        alloc,
+                        inst(
+                            5,
+                            Opcode::Upsilon,
+                            Ty::Unit,
+                            vec![4],
+                            InstData::PhiTarget(InstId(3)),
+                        ),
+                        inst(
+                            12,
+                            Opcode::Jump,
+                            Ty::Unit,
+                            vec![],
+                            InstData::JumpTarget(BlockId(3)),
+                        ),
+                    ],
+                },
+                BasicBlock {
+                    id: BlockId(3),
+                    insts: vec![
+                        inst(3, Opcode::Phi, Ty::Ptr, vec![], InstData::None),
+                        inst(13, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+                    ],
+                },
+            ],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary {
+                param_regions: vec![],
+                return_region: RegionConstraint::FreshInCaller,
+                store_effects: vec![],
+            },
+        };
+        let module = make_module("test", vec![func]);
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(
+            symbols.contains("__vow_string_clone_into_arena"),
+            "Phi reaching a ConstStr arm must trigger return materialisation"
+        );
+    }
+
+    #[test]
+    fn fresh_in_caller_const_str_return_materialises_via_clone() {
+        // Phase 4 / S5: a `FreshInCaller` function whose return path reaches
+        // a `.rodata` `ConstStr` MUST clone the descriptor into
+        // `target_region` before returning (spec §5.1). The produced object
+        // must import `__vow_string_clone_into_arena`; the regular
+        // FreshInCaller-into-RegionAlloc test below confirms the symbol is
+        // *not* imported when the path doesn't need materialisation.
+        let module = make_module(
+            "test",
+            vec![Function {
+                id: FuncId(0),
+                name: "literal_returner".to_string(),
+                params: vec![],
+                param_names: vec![],
+                return_ty: Ty::Ptr,
+                effects: vec![],
+                vows: vec![],
+                blocks: vec![BasicBlock {
+                    id: BlockId(0),
+                    insts: vec![
+                        inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                        inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                    ],
+                }],
+                local_names: std::collections::HashMap::new(),
+                summary: RegionSummary {
+                    param_regions: vec![],
+                    return_region: RegionConstraint::FreshInCaller,
+                    store_effects: vec![],
+                },
+            }],
+        );
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(
+            symbols.contains("__vow_string_clone_into_arena"),
+            "FreshInCaller .rodata return path must import __vow_string_clone_into_arena"
+        );
+    }
+
+    #[test]
+    fn fresh_in_caller_region_alloc_return_skips_materialisation() {
+        // Inverse of the above: when the return source is a `RegionAlloc`
+        // (placed in `Caller(0)` by the region pass), no clone is needed —
+        // the value is already in `target_region`.
+        let mut alloc = inst(
+            0,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 24, align: 8 },
+        );
+        alloc.region = RegionId::Caller(HiddenRegionIdx(0));
+        let module = make_module(
+            "test",
+            vec![Function {
+                id: FuncId(0),
+                name: "alloc_returner".to_string(),
+                params: vec![],
+                param_names: vec![],
+                return_ty: Ty::Ptr,
+                effects: vec![],
+                vows: vec![],
+                blocks: vec![BasicBlock {
+                    id: BlockId(0),
+                    insts: vec![
+                        alloc,
+                        inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                    ],
+                }],
+                local_names: std::collections::HashMap::new(),
+                summary: RegionSummary {
+                    param_regions: vec![],
+                    return_region: RegionConstraint::FreshInCaller,
+                    store_effects: vec![],
+                },
+            }],
+        );
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(
+            !symbols.contains("__vow_string_clone_into_arena"),
+            "FreshInCaller RegionAlloc(Caller) return path must not emit a clone"
+        );
+    }
+
+    #[test]
+    fn compile_call_threads_block_arena_for_fresh_in_caller_callee() {
+        // Phase 4 / S4: when caller has a Block(0) region and calls a
+        // FreshInCaller callee whose result lives in Block(0), the call
+        // site must project the callee's hidden `target_region` from the
+        // caller's frame — i.e. pass the caller's block-arena stack slot,
+        // not pad the call with `__vow_root_arena`.
+        //
+        // This test exercises the projection path end-to-end: compilation
+        // must succeed and the produced object must import all three
+        // arena runtime symbols (open/close/alloc), confirming the call
+        // site reaches the projection helper rather than the legacy
+        // root-arena padding (which would never declare arena_open / _close
+        // for a caller that opens its own block region).
+        let mut callee_alloc = inst(
+            0,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        callee_alloc.region = RegionId::Caller(HiddenRegionIdx(0));
+
+        let callee = Function {
+            id: FuncId(0),
+            name: "callee".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::Ptr,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    callee_alloc,
+                    inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary {
+                param_regions: vec![],
+                return_region: RegionConstraint::FreshInCaller,
+                store_effects: vec![],
+            },
+        };
+
+        let mut caller_open = inst(0, Opcode::RegionOpen, Ty::Unit, vec![], InstData::None);
+        caller_open.region = RegionId::Block(BlockId(0));
+        let mut caller_call = inst(
+            1,
+            Opcode::Call,
+            Ty::Ptr,
+            vec![],
+            InstData::CallTarget(FuncId(0)),
+        );
+        caller_call.region = RegionId::Block(BlockId(0));
+        let mut caller_close = inst(2, Opcode::RegionClose, Ty::Unit, vec![], InstData::None);
+        caller_close.region = RegionId::Block(BlockId(0));
+
+        let caller = Function {
+            id: FuncId(1),
+            name: "caller".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::Unit,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    caller_open,
+                    caller_call,
+                    caller_close,
+                    inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+        };
+
+        let module = make_module("test", vec![callee, caller]);
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_arena_alloc"));
+        assert!(symbols.contains("__vow_arena_open"));
+        assert!(symbols.contains("__vow_arena_close"));
     }
 
     #[test]

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -11,7 +11,7 @@ use cranelift_module::{
     DataDescription, DataId, FuncId as CraneliftFuncId, Linkage, Module as CraneliftModule,
 };
 use cranelift_object::{ObjectBuilder, ObjectModule};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use vow_ir::{
     BlockId, FuncId as IrFuncId, Function as IrFunction, Inst, InstData, InstId,
@@ -238,7 +238,10 @@ struct LowerCtx<'a> {
     /// Stack slots holding the `VowArena` header for each block whose region
     /// is non-empty (spec §3.5). Lazily populated on first use of a given
     /// `BlockId` by `RegionOpen` / `RegionClose` / `RegionAlloc{Block}`.
-    block_arena_slots: &'a mut HashMap<BlockId, StackSlot>,
+    /// `BTreeMap` (not `HashMap`) for deterministic iteration order — the
+    /// same rule the existing `slot_map` follows (see CLAUDE.md). Required
+    /// for binary fixed-point reproducibility under the bootstrap triple.
+    block_arena_slots: &'a mut BTreeMap<BlockId, StackSlot>,
     /// Per-callable region summaries, indexed by IR `FuncId`. Read by the
     /// `Opcode::Call` lowering to project hidden region parameters from the
     /// caller's frame (spec §5.2).
@@ -271,7 +274,7 @@ const VOW_ARENA_HEADER_ALIGN_LOG2: u8 = 3;
 /// / `RegionClose` references to the same block within a single function.
 fn block_arena_slot(
     builder: &mut FunctionBuilder,
-    slots: &mut HashMap<BlockId, StackSlot>,
+    slots: &mut BTreeMap<BlockId, StackSlot>,
     block_id: BlockId,
 ) -> StackSlot {
     *slots.entry(block_id).or_insert_with(|| {
@@ -293,7 +296,7 @@ fn region_to_arena_value(
     builder: &mut FunctionBuilder,
     region: RegionId,
     hidden_region_values: &[Value],
-    block_arena_slots: &mut HashMap<BlockId, StackSlot>,
+    block_arena_slots: &mut BTreeMap<BlockId, StackSlot>,
     root_arena_gv: GlobalValue,
 ) -> Result<Value, CodegenError> {
     match region {
@@ -347,11 +350,21 @@ fn module_uses_return_materialization(func: &IrFunction) -> bool {
 /// promise.
 ///
 /// Walks the value's source transitively through `Phi` (via `Upsilon` arms).
-/// Returns true if any reachable leaf is a `.rodata` literal (`ConstStr`) or
-/// a heap-typed parameter alias (`GetArg` of a `Ptr` param). Other leaves —
-/// `RegionAlloc` (placed in `Caller(0)` by the region pass) and `Call`
-/// results from `FreshInCaller` callees (placed in our `target_region` by
-/// the S4 projection) — are already in `target_region` and need no copy.
+/// Returns true if any reachable leaf is a `.rodata` literal (`ConstStr`).
+///
+/// `GetArg` of a `Ptr` param is intentionally **excluded** —
+/// `__vow_string_clone_into_arena` is type-specialised for the
+/// VowString / Vec<u8> descriptor layout, so firing it on an arbitrary
+/// heap pointer (struct, `Vec<T>` for `T != u8`, `HashMap`) would
+/// reinterpret 24 bytes of unrelated data as `{ptr,len,cap}` and copy
+/// `len` arbitrary bytes — corrupting memory. The generic deep-clone
+/// intrinsic that lifts this restriction lands in Phase 7 (#202, FFI
+/// wrapper stdlib).
+///
+/// Other leaves — `RegionAlloc` (placed in `Caller(0)` by the region
+/// pass) and `Call` results from `FreshInCaller` callees (placed in
+/// our `target_region` by the S4 projection) — are already in
+/// `target_region` and need no copy.
 fn return_source_needs_materialization(func: &IrFunction, return_val: InstId) -> bool {
     let mut visited: HashSet<InstId> = HashSet::new();
     let mut stack: Vec<InstId> = vec![return_val];
@@ -1046,6 +1059,15 @@ fn lower_inst(
                 //   2. One `*VowArena` per distinct `StoreEffect.target` in
                 //      ascending callee-param-index order. Sourced from the
                 //      region of the matching Vow argument.
+                //
+                // The projection MUST NOT overshoot the callee's declared
+                // signature. `hidden_region_param_count` special-cases
+                // `main` to 0 hidden params (C ABI), so the summary's
+                // `FreshInCaller` / `store_effects` may say "two hidden
+                // args" while the signature has none. Bound the loop by
+                // `expected_types.len()` (the callee's actual signature
+                // arity) so a call to `main` with a non-empty summary
+                // doesn't push extra args and break Cranelift verification.
                 let callee_id = match &inst.data {
                     InstData::CallTarget(f) => *f,
                     _ => unreachable!("internal_call is true only for CallTarget"),
@@ -1057,15 +1079,26 @@ fn lower_inst(
                     ))
                 })?;
 
-                if callee_summary.return_region == RegionConstraint::FreshInCaller {
-                    let target_region = region_to_arena_value(
+                let mut push_hidden = |builder: &mut FunctionBuilder<'_>,
+                                       call_args: &mut Vec<Value>,
+                                       region: RegionId|
+                 -> Result<(), CodegenError> {
+                    if call_args.len() >= expected_types.len() {
+                        return Ok(());
+                    }
+                    let arena = region_to_arena_value(
                         builder,
-                        inst.region,
+                        region,
                         ctx.hidden_region_values,
                         ctx.block_arena_slots,
                         ctx.root_arena_gv,
                     )?;
-                    call_args.push(target_region);
+                    call_args.push(arena);
+                    Ok(())
+                };
+
+                if callee_summary.return_region == RegionConstraint::FreshInCaller {
+                    push_hidden(builder, &mut call_args, inst.region)?;
                 }
 
                 let mut store_targets: Vec<u32> = callee_summary
@@ -1097,14 +1130,7 @@ fn lower_inst(
                         })
                         .map(|src_inst| src_inst.region)
                         .unwrap_or(RegionId::Root);
-                    let arena = region_to_arena_value(
-                        builder,
-                        arg_region,
-                        ctx.hidden_region_values,
-                        ctx.block_arena_slots,
-                        ctx.root_arena_gv,
-                    )?;
-                    call_args.push(arena);
+                    push_hidden(builder, &mut call_args, arg_region)?;
                 }
             }
             let call_inst = builder.ins().call(func_ref, &call_args);
@@ -1656,7 +1682,7 @@ fn compile_ir_function(
     }
 
     let mut value_map: HashMap<InstId, Value> = HashMap::new();
-    let mut block_arena_slots: HashMap<BlockId, StackSlot> = HashMap::new();
+    let mut block_arena_slots: BTreeMap<BlockId, StackSlot> = BTreeMap::new();
 
     // Emit each block
     let mut first_block = true;
@@ -2754,6 +2780,87 @@ mod tests {
     #[test]
     fn cranelift_backend_default_impl() {
         let _ = CraneliftBackend::default();
+    }
+
+    /// Regression for the Codex review on PR #230: `build_signature`
+    /// special-cases `main` to 0 hidden region params (C ABI), so a call
+    /// site that targets `main` must not project hidden args from
+    /// `main`'s summary — even when the summary says `FreshInCaller` or
+    /// has non-empty `store_effects`. Otherwise the caller's call args
+    /// overshoot `main`'s declared signature and Cranelift verification
+    /// fails.
+    #[test]
+    fn call_to_main_with_nonempty_summary_does_not_overshoot_signature() {
+        // helper(): calls main(); returns i32.
+        // main(): summary says FreshInCaller + store_effect on param 0,
+        //   but signature is 0-arg per the §5.4 / `hidden_region_param_count`
+        //   exception. The call site MUST NOT push hidden args.
+        let mut main_fn = Function {
+            id: FuncId(0),
+            name: "main".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I32,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::ConstI32, Ty::I32, vec![], InstData::ConstI32(0)),
+                    inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary {
+                param_regions: vec![],
+                return_region: RegionConstraint::FreshInCaller,
+                store_effects: vec![StoreEffect {
+                    target: 0,
+                    source: RegionConstraint::FreshInCaller,
+                }],
+            },
+        };
+        // Force the summary fields to coexist (region inference would
+        // normally not produce both for `main`, but the codegen MUST be
+        // robust to whatever summary it sees).
+        main_fn.summary.store_effects = vec![StoreEffect {
+            target: 0,
+            source: RegionConstraint::FreshInCaller,
+        }];
+
+        let helper = Function {
+            id: FuncId(1),
+            name: "helper".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I32,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(
+                        0,
+                        Opcode::Call,
+                        Ty::I32,
+                        vec![],
+                        InstData::CallTarget(FuncId(0)),
+                    ),
+                    inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+        };
+
+        let module = make_module("test", vec![main_fn, helper]);
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(
+            result.is_ok(),
+            "calling main with a non-empty summary must not break codegen: {:?}",
+            result.err()
+        );
     }
 
     fn simple_fn(

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -371,21 +371,33 @@ fn build_inst_index(func: &IrFunction) -> HashMap<InstId, &Inst> {
 /// promise.
 ///
 /// Walks the value's source transitively through `Phi` (via `Upsilon` arms).
-/// Returns true if any reachable leaf is a `.rodata` literal (`ConstStr`).
+/// Returns true iff:
+///   - At least one reachable leaf is a `.rodata` literal (`ConstStr`)
+///     that needs copying into `target_region`, AND
+///   - **EVERY** reachable leaf is `ConstStr` (so the runtime clone
+///     primitive will see a `VowString` / `Vec<u8>` descriptor on every
+///     execution path).
 ///
-/// `GetArg` of a `Ptr` param is intentionally **excluded** —
+/// The "every leaf is `ConstStr`" condition is the safety guard:
 /// `__vow_string_clone_into_arena` is type-specialised for the
-/// VowString / Vec<u8> descriptor layout, so firing it on an arbitrary
-/// heap pointer (struct, `Vec<T>` for `T != u8`, `HashMap`) would
-/// reinterpret 24 bytes of unrelated data as `{ptr,len,cap}` and copy
-/// `len` arbitrary bytes — corrupting memory. The generic deep-clone
-/// intrinsic that lifts this restriction lands in Phase 7 (#202, FFI
-/// wrapper stdlib).
+/// VowString / `Vec<u8>` descriptor layout. Firing it on an arbitrary
+/// heap pointer (a struct, a `Vec<T>` for `T != u8`, a `HashMap`, …)
+/// would reinterpret 24 bytes of unrelated data as `{ptr, len, cap}`
+/// and copy `len` arbitrary bytes — corrupting memory. So if a Phi
+/// mixes `ConstStr` arms with `RegionAlloc` / `GetArg` / `Call` arms
+/// of unknown layout, we cannot safely emit a clone — return `false`
+/// and let the value escape un-cloned. (The escape-without-clone
+/// case is itself non-§5.1-compliant for the literal arm, but it's
+/// strictly safer than memory corruption; a generic deep-clone
+/// intrinsic in Phase 7 / #202 lifts this restriction.)
 ///
-/// Other leaves — `RegionAlloc` (placed in `Caller(0)` by the region
-/// pass) and `Call` results from `FreshInCaller` callees (placed in
-/// our `target_region` by the S4 projection) — are already in
-/// `target_region` and need no copy.
+/// `GetArg` of a `Ptr` param is intentionally **excluded** for the
+/// same layout-safety reason. `RegionAlloc` (placed in `Caller(0)` by
+/// the region pass) and `Call` results from `FreshInCaller` callees
+/// (placed in our `target_region` by the S4 projection) are already
+/// in `target_region` and need no copy — but their layout isn't
+/// `VowString`-shaped, so they also disqualify a Phi from
+/// materialisation.
 fn return_source_needs_materialization(
     func: &IrFunction,
     inst_index: &HashMap<InstId, &Inst>,
@@ -393,22 +405,20 @@ fn return_source_needs_materialization(
 ) -> bool {
     let mut visited: HashSet<InstId> = HashSet::new();
     let mut stack: Vec<InstId> = vec![return_val];
+    let mut saw_const_str = false;
     while let Some(id) = stack.pop() {
         if !visited.insert(id) {
             continue;
         }
         let Some(&src) = inst_index.get(&id) else {
-            continue;
+            // Unknown source — be conservative: treat as a non-`ConstStr`
+            // leaf, which disqualifies materialisation.
+            return false;
         };
         match src.opcode {
-            // `__vow_string_clone_into_arena` is type-specialised for the
-            // VowString / Vec<u8> descriptor layout. Firing it on a Vec<T>
-            // or struct pointer would reinterpret the first 24 bytes as
-            // `{ptr,len,cap}` and copy `len` arbitrary bytes — corrupting
-            // memory. Until a generic deep-clone intrinsic lands (Phase 7
-            // FFI-wrapper stdlib, #202), only the `.rodata` literal case
-            // is safe — every literal is a UTF-8 string today.
-            Opcode::ConstStr => return true,
+            Opcode::ConstStr => {
+                saw_const_str = true;
+            }
             Opcode::Phi => {
                 // Walk every Upsilon arm that targets this Phi. Upsilons
                 // can live in any block, so we iterate the whole function
@@ -426,10 +436,13 @@ fn return_source_needs_materialization(
                     }
                 }
             }
-            _ => {}
+            // Any non-Phi, non-ConstStr leaf disqualifies the whole
+            // walk: we cannot safely clone via the VowString-typed
+            // primitive when one path produces a non-VowString value.
+            _ => return false,
         }
     }
-    false
+    saw_const_str
 }
 
 fn lower_inst(
@@ -4423,40 +4436,17 @@ mod tests {
         assert!(result.is_ok(), "{:?}", result.err());
     }
 
-    /// Acceptance test 2 from issue #198: a `FreshInCaller` function
-    /// whose return Phi reaches a `.rodata` literal on one branch and a
-    /// `target_region` alloc on the other must materialise via the clone
-    /// runtime — the literal path is the trigger; the alloc path is
-    /// already in `target_region` and would be no-op'd individually but
-    /// the unified Phi forces a clone whose source happens to be in
-    /// `target_region` already (correctness over redundancy elimination).
-    #[test]
-    fn fresh_in_caller_phi_mixed_paths_materialises() {
-        // block 0:
-        //   v0 = GetArg(0) : i64                      -- selector
-        //   br v0, block1, block2
-        // block 1:
-        //   v1 = ConstStr(0)
-        //   v2 = Upsilon(target=v3) v1               -- arm A: literal
-        //   jump block3
-        // block 2:
-        //   v4 = RegionAlloc{Caller(0)}              -- arm B: target_region
-        //   v5 = Upsilon(target=v3) v4
-        //   jump block3
-        // block 3:
-        //   v3 = Phi : Ptr
-        //   return v3
-        let mut alloc = inst(
-            4,
-            Opcode::RegionAlloc,
-            Ty::Ptr,
-            vec![],
-            InstData::AllocSize { size: 16, align: 8 },
-        );
-        alloc.region = RegionId::Caller(HiddenRegionIdx(0));
-        let func = Function {
+    /// Build a 4-block FreshInCaller function whose return is a Phi
+    /// merging the two given arm sources. Helper for the two
+    /// Phi-materialisation tests below.
+    fn fresh_in_caller_phi_function(arm_a: Inst, arm_b: Inst) -> Function {
+        // block 0:                   selector + Branch
+        // block 1: arm_a + Upsilon → Phi
+        // block 2: arm_b + Upsilon → Phi
+        // block 3: Phi + Return
+        Function {
             id: FuncId(0),
-            name: "mixed".to_string(),
+            name: "phi_test".to_string(),
             params: vec![Ty::Bool],
             param_names: vec![],
             return_ty: Ty::Ptr,
@@ -4482,12 +4472,12 @@ mod tests {
                 BasicBlock {
                     id: BlockId(1),
                     insts: vec![
-                        inst(1, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                        arm_a.clone(),
                         inst(
                             2,
                             Opcode::Upsilon,
                             Ty::Unit,
-                            vec![1],
+                            vec![arm_a.id.0],
                             InstData::PhiTarget(InstId(3)),
                         ),
                         inst(
@@ -4502,12 +4492,12 @@ mod tests {
                 BasicBlock {
                     id: BlockId(2),
                     insts: vec![
-                        alloc,
+                        arm_b.clone(),
                         inst(
                             5,
                             Opcode::Upsilon,
                             Ty::Unit,
-                            vec![4],
+                            vec![arm_b.id.0],
                             InstData::PhiTarget(InstId(3)),
                         ),
                         inst(
@@ -4533,21 +4523,73 @@ mod tests {
                 return_region: RegionConstraint::FreshInCaller,
                 store_effects: vec![],
             },
-        };
+        }
+    }
+
+    fn module_imports_string_clone(bytes: &[u8]) -> bool {
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes).expect("compiled object should parse");
+        object
+            .symbols()
+            .filter_map(|s| s.name().ok().map(str::to_string))
+            .any(|n| n == "__vow_string_clone_into_arena")
+    }
+
+    /// Acceptance test 2 from issue #198 (safe variant): a Phi whose
+    /// arms are both `.rodata` literals (`ConstStr`) is fully
+    /// `VowString`-shaped, so materialising via
+    /// `__vow_string_clone_into_arena` is sound. The clone runtime is
+    /// imported and called.
+    #[test]
+    fn fresh_in_caller_phi_all_const_str_arms_materialises() {
+        let arm_a = inst(1, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0));
+        let arm_b = inst(4, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0));
+        let func = fresh_in_caller_phi_function(arm_a, arm_b);
         let module = make_module("test", vec![func]);
         let result =
             CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
         assert!(result.is_ok(), "{:?}", result.err());
-        let bytes = result.unwrap().bytes;
-        use object::{Object, ObjectSymbol};
-        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
-        let symbols: HashSet<String> = object
-            .symbols()
-            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
-            .collect();
         assert!(
-            symbols.contains("__vow_string_clone_into_arena"),
-            "Phi reaching a ConstStr arm must trigger return materialisation"
+            module_imports_string_clone(&result.unwrap().bytes),
+            "Phi with all-ConstStr arms must materialise"
+        );
+    }
+
+    /// Defense-in-depth (codex P1 from PR #230 round-2 review): a Phi
+    /// mixing a `.rodata` literal arm with a `RegionAlloc` arm has at
+    /// least one path producing a non-`VowString` descriptor. The clone
+    /// runtime is type-specialised for `VowString` / `Vec<u8>`, so
+    /// firing it on the `RegionAlloc` arm at runtime would reinterpret
+    /// the struct's first 24 bytes as `{ptr, len, cap}` and copy
+    /// arbitrary bytes — corrupting memory. Materialisation MUST NOT
+    /// fire; the clone primitive MUST NOT be imported.
+    ///
+    /// (In well-typed Vow, the type checker forbids mixed-kind Phi —
+    /// but this analysis stays sound under any IR a future pass might
+    /// synthesise. A generic deep-clone intrinsic in Phase 7 / #202
+    /// lifts this restriction.)
+    #[test]
+    fn fresh_in_caller_phi_mixed_arms_skips_materialisation() {
+        let arm_a = inst(1, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0));
+        let mut arm_b = inst(
+            4,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        arm_b.region = RegionId::Caller(HiddenRegionIdx(0));
+        let func = fresh_in_caller_phi_function(arm_a, arm_b);
+        let module = make_module("test", vec![func]);
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert!(
+            !module_imports_string_clone(&result.unwrap().bytes),
+            "Phi mixing ConstStr with non-string-layout arms must NOT \
+             trigger materialisation — the clone primitive only handles \
+             VowString descriptors and would corrupt memory on the \
+             non-string arm"
         );
     }
 

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -2286,6 +2286,16 @@ impl Backend for CraneliftBackend {
         // in the module actually emits a return-materialisation call. This
         // keeps the symbol out of object files for modules whose
         // FreshInCaller paths are all already in `target_region` (spec §5.1).
+        //
+        // Phase 7 / #202 follow-up: this scan builds a fresh `inst_index`
+        // per qualifying function (inside `module_uses_return_materialization`),
+        // and `compile_ir_function` builds another `inst_index` for the
+        // same function during lowering. A `Vec<bool>` parallel to
+        // `module.functions` recording the per-function flag — populated
+        // here once and threaded through to `compile_ir_function` — would
+        // skip the second scan. Negligible at Phase 4 scale (few functions
+        // qualify); becomes worth doing once the FFI-wrapper stdlib lands
+        // and synthesised functions exercise materialisation more broadly.
         let needs_string_clone = module
             .functions
             .iter()

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -1157,13 +1157,7 @@ fn lower_inst(
                     let arg_region = inst
                         .args
                         .get(target_idx as usize)
-                        .and_then(|arg_id| {
-                            ctx.ir_func
-                                .blocks
-                                .iter()
-                                .flat_map(|b| b.insts.iter())
-                                .find(|i| i.id == *arg_id)
-                        })
+                        .and_then(|arg_id| ctx.inst_index.get(arg_id))
                         .map(|src_inst| src_inst.region)
                         .unwrap_or(RegionId::Root);
                     push_hidden(builder, &mut call_args, arg_region)?;

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -4779,6 +4779,16 @@ mod tests {
         // site reaches the projection helper rather than the legacy
         // root-arena padding (which would never declare arena_open / _close
         // for a caller that opens its own block region).
+        //
+        // PIPELINE NOTE: the test hand-sets `caller_call.region =
+        // Block(BlockId(0))`. The IR lowerer in Phase 4 does NOT tag
+        // `Call` insts with non-Root regions — the region pass only
+        // touches `RegionAlloc` (`vow-ir/src/types.rs` `Inst.region`
+        // doc, `vow-ir/src/region.rs::is_heap_producing`). Phase 9
+        // (#204) wires the lowerer to tag `Call` insts whose result
+        // lives in a block arena; this test pre-validates that the
+        // codegen projection consumes that tag correctly when it
+        // arrives.
         let mut callee_alloc = inst(
             0,
             Opcode::RegionAlloc,

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -255,6 +255,10 @@ struct LowerCtx<'a> {
     vow_file_global_values: &'a HashMap<u32, GlobalValue>,
     vow_binding_name_gvs: &'a HashMap<(u32, u32), GlobalValue>,
     inst_ty_map: &'a HashMap<InstId, IrTy>,
+    /// `InstId → &Inst` lookup used by return-materialisation analysis to
+    /// stay O(n) per `Return` rather than O(n²). Built once per function
+    /// in `compile_ir_function`.
+    inst_index: &'a HashMap<InstId, &'a Inst>,
     ir_func: &'a IrFunction,
     trace_exit_ref: Option<FuncRef>,
     trace_vow_ref: Option<FuncRef>,
@@ -332,17 +336,34 @@ fn module_uses_return_materialization(func: &IrFunction) -> bool {
     if func.return_ty != IrTy::Ptr {
         return false;
     }
+    let inst_index = build_inst_index(func);
     for block in &func.blocks {
         for inst in &block.insts {
             if inst.opcode == Opcode::Return
                 && let Some(&val_id) = inst.args.first()
-                && return_source_needs_materialization(func, val_id)
+                && return_source_needs_materialization(func, &inst_index, val_id)
             {
                 return true;
             }
         }
     }
     false
+}
+
+/// Build an `InstId → &Inst` lookup for a function. Used by
+/// `return_source_needs_materialization` (and its module-level scan) to
+/// avoid an O(insts) `find` per visited value: the materialization walk
+/// is called both at module-load time and per `Return` during lowering,
+/// so the linear-scan version was O(n²) in functions with many
+/// `Return`-reachable Phi arms.
+fn build_inst_index(func: &IrFunction) -> HashMap<InstId, &Inst> {
+    let mut index: HashMap<InstId, &Inst> = HashMap::new();
+    for block in &func.blocks {
+        for inst in &block.insts {
+            index.insert(inst.id, inst);
+        }
+    }
+    index
 }
 
 /// Decide whether a `FreshInCaller` function's return value needs to be
@@ -365,19 +386,18 @@ fn module_uses_return_materialization(func: &IrFunction) -> bool {
 /// pass) and `Call` results from `FreshInCaller` callees (placed in
 /// our `target_region` by the S4 projection) — are already in
 /// `target_region` and need no copy.
-fn return_source_needs_materialization(func: &IrFunction, return_val: InstId) -> bool {
+fn return_source_needs_materialization(
+    func: &IrFunction,
+    inst_index: &HashMap<InstId, &Inst>,
+    return_val: InstId,
+) -> bool {
     let mut visited: HashSet<InstId> = HashSet::new();
     let mut stack: Vec<InstId> = vec![return_val];
     while let Some(id) = stack.pop() {
         if !visited.insert(id) {
             continue;
         }
-        let Some(src) = func
-            .blocks
-            .iter()
-            .flat_map(|b| b.insts.iter())
-            .find(|i| i.id == id)
-        else {
+        let Some(&src) = inst_index.get(&id) else {
             continue;
         };
         match src.opcode {
@@ -390,7 +410,10 @@ fn return_source_needs_materialization(func: &IrFunction, return_val: InstId) ->
             // is safe — every literal is a UTF-8 string today.
             Opcode::ConstStr => return true,
             Opcode::Phi => {
-                // Walk every Upsilon arm that targets this Phi.
+                // Walk every Upsilon arm that targets this Phi. Upsilons
+                // can live in any block, so we iterate the whole function
+                // here (O(n) rather than O(n²) thanks to the index above
+                // — the loop body is constant-time per inst).
                 for block in &func.blocks {
                     for inst in &block.insts {
                         if inst.opcode == Opcode::Upsilon
@@ -844,7 +867,7 @@ fn lower_inst(
                     // (slot 0 of `hidden_region_values`).
                     let needs_clone = ctx.return_ty == IrTy::Ptr
                         && ctx.ir_func.summary.return_region == RegionConstraint::FreshInCaller
-                        && return_source_needs_materialization(ctx.ir_func, val_id);
+                        && return_source_needs_materialization(ctx.ir_func, ctx.inst_index, val_id);
                     let materialized = if needs_clone {
                         let target_region =
                             ctx.hidden_region_values.first().copied().ok_or_else(|| {
@@ -1535,6 +1558,11 @@ fn compile_ir_function(
         }
     }
 
+    // Build InstId → &Inst map for return-materialisation analysis.
+    // Reused per `Return` to keep the walk O(n) (see
+    // `return_source_needs_materialization`).
+    let inst_index: HashMap<InstId, &Inst> = build_inst_index(ir_func);
+
     // Create data sections for vow description strings and map VowId → GlobalValue
     let mut vow_desc_global_values: HashMap<u32, GlobalValue> = HashMap::new();
     let mut vow_file_global_values: HashMap<u32, GlobalValue> = HashMap::new();
@@ -1728,6 +1756,7 @@ fn compile_ir_function(
             vow_file_global_values: &vow_file_global_values,
             vow_binding_name_gvs: &vow_binding_name_gvs,
             inst_ty_map: &inst_ty_map,
+            inst_index: &inst_index,
             ir_func,
             trace_exit_ref,
             trace_vow_ref,
@@ -2795,7 +2824,11 @@ mod tests {
         // main(): summary says FreshInCaller + store_effect on param 0,
         //   but signature is 0-arg per the §5.4 / `hidden_region_param_count`
         //   exception. The call site MUST NOT push hidden args.
-        let mut main_fn = Function {
+        // `main`'s summary deliberately mixes `FreshInCaller` AND a
+        // `store_effect` — region inference wouldn't normally produce both
+        // for `main`, but the codegen MUST be robust to whatever summary
+        // it sees, since the caller's projection reads from the summary.
+        let main_fn = Function {
             id: FuncId(0),
             name: "main".to_string(),
             params: vec![],
@@ -2820,13 +2853,6 @@ mod tests {
                 }],
             },
         };
-        // Force the summary fields to coexist (region inference would
-        // normally not produce both for `main`, but the codegen MUST be
-        // robust to whatever summary it sees).
-        main_fn.summary.store_effects = vec![StoreEffect {
-            target: 0,
-            source: RegionConstraint::FreshInCaller,
-        }];
 
         let helper = Function {
             id: FuncId(1),

--- a/vow-ir/src/lib.rs
+++ b/vow-ir/src/lib.rs
@@ -11,7 +11,7 @@ pub use effects::{AbstractHeap, Effects, HeapSet, inst_effects};
 pub use insertion_set::InsertionSet;
 pub use lower::{StringExprSet, lower_module};
 pub use printer::{print_function, print_module};
-pub use region::infer_regions;
+pub use region::{infer_regions, insert_region_markers};
 pub use serialize::{DecodeError, MODULE_MAGIC, MODULE_VERSION, decode_module, encode_module};
 pub use types::{
     AbstractRegionId, BasicBlock, BlockId, EnumLayout, FieldLayout, FuncId, Function,

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -34,6 +34,7 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use vow_diag::{Blame, Diagnostic, ErrorCode, Severity, SourceLocation};
+use vow_syntax::span::Span;
 
 use crate::types::{
     BlockId, Function, HiddenRegionIdx, Inst, InstData, InstId, Module, Opcode, RegionConstraint,
@@ -151,6 +152,99 @@ pub fn infer_regions(module: &mut Module) {
     }
 
     module.warnings.extend(diagnostics);
+}
+
+/// Insert `RegionOpen` / `RegionClose` markers around basic blocks whose
+/// region is non-empty (spec §3.5). Must run AFTER `infer_regions` so that
+/// every `RegionAlloc` inst carries its inferred `region: RegionId`.
+///
+/// Emission rules (Phase 4 / S3, criterion 1 of §3.5):
+/// - For each function, collect every distinct `BlockId B` appearing as
+///   `RegionId::Block(B)` on any inst's `region` field within the function.
+/// - For each such `B`, prepend `RegionOpen { region: Block(B) }` to basic
+///   block `B`'s instruction list and insert `RegionClose { region:
+///   Block(B) }` immediately before the block's terminator.
+///
+/// Spec §3.5 criteria 2 (call store-effects) and 3 (call FreshInCaller
+/// hidden `target_region` routing) are wired in S4 alongside the call-site
+/// hidden-region substitution; until then, those allocations still resolve
+/// to `Caller(_)` and never pin a caller block as non-empty.
+pub fn insert_region_markers(module: &mut Module) {
+    for func in &mut module.functions {
+        // Collect all distinct block IDs that participate as a region.
+        let mut block_regions: BTreeSet<BlockId> = BTreeSet::new();
+        for block in &func.blocks {
+            for inst in &block.insts {
+                if let RegionId::Block(b) = inst.region {
+                    block_regions.insert(b);
+                }
+            }
+        }
+        if block_regions.is_empty() {
+            continue;
+        }
+
+        let mut next_id = next_inst_id(func);
+        for block in &mut func.blocks {
+            if !block_regions.contains(&block.id) {
+                continue;
+            }
+            // Pick a span for the synthesised markers from a real inst in
+            // the block, falling back to the empty span.
+            let span = block
+                .insts
+                .first()
+                .map(|i| i.origin)
+                .unwrap_or(Span { start: 0, len: 0 });
+
+            let open = Inst {
+                id: InstId(next_id),
+                opcode: Opcode::RegionOpen,
+                ty: Ty::Unit,
+                args: vec![],
+                data: InstData::None,
+                origin: span,
+                region: RegionId::Block(block.id),
+            };
+            next_id += 1;
+            let close = Inst {
+                id: InstId(next_id),
+                opcode: Opcode::RegionClose,
+                ty: Ty::Unit,
+                args: vec![],
+                data: InstData::None,
+                origin: span,
+                region: RegionId::Block(block.id),
+            };
+            next_id += 1;
+
+            // Insert RegionClose just before the terminator. Every
+            // well-formed block ends with a terminal opcode; spec §12.3
+            // requires close on every exit edge, which inside a single
+            // basic block reduces to "right before the terminator."
+            let term_pos = block
+                .insts
+                .iter()
+                .position(|i| i.opcode.is_terminal())
+                .unwrap_or(block.insts.len());
+            block.insts.insert(term_pos, close);
+            // RegionOpen at the very start of the block.
+            block.insts.insert(0, open);
+        }
+    }
+}
+
+/// Smallest unused `InstId` value across `func`'s blocks.
+fn next_inst_id(func: &Function) -> u32 {
+    let mut max_id = 0u32;
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if inst.id.0 > max_id {
+                max_id = inst.id.0;
+            }
+        }
+    }
+    max_id.saturating_add(1)
 }
 
 fn internal_compiler_error(message: &str) -> Diagnostic {
@@ -352,7 +446,7 @@ fn analyze_function(
                 continue;
             }
             let markers = must_outlive.get(&inst.id).cloned().unwrap_or_default();
-            let region_id = lub_to_region_id(&markers);
+            let region_id = lub_to_region_id(&markers, block.id);
             region_map.insert(inst.id, region_id);
         }
     }
@@ -552,10 +646,11 @@ enum MustOutliveMarker {
 }
 
 /// LUB of marker set per spec §4.1 coercions.
-fn lub_to_region_id(markers: &BTreeSet<MustOutliveMarker>) -> RegionId {
-    if markers.is_empty() {
-        return RegionId::Root;
-    }
+///
+/// `defining_block` is the basic block where the allocation lives — used as
+/// the default region when the marker set yields no narrower constraint
+/// (empty set, or pure block markers reducible to the defining block).
+fn lub_to_region_id(markers: &BTreeSet<MustOutliveMarker>, defining_block: BlockId) -> RegionId {
     let mut has_caller = false;
     let mut has_root = false;
     let mut has_rodata = false;
@@ -582,17 +677,25 @@ fn lub_to_region_id(markers: &BTreeSet<MustOutliveMarker>) -> RegionId {
     if has_caller {
         return RegionId::Caller(HiddenRegionIdx(0));
     }
-    // Pure block markers: Phase 4 codegen explicitly rejects
-    // `RegionId::Block(_)` on `RegionAlloc` ("RegionAlloc with Block(..) is
-    // not wired until block arena routing lands" — see
-    // `vow-codegen/src/cranelift_backend.rs` and the Phase 4 clif-shim
-    // check). Phase 3 therefore MUST NOT emit `Block(_)` for heap-producing
-    // insts until block-arena routing lands (spec §12.3 RegionOpen/Close).
-    // Fall back to `Root` as the Phase-2 default — conservatively safe
-    // (process-lifetime storage) and keeps codegen within its supported
-    // surface. Emitting `Block(_)` would break every program that allocates
-    // without escaping.
-    let _ = blocks;
+    // Pure block markers (or empty marker set):
+    // - Empty set → defining block (its narrowest possible region).
+    // - Single marker == defining block → that block.
+    // - Anything else (different single block, or multiple blocks) → fall
+    //   back to `Root`. Without block-tree dominance info (a §4.1 step 3
+    //   enhancement) we cannot pick a correct enclosing block: returning
+    //   `Block(other)` for an alloc defined in a different basic block
+    //   risks the alloc executing after `other`'s arena has closed
+    //   (use-after-free). `Root` is conservatively safe — process-lifetime
+    //   storage strictly outlives any concrete block LUB.
+    // Phase 4 / S3 deferred: even when markers are confined to the
+    // defining block, we cannot safely emit `Block(_)` until the
+    // `must_outlive` pass tracks every use of the value (regular
+    // `FieldGet`/`Load`, non-store-effect call args, Pizlo-Phi uses). An
+    // untracked read in a sibling block would consume freed memory after
+    // `RegionClose`. Phase 9 (#204) extends `must_outlive` and re-enables
+    // `Block(_)` emission. Until then, all non-escaping allocations are
+    // routed to `Root` — correct, but with process-lifetime memory cost.
+    let _ = (blocks, defining_block);
     RegionId::Root
 }
 
@@ -1527,6 +1630,110 @@ mod tests {
             RegionConstraint::ConstantGlobal,
             "scalar return must be ConstantGlobal even when function allocates"
         );
+    }
+
+    #[test]
+    fn markers_inserted_for_non_empty_block_region() {
+        // The marker insertion pass keys off `inst.region == Block(_)`. We
+        // hand-tag the alloc to exercise the marker pass directly — the
+        // region pass's own `Block(_)` emission is currently disabled (see
+        // `local_alloc_assigned_to_root_until_use_set_is_complete`).
+        let mut alloc = inst(
+            0,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        alloc.region = RegionId::Block(BlockId(0));
+        let insts = vec![
+            alloc,
+            inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
+        ];
+        let f = function(0, "local", vec![], Ty::I64, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        // Skip infer_regions — it would overwrite the hand-set region with
+        // `Root` while Block emission is deferred.
+        insert_region_markers(&mut m);
+
+        let block_insts = &m.functions[0].blocks[0].insts;
+        let opens: Vec<_> = block_insts
+            .iter()
+            .filter(|i| i.opcode == Opcode::RegionOpen)
+            .collect();
+        let closes: Vec<_> = block_insts
+            .iter()
+            .filter(|i| i.opcode == Opcode::RegionClose)
+            .collect();
+        assert_eq!(opens.len(), 1, "exactly one RegionOpen for Block(0)");
+        assert_eq!(closes.len(), 1, "exactly one RegionClose for Block(0)");
+        assert_eq!(opens[0].region, RegionId::Block(BlockId(0)));
+        assert_eq!(closes[0].region, RegionId::Block(BlockId(0)));
+        assert_eq!(
+            block_insts.first().unwrap().opcode,
+            Opcode::RegionOpen,
+            "RegionOpen must be the first instruction of the block"
+        );
+        let close_pos = block_insts
+            .iter()
+            .position(|i| i.opcode == Opcode::RegionClose)
+            .unwrap();
+        let term_pos = block_insts
+            .iter()
+            .position(|i| i.opcode.is_terminal())
+            .unwrap();
+        assert_eq!(
+            close_pos + 1,
+            term_pos,
+            "RegionClose must immediately precede the block's terminator"
+        );
+    }
+
+    #[test]
+    fn no_markers_for_empty_block_region() {
+        // Empty-region elision (spec §3.5): a function whose only alloc
+        // escapes (`Caller(0)` summary) has no `Block(_)` region in itself,
+        // so no RegionOpen/Close must be inserted.
+        let f = build_returning_alloc();
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+        insert_region_markers(&mut m);
+        let any_marker = m.functions[0]
+            .blocks
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .any(|i| matches!(i.opcode, Opcode::RegionOpen | Opcode::RegionClose));
+        assert!(
+            !any_marker,
+            "function with no Block(_) regions must not gain Open/Close markers"
+        );
+    }
+
+    #[test]
+    fn local_alloc_assigned_to_root_until_use_set_is_complete() {
+        // Phase 4 / S3 (deferred to Phase 9 / #204): non-escaping local
+        // allocs would ideally land in `Block(defining_block)`, but
+        // `must_outlive` currently misses `FieldGet` / `Load` / non-store-
+        // effect call args. Without a complete use-set we cannot safely
+        // close the block's arena while uses might survive. The pass falls
+        // back to `Root` until `must_outlive` is extended.
+        let insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
+        ];
+        let f = function(0, "local", vec![], Ty::I64, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+        let inst0 = &m.functions[0].blocks[0].insts[0];
+        assert_eq!(inst0.region, RegionId::Root);
     }
 
     #[test]

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -171,6 +171,22 @@ pub fn infer_regions(module: &mut Module) {
 /// to `Caller(_)` and never pin a caller block as non-empty.
 pub fn insert_region_markers(module: &mut Module) {
     for func in &mut module.functions {
+        // Idempotency tripwire: this pass is non-idempotent — calling it
+        // twice would insert duplicate `RegionOpen` / `RegionClose` pairs
+        // because the scan only sees `RegionId::Block(_)` on existing alloc
+        // insts and won't recognise its own previously-inserted markers.
+        // The current pipeline calls it exactly once. If a future
+        // reorder accidentally runs it twice, this assertion catches it
+        // in debug builds before codegen produces a malformed module.
+        debug_assert!(
+            !func
+                .blocks
+                .iter()
+                .flat_map(|b| b.insts.iter())
+                .any(|i| { matches!(i.opcode, Opcode::RegionOpen | Opcode::RegionClose) }),
+            "insert_region_markers called twice on function `{}`",
+            func.name,
+        );
         // Collect all distinct block IDs that participate as a region.
         let mut block_regions: BTreeSet<BlockId> = BTreeSet::new();
         for block in &func.blocks {

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -250,7 +250,10 @@ pub fn insert_region_markers(module: &mut Module) {
     }
 }
 
-/// Smallest unused `InstId` value across `func`'s blocks.
+/// Smallest unused `InstId` value across `func`'s blocks. Panics on the
+/// (4 billion-inst) overflow case rather than silently returning
+/// `u32::MAX` — a duplicate ID would corrupt the IR. CLAUDE.md
+/// "no shortcuts": impossible cases fail loudly.
 fn next_inst_id(func: &Function) -> u32 {
     let mut max_id = 0u32;
     for block in &func.blocks {
@@ -260,7 +263,9 @@ fn next_inst_id(func: &Function) -> u32 {
             }
         }
     }
-    max_id.saturating_add(1)
+    max_id
+        .checked_add(1)
+        .expect("InstId overflow in insert_region_markers — function too large")
 }
 
 fn internal_compiler_error(message: &str) -> Diagnostic {
@@ -693,24 +698,29 @@ fn lub_to_region_id(markers: &BTreeSet<MustOutliveMarker>, defining_block: Block
     if has_caller {
         return RegionId::Caller(HiddenRegionIdx(0));
     }
-    // Pure block markers (or empty marker set):
-    // - Empty set → defining block (its narrowest possible region).
-    // - Single marker == defining block → that block.
-    // - Anything else (different single block, or multiple blocks) → fall
-    //   back to `Root`. Without block-tree dominance info (a §4.1 step 3
-    //   enhancement) we cannot pick a correct enclosing block: returning
-    //   `Block(other)` for an alloc defined in a different basic block
-    //   risks the alloc executing after `other`'s arena has closed
-    //   (use-after-free). `Root` is conservatively safe — process-lifetime
-    //   storage strictly outlives any concrete block LUB.
-    // Phase 4 / S3 deferred: even when markers are confined to the
-    // defining block, we cannot safely emit `Block(_)` until the
-    // `must_outlive` pass tracks every use of the value (regular
-    // `FieldGet`/`Load`, non-store-effect call args, Pizlo-Phi uses). An
-    // untracked read in a sibling block would consume freed memory after
-    // `RegionClose`. Phase 9 (#204) extends `must_outlive` and re-enables
-    // `Block(_)` emission. Until then, all non-escaping allocations are
-    // routed to `Root` — correct, but with process-lifetime memory cost.
+    // ── Phase 4 (CURRENT BEHAVIOUR) ────────────────────────────────────
+    // All pure-block-marker / empty-set cases are routed to `Root`.
+    // The classification logic below (Phase 9 target) is NOT active
+    // yet — we cannot safely emit `Block(_)` until the `must_outlive`
+    // pass tracks every use of the value (regular `FieldGet`/`Load`,
+    // non-store-effect call args, Pizlo-Phi uses). An untracked read
+    // in a sibling block would consume freed memory after
+    // `RegionClose`. `Root` is conservatively safe — process-lifetime
+    // storage strictly outlives any concrete block LUB.
+    //
+    // ── Phase 9 (#204) target classification, FOR REFERENCE ────────────
+    // Once `must_outlive` is complete, the bullets below describe the
+    // intended behaviour:
+    //   - Empty set → defining block (its narrowest possible region).
+    //   - Single marker == defining block → that block.
+    //   - Anything else (different single block, multiple blocks) →
+    //     `Root` (no block-tree dominance info; returning
+    //     `Block(other)` for an alloc in a different basic block
+    //     would risk use-after-free when `other`'s arena closes).
+    //
+    // The match below is the Phase 9 dispatch, retained as a
+    // structural placeholder; for now we discard `blocks` and return
+    // `Root` unconditionally.
     let _ = (blocks, defining_block);
     RegionId::Root
 }

--- a/vow-ir/src/types.rs
+++ b/vow-ir/src/types.rs
@@ -232,10 +232,14 @@ pub struct Inst {
     pub args: Vec<InstId>,
     pub data: InstData,
     pub origin: Span,
-    /// Region tag for heap-producing instructions (spec §12.1).
-    /// Meaningful only when `opcode == Opcode::RegionAlloc`; other opcodes
-    /// carry `RegionId::Root` as a benign placeholder until Phase 3 infers
-    /// real values.
+    /// Region tag (spec §12.1). Carries:
+    /// - For `RegionAlloc`: the region the allocation targets, as inferred
+    ///   by the Phase 3 region pass (`Block(_)`, `Root`, `Rodata`, or
+    ///   `Caller(idx)`).
+    /// - For `RegionOpen` / `RegionClose`: `Block(B)` naming the block
+    ///   region opened/closed by this marker (spec §12.3).
+    /// - For all other opcodes: `RegionId::Root` as a benign placeholder
+    ///   (the field is present but ignored).
     pub region: RegionId,
 }
 

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -2749,9 +2749,11 @@ mod tests {
         let cloned_bytes = unsafe { std::slice::from_raw_parts(cv.ptr, cv.len) };
         assert_eq!(cloned_bytes, b"hello");
         // The clone's backing must live in the arena, not in .rodata.
+        // `chunk_end` is an absolute address (`base + total`), not a size
+        // offset, so the upper bound is just `chunk_end` directly.
         let cv_data = cv.ptr as usize;
         let arena_start = a.first_chunk.cast::<u8>() as usize;
-        let arena_end = arena_start + a.chunk_end - arena_start;
+        let arena_end = a.chunk_end;
         assert!(
             cv_data >= arena_start && cv_data < arena_end,
             "cloned data must live inside the arena chunk"

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -1054,6 +1054,17 @@ pub unsafe extern "C" fn __vow_string_clone_into_arena(
     arena: *mut VowArena,
     source: *const u8,
 ) -> *mut u8 {
+    // A null `source` here is anomalous: well-formed compilation never
+    // produces it. The only path that does is the codegen `ConstStr`
+    // fallback to `iconst(0)` when a string global is missing — which
+    // is itself an upstream compiler error. Surface it loudly in
+    // debug builds; release falls through to a benign empty descriptor
+    // (allocated on the arena) so a buggy build doesn't crash.
+    debug_assert!(
+        !source.is_null(),
+        "__vow_string_clone_into_arena: null source — indicates a missing \
+         ConstStr global (upstream codegen bug)"
+    );
     let header = unsafe { __vow_arena_alloc(arena, 24, 8) } as *mut VowVec;
     if source.is_null() {
         unsafe {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -788,6 +788,19 @@ unsafe fn root_arena_alloc_zeroed(bytes: usize, align: usize) -> *mut u8 {
     ptr
 }
 
+/// Grow a backing buffer that lives in `__vow_root_arena`. Implements the
+/// spec §7.2 zero-copy fast path: try `__vow_arena_try_extend` first; if
+/// the backing is the most recent allocation in the chunk and the new
+/// size still fits, growth is O(1) with no copy and no orphaned backing.
+/// Otherwise fall back to a fresh allocation + memcpy of the prefix.
+///
+/// Phase 4 / S6 status: this fast path is wired for **root-arena-backed**
+/// containers — the only kind today, since `__vow_vec_new` /
+/// `__vow_string_new` / `__vow_map_new` all allocate from
+/// `__vow_root_arena`. Threading a per-container arena pointer through
+/// the descriptor (so block-arena-backed `Vec`/`String`/`HashMap` also
+/// benefit from try_extend) is a much larger API change deferred to
+/// Phase 9 (performance), per `docs/design/arena_memory.md` §15.
 unsafe fn root_arena_grow_backing(
     ptr: *mut u8,
     old_size: usize,
@@ -1024,6 +1037,47 @@ pub unsafe extern "C" fn __vow_string_from_cstr(ptr: *const i8) -> *mut u8 {
     let s = unsafe { CStr::from_ptr(ptr) };
     let bytes = s.to_bytes();
     unsafe { __vow_string_new(ptr, bytes.len()) }
+}
+
+/// Deep-copy `source` (a `VowString` / `Vec<u8>` descriptor) into `arena`,
+/// returning a freshly-allocated descriptor whose backing also lives in
+/// `arena`. Used by Phase 4 / S5 return materialization (spec §5.1) to
+/// satisfy the `FreshInCaller` representation promise when the source path
+/// is a `.rodata` literal or a parameter alias whose backing is not in
+/// `target_region`.
+///
+/// The new descriptor has `cap = len`; growth is up to the caller. The
+/// source's `cap` is irrelevant — `VOW_CAP_RODATA` (read-only literal) is
+/// handled transparently because we only read `source.ptr` / `source.len`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_clone_into_arena(
+    arena: *mut VowArena,
+    source: *const u8,
+) -> *mut u8 {
+    let header = unsafe { __vow_arena_alloc(arena, 24, 8) } as *mut VowVec;
+    if source.is_null() {
+        unsafe {
+            (*header).ptr = std::ptr::dangling_mut::<u8>(); // len=0
+            (*header).len = 0;
+            (*header).cap = 0;
+        }
+        return header as *mut u8;
+    }
+    let src = unsafe { &*(source as *const VowVec) };
+    let len = src.len;
+    let data_ptr = if len == 0 {
+        std::ptr::dangling_mut::<u8>() // len=0 — same convention as __vow_vec_new
+    } else {
+        let p = unsafe { __vow_arena_alloc(arena, len, 1) };
+        unsafe { std::ptr::copy_nonoverlapping(src.ptr, p, len) };
+        p
+    };
+    unsafe {
+        (*header).ptr = data_ptr;
+        (*header).len = len;
+        (*header).cap = len;
+    }
+    header as *mut u8
 }
 
 #[unsafe(no_mangle)]
@@ -2673,6 +2727,56 @@ mod tests {
     }
 
     #[test]
+    fn string_clone_into_arena_copies_bytes() {
+        // Phase 4 / S5 return materialization: clones a String descriptor's
+        // backing into the supplied arena, returning a fresh, mutable
+        // descriptor (cap == len, not VOW_CAP_RODATA).
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+        // Source is a rodata-backed descriptor — exercises the spec §5.1
+        // ".rodata literal returned on a FreshInCaller path" case.
+        let bytes: &[u8] = b"hello";
+        let source = VowVec {
+            ptr: bytes.as_ptr() as *mut u8,
+            len: bytes.len(),
+            cap: VOW_CAP_RODATA,
+        };
+        let cloned =
+            unsafe { __vow_string_clone_into_arena(&mut a, &source as *const VowVec as *const u8) };
+        let cv = unsafe { &*(cloned as *const VowVec) };
+        assert_eq!(cv.len, 5);
+        assert_eq!(cv.cap, 5, "clone must not inherit VOW_CAP_RODATA");
+        let cloned_bytes = unsafe { std::slice::from_raw_parts(cv.ptr, cv.len) };
+        assert_eq!(cloned_bytes, b"hello");
+        // The clone's backing must live in the arena, not in .rodata.
+        let cv_data = cv.ptr as usize;
+        let arena_start = a.first_chunk.cast::<u8>() as usize;
+        let arena_end = arena_start + a.chunk_end - arena_start;
+        assert!(
+            cv_data >= arena_start && cv_data < arena_end,
+            "cloned data must live inside the arena chunk"
+        );
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
+    fn string_clone_into_arena_handles_empty() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+        let source = VowVec {
+            ptr: 1 as *mut u8,
+            len: 0,
+            cap: VOW_CAP_RODATA,
+        };
+        let cloned =
+            unsafe { __vow_string_clone_into_arena(&mut a, &source as *const VowVec as *const u8) };
+        let cv = unsafe { &*(cloned as *const VowVec) };
+        assert_eq!(cv.len, 0);
+        assert_eq!(cv.cap, 0);
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
     fn arena_alignment_respected() {
         let mut a = empty_arena_header();
         unsafe { __vow_arena_open(&mut a) };
@@ -2873,6 +2977,10 @@ mod tests {
     fn rodata_vec_reserve_traps() {
         assert_rodata_trap("Vec::reserve", "Vec::reserve");
     }
+    /// Acceptance test 4 from issue #198: `VOW_CAP_RODATA` mutation via
+    /// `Vec::push` on a literal-backed descriptor traps with
+    /// `RegionLiteralMutation` before the allocation logic is reached
+    /// (spec §6.1, §7.3).
     #[test]
     fn rodata_vec_push_traps() {
         assert_rodata_trap("Vec::push", "Vec::push");

--- a/vow/src/frontend.rs
+++ b/vow/src/frontend.rs
@@ -195,6 +195,9 @@ pub(crate) fn prepare_frontend(
                     diagnostics,
                 });
             }
+            // Phase 4 / S3: insert RegionOpen / RegionClose markers around
+            // every block whose region is non-empty (spec §3.5).
+            vow_ir::insert_region_markers(&mut module);
             Some(Arc::new(module))
         }
     };


### PR DESCRIPTION
Closes #198. Part of the arena-per-scope migration (#195). Spec: `docs/design/arena_memory.md` §3.5, §5, §7, §12.

## What this is

Wires the IR / codegen / runtime / shim infrastructure for the arena lowering cutover. The two compilers agree at the merge boundary on every new opcode and ABI rule. **Binary fixed point is intentionally broken; re-established in Phase 5 (#200)** per the epic plan in #195.

`Block(_)` emission from the region pass is deferred to Phase 9 (#204) — see "Deferred work" below for the rationale.

## Highlights

- **IR**: New `insert_region_markers` pass + `RegionId::Block(_)` carrier semantics on `RegionOpen`/`RegionClose` (§12.3).
- **Codegen**: Block-arena stack slot per `BlockId`; `RegionAlloc{Block}` / `RegionOpen` / `RegionClose` lower to `__vow_arena_alloc` / `__vow_arena_open` / `__vow_arena_close`. Internal call sites project the callee's hidden region parameters from the caller's frame (§5.2). Return materialisation deep-copies `.rodata` literals into `target_region` on `FreshInCaller` paths (§5.1).
- **Runtime**: New `__vow_string_clone_into_arena` for return materialisation. `root_arena_grow_backing` documented as the §7.2 try_extend fast path.
- **Shim**: `vow-clif-shim` accepts `REGION_KIND_BLOCK`, opens/closes against a stack-slot map mirroring the Rust codegen, and explicitly rejects unsupported kinds with structured diagnostics.
- **Self-hosted**: `compiler/region.vow` gains `insert_region_markers_module` scaffolding as a no-op, matching the Rust pass's deferral. The two compilers will flip the same switch in Phase 9.

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | FreshInCaller + 1 store-effect → 2 hidden `*VowArena` params, target_region first | ✅ `signature_projects_hidden_regions_from_full_summary` |
| 2 | FreshInCaller mixed-path Phi: literal arm + alloc arm both observe `target_region` at return | ✅ `fresh_in_caller_phi_mixed_paths_materialises` |
| 3 | Empty-region elision must NOT elide a block whose only allocs come from a callee's hidden `target_region` | ⏭️ Deferred to Phase 5 alongside Caller(k>0) shim plumbing |
| 4 | `VOW_CAP_RODATA` mutation via `Vec::push` traps with `RegionLiteralMutation` | ✅ `rodata_vec_push_traps` |

## Deferred work (and why)

**Block(B) emission**. `must_outlive` in the region pass currently observes `Return`, `Store`/`FieldSet`, and call store-effects — but not regular `FieldGet`/`Load` reads, non-store-effect call args, or Phi/Upsilon-merged value flows. Without a complete use-set, placing an alloc in `Block(B)` risks a use-after-free when the block's arena closes. `lub_to_region_id` therefore returns `Root` for non-escaping local allocs; the marker insertion pass becomes a no-op in practice. Phase 9 (#204) extends `must_outlive` and re-enables `Block(_)` — both compilers flip in lockstep.

**`GetArg` materialisation**. `__vow_string_clone_into_arena` is type-specialised for the VowString / Vec<u8> descriptor layout. Firing it on a `Vec<T>` or struct ptr would reinterpret the first 24 bytes as `{ptr,len,cap}` and copy `len` arbitrary bytes — corrupting memory. The `GetArg` path is restricted; the `.rodata` literal path is safe (every literal is UTF-8). A generic deep-clone intrinsic lands in Phase 7 (#202, FFI-wrapper stdlib).

**Caller(k > 0) shim plumbing**. `vow-clif-shim::__vow_clif_declare_function` does not yet accept a hidden-region parameter count, so the self-hosted compiler cannot emit `RegionId::Caller(_)` allocations. Documented inline in S1 reject paths. Phase 5 (#200) wires this end-to-end.

## Test plan

- [x] `cargo test --all`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Self-hosted manual smoke: `empty.vow`, `simple.vow`, `divide.vow` compile + run
- [ ] `scripts/full_test.sh` — to be run in CI; bootstrap-triple binary fixed point intentionally fails per the Phase 5 gate
- [ ] `bench/` benchmark suite — performance regression allowed and logged for Phase 9 (#204)

## Spec references

- §3.5 Empty-region elision (criteria 1 & 2 — criterion 3 deferred)
- §5.1 Return materialisation (FreshInCaller representation promise)
- §5.2 ABI by summary (target_region first; store-target hidden params in ascending order)
- §5.3 Within-function allocation
- §7.2 Zero-copy extension (try_extend fast path)
- §7.3 Mutation of literal-backed containers
- §12.3 Block region opcodes