### PR TITLE
Harden release workflow against untrusted ESBMC execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ concurrency:
 permissions:
   contents: write
 
-env:
-  ESBMC_VERSION: "8.1"
-
 jobs:
   release:
     runs-on: ubuntu-24.04
@@ -40,22 +37,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache ESBMC
-        id: cache-esbmc
-        uses: actions/cache@v5
-        with:
-          path: ~/esbmc
-          key: esbmc-${{ env.ESBMC_VERSION }}-ubuntu-24.04
-
-      - name: Install ESBMC
-        if: steps.cache-esbmc.outputs.cache-hit != 'true'
-        run: |
-          curl -sL -o /tmp/esbmc.zip "https://github.com/esbmc/esbmc/releases/download/v$ESBMC_VERSION/release-ubuntu-24.04--b.RelWithDebInfo.-e.OFF.zip"
-          unzip -q /tmp/esbmc.zip -d ~/esbmc
-          rm /tmp/esbmc.zip
-
-      - run: echo "$HOME/esbmc/bin" >> "$GITHUB_PATH"
-
       - name: Bump version
         id: bump
         run: |
@@ -64,7 +45,7 @@ jobs:
           echo "tag=v$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Bootstrap compiler
-        run: scripts/bootstrap.sh
+        run: scripts/bootstrap.sh --no-verify
 
       - name: Verify compiler binary
         run: build/vowc --help > /dev/null

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,6 +10,7 @@ cd "$(dirname "$0")/.."
 mkdir -p build
 
 SKIP_CARGO=false
+NO_VERIFY=false
 VMEM_LIMIT_KB="${VOW_BOOTSTRAP_VMEM_KB:-0}"
 if ! [[ "$VMEM_LIMIT_KB" =~ ^[0-9]+$ ]]; then
     echo "Error: VOW_BOOTSTRAP_VMEM_KB must be a non-negative integer (got: '$VMEM_LIMIT_KB')" >&2
@@ -17,7 +18,7 @@ if ! [[ "$VMEM_LIMIT_KB" =~ ^[0-9]+$ ]]; then
 fi
 
 usage() {
-    echo "Usage: $0 [--skip-cargo] [--help|-h]"
+    echo "Usage: $0 [--skip-cargo] [--no-verify] [--help|-h]"
     echo ""
     echo "Bootstrap the self-hosted Vow compiler and verify the fixed point."
     echo ""
@@ -30,6 +31,7 @@ usage() {
     echo ""
     echo "Options:"
     echo "  --skip-cargo  Skip Stage 0 if Rust binary already built"
+    echo "  --no-verify   Build without running ESBMC verification"
     echo "  -h, --help    Show this help"
     echo ""
     echo "Environment:"
@@ -62,10 +64,16 @@ run_stage_cmd() {
 for arg in "$@"; do
     case "$arg" in
         --skip-cargo) SKIP_CARGO=true ;;
+        --no-verify)  NO_VERIFY=true ;;
         -h|--help)    usage ;;
         *)            echo "Unknown flag: $arg"; usage ;;
     esac
 done
+
+BUILD_FLAGS=""
+if [ "$NO_VERIFY" = true ]; then
+    BUILD_FLAGS="--no-verify"
+fi
 
 # ─── Stage 0: Build Rust compiler ────────────────────────────────────
 
@@ -83,7 +91,7 @@ fi
 
 printf "${BOLD}Stage 1:${RESET} Rust compiler -> build/vowc\n"
 t0=$(date +%s)
-if ! run_logged "./target/release/vow build compiler/main.vow -o build/vowc"; then
+if ! run_logged "./target/release/vow build $BUILD_FLAGS compiler/main.vow -o build/vowc"; then
     printf "  ${RED}FAILED${RESET}\n"
     exit 1
 fi
@@ -94,7 +102,7 @@ printf "  done in %ds\n" $((t1 - t0))
 
 printf "${BOLD}Stage 2:${RESET} build/vowc -> build/vowc2\n"
 t0=$(date +%s)
-if ! run_stage_cmd "build/vowc build compiler/main.vow -o build/vowc2"; then
+if ! run_stage_cmd "build/vowc build $BUILD_FLAGS compiler/main.vow -o build/vowc2"; then
     printf "  ${RED}FAILED${RESET}\n"
     if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
         printf "  Hint: rerun with a higher VOW_BOOTSTRAP_VMEM_KB or unset it for no cap.\n"
@@ -108,7 +116,7 @@ printf "  done in %ds\n" $((t1 - t0))
 
 printf "${BOLD}Stage 3:${RESET} build/vowc2 -> build/vowc3\n"
 t0=$(date +%s)
-if ! run_stage_cmd "build/vowc2 build compiler/main.vow -o build/vowc3"; then
+if ! run_stage_cmd "build/vowc2 build $BUILD_FLAGS compiler/main.vow -o build/vowc3"; then
     printf "  ${RED}FAILED${RESET}\n"
     if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
         printf "  Hint: rerun with a higher VOW_BOOTSTRAP_VMEM_KB or unset it for no cap.\n"


### PR DESCRIPTION
### Motivation
- The release job previously downloaded an ESBMC binary from the network and added it to `PATH` before running the bootstrap, which allowed a network-fetched verifier to execute in a write-scoped release job and created an RCE supply-chain risk.
- The intent is to prevent the release pipeline from executing any network-fetched verifier binary while preserving the normal bootstrap flow for developers who opt into verification locally.

### Description
- Remove the ESBMC download/cache/PATH steps from `.github/workflows/release.yml` so the release job no longer fetches or exposes an untrusted verifier binary.
- Run the release bootstrap step as `scripts/bootstrap.sh --no-verify` so the release pipeline does not invoke ESBMC during build.
- Add a `--no-verify` flag to `scripts/bootstrap.sh` and thread it through all `vow build` invocations so verification is disabled when the flag is passed while remaining opt-in for developers running bootstrap manually.
- Preserve default behavior of `scripts/bootstrap.sh` (verification remains enabled unless `--no-verify` is specified) so local/dev workflows are unaffected.

### Testing
- Ran shell syntax check with `bash -n scripts/bootstrap.sh`, which succeeded. 
- Ran `./scripts/bootstrap.sh --help` to validate the new option is documented and prints usage, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e743e38448833283aaefb0e3ca8721)