### PR TITLE
fix(selfhosted): avoid contracts --verify status collisions by using function id

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -4711,7 +4711,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
                 let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache, solver, encoding, vec_max_c, string_max_c, hashmap_max_c);
                 let st: i64 = vr.status;
                 let mut ei: i64 = 0;
-                while ei < e_func_names.len() {
+                while ei < e_func_ids.len() {
                     if e_func_ids[ei] == func.id {
                         if st == VERIFY_PROVEN() {
                             e_statuses[ei] = String::from("proven");

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -4663,6 +4663,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
 
     // Collect per-contract entries into parallel arrays
     let e_vow_ids: Vec<i64> = Vec::new();
+    let e_func_ids: Vec<i64> = Vec::new();
     let e_func_names: Vec<String> = Vec::new();
     let e_kinds: Vec<String> = Vec::new();
     let e_descs: Vec<String> = Vec::new();
@@ -4680,6 +4681,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
         while vi < nv {
             let ve: IrVowEntry = func.vows[vi];
             e_vow_ids.push(ve.id);
+            e_func_ids.push(func.id);
             e_func_names.push(func.name);
             e_kinds.push(vow_kind_from_desc(ve.description));
             e_descs.push(ve.description);
@@ -4710,7 +4712,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
                 let st: i64 = vr.status;
                 let mut ei: i64 = 0;
                 while ei < e_func_names.len() {
-                    if e_func_names[ei] == func.name {
+                    if e_func_ids[ei] == func.id {
                         if st == VERIFY_PROVEN() {
                             e_statuses[ei] = String::from("proven");
                         } else if st == VERIFY_FAILED() {

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -4209,6 +4209,8 @@ pub struct BuildResult {
 pub struct ContractEntryJson {
     pub vow_id: u32,
     pub function: String,
+    #[serde(skip)]
+    pub function_id: u32,
     pub kind: String,
     pub description: String,
     pub blame: String,
@@ -5756,7 +5758,7 @@ fn update_contract_statuses(
                     Some(p) => p,
                     None => {
                         for entry in entries.iter_mut() {
-                            if entry.function == func.name {
+                            if entry.function_id == func.id.0 {
                                 entry.status = "error".to_string();
                             }
                         }
@@ -5802,7 +5804,7 @@ fn update_contract_statuses(
         };
 
         for entry in entries.iter_mut() {
-            if entry.function == func.name {
+            if entry.function_id == func.id.0 {
                 match &result {
                     VerificationResult::Proven => {
                         entry.status = "proven".to_string();
@@ -5860,6 +5862,7 @@ fn run_contracts_command(
             entries.push(ContractEntryJson {
                 vow_id: vow.id.0,
                 function: func.name.clone(),
+                function_id: func.id.0,
                 kind: kind.to_string(),
                 description: vow.description.clone(),
                 blame: blame.to_string(),


### PR DESCRIPTION
### Motivation
- `contracts --verify` previously updated per-contract statuses by comparing function *names*, which allows different functions with the same name (merged from dependencies) to overwrite each other’s results; statuses must be keyed by a unique function identifier to preserve verification integrity.

### Description
- Add a per-entry `e_func_ids` array populated with `func.id` when collecting vow entries and change the verification update to match `e_func_ids[ei] == func.id` instead of comparing names, so each contract status is attributed to the correct function.

### Testing
- Attempted to run `build/vowc --help` and `build/vowc build --no-verify compiler/main.vow -o /tmp/vow_main_test`, but `build/vowc` is not present in this environment so those checks could not be executed.
- Ran `cargo test -p vow --no-run`, which failed due to pre-existing Cranelift dependency version mismatches in `vow-codegen` unrelated to this change, so no full test-suite verification was possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e743e3bf5c8332b77e9506af37d1b2)