### PR TITLE
fix(verify): prevent reserved ESBMC/VERIFIER symbol shadowing in modelable callees

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -116,6 +116,12 @@ fn is_known_builtin(name: String) -> bool {
     || name == String::from("__vow_map_remove")
 }
 
+fn is_reserved_verifier_symbol(name: String) -> bool {
+    name == String::from("__ESBMC_assume")
+    || name == String::from("__ESBMC_assert")
+    || str_starts_with(name, String::from("__VERIFIER_nondet_"))
+}
+
 fn is_modelable(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>, modelable_cache_ids: Vec<i64>, modelable_cache_vals: Vec<i64>) -> bool {
     let fid: i64 = f.id;
     let nc: i64 = modelable_cache_ids.len();
@@ -128,6 +134,10 @@ fn is_modelable(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>, modelabl
     }
     modelable_cache_ids.push(fid);
     modelable_cache_vals.push(0);
+
+    if is_reserved_verifier_symbol(f.name) {
+        return false;
+    }
 
     if f.effects != 0 {
         return false;
@@ -255,7 +265,8 @@ fn collect_callees_dfs(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>,
                     while fi < fns.len() {
                         let callee: IrFunction = fns[fi];
                         if callee.id == target_fi {
-                            if is_modelable(callee, m, const_fn_indices, modelable_cache_ids, modelable_cache_vals) {
+                            if !is_reserved_verifier_symbol(callee.name)
+                               && is_modelable(callee, m, const_fn_indices, modelable_cache_ids, modelable_cache_vals) {
                                 visited.push(target_fi);
                                 collect_callees_dfs(callee, m, const_fn_indices, modelable_cache_ids, modelable_cache_vals, visited, order);
                                 order.push(target_fi);

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -117,12 +117,15 @@ fn is_known_builtin(name: String) -> bool {
 }
 
 fn is_reserved_verifier_symbol(name: String) -> bool {
-    name == String::from("__ESBMC_assume")
-    || name == String::from("__ESBMC_assert")
-    || str_starts_with(name, String::from("__VERIFIER_nondet_"))
+    str_starts_with(name, String::from("__ESBMC_"))
+    || str_starts_with(name, String::from("__VERIFIER_"))
 }
 
 fn is_modelable(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>, modelable_cache_ids: Vec<i64>, modelable_cache_vals: Vec<i64>) -> bool {
+    if is_reserved_verifier_symbol(f.name) {
+        return false;
+    }
+
     let fid: i64 = f.id;
     let nc: i64 = modelable_cache_ids.len();
     let mut ci: i64 = 0;
@@ -134,10 +137,6 @@ fn is_modelable(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>, modelabl
     }
     modelable_cache_ids.push(fid);
     modelable_cache_vals.push(0);
-
-    if is_reserved_verifier_symbol(f.name) {
-        return false;
-    }
 
     if f.effects != 0 {
         return false;
@@ -265,8 +264,7 @@ fn collect_callees_dfs(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>,
                     while fi < fns.len() {
                         let callee: IrFunction = fns[fi];
                         if callee.id == target_fi {
-                            if !is_reserved_verifier_symbol(callee.name)
-                               && is_modelable(callee, m, const_fn_indices, modelable_cache_ids, modelable_cache_vals) {
+                            if is_modelable(callee, m, const_fn_indices, modelable_cache_ids, modelable_cache_vals) {
                                 visited.push(target_fi);
                                 collect_callees_dfs(callee, m, const_fn_indices, modelable_cache_ids, modelable_cache_vals, visited, order);
                                 order.push(target_fi);

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -215,6 +215,10 @@ fn is_known_builtin(name: &str) -> bool {
     )
 }
 
+fn is_reserved_verifier_symbol(name: &str) -> bool {
+    matches!(name, "__ESBMC_assume" | "__ESBMC_assert") || name.starts_with("__VERIFIER_nondet_")
+}
+
 /// Check whether a function can be precisely modeled in the C emitter.
 /// Modelable functions are pure (no effects) and use only opcodes that the
 /// C emitter handles without resorting to `__VERIFIER_nondet`.
@@ -224,6 +228,10 @@ pub fn is_modelable(
     const_fns: &HashMap<FuncId, ConstantValue>,
     cache: &mut HashMap<FuncId, bool>,
 ) -> bool {
+    if is_reserved_verifier_symbol(&func.name) {
+        return false;
+    }
+
     if let Some(&cached) = cache.get(&func.id) {
         return cached;
     }
@@ -425,6 +433,7 @@ fn collect_callees_dfs(
                     continue;
                 }
                 if let Some(callee) = module.functions.iter().find(|f| f.id == *fid)
+                    && !is_reserved_verifier_symbol(&callee.name)
                     && is_modelable(callee, module, const_fns, modelable_cache)
                 {
                     visited.insert(*fid);
@@ -1561,6 +1570,86 @@ mod tests {
             origin: sp(),
             region: RegionId::Root,
         }
+    }
+
+    #[test]
+    fn collect_modelable_callees_skips_reserved_verifier_names() {
+        let caller = Function {
+            id: FuncId(0),
+            name: "caller".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(
+                        0,
+                        Opcode::Call,
+                        Ty::I64,
+                        vec![],
+                        InstData::CallTarget(FuncId(1)),
+                    ),
+                    inst(
+                        1,
+                        Opcode::Call,
+                        Ty::I64,
+                        vec![],
+                        InstData::CallTarget(FuncId(2)),
+                    ),
+                    inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+        };
+        let reserved = Function {
+            id: FuncId(1),
+            name: "__VERIFIER_nondet_int".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(7)),
+                    inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+        };
+        let safe = Function {
+            id: FuncId(2),
+            name: "safe".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(42)),
+                    inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+        };
+        let module = Module {
+            name: "test".to_string(),
+            functions: vec![caller.clone(), reserved, safe],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+            warnings: vec![],
+        };
+
+        let mut cache = HashMap::new();
+        let callees = collect_modelable_callees(&caller, &module, &HashMap::new(), &mut cache);
+        assert_eq!(callees, vec![FuncId(2)]);
     }
 
     #[test]

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -216,7 +216,7 @@ fn is_known_builtin(name: &str) -> bool {
 }
 
 fn is_reserved_verifier_symbol(name: &str) -> bool {
-    matches!(name, "__ESBMC_assume" | "__ESBMC_assert") || name.starts_with("__VERIFIER_nondet_")
+    name.starts_with("__ESBMC_") || name.starts_with("__VERIFIER_")
 }
 
 /// Check whether a function can be precisely modeled in the C emitter.
@@ -433,7 +433,6 @@ fn collect_callees_dfs(
                     continue;
                 }
                 if let Some(callee) = module.functions.iter().find(|f| f.id == *fid)
-                    && !is_reserved_verifier_symbol(&callee.name)
                     && is_modelable(callee, module, const_fns, modelable_cache)
                 {
                     visited.insert(*fid);
@@ -1599,12 +1598,20 @@ mod tests {
                         vec![],
                         InstData::CallTarget(FuncId(2)),
                     ),
-                    inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
+                    inst(
+                        2,
+                        Opcode::Call,
+                        Ty::I64,
+                        vec![],
+                        InstData::CallTarget(FuncId(3)),
+                    ),
+                    inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
                 ],
             }],
             local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
         };
-        let reserved = Function {
+        let nondet_reserved = Function {
             id: FuncId(1),
             name: "__VERIFIER_nondet_int".to_string(),
             params: vec![],
@@ -1620,9 +1627,28 @@ mod tests {
                 ],
             }],
             local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+        };
+        let assume_reserved = Function {
+            id: FuncId(2),
+            name: "__ESBMC_assume".to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
         };
         let safe = Function {
-            id: FuncId(2),
+            id: FuncId(3),
             name: "safe".to_string(),
             params: vec![],
             param_names: vec![],
@@ -1637,10 +1663,11 @@ mod tests {
                 ],
             }],
             local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
         };
         let module = Module {
             name: "test".to_string(),
-            functions: vec![caller.clone(), reserved, safe],
+            functions: vec![caller.clone(), nondet_reserved, assume_reserved, safe],
             strings: vec![],
             struct_layouts: vec![],
             enum_layouts: vec![],
@@ -1649,7 +1676,7 @@ mod tests {
 
         let mut cache = HashMap::new();
         let callees = collect_modelable_callees(&caller, &module, &HashMap::new(), &mut cache);
-        assert_eq!(callees, vec![FuncId(2)]);
+        assert_eq!(callees, vec![FuncId(3)]);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- The verification pipeline emitted user-defined &#34;modelable&#34; callees verbatim into the generated C, which allowed user functions to collide with ESBMC/VERIFIER intrinsics (e.g., `__ESBMC_assert`, `__VERIFIER_nondet_*`) and undermine verification integrity.
- The minimal safe mitigation is to disallow emitting any user function whose name would shadow those reserved verifier symbols.

### Description

- Added a small helper `is_reserved_verifier_symbol` that recognizes any name starting with `__ESBMC_` or `__VERIFIER_` (covering all ESBMC/VERIFIER intrinsics including `__ESBMC_assume`, `__ESBMC_assert`, `__VERIFIER_assume`, `__VERIFIER_error`, `__VERIFIER_atomic_*`, `__VERIFIER_nondet_*`, etc.).
- Updated modelable detection so `is_modelable` returns `false` for functions with reserved verifier names, preventing them from being emitted as modelable callees in Rust verifier emitter (`vow-verify/src/c_emitter.rs`).
- Applied the same reserved-name check in the self-hosted emitter (`compiler/c_emitter.vow`) so Rust and self-hosted compilers remain behaviorally aligned. Both compilers check the reserved-symbol predicate before any cache interaction.
- Removed the redundant `!is_reserved_verifier_symbol(callee.name)` guard from `collect_callees_dfs` in both compilers — `is_modelable` now handles this case authoritatively.
- Added a unit test `collect_modelable_callees_skips_reserved_verifier_names` in `vow-verify/src/c_emitter.rs` that exercises both `__VERIFIER_*` and `__ESBMC_*` callee names and verifies they are excluded while normal modelable callees are still collected.

### Testing

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --tests --all` (full workspace, all green)
- Targeted unit test passes: `cargo test -p vow-verify c_emitter::tests::collect_modelable_callees_skips_reserved_verifier_names`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e743e341a883328c23df4f0e5deeb6)