### PR TITLE
fix: accept keywords as use-path segments in self-hosted parser (#248)

### DIFF
--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -80,6 +80,29 @@ fn expect_ident(p: Parser) -> i64 {
     }
 }
 
+// Accepts an identifier OR any keyword as a path segment, mirroring the
+// Rust parser's `expect_name_or_keyword`. Required so that `use` paths
+// can name modules whose final component is a Vow keyword (e.g.
+// `use region`, `use std.io`). Without this, the keyword token's empty
+// `str_val` propagates as sid -1 through `parse_path` and triggers an
+// IndexOutOfBounds when the frontend later reads `arena.strs[-1]`.
+fn expect_ident_or_keyword(p: Parser) -> i64 {
+    let t: Token = peek(p);
+    if t.tag == tok_ident() {
+        let _adv: Token = advance(p);
+        arena_intern_str(p.arena, t.str_val)
+    } else {
+        let kw: String = keyword_text(t.tag);
+        if kw.len() > 0 {
+            let _adv: Token = advance(p);
+            arena_intern_str(p.arena, kw)
+        } else {
+            push_error(p, String::from("expected identifier"));
+            -1
+        }
+    }
+}
+
 fn span_pack(start: i64, len: i64) -> i64 vow {
     requires: start >= 0,
     requires: len >= 0,
@@ -115,7 +138,9 @@ fn parse_module_into(tokens: Vec<Token>, arena: AstArena, dctx: DiagCtx, file: S
     while at(p, tok_kw_use()) {
         let _kw: Token = advance(p);
         let path: i64 = parse_path(p);
-        uses.push(path);
+        if path != -1 {
+            uses.push(path);
+        }
     }
 
     let items: Vec<i64> = Vec::new();
@@ -139,11 +164,17 @@ fn parse_module_into(tokens: Vec<Token>, arena: AstArena, dctx: DiagCtx, file: S
 
 fn parse_path(p: Parser) -> i64 {
     let items: Vec<i64> = Vec::new();
-    let sid: i64 = expect_ident(p);
+    let sid: i64 = expect_ident_or_keyword(p);
+    if sid == -1 {
+        return -1;
+    }
     items.push(sid);
     while at(p, tok_dot()) {
         let _dot: Token = advance(p);
-        let s: i64 = expect_ident(p);
+        let s: i64 = expect_ident_or_keyword(p);
+        if s == -1 {
+            return -1;
+        }
         items.push(s);
     }
     arena_add_list(p.arena, items)

--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -80,12 +80,7 @@ fn expect_ident(p: Parser) -> i64 {
     }
 }
 
-// Accepts an identifier OR any keyword as a path segment, mirroring the
-// Rust parser's `expect_name_or_keyword`. Required so that `use` paths
-// can name modules whose final component is a Vow keyword (e.g.
-// `use region`, `use std.io`). Without this, the keyword token's empty
-// `str_val` propagates as sid -1 through `parse_path` and triggers an
-// IndexOutOfBounds when the frontend later reads `arena.strs[-1]`.
+// Mirrors Rust's `expect_name_or_keyword`; keywords are valid use-path segments (e.g. `use region`, `use std.io`).
 fn expect_ident_or_keyword(p: Parser) -> i64 {
     let t: Token = peek(p);
     if t.tag == tok_ident() {
@@ -97,7 +92,7 @@ fn expect_ident_or_keyword(p: Parser) -> i64 {
             let _adv: Token = advance(p);
             arena_intern_str(p.arena, kw)
         } else {
-            push_error(p, String::from("expected identifier"));
+            push_error(p, String::from("expected identifier or keyword"));
             -1
         }
     }

--- a/compiler/token.vow
+++ b/compiler/token.vow
@@ -115,9 +115,7 @@ fn make_token(tag: i64, int_val: i64, int_val2: i64, str_val: String, span_start
     }
 }
 
-// Returns the source spelling of a keyword tag, or an empty string for
-// non-keyword tags. Used by the parser to accept keywords as path
-// segments in `use` declarations (e.g. `use std.io`, `use region`).
+// Maps a keyword tag to its source spelling; empty string for non-keyword tags.
 fn keyword_text(tag: i64) -> String {
     if tag == tok_kw_fn() { String::from("fn") }
     else if tag == tok_kw_let() { String::from("let") }

--- a/compiler/token.vow
+++ b/compiler/token.vow
@@ -114,3 +114,46 @@ fn make_token(tag: i64, int_val: i64, int_val2: i64, str_val: String, span_start
         span_len: span_len,
     }
 }
+
+// Returns the source spelling of a keyword tag, or an empty string for
+// non-keyword tags. Used by the parser to accept keywords as path
+// segments in `use` declarations (e.g. `use std.io`, `use region`).
+fn keyword_text(tag: i64) -> String {
+    if tag == tok_kw_fn() { String::from("fn") }
+    else if tag == tok_kw_let() { String::from("let") }
+    else if tag == tok_kw_mut() { String::from("mut") }
+    else if tag == tok_kw_struct() { String::from("struct") }
+    else if tag == tok_kw_enum() { String::from("enum") }
+    else if tag == tok_kw_match() { String::from("match") }
+    else if tag == tok_kw_if() { String::from("if") }
+    else if tag == tok_kw_else() { String::from("else") }
+    else if tag == tok_kw_while() { String::from("while") }
+    else if tag == tok_kw_loop() { String::from("loop") }
+    else if tag == tok_kw_break() { String::from("break") }
+    else if tag == tok_kw_continue() { String::from("continue") }
+    else if tag == tok_kw_return() { String::from("return") }
+    else if tag == tok_kw_pub() { String::from("pub") }
+    else if tag == tok_kw_use() { String::from("use") }
+    else if tag == tok_kw_module() { String::from("module") }
+    else if tag == tok_kw_vow() { String::from("vow") }
+    else if tag == tok_kw_requires() { String::from("requires") }
+    else if tag == tok_kw_ensures() { String::from("ensures") }
+    else if tag == tok_kw_invariant() { String::from("invariant") }
+    else if tag == tok_kw_where() { String::from("where") }
+    else if tag == tok_kw_region() { String::from("region") }
+    else if tag == tok_kw_linear() { String::from("linear") }
+    else if tag == tok_kw_extern() { String::from("extern") }
+    else if tag == tok_kw_impl() { String::from("impl") }
+    else if tag == tok_kw_trait() { String::from("trait") }
+    else if tag == tok_kw_type() { String::from("type") }
+    else if tag == tok_kw_for() { String::from("for") }
+    else if tag == tok_kw_in() { String::from("in") }
+    else if tag == tok_kw_as() { String::from("as") }
+    else if tag == tok_kw_read() { String::from("read") }
+    else if tag == tok_kw_write() { String::from("write") }
+    else if tag == tok_kw_io() { String::from("io") }
+    else if tag == tok_kw_panic() { String::from("panic") }
+    else if tag == tok_kw_unsafe() { String::from("unsafe") }
+    else if tag == tok_kw_const() { String::from("const") }
+    else { String::from("") }
+}

--- a/tests/multi/use_keyword_dotted/main.vow
+++ b/tests/multi/use_keyword_dotted/main.vow
@@ -1,0 +1,10 @@
+// TEST: stdout "11\n"
+module Main
+
+use sub.io
+
+fn main() -> i32 [io] {
+    print_i64(dotted_value());
+    print_str(String::from("\n"));
+    0
+}

--- a/tests/multi/use_keyword_dotted/sub/io.vow
+++ b/tests/multi/use_keyword_dotted/sub/io.vow
@@ -1,0 +1,5 @@
+module SubIo
+
+fn dotted_value() -> i64 {
+    11
+}

--- a/tests/multi/use_keyword_path/main.vow
+++ b/tests/multi/use_keyword_path/main.vow
@@ -1,0 +1,10 @@
+// TEST: stdout "7\n"
+module Main
+
+use region
+
+fn main() -> i32 [io] {
+    print_i64(region_value());
+    print_str(String::from("\n"));
+    0
+}

--- a/tests/multi/use_keyword_path/region.vow
+++ b/tests/multi/use_keyword_path/region.vow
@@ -1,0 +1,5 @@
+module Region
+
+fn region_value() -> i64 {
+    7
+}


### PR DESCRIPTION
## Summary

- Fix `IndexOutOfBounds` in the self-hosted compiler when an input module has `use` declarations whose path segment is a Vow keyword (`use region`, `use std.io`).
- `compiler/parser.vow::parse_path` only accepted `tok_ident()`, so keyword segments returned `-1`, which propagated into the arena list and surfaced as `arena.strs[-1]` OOB inside `frontend.vow::resolve_use_path`.
- Add `keyword_text(tag)` (mirror of Rust's `keyword_as_str`) and `expect_ident_or_keyword`. Bail out from `parse_path` cleanly on failure so non-keyword garbage like `use 123` also stops crashing later.
- No Rust compiler change needed — Rust already handles this via `expect_name_or_keyword` (`vow-syntax/src/parser/mod.rs:139`, with a dedicated test).

Closes #248. The bootstrap triple still hits #249 (clif-shim arg-count mismatch on `compiler/lower.vow`); that companion blocker is being fixed separately.

## Test plan

- [x] `cargo test --all` — 0 failed across 26 result sets
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] New `tests/multi/use_keyword_path/` (single-segment `use region`) passes
- [x] New `tests/multi/use_keyword_dotted/` (dotted `use sub.io`) passes
- [x] Malformed `use 123` reports clean diagnostics instead of `IndexOutOfBounds`
- [x] `tests/run_tests.sh --no-bootstrap --no-verify` — 83 passed, 1 pre-existing unrelated failure (`string_parse`), 1 skipped
- [x] Reproduction `vowc build --no-verify compiler/frontend.vow` no longer raises `IndexOutOfBounds`
