### PR TITLE
fix: self-hosted typechecker emits undefined-function errors (#249)

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -1,5 +1,6 @@
 module CEmitter
 
+use clif
 use ir
 use ir_printer
 

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -686,6 +686,10 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
             let name: String = arena_str(a, name_sid);
             let fidx: i64 = env_lookup_fn(e, name);
             if fidx == -1 {
+                let msg: String = String::from("undefined function `");
+                msg.push_str(name);
+                msg.push_str(String::from("`"));
+                env_emit_error(e, msg, expr_span(a, eid));
                 return CTY_NEVER();
             }
             if e.fn_param_count[fidx] != n_args {

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -1,6 +1,7 @@
 module Clif
 
 use ir
+use lower
 
 fn str2(a: String, b: String) -> String {
     let r: String = String::from("");

--- a/compiler/env.vow
+++ b/compiler/env.vow
@@ -260,6 +260,78 @@ fn env_new(dctx: DiagCtx, file: String) -> CheckEnv {
     env_define_fn(e, String::from("process_stdout_for"), vec_of_1(i64_tid), str_tid, eff_io);
     env_define_fn(e, String::from("process_stderr_for"), vec_of_1(i64_tid), str_tid, eff_io);
 
+    // Cranelift shim FFI symbols invoked directly from compiler/clif.vow.
+    // Mirrors the Rust env.rs registrations so calls like `__vow_clif_create(...)`
+    // resolve as known functions rather than triggering "undefined function".
+    let clif_ii_p: Vec<i64> = Vec::new();
+    clif_ii_p.push(i64_tid);
+    clif_ii_p.push(i64_tid);
+    env_define_fn(e, String::from("__vow_clif_create"), clif_ii_p, i64_tid, eff_io);
+
+    let clif_is_p: Vec<i64> = Vec::new();
+    clif_is_p.push(i64_tid);
+    clif_is_p.push(str_tid);
+    env_define_fn(e, String::from("__vow_clif_add_string"), clif_is_p, unit_tid, eff_io);
+
+    let clif_is2_p: Vec<i64> = Vec::new();
+    clif_is2_p.push(i64_tid);
+    clif_is2_p.push(str_tid);
+    env_define_fn(e, String::from("__vow_clif_declare_extern"), clif_is2_p, unit_tid, eff_io);
+
+    let clif_decl_p: Vec<i64> = Vec::new();
+    clif_decl_p.push(i64_tid);
+    clif_decl_p.push(i64_tid);
+    clif_decl_p.push(str_tid);
+    clif_decl_p.push(vec_i64_tid);
+    clif_decl_p.push(i64_tid);
+    clif_decl_p.push(i64_tid);
+    clif_decl_p.push(i64_tid);
+    env_define_fn(e, String::from("__vow_clif_declare_function"), clif_decl_p, unit_tid, eff_io);
+
+    let clif_begin_p: Vec<i64> = Vec::new();
+    clif_begin_p.push(i64_tid);
+    clif_begin_p.push(i64_tid);
+    clif_begin_p.push(i64_tid);
+    clif_begin_p.push(vec_i64_tid);
+    env_define_fn(e, String::from("__vow_clif_fn_begin"), clif_begin_p, i64_tid, eff_io);
+
+    env_define_fn(e, String::from("__vow_clif_fn_block"), vec_of_1(i64_tid), i64_tid, eff_io);
+
+    let clif_inst_p: Vec<i64> = Vec::new();
+    clif_inst_p.push(i64_tid);
+    clif_inst_p.push(i64_tid);
+    clif_inst_p.push(i64_tid);
+    clif_inst_p.push(i64_tid);
+    clif_inst_p.push(i64_tid);
+    clif_inst_p.push(i64_tid);
+    clif_inst_p.push(i64_tid);
+    clif_inst_p.push(str_tid);
+    clif_inst_p.push(vec_i64_tid);
+    clif_inst_p.push(i64_tid);
+    env_define_fn(e, String::from("__vow_clif_fn_inst"), clif_inst_p, i64_tid, eff_io);
+
+    let clif_vow_p: Vec<i64> = Vec::new();
+    clif_vow_p.push(i64_tid);
+    clif_vow_p.push(i64_tid);
+    clif_vow_p.push(str_tid);
+    clif_vow_p.push(vec_i64_tid);
+    clif_vow_p.push(vec_str_tid);
+    env_define_fn(e, String::from("__vow_clif_fn_vow"), clif_vow_p, i64_tid, eff_io);
+
+    env_define_fn(e, String::from("__vow_clif_fn_end"), vec_of_1(i64_tid), i64_tid, eff_io);
+
+    let clif_finish_p: Vec<i64> = Vec::new();
+    clif_finish_p.push(i64_tid);
+    clif_finish_p.push(str_tid);
+    env_define_fn(e, String::from("__vow_clif_finish"), clif_finish_p, i64_tid, eff_io);
+
+    let clif_link_p: Vec<i64> = Vec::new();
+    clif_link_p.push(str_tid);
+    clif_link_p.push(str_tid);
+    env_define_fn(e, String::from("__vow_clif_link"), clif_link_p, i64_tid, eff_io);
+
+    env_define_fn(e, String::from("__vow_clif_destroy"), vec_of_1(i64_tid), unit_tid, eff_io);
+
     e
 }
 

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1,6 +1,7 @@
 module Lower
 
 use ast
+use diag
 use ir
 
 struct LowerCtx {

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -1,8 +1,9 @@
 module Verifier
 
+use c_emitter
+use clif
 use ir
 use ir_printer
-use c_emitter
 
 fn VERIFY_PROVEN() -> i64 vow { ensures: result >= 0 } { 0 }
 fn VERIFY_FAILED() -> i64 vow { ensures: result >= 0 } { 1 }

--- a/tests/error/undefined_function.vow
+++ b/tests/error/undefined_function.vow
@@ -1,0 +1,7 @@
+// TEST: stderr "undefined function"
+module UndefinedFunction
+
+fn main() -> i32 {
+  let _x: i64 = nonexistent_function(42);
+  0
+}


### PR DESCRIPTION
## Summary

- Fixes #249. The self-hosted typechecker silently returned `CTY_NEVER` for unresolved call callees instead of erroring; that let `compiler/lower.vow` typecheck despite calling `span_unpack_start` without `use diag`. The unresolved name flowed through IR lowering as an extern call; the clif shim's no-arg fallback collided with a 1-arg call site, surfacing as `fn380(v42): got 1, expected 0`.
- Mirrors the Rust compiler's behaviour: `vow-types/src/check.rs` already emits `undefined function` and `vow-types/src/env.rs` already pre-registers the `__vow_clif_*` FFI signatures. No Rust-side change is needed.
- Codex review caught a regression — making the typechecker strict exposed two cross-module helper deps (`vec_contains_str` from `lower`, `str2` from `clif`) used by `clif`/`c_emitter`/`verifier` without explicit `use`. Added the missing imports.

## Changes

- `compiler/checker.vow` — emit `TypeMismatch` (``undefined function `<name>` ``) when `env_lookup_fn` returns -1 in the `EXPR_CALL` branch.
- `compiler/env.vow` — pre-register the 12 `__vow_clif_*` shim FFI symbols invoked from `compiler/clif.vow`.
- `compiler/lower.vow` — add `use diag` so `span_unpack_start` resolves.
- `compiler/clif.vow`, `c_emitter.vow`, `verifier.vow` — declare cross-module helpers (`vec_contains_str`, `str2`).
- `tests/error/undefined_function.vow` — regression test.

## Test plan

- [x] Original reproduction (build `compiler/lower.vow` standalone with `--no-verify`) — `436 items, 0 errors`; only remaining failure is the link step (no `main`, expected for a library module).
- [x] `tests/run_tests.sh --no-verify` — 82 passed, bootstrap fixed-point sha256 match. The single failure (`string_parse: exit 224`) is pre-existing and reproduces with the changes stashed.
- [x] `cargo test --all` — all suites green.
- [x] `cargo clippy --all -- -D warnings` — clean.
- [ ] `scripts/bootstrap.sh` stage 2 still hits #248 (multi-module IOOB). That's tracked separately.

## Out of scope

- Companion #248 (multi-module `IndexOutOfBounds`) is being fixed separately.
- The self-hosted parser passes `span=0` for `EXPR_IDENT`/`EXPR_CALL`, so the new diagnostic has a precise message but a poor location. Worth a follow-up.
