### PR TITLE
fix: bound --max-k-step to prevent verification DoS

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -247,9 +247,15 @@ fn emit_ir_warnings(ir_mod: IrModule, dctx: DiagCtx) [io] {
     }
 }
 
-fn validate_limits(vec_max: i64, string_max: i64, hashmap_max: i64) [io] {
+const MAX_ALLOWED_MAX_K_STEP: i64 = 1000;
+
+fn validate_limits(max_k_step: i64, vec_max: i64, string_max: i64, hashmap_max: i64) [io] {
     if vec_max <= 0 || string_max <= 0 || hashmap_max <= 0 {
         eprintln_str(String::from("error: --vec-max, --string-max, and --hashmap-max must be >= 1"));
+        process_exit(1);
+    }
+    if max_k_step <= 0 || max_k_step > MAX_ALLOWED_MAX_K_STEP {
+        eprintln_str(str3(String::from("error: --max-k-step must be in the range 1..=1000 (got "), i64_to_str(max_k_step), String::from(")")));
         process_exit(1);
     }
 }
@@ -278,7 +284,7 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     let string_max: i64 = { if string_max_str.len() > 0 { parse_i64(string_max_str) } else { 256 } };
     let hashmap_max_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
     let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
-    validate_limits(vec_max, string_max, hashmap_max);
+    validate_limits(parse_i64(max_k_step), vec_max, string_max, hashmap_max);
     let use_cache: bool = !has_flag(argv, String::from("--no-cache"));
     let mut solver: String = get_flag_arg(argv, String::from("--solver"));
     let encoding: String = get_flag_arg(argv, String::from("--encoding"));
@@ -381,7 +387,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     let string_max: i64 = { if string_max_str.len() > 0 { parse_i64(string_max_str) } else { 256 } };
     let hashmap_max_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
     let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
-    validate_limits(vec_max, string_max, hashmap_max);
+    validate_limits(parse_i64(max_k_step), vec_max, string_max, hashmap_max);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let handles: Vec<i64> = Vec::new();
     let vow_fn_indices: Vec<i64> = Vec::new();
@@ -569,7 +575,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
     let t_string_max: i64 = { if t_sm_str.len() > 0 { parse_i64(t_sm_str) } else { 256 } };
     let t_hm_str: String = get_flag_arg(argv, String::from("--hashmap-max"));
     let t_hashmap_max: i64 = { if t_hm_str.len() > 0 { parse_i64(t_hm_str) } else { 64 } };
-    validate_limits(t_vec_max, t_string_max, t_hashmap_max);
+    validate_limits(parse_i64(t_max_k_step), t_vec_max, t_string_max, t_hashmap_max);
 
     // Validate path exists
     if fs_exists(path) == 0 {
@@ -821,7 +827,7 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             let vec_max_leg: i64 = { let s: String = get_flag_arg(argv, String::from("--vec-max")); if s.len() > 0 { parse_i64(s) } else { 128 } };
             let string_max_leg: i64 = { let s: String = get_flag_arg(argv, String::from("--string-max")); if s.len() > 0 { parse_i64(s) } else { 256 } };
             let hashmap_max_leg: i64 = { let s: String = get_flag_arg(argv, String::from("--hashmap-max")); if s.len() > 0 { parse_i64(s) } else { 64 } };
-            validate_limits(vec_max_leg, string_max_leg, hashmap_max_leg);
+            validate_limits(parse_i64(max_k_step), vec_max_leg, string_max_leg, hashmap_max_leg);
             emit_ir_warnings(ir_mod, dctx);
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
@@ -4659,7 +4665,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let vec_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--vec-max")); if s.len() > 0 { parse_i64(s) } else { 128 } };
     let string_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--string-max")); if s.len() > 0 { parse_i64(s) } else { 256 } };
     let hashmap_max_c: i64 = { let s: String = get_flag_arg(argv, String::from("--hashmap-max")); if s.len() > 0 { parse_i64(s) } else { 64 } };
-    validate_limits(vec_max_c, string_max_c, hashmap_max_c);
+    validate_limits(parse_i64(max_k_step), vec_max_c, string_max_c, hashmap_max_c);
 
     // Collect per-contract entries into parallel arrays
     let e_vow_ids: Vec<i64> = Vec::new();

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -23,6 +23,8 @@ use vow_verify::{
 use cache::{CachedVerifyResult, VerifyCache};
 use frontend::{FrontendBundle, FrontendError, FrontendGoal, prepare_frontend};
 
+const MAX_ALLOWED_MAX_K_STEP: u32 = 1_000;
+
 // ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
@@ -5607,6 +5609,13 @@ fn run_test_command(
 fn validate_limits(limits: &VerifyLimits) {
     if limits.vec_max == 0 || limits.string_max == 0 || limits.hashmap_max == 0 {
         eprintln!("error: --vec-max, --string-max, and --hashmap-max must be >= 1");
+        std::process::exit(1);
+    }
+    if limits.max_k_step == 0 || limits.max_k_step > MAX_ALLOWED_MAX_K_STEP {
+        eprintln!(
+            "error: --max-k-step must be in the range 1..={MAX_ALLOWED_MAX_K_STEP} (got {})",
+            limits.max_k_step
+        );
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
### Motivation

- The verification flag (`--max-k-step` / previously `--unwind`) was user-controllable and forwarded directly to ESBMC with no upper bound, enabling attackers to request very large unwind/iteration limits and exhaust ESBMC/host resources.  
- A hard ceiling is required to prevent resource-exhaustion (availability) attacks while preserving normal verifier configurability.  
- Both the Rust driver and the self-hosted compiler must enforce the same limit to keep behavior consistent across toolchains.

### Description

- Introduce a hard limit constant `MAX_ALLOWED_MAX_K_STEP` and enforce it in the Rust CLI path by validating `limits.max_k_step` is `1..=1000`, failing fast with a clear error message.  
- Apply the same bound in the self-hosted compiler (`compiler/main.vow`) by adding `MAX_ALLOWED_MAX_K_STEP` and extending `validate_limits` to check the parsed `max_k_step` value.  
- Thread the new validation through all verification entry points in the self-hosted code (`build`, `verify`, `test --verify`, legacy mode, and `contracts`) so every path validates `max_k_step` before invoking ESBMC.

### Testing

- Attempted to run `cargo test --all`, but the run failed in this environment due to crates.io download failures (HTTP 403), so unit/integration tests could not be executed.  
- Attempted to run the repository `scripts/full_test.sh`, but it failed for the same dependency download restriction while building the Rust compiler, so the full test suite could not be completed.  
- Static checks and targeted repository updates were verified (both compilers modified and the validation added), and the change is a minimal, local validation that preserves existing verification behavior for values within the allowed range.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e747e2eb3c8332af92f1721f5a816d)