### PR TITLE
ci: verify ESBMC release artifact checksum before install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,17 @@ jobs:
       - name: Install ESBMC
         if: steps.cache-esbmc.outputs.cache-hit != 'true'
         run: |
-          curl -sL -o /tmp/esbmc.zip "https://github.com/esbmc/esbmc/releases/download/v$ESBMC_VERSION/release-ubuntu-24.04--b.RelWithDebInfo.-e.OFF.zip"
+          ESBMC_ZIP="release-ubuntu-24.04--b.RelWithDebInfo.-e.OFF.zip"
+          ESBMC_BASE_URL="https://github.com/esbmc/esbmc/releases/download/v$ESBMC_VERSION"
+
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+            -o /tmp/esbmc.zip "$ESBMC_BASE_URL/$ESBMC_ZIP"
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+            -o /tmp/esbmc.zip.sha256 "$ESBMC_BASE_URL/$ESBMC_ZIP.sha256"
+
+          (cd /tmp && sha256sum --check esbmc.zip.sha256)
           unzip -q /tmp/esbmc.zip -d ~/esbmc
-          rm /tmp/esbmc.zip
+          rm /tmp/esbmc.zip /tmp/esbmc.zip.sha256
       - run: echo "$HOME/esbmc/bin" >> "$GITHUB_PATH"
       - run: cargo build --all
       - run: cargo llvm-cov --all --lcov --output-path lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,19 @@ jobs:
           key: esbmc-${{ env.ESBMC_VERSION }}-ubuntu-24.04
       - name: Install ESBMC
         if: steps.cache-esbmc.outputs.cache-hit != 'true'
+        env:
+          ESBMC_ZIP: release-ubuntu-24.04--b.RelWithDebInfo.-e.OFF.zip
+          ESBMC_SHA256: daec35870fdee07e1298676646ae6cf1d631c6272594e7e86479cdb9caa67ec5
         run: |
-          ESBMC_ZIP="release-ubuntu-24.04--b.RelWithDebInfo.-e.OFF.zip"
-          ESBMC_BASE_URL="https://github.com/esbmc/esbmc/releases/download/v$ESBMC_VERSION"
+          ESBMC_URL="https://github.com/esbmc/esbmc/releases/download/v$ESBMC_VERSION/$ESBMC_ZIP"
 
           curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
-            -o /tmp/esbmc.zip "$ESBMC_BASE_URL/$ESBMC_ZIP"
-          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
-            -o /tmp/esbmc.zip.sha256 "$ESBMC_BASE_URL/$ESBMC_ZIP.sha256"
+            -o "/tmp/$ESBMC_ZIP" "$ESBMC_URL"
 
-          (cd /tmp && sha256sum --check esbmc.zip.sha256)
-          unzip -q /tmp/esbmc.zip -d ~/esbmc
-          rm /tmp/esbmc.zip /tmp/esbmc.zip.sha256
+          echo "$ESBMC_SHA256  /tmp/$ESBMC_ZIP" | sha256sum --check --strict -
+
+          unzip -q "/tmp/$ESBMC_ZIP" -d ~/esbmc
+          rm "/tmp/$ESBMC_ZIP"
       - run: echo "$HOME/esbmc/bin" >> "$GITHUB_PATH"
       - run: cargo build --all
       - run: cargo llvm-cov --all --lcov --output-path lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
 env:
   ESBMC_VERSION: "8.1"
+  # SHA-256 of the ESBMC release artifact. Must be updated in lockstep with
+  # ESBMC_VERSION; it is also part of the cache key so a rotation forces
+  # a fresh download + verify even if the version is unchanged.
+  ESBMC_SHA256: daec35870fdee07e1298676646ae6cf1d631c6272594e7e86479cdb9caa67ec5
 
 jobs:
   build-and-test:
@@ -23,12 +27,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/esbmc
-          key: esbmc-${{ env.ESBMC_VERSION }}-ubuntu-24.04
+          key: esbmc-${{ env.ESBMC_VERSION }}-${{ env.ESBMC_SHA256 }}-ubuntu-24.04
       - name: Install ESBMC
         if: steps.cache-esbmc.outputs.cache-hit != 'true'
         env:
           ESBMC_ZIP: release-ubuntu-24.04--b.RelWithDebInfo.-e.OFF.zip
-          ESBMC_SHA256: daec35870fdee07e1298676646ae6cf1d631c6272594e7e86479cdb9caa67ec5
         run: |
           ESBMC_URL="https://github.com/esbmc/esbmc/releases/download/v$ESBMC_VERSION/$ESBMC_ZIP"
 


### PR DESCRIPTION
### Motivation

- The CI previously downloaded and unzipped a prebuilt ESBMC release and added its `bin` to `PATH` without validating integrity, creating a supply-chain risk if the release or transport were compromised.
- Add a minimal integrity check that prevents executing tampered ESBMC artifacts while preserving the existing cache/install flow.

### Description

- Update `.github/workflows/ci.yml` `Install ESBMC` step to define `ESBMC_ZIP` and `ESBMC_BASE_URL` and keep the same cache semantics. 
- Use stricter `curl` flags (`--fail --silent --show-error --location --proto '=https' --tlsv1.2`) to fetch both the archive and its `.sha256` sidecar. 
- Verify the downloaded archive using `(cd /tmp && sha256sum --check esbmc.zip.sha256)` before extracting and adding to `PATH`. 
- Remove both the zip and checksum files after successful extraction.

### Testing

- Applied the patch and committed the change, and the update to `.github/workflows/ci.yml` was recorded successfully. (commit: `ci: verify ESBMC release artifact checksum`.)
- Verified the diff with `git diff -- .github/workflows/ci.yml` and inspected the workflow lines with `nl -ba .github/workflows/ci.yml | sed -n '18,55p'`, both succeeding and showing the intended changes. 
- Confirmed the local file content matches the intended checksum-verification flow by manual inspection of the updated workflow, with no automated CI run performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e743e2f3f483328289588739ca2ef2)