### PR TITLE
fix(verify): remove per-pair string-eq cache to avoid unsound verification

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -944,17 +944,12 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64) {
         if a == b {
             out.push_str(str3(String::from("  v"), ids, String::from(" = 1;\n")));
         } else {
-            let lo: i64 = if a < b { a } else { b };
-            let hi: i64 = if a < b { b } else { a };
             let as_: String = i64_to_str(a);
             let bs: String = i64_to_str(b);
-            let los: String = i64_to_str(lo);
-            let his: String = i64_to_str(hi);
             out.push_str(str5(String::from("  v"), ids,
                 String::from(" = (v"), as_, str3(String::from(".len == v"),
                 bs, String::from(".len)"))));
-            out.push_str(str5(String::from(" ? __str_eq_"), los,
-                String::from("_"), his, String::from(" : 0;\n")));
+            out.push_str(String::from(" ? __VERIFIER_nondet_bool() : 0;\n"));
         }
         return;
     }
@@ -1255,52 +1250,6 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
     while ui < ups_sources.len() {
         out.push_str(str3(String::from("  int64_t __ups_"), i64_to_str(ups_sources[ui]), String::from(";\n")));
         ui = ui + 1;
-    }
-
-    // Per-pair nondet cache for abstract __vow_string_eq. Mirrors the Rust
-    // emitter: one shared _Bool per unordered (a, b) pair ensures repeated
-    // comparisons of the same pair agree.
-    let eq_lo: Vec<i64> = Vec::new();
-    let eq_hi: Vec<i64> = Vec::new();
-    bi = 0;
-    while bi < n_blocks {
-        let blk: IrBlock = blocks[bi];
-        let insts: Vec<IrInst> = blk.insts;
-        let mut ii: i64 = 0;
-        while ii < insts.len() {
-            let inst: IrInst = insts[ii];
-            if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN()
-                && inst.ds == String::from("__vow_string_eq") {
-                let ea: Vec<i64> = inst.args;
-                if ea.len() == 2 {
-                    let a: i64 = ea[0];
-                    let b: i64 = ea[1];
-                    if a != b {
-                        let lo: i64 = if a < b { a } else { b };
-                        let hi: i64 = if a < b { b } else { a };
-                        let mut found: bool = false;
-                        let mut pi: i64 = 0;
-                        while pi < eq_lo.len() {
-                            if eq_lo[pi] == lo && eq_hi[pi] == hi { found = true; }
-                            pi = pi + 1;
-                        }
-                        if !found {
-                            eq_lo.push(lo);
-                            eq_hi.push(hi);
-                        }
-                    }
-                }
-            }
-            ii = ii + 1;
-        }
-        bi = bi + 1;
-    }
-    let mut ei: i64 = 0;
-    while ei < eq_lo.len() {
-        out.push_str(str5(String::from("  _Bool __str_eq_"), i64_to_str(eq_lo[ei]),
-            String::from("_"), i64_to_str(eq_hi[ei]),
-            String::from(" = __VERIFIER_nondet_bool();\n")));
-        ei = ei + 1;
     }
 
     bi = 0;

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -786,10 +786,8 @@ fn emit_inst(
                         if a == b {
                             out.push_str(&format!("  v{id} = 1;\n"));
                         } else {
-                            let lo = a.min(b);
-                            let hi = a.max(b);
                             out.push_str(&format!(
-                                "  v{id} = (v{a}.len == v{b}.len) ? __str_eq_{lo}_{hi} : 0;\n"
+                                "  v{id} = (v{a}.len == v{b}.len) ? __VERIFIER_nondet_bool() : 0;\n"
                             ));
                         }
                     }
@@ -1200,39 +1198,6 @@ pub fn emit_c_function_full(
         ups_sources.sort();
         for src in ups_sources {
             out.push_str(&format!("  int64_t __ups_{};\n", src));
-        }
-    }
-
-    // Per-pair nondet cache for abstract __vow_string_eq. A fresh
-    // __VERIFIER_nondet_bool() on every call would let ESBMC pick different
-    // values for the same (a,b) pair, breaking determinism (e.g. body proves
-    // `a.eq(b)` then `ensures: a.eq(b)` fails). Declare one shared bool per
-    // unordered pair (min, max) and reuse it at every call site.
-    {
-        let mut eq_pairs: Vec<(u32, u32)> = Vec::new();
-        for block in &func.blocks {
-            for inst in &block.insts {
-                if inst.opcode == Opcode::Call
-                    && let InstData::CallExtern(ref name) = inst.data
-                    && name == "__vow_string_eq"
-                    && inst.args.len() == 2
-                {
-                    let a = inst.args[0].0;
-                    let b = inst.args[1].0;
-                    if a != b {
-                        let pair = (a.min(b), a.max(b));
-                        if !eq_pairs.contains(&pair) {
-                            eq_pairs.push(pair);
-                        }
-                    }
-                }
-            }
-        }
-        eq_pairs.sort();
-        for (lo, hi) in eq_pairs {
-            out.push_str(&format!(
-                "  _Bool __str_eq_{lo}_{hi} = __VERIFIER_nondet_bool();\n"
-            ));
         }
     }
 
@@ -2910,20 +2875,17 @@ mod tests {
         );
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(
-            c.contains("_Bool __str_eq_1_3 = __VERIFIER_nondet_bool();"),
-            "string eq must declare shared per-pair nondet: {c}"
+            !c.contains("__str_eq_"),
+            "string eq must not cache per-pair nondet state: {c}"
         );
         assert!(
-            c.contains("v4 = (v1.len == v3.len) ? __str_eq_1_3 : 0"),
-            "string eq abstract model must reference shared nondet: {c}"
+            c.contains("v4 = (v1.len == v3.len) ? __VERIFIER_nondet_bool() : 0"),
+            "string eq abstract model must use a fresh nondet per call: {c}"
         );
     }
 
     #[test]
-    fn emit_string_eq_is_deterministic_per_pair() {
-        // Two __vow_string_eq calls on the same (a, b) pair must read the same
-        // cached nondet — otherwise ESBMC can pick different values and reject
-        // contracts like `ensures: a.eq(b)` after the body established it.
+    fn emit_string_eq_uses_fresh_nondet_per_call() {
         use vow_ir::InstId;
         let func = make_func(
             "two_compares",
@@ -2969,19 +2931,14 @@ mod tests {
             ],
         );
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
-        // Exactly one shared nondet declaration for the (1, 3) pair.
-        let decls = c
-            .matches("_Bool __str_eq_1_3 = __VERIFIER_nondet_bool();")
-            .count();
-        assert_eq!(decls, 1, "expected exactly one shared nondet decl: {c}");
-        // Both call sites reference the same cached name.
         assert!(
-            c.contains("v4 = (v1.len == v3.len) ? __str_eq_1_3 : 0"),
-            "first eq call must use cached nondet: {c}"
+            !c.contains("__str_eq_"),
+            "string eq must not emit per-pair cache declarations: {c}"
         );
+        let call_nondet_uses = c.matches("__VERIFIER_nondet_bool()").count();
         assert!(
-            c.contains("v5 = (v3.len == v1.len) ? __str_eq_1_3 : 0"),
-            "swapped-order eq call must use the same cached nondet: {c}"
+            call_nondet_uses >= 2,
+            "expected two string-eq call sites to use fresh nondet values: {c}"
         );
     }
 


### PR DESCRIPTION
### Motivation
- The verification C emitter previously declared one `_Bool __str_eq_<lo>_<hi>` per unordered `(a,b)` string pair and reused it for every `__vow_string_eq` call, which assumed equality was fixed across the function. 
- Vow strings are mutable at runtime (e.g. `__vow_string_push_str`/`__vow_string_push_byte`), so a cached equality can under-approximate behaviors and produce unsound proofs when contents change after a comparison. 
- The change restores a sounder model by avoiding long-lived cached equality state that ignores in-place mutations. 

### Description
- Removed the function-scope per-pair `_Bool __str_eq_*` cache from the Rust emitter `vow-verify/src/c_emitter.rs` and from the self-hosted emitter `compiler/c_emitter.vow`. 
- Emit a fresh `__VERIFIER_nondet_bool()` at each non-reflexive `__vow_string_eq` call site, still guarded by the length-equality check, while keeping reflexive `a == b` comparisons as `1`. 
- Updated unit tests in `vow-verify` to assert that no `__str_eq_*` declarations are emitted and that string-eq sites use fresh nondet calls. 

### Testing
- Ran `cargo test -p vow-verify emit_string_eq -- --nocapture`, which passed. 
- Ran `cargo test -p vow-verify`, which passed all `vow-verify` tests. 
- Attempted `cargo test --all` but it failed in this environment due to network/crates.io download errors (HTTP 403), so full-workspace tests were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e741e22c7483328bc1e06c58aaae10)