### PR TITLE
fix(verify): guard __vow_vec_pop model against underflow

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -867,7 +867,10 @@ fn emit_vec_op(out: String, inst: IrInst, vec_max: i64) {
     }
     if ds == String::from("__vow_vec_pop") {
         let vec: i64 = iargs[0];
-        out.push_str(str3(String::from("  v"), i64_to_str(vec), String::from(".len--;\n")));
+        let vs: String = i64_to_str(vec);
+        out.push_str(str5(String::from("  if (v"), vs,
+            String::from(".len > 0) { v"), i64_to_str(vec),
+            String::from(".len--; }\n")));
         return;
     }
     if ds == String::from("__vow_vec_set_val") {

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -726,7 +726,7 @@ fn emit_inst(
                     }
                     "__vow_vec_pop" => {
                         let vec = inst.args[0].0;
-                        out.push_str(&format!("  v{vec}.len--;\n"));
+                        out.push_str(&format!("  if (v{vec}.len > 0) {{ v{vec}.len--; }}\n"));
                     }
                     "__vow_vec_set_val" => {
                         let vec = inst.args[0].0;
@@ -2422,7 +2422,10 @@ mod tests {
             ],
         );
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
-        assert!(c.contains("v2.len--;"), "pop decrement: {c}");
+        assert!(
+            c.contains("if (v2.len > 0) { v2.len--; }"),
+            "pop decrement: {c}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The ESBMC C emitter previously emitted an unconditional `v.len--` for `__vow_vec_pop`, diverging from the runtime `__vow_vec_pop` which only decrements when `len > 0`, and enabling the verifier to reason about impossible negative-length states.

### Description
- Adjusted the C emitter in `vow-verify/src/c_emitter.rs` to emit `if (v{vec}.len > 0) { v{vec}.len--; }` for `__vow_vec_pop` so the model matches runtime behavior.
- Updated the `emit_vec_pop` unit test to assert the guarded decrement is emitted.

### Testing
- Ran `cargo test -p vow-verify emit_vec_pop` and the test passed.
- Ran `cargo test -p vow-verify c_emitter::tests::emit_vec_` (all vec-related emitter tests) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e743e342f083328cbe49fabc800372)