### PR TITLE
fix: stop writing test binaries to shared /tmp paths

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -679,7 +679,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
 
             if !skip_exec {
                 // Compile to binary
-                let tmp_out: String = str2(str3(String::from("/tmp/vow_test_"), short_name, String::from("_")), i64_to_string(time_unix_ms()));
+                let tmp_out: String = str2(str3(String::from("build/vow_test_"), short_name, String::from("_")), i64_to_string(time_unix_ms()));
                 let result: i64 = clif_emit_module(ir_mod, tmp_out, mode, 0);
                 if result == -1 {
                     let duration: i64 = time_unix_ms() - start_time;

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -599,6 +599,10 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
         }
     }
 
+    // Ensure the build/ output directory exists before emitting test binaries.
+    // Mirrors the Rust runner's std::fs::create_dir_all guard.
+    fs_mkdir(String::from("build"));
+
     let entries_json: Vec<String> = Vec::new();
     let mut passed: i64 = 0;
     let mut failed: i64 = 0;

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -599,8 +599,6 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
         }
     }
 
-    // Ensure the build/ output directory exists before emitting test binaries.
-    // Mirrors the Rust runner's std::fs::create_dir_all guard.
     fs_mkdir(String::from("build"));
 
     let entries_json: Vec<String> = Vec::new();

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -5399,7 +5399,7 @@ fn run_test_command(
         total_density.functions_total += density.functions_total;
         total_density.functions_with_vows += density.functions_with_vows;
 
-        let tmp_out = std::env::temp_dir().join(format!("vow_test_{name}_{}", std::process::id()));
+        let tmp_out = Path::new("build").join(format!("vow_test_{name}_{}", std::process::id()));
         let result = run_pipeline_from_frontend(
             frontend,
             test_file,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -5359,6 +5359,8 @@ fn run_test_command(
         density_pct: 0.0,
     };
 
+    let _ = std::fs::create_dir_all("build");
+
     for test_file in &test_files {
         let start = std::time::Instant::now();
         let file_str = test_file.to_string_lossy().to_string();


### PR DESCRIPTION
### Motivation
- The test runners were emitting predictable `/tmp/vow_test_*` output paths which allow a local attacker to pre-create symlinks in a shared `/tmp` and cause file clobbering when `vow test` runs, so the output path must be moved out of the global temp directory to remove the attack surface.

### Description
- Replace use of `std::env::temp_dir().join(...)` with a repository-local `Path::new("build").join(...)` for test binary output in `vow/src/main.rs` so test artifacts are produced under the project `build/` directory instead of `/tmp`.
- Apply the same change in the self-hosted compiler test runner by switching `/tmp/vow_test_*` to `build/vow_test_*` in `compiler/main.vow` to keep behavior aligned and preserve per-test uniqueness.

### Testing
- `cargo fmt --all -- --check` was run and succeeded.
- `cargo test -p vow --quiet` was attempted but could not complete in this environment due to crates.io network download restrictions (HTTP 403), so full automated test validation could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e747e340488332bd173d1937c8521f)