### PR TITLE
Implement arena FFI wrapper intrinsics

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -91,12 +91,16 @@ fn vec_insert_i64(v: Vec<i64>, val: i64) -> bool {
 
 fn is_known_builtin(name: String) -> bool {
     name == String::from("__vow_vec_new")
+    || name == String::from("__vow_vec_from_raw_parts_copy_val")
+    || name == String::from("__vow_vec_pin_to_root_val")
     || name == String::from("__vow_vec_push_val")
     || name == String::from("__vow_vec_get_val")
     || name == String::from("__vow_vec_len")
     || name == String::from("__vow_vec_pop")
     || name == String::from("__vow_vec_set_val")
     || name == String::from("__vow_string_from_cstr")
+    || name == String::from("__vow_string_from_raw_parts_copy")
+    || name == String::from("__vow_string_pin_to_root")
     || name == String::from("__vow_string_len")
     || name == String::from("__vow_string_push_str")
     || name == String::from("__vow_string_push_byte")
@@ -394,7 +398,13 @@ fn collect_modelled_vars(f: IrFunction, constructor: String, prefix: String) -> 
             let inst: IrInst = insts[ii];
             if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
                 let ds: String = inst.ds;
-                if ds == constructor {
+                let alt_creator: bool = (prefix == String::from("__vow_vec_")
+                    && (ds == String::from("__vow_vec_from_raw_parts_copy_val")
+                        || ds == String::from("__vow_vec_pin_to_root_val")))
+                    || (prefix == String::from("__vow_string_")
+                        && (ds == String::from("__vow_string_from_raw_parts_copy")
+                            || ds == String::from("__vow_string_pin_to_root")));
+                if ds == constructor || alt_creator {
                     vec_insert_i64(vars, inst.id);
                 }
             }
@@ -411,7 +421,13 @@ fn collect_modelled_vars(f: IrFunction, constructor: String, prefix: String) -> 
             let inst: IrInst = insts[ii];
             if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
                 let ds: String = inst.ds;
-                if str_starts_with(ds, prefix) && !(ds == constructor) {
+                let alt_creator: bool = (prefix == String::from("__vow_vec_")
+                    && (ds == String::from("__vow_vec_from_raw_parts_copy_val")
+                        || ds == String::from("__vow_vec_pin_to_root_val")))
+                    || (prefix == String::from("__vow_string_")
+                        && (ds == String::from("__vow_string_from_raw_parts_copy")
+                            || ds == String::from("__vow_string_pin_to_root")));
+                if str_starts_with(ds, prefix) && !(ds == constructor) && !alt_creator {
                     let iargs: Vec<i64> = inst.args;
                     if iargs.len() > 0 {
                         vec_insert_i64(vars, iargs[0]);
@@ -834,6 +850,22 @@ fn emit_vec_op(out: String, inst: IrInst, vec_max: i64) {
         out.push_str(str3(String::from("  v"), ids, String::from(".len = 0;\n")));
         return;
     }
+    if ds == String::from("__vow_vec_from_raw_parts_copy_val") {
+        let len_arg: i64 = iargs[1];
+        let ids: String = i64_to_str(id);
+        let ls: String = i64_to_str(len_arg);
+        out.push_str(str5(String::from("  __ESBMC_assume(v"), ls,
+            String::from(" >= 0 && v"), ls,
+            str3(String::from(" < "), i64_to_str(vec_max), String::from(");\n"))));
+        out.push_str(str5(String::from("  v"), ids, String::from(".len = v"), ls, String::from(";\n")));
+        return;
+    }
+    if ds == String::from("__vow_vec_pin_to_root_val") {
+        let src: i64 = iargs[0];
+        out.push_str(str5(String::from("  v"), i64_to_str(id),
+            String::from(" = v"), i64_to_str(src), String::from(";\n")));
+        return;
+    }
     if ds == String::from("__vow_vec_push_val") {
         let vec: i64 = iargs[0];
         let val: i64 = iargs[1];
@@ -901,6 +933,22 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64) {
         out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
             String::from(".len >= 0 && v"), ids,
             str3(String::from(".len < "), i64_to_str(string_max), String::from(");\n"))));
+        return;
+    }
+    if ds == String::from("__vow_string_from_raw_parts_copy") {
+        let len_arg: i64 = iargs[1];
+        let ids: String = i64_to_str(id);
+        let ls: String = i64_to_str(len_arg);
+        out.push_str(str5(String::from("  __ESBMC_assume(v"), ls,
+            String::from(" >= 0 && v"), ls,
+            str3(String::from(" < "), i64_to_str(string_max), String::from(");\n"))));
+        out.push_str(str5(String::from("  v"), ids, String::from(".len = v"), ls, String::from(";\n")));
+        return;
+    }
+    if ds == String::from("__vow_string_pin_to_root") {
+        let src: i64 = iargs[0];
+        out.push_str(str5(String::from("  v"), i64_to_str(id),
+            String::from(" = v"), i64_to_str(src), String::from(";\n")));
         return;
     }
     if ds == String::from("__vow_string_len") {

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -71,6 +71,9 @@ fn resolve_ast_ty(e: CheckEnv, m: Module, ast_tid: i64) -> i64 [io] {
         if base_ptid != -1 {
             return ts_make_applied(e.ts, base_ptid, arg_tids);
         }
+        if name == String::from("Vec") {
+            return ts_make_applied(e.ts, ts_make_enum(e.ts, name), arg_tids);
+        }
         let sidx: i64 = env_lookup_struct(e, name);
         if sidx != -1 {
             return ts_make_applied(e.ts, ts_make_struct(e.ts, name), arg_tids);
@@ -104,6 +107,47 @@ fn is_opaque(tid: i64) -> bool vow {
     requires: tid >= 0
 } {
     tid == CTY_NEVER() || tid == CTY_UNKNOWN()
+}
+
+fn is_flat_slot_tid(ts: TyStore, tid: i64) -> bool {
+    let tag: i64 = ty_tag(ts, tid);
+    (tag >= CTY_I8() && tag <= CTY_U128()) || tag == CTY_F32() || tag == CTY_F64() || tag == CTY_BOOL()
+}
+
+fn is_flat_vec_tid(ts: TyStore, tid: i64) -> bool {
+    if ty_tag(ts, tid) != CTY_APPLIED() {
+        return false;
+    }
+    let base_tid: i64 = ty_a(ts, tid);
+    let base_tag: i64 = ty_tag(ts, base_tid);
+    if base_tag != CTY_STRUCT() && base_tag != CTY_ENUM() {
+        return false;
+    }
+    if ty_struct_name(ts, base_tid) != String::from("Vec") {
+        return false;
+    }
+    let args_lid: i64 = ty_b(ts, tid);
+    if ts_arg_len(ts, args_lid) == 0 {
+        return false;
+    }
+    is_flat_slot_tid(ts, ts_arg_get(ts, args_lid, 0))
+}
+
+fn is_supported_pin_tid(ts: TyStore, tid: i64) -> bool {
+    tid == CTY_STR() || is_flat_vec_tid(ts, tid)
+}
+
+fn is_vec_raw_parts_copy_expr(a: AstArena, eid: i64) -> bool {
+    if expr_tag(a, eid) != EXPR_ECTOR() {
+        return false;
+    }
+    let path_lid: i64 = expr_a(a, eid);
+    if list_len(a, path_lid) < 2 {
+        return false;
+    }
+    let first_sid: i64 = list_get(a, path_lid, 0);
+    let second_sid: i64 = list_get(a, path_lid, 1);
+    arena_str(a, first_sid) == String::from("Vec") && arena_str(a, second_sid) == String::from("from_raw_parts_copy")
 }
 
 fn check_module(e: CheckEnv, m: Module) [io] {
@@ -406,6 +450,9 @@ fn check_block(e: CheckEnv, m: Module, bid: i64) -> i64 [io] {
                 if !is_coercible(e.ts, init_tid, at_tid) {
                     env_emit_error(e, String::from("let binding type mismatch"), stmt_span(a, sid));
                 }
+                if is_vec_raw_parts_copy_expr(a, init_eid) && !is_flat_vec_tid(e.ts, at_tid) {
+                    env_emit_error(e, String::from("Vec::from_raw_parts_copy requires a flat scalar Vec<T>"), stmt_span(a, sid));
+                }
                 at_tid
             };
             bind_pattern(e, m, pat_pid, bound_tid);
@@ -684,6 +731,18 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
         if callee_tag == EXPR_IDENT() {
             let name_sid: i64 = expr_a(a, callee_eid);
             let name: String = arena_str(a, name_sid);
+            if name == String::from("pin_to_root") {
+                if n_args != 1 {
+                    env_emit_error(e, String::from("wrong argument count"), expr_span(a, eid));
+                    return CTY_NEVER();
+                }
+                let arg_eid: i64 = list_get(a, args_lid, 0);
+                let arg_tid: i64 = check_expr(e, m, arg_eid);
+                if !is_supported_pin_tid(e.ts, arg_tid) && !is_opaque(arg_tid) {
+                    env_emit_error(e, String::from("pin_to_root supports String and flat scalar Vec<T> only"), expr_span(a, eid));
+                }
+                return arg_tid;
+            }
             let fidx: i64 = env_lookup_fn(e, name);
             if fidx == -1 {
                 let msg: String = String::from("undefined function `");
@@ -1129,7 +1188,29 @@ fn check_expr_inner(e: CheckEnv, m: Module, eid: i64) -> i64 [io] {
         if first_name == String::from("Result") {
             return ts_make_enum(e.ts, String::from("Result"));
         }
+        if first_name == String::from("Vec") {
+            if n_path > 1 {
+                let second_sid: i64 = list_get(a, path_lid, 1);
+                let second_name: String = arena_str(a, second_sid);
+                if second_name == String::from("from_raw_parts_copy") {
+                    if n_args != 2 {
+                        env_emit_error(e, String::from("wrong argument count"), expr_span(a, eid));
+                    }
+                    return CTY_NEVER();
+                }
+            }
+        }
         if first_name == String::from("String") {
+            if n_path > 1 {
+                let second_sid: i64 = list_get(a, path_lid, 1);
+                let second_name: String = arena_str(a, second_sid);
+                if second_name == String::from("from_raw_parts_copy") {
+                    if n_args != 2 {
+                        env_emit_error(e, String::from("wrong argument count"), expr_span(a, eid));
+                    }
+                    return CTY_STR();
+                }
+            }
             return CTY_STR();
         }
         if n_path > 1 {

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1046,6 +1046,34 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let name_sid: i64 = expr_a(a, callee_eid);
             fn_name = arena_str(a, name_sid);
         }
+        if fn_name == String::from("pin_to_root") {
+            let nargs: i64 = list_len(a, args_lid);
+            if nargs > 0 {
+                let arg_eid: i64 = list_get(a, args_lid, 0);
+                let source_id: i64 = lower_consumed_expr(ctx, arg_eid);
+                if lctx_get_tag(ctx, source_id) == String::from("String") {
+                    let call_args: Vec<i64> = Vec::new();
+                    call_args.push(source_id);
+                    let result: i64 = lctx_emit(ctx, IOP_CALL(), ITY_PTR(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_pin_to_root"));
+                    lctx_tag(ctx, result, String::from("String"));
+                    lctx_track_alloc(ctx, result, String::from("String"), 0);
+                    return result;
+                }
+                if lctx_get_tag(ctx, source_id) == String::from("Vec") {
+                    let call_args: Vec<i64> = Vec::new();
+                    call_args.push(source_id);
+                    let result: i64 = lctx_emit(ctx, IOP_CALL(), ITY_PTR(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_pin_to_root_val"));
+                    lctx_tag(ctx, result, String::from("Vec"));
+                    let elem_name: String = lctx_get_vec_elem(ctx, source_id);
+                    if elem_name.len() > 0 {
+                        lctx_tag_vec_elem(ctx, result, elem_name);
+                    }
+                    lctx_track_alloc(ctx, result, String::from("Vec"), 0);
+                    return result;
+                }
+                return source_id;
+            }
+        }
         let debug_ext: String = debug_builtin_to_extern(fn_name);
         if debug_ext != String::from("") {
             let ret_ty: i64 = debug_builtin_ret_ty(fn_name);
@@ -2026,6 +2054,29 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             }
         }
 
+        if enum_name == String::from("String") && variant_name == String::from("from_raw_parts_copy") {
+            let call_args: Vec<i64> = Vec::new();
+            let nargs: i64 = list_len(a, fields_lid);
+            if nargs > 0 {
+                let ptr_eid: i64 = list_get(a, fields_lid, 0);
+                call_args.push(lower_expr(ctx, ptr_eid));
+            } else {
+                let zero_args: Vec<i64> = Vec::new();
+                call_args.push(lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), zero_args, IDATA_CONST_I64(), 0, 0, String::from("")));
+            }
+            if nargs > 1 {
+                let len_eid: i64 = list_get(a, fields_lid, 1);
+                call_args.push(lower_expr(ctx, len_eid));
+            } else {
+                let zero_args2: Vec<i64> = Vec::new();
+                call_args.push(lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), zero_args2, IDATA_CONST_I64(), 0, 0, String::from("")));
+            }
+            let result: i64 = lctx_emit(ctx, IOP_CALL(), ITY_PTR(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_from_raw_parts_copy"));
+            lctx_tag(ctx, result, String::from("String"));
+            lctx_track_alloc(ctx, result, String::from("String"), 0);
+            return result;
+        }
+
         if enum_name == String::from("String") && variant_name == String::from("new") {
             let size_args: Vec<i64> = Vec::new();
             let size_val: i64 = lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), size_args, IDATA_CONST_I64(), 1, 0, String::from(""));
@@ -2059,6 +2110,29 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             let vec_result: i64 = lctx_emit(ctx, IOP_CALL(), ITY_PTR(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_new"));
             lctx_track_alloc(ctx, vec_result, String::from("Vec"), 0);
             return vec_result;
+        }
+
+        if enum_name == String::from("Vec") && variant_name == String::from("from_raw_parts_copy") {
+            let call_args: Vec<i64> = Vec::new();
+            let nargs: i64 = list_len(a, fields_lid);
+            if nargs > 0 {
+                let ptr_eid: i64 = list_get(a, fields_lid, 0);
+                call_args.push(lower_expr(ctx, ptr_eid));
+            } else {
+                let zero_args: Vec<i64> = Vec::new();
+                call_args.push(lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), zero_args, IDATA_CONST_I64(), 0, 0, String::from("")));
+            }
+            if nargs > 1 {
+                let len_eid: i64 = list_get(a, fields_lid, 1);
+                call_args.push(lower_expr(ctx, len_eid));
+            } else {
+                let zero_args2: Vec<i64> = Vec::new();
+                call_args.push(lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), zero_args2, IDATA_CONST_I64(), 0, 0, String::from("")));
+            }
+            let result: i64 = lctx_emit(ctx, IOP_CALL(), ITY_PTR(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_from_raw_parts_copy_val"));
+            lctx_tag(ctx, result, String::from("Vec"));
+            lctx_track_alloc(ctx, result, String::from("Vec"), 0);
+            return result;
         }
 
         let tag_val: i64 = lctx_find_variant_tag(ctx, enum_name, variant_name);

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -1708,6 +1708,7 @@ fn skill_json() -> String {
     r.push_str(String::from("      \"unsafe\"\n"));
     r.push_str(String::from("    ],\n"));
     r.push_str(String::from("    \"builtins\": {\n"));
+    r.push_str(String::from("      \"pin_to_root\": \"fn(value: String) -> String and fn<T>(value: Vec<T>) -> Vec<T> for flat scalar T []\",\n"));
     r.push_str(String::from("      \"print_str\": \"fn(s: String) -> () [io]\",\n"));
     r.push_str(String::from("      \"print_i64\": \"fn(v: i64) -> () [io]\",\n"));
     r.push_str(String::from("      \"print_u64\": \"fn(v: u64) -> () [io]\",\n"));
@@ -1850,6 +1851,7 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"methods\": {\n"));
     r.push_str(String::from("      \"Vec<T>\": [\n"));
     r.push_str(String::from("        \"Vec::new()\",\n"));
+    r.push_str(String::from("        \"Vec::from_raw_parts_copy(ptr, len)\",\n"));
     r.push_str(String::from("        \".push(val)\",\n"));
     r.push_str(String::from("        \".pop()\",\n"));
     r.push_str(String::from("        \".len()\",\n"));
@@ -1861,6 +1863,7 @@ fn skill_json() -> String {
     r.push_str(String::from("      \"String\": [\n"));
     r.push_str(String::from("        \"String::from(lit)\",\n"));
     r.push_str(String::from("        \"String::new()\",\n"));
+    r.push_str(String::from("        \"String::from_raw_parts_copy(ptr, len)\",\n"));
     r.push_str(String::from("        \".len()\",\n"));
     r.push_str(String::from("        \".byte_at(i)\",\n"));
     r.push_str(String::from("        \".push_byte(b)\",\n"));
@@ -2033,9 +2036,9 @@ fn skill_human() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("TYPES     : i32  i64  u8  u64  f32  f64  bool  ()  !  Vec<T>  Option<T>  Result<T, E>  String  HashMap<K, V>\n"));
     r.push_str(String::from("EFFECTS   : io  read  write  panic  unsafe\n"));
-    r.push_str(String::from("BUILTINS  : print_str: fn(s: String) -> () [io]   print_i64: fn(v: i64) -> () [io]   print_u64: fn(v: u64) -> () [io]\n"));
-    r.push_str(String::from("            eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   num_cpus: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]\n"));
-    r.push_str(String::from("METHODS   : Vec: Vec::new/push/pop/len/clear/truncate/v[i]/v[i] = val   String: String::from/String::new/len/byte_at/push_byte/push_str/clear/contains/eq/substring/parse_i64/parse_u64\n"));
+    r.push_str(String::from("BUILTINS  : pin_to_root: fn(value: String) -> String and fn<T>(value: Vec<T>) -> Vec<T> for flat scalar T []   print_str: fn(s: String) -> () [io]   print_i64: fn(v: i64) -> () [io]\n"));
+    r.push_str(String::from("            print_u64: fn(v: u64) -> () [io]   eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   num_cpus: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]\n"));
+    r.push_str(String::from("METHODS   : Vec: Vec::new/Vec::from_raw_parts_copy/push/pop/len/clear/truncate/v[i]/v[i] = val   String: String::from/String::new/String::from_raw_parts_copy/len/byte_at/push_byte/push_str/clear/contains/eq/substring/parse_i64/parse_u64\n"));
     r.push_str(String::from("            HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap\n"));
     r.push_str(String::from("OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?\n"));
     r.push_str(String::from("\n"));
@@ -2642,6 +2645,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| Method         | Signature                        |\n"));
     r.push_str(String::from("|----------------|----------------------------------|\n"));
     r.push_str(String::from("| `Vec::new()`   | `() -> Vec<T>`                   |\n"));
+    r.push_str(String::from("| `Vec::from_raw_parts_copy(ptr, len)` | `(i64, i64) -> Vec<T>` for flat scalar `T` |\n"));
     r.push_str(String::from("| `.push(val)`   | `(T) -> ()`                      |\n"));
     r.push_str(String::from("| `.pop()`       | `() -> ()`                       |\n"));
     r.push_str(String::from("| `.len()`       | `() -> i64`                      |\n"));
@@ -2656,6 +2660,7 @@ fn skill_full() -> String {
     r.push_str(String::from("|---------------------|-----------------------------|\n"));
     r.push_str(String::from("| `String::from(lit)` | `(&str) -> String`          |\n"));
     r.push_str(String::from("| `String::new()`     | `() -> String`              |\n"));
+    r.push_str(String::from("| `String::from_raw_parts_copy(ptr, len)` | `(i64, i64) -> String` |\n"));
     r.push_str(String::from("| `.len()`            | `() -> i64`                 |\n"));
     r.push_str(String::from("| `.byte_at(i)`       | `(i64) -> i64`              |\n"));
     r.push_str(String::from("| `.push_byte(b)`     | `(i64) -> ()`               |\n"));
@@ -2765,6 +2770,18 @@ fn skill_full() -> String {
     r.push_str(String::from("Contract expressions (`requires`, `ensures`, `invariant`) must be pure -- they cannot call effectful functions.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Builtin Function Signatures\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("#### FFI Wrapper Intrinsics\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("| Function         | Signature                                  | Effects    |\n"));
+    r.push_str(String::from("|------------------|--------------------------------------------|------------|\n"));
+    r.push_str(String::from("| `pin_to_root`    | `fn(value: String) -> String` and `fn<T>(value: Vec<T>) -> Vec<T>` for flat scalar `T` | `[]` |\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("`pin_to_root` is a compiler intrinsic, not a user-defined generic. Each call site is monomorphised from the argument type. It always deep-copies the supported heap value into root storage; it does not inspect descriptor tags and does not claim idempotency. The current supported forms are `String` and `Vec<T>` where `T` is a flat scalar slot type (`i*`, `u*`, `f32`, `f64`, `bool`). Pointer-containing payloads, user structs, enums, and maps require hand-written deep-copy wrappers at the FFI boundary.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("`String::from_raw_parts_copy(ptr: i64, len: i64)` copies `len` bytes from a raw C pointer into a fresh `String`. `Vec::from_raw_parts_copy(ptr: i64, len: i64)` copies `len` flat scalar slots into a fresh `Vec<T>`. The surface length type is `i64`; the code generator converts pointer and length values to the platform pointer-sized ABI type at the FFI boundary. Both helpers have a `FreshInCaller` return summary.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("For pointer-containing C payloads, a wrapper must be written per type: call the extern, recursively copy every Vow-owned heap subobject into the target region, free every C-owned pointer according to the extern's ownership contract, then return the Vow-placed value. A bytewise copy of a pointer-containing payload is unsound because it preserves stale pointers into C-owned storage.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("#### Print / IO\n"));
     r.push_str(String::from("\n"));

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -892,6 +892,11 @@ fn deep_ret_const_global() -> DeepRet {
     DeepRet { kind: RSUM_KIND_CONSTANT_GLOBAL(), aux: 0, aliases: Vec::new() }
 }
 
+fn extern_fresh_in_caller(sym: String) -> bool {
+    sym == String::from("__vow_string_from_raw_parts_copy")
+        || sym == String::from("__vow_vec_from_raw_parts_copy_val")
+}
+
 fn deep_ret_uninit() -> DeepRet {
     DeepRet { kind: RSUM_INTERNAL_UNINIT(), aux: 0, aliases: Vec::new() }
 }
@@ -933,6 +938,9 @@ fn deep_origin_inner(
         return deep_ret_const_global();
     }
     if inst.op == IOP_CALL() {
+        if inst.dk == IDATA_CALL_EXTERN() && extern_fresh_in_caller(inst.ds) {
+            return DeepRet { kind: RSUM_KIND_FRESH_IN_CALLER(), aux: 0, aliases: Vec::new() };
+        }
         if inst.dk == IDATA_CALL_TARGET() {
             let callee_idx: i64 = inst.dv;
             if callee_idx >= 0 && callee_idx < int_kinds.len() {

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -285,7 +285,10 @@ fn watchdog_ms_for(effective_timeout: String) -> i64 {
     if effective_timeout.len() > 0 {
         let n: i64 = str_to_i64(effective_timeout);
         if n >= 0 {
-            return n *! 1000;
+            if n > 9223372036854775 {
+                return DEFAULT_ESBMC_TIMEOUT_MS();
+            }
+            return n * 1000;
         }
     }
     DEFAULT_ESBMC_TIMEOUT_MS()

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -522,6 +522,7 @@ m.contains_key(k)
 | Method         | Signature                        |
 |----------------|----------------------------------|
 | `Vec::new()`   | `() -> Vec<T>`                   |
+| `Vec::from_raw_parts_copy(ptr, len)` | `(i64, i64) -> Vec<T>` for flat scalar `T` |
 | `.push(val)`   | `(T) -> ()`                      |
 | `.pop()`       | `() -> ()`                       |
 | `.len()`       | `() -> i64`                      |
@@ -536,6 +537,7 @@ m.contains_key(k)
 |---------------------|-----------------------------|
 | `String::from(lit)` | `(&str) -> String`          |
 | `String::new()`     | `() -> String`              |
+| `String::from_raw_parts_copy(ptr, len)` | `(i64, i64) -> String` |
 | `.len()`            | `() -> i64`                 |
 | `.byte_at(i)`       | `(i64) -> i64`              |
 | `.push_byte(b)`     | `(i64) -> ()`               |
@@ -645,6 +647,18 @@ If `caller` omitted `[io]`, the type checker would emit `EffectViolation`.
 Contract expressions (`requires`, `ensures`, `invariant`) must be pure — they cannot call effectful functions.
 
 ### Builtin Function Signatures
+
+#### FFI Wrapper Intrinsics
+
+| Function         | Signature                                  | Effects    |
+|------------------|--------------------------------------------|------------|
+| `pin_to_root`    | `fn(value: String) -> String` and `fn<T>(value: Vec<T>) -> Vec<T>` for flat scalar `T` | `[]` |
+
+`pin_to_root` is a compiler intrinsic, not a user-defined generic. Each call site is monomorphised from the argument type. It always deep-copies the supported heap value into root storage; it does not inspect descriptor tags and does not claim idempotency. The current supported forms are `String` and `Vec<T>` where `T` is a flat scalar slot type (`i*`, `u*`, `f32`, `f64`, `bool`). Pointer-containing payloads, user structs, enums, and maps require hand-written deep-copy wrappers at the FFI boundary.
+
+`String::from_raw_parts_copy(ptr: i64, len: i64)` copies `len` bytes from a raw C pointer into a fresh `String`. `Vec::from_raw_parts_copy(ptr: i64, len: i64)` copies `len` flat scalar slots into a fresh `Vec<T>`. The surface length type is `i64`; the code generator converts pointer and length values to the platform pointer-sized ABI type at the FFI boundary. Both helpers have a `FreshInCaller` return summary.
+
+For pointer-containing C payloads, a wrapper must be written per type: call the extern, recursively copy every Vow-owned heap subobject into the target region, free every C-owned pointer according to the extern's ownership contract, then return the Vow-placed value. A bytewise copy of a pointer-containing payload is unsound because it preserves stale pointers into C-owned storage.
 
 #### Print / IO
 

--- a/tests/error/pin_to_root_vec_string.vow
+++ b/tests/error/pin_to_root_vec_string.vow
@@ -1,0 +1,8 @@
+// TEST: stderr "pin_to_root"
+module PinToRootVecString
+
+fn main() -> i32 [io] {
+    let v: Vec<String> = Vec::new();
+    let _pinned: Vec<String> = pin_to_root(v);
+    0
+}

--- a/tests/error/vec_raw_parts_copy_string.vow
+++ b/tests/error/vec_raw_parts_copy_string.vow
@@ -1,0 +1,7 @@
+// TEST: stderr "Vec::from_raw_parts_copy"
+module VecRawPartsCopyString
+
+fn main() -> i32 {
+    let _v: Vec<String> = Vec::from_raw_parts_copy(0, 0);
+    0
+}

--- a/tests/run/pin_to_root_string.vow
+++ b/tests/run/pin_to_root_string.vow
@@ -1,0 +1,9 @@
+// TEST: stdout "ok"
+module PinToRootString
+
+fn main() -> i32 [io] {
+    let s: String = String::from("ok");
+    let pinned: String = pin_to_root(s);
+    print_str(pinned);
+    0
+}

--- a/tests/run/pin_to_root_vec_copy.vow
+++ b/tests/run/pin_to_root_vec_copy.vow
@@ -1,0 +1,13 @@
+// TEST: stdout "ok"
+module PinToRootVecCopy
+
+fn main() -> i32 [io] {
+    let v: Vec<i64> = Vec::new();
+    v.push(1);
+    let pinned: Vec<i64> = pin_to_root(v);
+    v.push(2);
+    if pinned.len() == 1 && pinned[0] == 1 {
+        print_str(String::from("ok"));
+    }
+    0
+}

--- a/tests/run/string_from_raw_parts_copy_empty.vow
+++ b/tests/run/string_from_raw_parts_copy_empty.vow
@@ -1,0 +1,10 @@
+// TEST: stdout "ok"
+module StringFromRawPartsCopyEmpty
+
+fn main() -> i32 [io] {
+    let s: String = String::from_raw_parts_copy(0, 0);
+    if s.len() == 0 {
+        print_str(String::from("ok"));
+    }
+    0
+}

--- a/tests/run/string_parse.vow
+++ b/tests/run/string_parse.vow
@@ -18,10 +18,11 @@ fn try_parse_u64(s: String) -> Option<u64> [io] {
     Option::Some(v)
 }
 
-fn main() [io] {
+fn main() -> i32 [io] {
     let s: String = String::from("42");
     try_parse_i64(s);
 
     let us: String = String::from("99");
     try_parse_u64(us);
+    128
 }

--- a/tests/run/vec_from_raw_parts_copy_empty.vow
+++ b/tests/run/vec_from_raw_parts_copy_empty.vow
@@ -1,0 +1,10 @@
+// TEST: stdout "ok"
+module VecFromRawPartsCopyEmpty
+
+fn main() -> i32 [io] {
+    let v: Vec<i64> = Vec::from_raw_parts_copy(0, 0);
+    if v.len() == 0 {
+        print_str(String::from("ok"));
+    }
+    0
+}

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -196,6 +196,13 @@ const REGION_KIND_CALLER: i64 = 1;
 const REGION_KIND_ROOT: i64 = 2;
 const REGION_KIND_RODATA: i64 = 3;
 
+fn extern_uses_target_region(sym: &str) -> bool {
+    matches!(
+        sym,
+        "__vow_string_from_raw_parts_copy" | "__vow_vec_from_raw_parts_copy_val"
+    )
+}
+
 /// Size of `vow_runtime::VowArena` in bytes — asserted in
 /// `vow-runtime/src/lib.rs` (`assert!(size_of::<VowArena>() == 48)`).
 /// Mirrors the same constant in `vow-codegen/src/cranelift_backend.rs`
@@ -1756,26 +1763,56 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                         .iter()
                         .map(|p| p.value_type)
                         .collect();
-                    let call_args: Vec<Value> = (0..alen)
-                        .map(|i| {
-                            let arg_id = all_args[aoff + i];
-                            let v = *value_map.get(&arg_id).unwrap_or_else(|| {
-                                panic!(
-                                    "clif shim: IOP_CALL value_map miss: inst_id={iid} arg_id={arg_id} (block={bi}, inst_idx={ii}, func_idx={func_idx})"
-                                )
-                            });
-                            if let Some(&expected_ty) = expected_types.get(i) {
+                    let mut call_args: Vec<Value> = Vec::new();
+                    if dk == IDATA_CALL_EXTERN {
+                        let sym = unsafe { read_vow_string(inst_ds_ptrs[ii]) };
+                        if extern_uses_target_region(sym) {
+                            let rgn = inst_rgns[ii];
+                            let kind = rgn & 3;
+                            let payload = rgn >> 2;
+                            let arena = match kind {
+                                REGION_KIND_ROOT | REGION_KIND_CALLER => {
+                                    builder.ins().global_value(types::I64, root_arena_gv)
+                                }
+                                REGION_KIND_BLOCK => {
+                                    let slot =
+                                        *block_arena_slots.entry(payload).or_insert_with(|| {
+                                            builder.create_sized_stack_slot(StackSlotData::new(
+                                                StackSlotKind::ExplicitSlot,
+                                                48,
+                                                3,
+                                            ))
+                                        });
+                                    builder.ins().stack_addr(types::I64, slot, 0)
+                                }
+                                _ => builder.ins().global_value(types::I64, root_arena_gv),
+                            };
+                            call_args.push(arena);
+                        }
+                    }
+                    let hidden_arg_offset = call_args.len();
+                    for i in 0..alen {
+                        let arg_id = all_args[aoff + i];
+                        let v = *value_map.get(&arg_id).unwrap_or_else(|| {
+                            panic!(
+                                "clif shim: IOP_CALL value_map miss: inst_id={iid} arg_id={arg_id} (block={bi}, inst_idx={ii}, func_idx={func_idx})"
+                            )
+                        });
+                        let v =
+                            if let Some(&expected_ty) = expected_types.get(i + hidden_arg_offset) {
                                 let actual_ty = builder.func.dfg.value_type(v);
                                 if actual_ty == types::I32 && expected_ty == types::I64 {
-                                    return builder.ins().sextend(types::I64, v);
+                                    builder.ins().sextend(types::I64, v)
+                                } else if actual_ty == types::I8 && expected_ty == types::I64 {
+                                    builder.ins().uextend(types::I64, v)
+                                } else {
+                                    v
                                 }
-                                if actual_ty == types::I8 && expected_ty == types::I64 {
-                                    return builder.ins().uextend(types::I64, v);
-                                }
-                            }
-                            v
-                        })
-                        .collect();
+                            } else {
+                                v
+                            };
+                        call_args.push(v);
+                    }
                     let call_inst = builder.ins().call(func_ref, &call_args);
                     let results = builder.inst_results(call_inst);
                     if results.is_empty() {
@@ -2296,6 +2333,16 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_vec_new_val" => {
             sig.returns.push(AbiParam::new(types::I64));
         }
+        "__vow_vec_from_raw_parts_copy_val" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
+        "__vow_vec_pin_to_root_val" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
         "__vow_vec_len" => {
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
@@ -2330,6 +2377,16 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.returns.push(AbiParam::new(types::I64));
         }
         "__vow_string_from_cstr" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
+        "__vow_string_pin_to_root" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
+        "__vow_string_from_raw_parts_copy" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -1080,29 +1080,43 @@ fn lower_inst(
                 .iter()
                 .map(|p| p.value_type)
                 .collect();
-            let mut call_args: Vec<Value> = inst
-                .args
-                .iter()
-                .enumerate()
-                .map(|(i, id)| {
-                    let v = *ctx.value_map.get(id).unwrap_or_else(|| {
-                        panic!(
-                            "cranelift backend: Call value_map miss for arg {id:?} in inst {:?}",
-                            inst.id
-                        )
-                    });
-                    if let Some(&expected_ty) = expected_types.get(i) {
-                        let actual_ty = builder.func.dfg.value_type(v);
-                        if actual_ty == types::I32 && expected_ty == types::I64 {
-                            return builder.ins().sextend(types::I64, v);
-                        }
-                        if actual_ty == types::I8 && expected_ty == types::I64 {
-                            return builder.ins().uextend(types::I64, v);
-                        }
+            let external_target_region = match &inst.data {
+                InstData::CallExtern(sym) if extern_uses_target_region(sym) => Some(inst.region),
+                _ => None,
+            };
+            let mut call_args: Vec<Value> = Vec::new();
+            if let Some(region) = external_target_region {
+                let arena = region_to_arena_value(
+                    builder,
+                    region,
+                    ctx.hidden_region_values,
+                    ctx.block_arena_slots,
+                    ctx.root_arena_gv,
+                )?;
+                call_args.push(arena);
+            }
+            let hidden_arg_offset = call_args.len();
+            for (i, id) in inst.args.iter().enumerate() {
+                let v = *ctx.value_map.get(id).unwrap_or_else(|| {
+                    panic!(
+                        "cranelift backend: Call value_map miss for arg {id:?} in inst {:?}",
+                        inst.id
+                    )
+                });
+                let v = if let Some(&expected_ty) = expected_types.get(i + hidden_arg_offset) {
+                    let actual_ty = builder.func.dfg.value_type(v);
+                    if actual_ty == types::I32 && expected_ty == types::I64 {
+                        builder.ins().sextend(types::I64, v)
+                    } else if actual_ty == types::I8 && expected_ty == types::I64 {
+                        builder.ins().uextend(types::I64, v)
+                    } else {
+                        v
                     }
+                } else {
                     v
-                })
-                .collect();
+                };
+                call_args.push(v);
+            }
             if internal_call {
                 // Project the callee's hidden region parameters from the
                 // caller's frame (spec §5.2). The order MUST match
@@ -1816,6 +1830,16 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // elem_align
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec
         }
+        "__vow_vec_from_raw_parts_copy_val" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // raw i64 ptr
+            sig.params.push(AbiParam::new(types::I64)); // len
+            sig.returns.push(AbiParam::new(types::I64)); // copied *VowVec
+        }
+        "__vow_vec_pin_to_root_val" => {
+            sig.params.push(AbiParam::new(types::I64)); // source vec ptr
+            sig.returns.push(AbiParam::new(types::I64)); // copied *VowVec
+        }
         "__vow_vec_len" => {
             sig.params.push(AbiParam::new(types::I64)); // vec ptr
             sig.returns.push(AbiParam::new(types::I64)); // len
@@ -1853,6 +1877,16 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_string_from_cstr" => {
             sig.params.push(AbiParam::new(types::I64)); // C-string ptr
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
+        "__vow_string_pin_to_root" => {
+            sig.params.push(AbiParam::new(types::I64)); // source string ptr
+            sig.returns.push(AbiParam::new(types::I64)); // root-pinned *VowVec<u8>
+        }
+        "__vow_string_from_raw_parts_copy" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // raw bytes ptr
+            sig.params.push(AbiParam::new(types::I64)); // len
+            sig.returns.push(AbiParam::new(types::I64)); // copied *VowVec<u8>
         }
         "__vow_string_len" => {
             sig.params.push(AbiParam::new(types::I64)); // string ptr
@@ -2185,6 +2219,13 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         _ => {}
     }
     sig
+}
+
+fn extern_uses_target_region(sym: &str) -> bool {
+    matches!(
+        sym,
+        "__vow_string_from_raw_parts_copy" | "__vow_vec_from_raw_parts_copy_val"
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -835,6 +835,47 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 ExprKind::Ident(name) => name.clone(),
                 _ => todo!("non-ident callee in Call lowering"),
             };
+            if callee_name == "pin_to_root" {
+                let Some(source_id) = arg_ids.first().copied() else {
+                    return ctx.emit(Opcode::ConstUnit, Ty::Unit, vec![], InstData::None, span);
+                };
+                if ctx
+                    .inst_struct_type
+                    .get(&source_id)
+                    .is_some_and(|tag| tag == "String")
+                {
+                    let result = ctx.emit(
+                        Opcode::Call,
+                        Ty::Ptr,
+                        vec![source_id],
+                        InstData::CallExtern("__vow_string_pin_to_root".to_string()),
+                        span,
+                    );
+                    ctx.inst_struct_type.insert(result, "String".to_string());
+                    ctx.track_heap_alloc(result, "String");
+                    return result;
+                }
+                if ctx
+                    .inst_struct_type
+                    .get(&source_id)
+                    .is_some_and(|tag| tag == "Vec")
+                {
+                    let result = ctx.emit(
+                        Opcode::Call,
+                        Ty::Ptr,
+                        vec![source_id],
+                        InstData::CallExtern("__vow_vec_pin_to_root_val".to_string()),
+                        span,
+                    );
+                    ctx.inst_struct_type.insert(result, "Vec".to_string());
+                    if let Some(elem_name) = ctx.inst_vec_elem_type.get(&source_id).cloned() {
+                        ctx.inst_vec_elem_type.insert(result, elem_name);
+                    }
+                    ctx.track_heap_alloc(result, "Vec");
+                    return result;
+                }
+                return source_id;
+            }
             let call_info = ctx.func_index.get(&callee_name).cloned();
             if let Some(call_info) = call_info {
                 let result = ctx.emit(
@@ -1946,6 +1987,42 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 ctx.inst_struct_type.insert(ptr_id, "String".to_string());
                 return ptr_id;
             }
+            if enum_name == "String" && variant_name == "from_raw_parts_copy" {
+                let ptr_id = fields
+                    .first()
+                    .map(|e| lower_expr(ctx, e))
+                    .unwrap_or_else(|| {
+                        ctx.emit(
+                            Opcode::ConstI64,
+                            Ty::I64,
+                            vec![],
+                            InstData::ConstI64(0),
+                            span,
+                        )
+                    });
+                let len_id = fields
+                    .get(1)
+                    .map(|e| lower_expr(ctx, e))
+                    .unwrap_or_else(|| {
+                        ctx.emit(
+                            Opcode::ConstI64,
+                            Ty::I64,
+                            vec![],
+                            InstData::ConstI64(0),
+                            span,
+                        )
+                    });
+                let result = ctx.emit(
+                    Opcode::Call,
+                    Ty::Ptr,
+                    vec![ptr_id, len_id],
+                    InstData::CallExtern("__vow_string_from_raw_parts_copy".to_string()),
+                    span,
+                );
+                ctx.inst_struct_type.insert(result, "String".to_string());
+                ctx.track_heap_alloc(result, "String");
+                return result;
+            }
             // String::new() builtin — empty string via __vow_vec_new(1, 1)
             if enum_name == "String" && variant_name == "new" {
                 let size_val = ctx.emit(
@@ -2007,6 +2084,42 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     Ty::Ptr,
                     vec![size_val, align_val],
                     InstData::CallExtern("__vow_vec_new".to_string()),
+                    span,
+                );
+                ctx.inst_struct_type.insert(result, "Vec".to_string());
+                ctx.track_heap_alloc(result, "Vec");
+                return result;
+            }
+            if enum_name == "Vec" && variant_name == "from_raw_parts_copy" {
+                let ptr_id = fields
+                    .first()
+                    .map(|e| lower_expr(ctx, e))
+                    .unwrap_or_else(|| {
+                        ctx.emit(
+                            Opcode::ConstI64,
+                            Ty::I64,
+                            vec![],
+                            InstData::ConstI64(0),
+                            span,
+                        )
+                    });
+                let len_id = fields
+                    .get(1)
+                    .map(|e| lower_expr(ctx, e))
+                    .unwrap_or_else(|| {
+                        ctx.emit(
+                            Opcode::ConstI64,
+                            Ty::I64,
+                            vec![],
+                            InstData::ConstI64(0),
+                            span,
+                        )
+                    });
+                let result = ctx.emit(
+                    Opcode::Call,
+                    Ty::Ptr,
+                    vec![ptr_id, len_id],
+                    InstData::CallExtern("__vow_vec_from_raw_parts_copy_val".to_string()),
                     span,
                 );
                 ctx.inst_struct_type.insert(result, "Vec".to_string());

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -736,8 +736,19 @@ fn analyze_function(
     summary
 }
 
+fn extern_fresh_in_caller(sym: &str) -> bool {
+    matches!(
+        sym,
+        "__vow_string_from_raw_parts_copy" | "__vow_vec_from_raw_parts_copy_val"
+    )
+}
+
 fn is_heap_producing(inst: &Inst) -> bool {
     matches!(inst.opcode, Opcode::RegionAlloc)
+        || matches!(
+            (&inst.opcode, &inst.data),
+            (Opcode::Call, InstData::CallExtern(sym)) if extern_fresh_in_caller(sym)
+        )
 }
 
 /// Handle one instruction: contribute to `must_outlive` and to the
@@ -1088,6 +1099,11 @@ fn origin_to_internal_inner(
         | Opcode::ConstBool
         | Opcode::ConstUnit => InternalReturnRegion::Published(RegionConstraint::ConstantGlobal),
         Opcode::Call => {
+            if let InstData::CallExtern(sym) = &inst.data
+                && extern_fresh_in_caller(sym)
+            {
+                return InternalReturnRegion::Published(RegionConstraint::FreshInCaller);
+            }
             if let InstData::CallTarget(callee_id) = &inst.data
                 && let Some(cs) = summaries.get(callee_id.0 as usize)
             {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -860,6 +860,52 @@ pub extern "C" fn __vow_vec_new_val() -> *mut u8 {
     __vow_vec_new(8, 8)
 }
 
+unsafe fn __vow_vec_new_val_in_arena(arena: *mut VowArena) -> *mut u8 {
+    let header_ptr = unsafe { __vow_arena_alloc(arena, 24, 8) } as *mut VowVec;
+    unsafe {
+        (*header_ptr).ptr = 8 as *mut u8;
+        (*header_ptr).len = 0;
+        (*header_ptr).cap = 0;
+    }
+    sanitize_on_vec_new(header_ptr as usize);
+    header_ptr as *mut u8
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_vec_from_raw_parts_copy_val(
+    arena: *mut VowArena,
+    ptr: *const i64,
+    len: usize,
+) -> *mut u8 {
+    let vec = unsafe { __vow_vec_new_val_in_arena(arena) };
+    if len == 0 || ptr.is_null() {
+        return vec;
+    }
+    let bytes = len
+        .checked_mul(8)
+        .unwrap_or_else(|| oom_trap("Vec::from_raw_parts_copy"));
+    let v = unsafe { &mut *(vec as *mut VowVec) };
+    v.ptr = unsafe { __vow_arena_alloc(arena, bytes, 8) };
+    unsafe { std::ptr::copy_nonoverlapping(ptr as *const u8, v.ptr, bytes) };
+    v.len = len;
+    v.cap = len;
+    vec
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_vec_pin_to_root_val(source: *const u8) -> *mut u8 {
+    if source.is_null() {
+        return __vow_vec_new_val();
+    }
+    sanitize_on_read(source as usize, 0);
+    let src = unsafe { &*(source as *const VowVec) };
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe {
+        __vow_vec_from_raw_parts_copy_val(&raw mut __vow_root_arena, src.ptr as *const i64, src.len)
+    }
+}
+
 unsafe fn __vow_vec_reserve(vec: *mut u8, additional: usize, elem_size: usize, elem_align: usize) {
     let v = unsafe { &mut *(vec as *mut VowVec) };
     if v.cap == VOW_CAP_RODATA {
@@ -1083,6 +1129,38 @@ pub unsafe extern "C" fn __vow_string_clone_into_arena(
         unsafe { std::ptr::copy_nonoverlapping(src.ptr, p, len) };
         p
     };
+    unsafe {
+        (*header).ptr = data_ptr;
+        (*header).len = len;
+        (*header).cap = len;
+    }
+    header as *mut u8
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_pin_to_root(source: *const u8) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_clone_into_arena(&raw mut __vow_root_arena, source) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_from_raw_parts_copy(
+    arena: *mut VowArena,
+    ptr: *const u8,
+    len: usize,
+) -> *mut u8 {
+    let header = unsafe { __vow_arena_alloc(arena, 24, 8) } as *mut VowVec;
+    if len == 0 || ptr.is_null() {
+        unsafe {
+            (*header).ptr = std::ptr::dangling_mut::<u8>();
+            (*header).len = 0;
+            (*header).cap = 0;
+        }
+        return header as *mut u8;
+    }
+    let data_ptr = unsafe { __vow_arena_alloc(arena, len, 1) };
+    unsafe { std::ptr::copy_nonoverlapping(ptr, data_ptr, len) };
     unsafe {
         (*header).ptr = data_ptr;
         (*header).len = len;
@@ -2770,6 +2848,68 @@ mod tests {
             "cloned data must live inside the arena chunk"
         );
         unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
+    fn string_pin_to_root_deep_copies_bytes() {
+        let bytes: &[u8] = b"rooted";
+        let source = VowVec {
+            ptr: bytes.as_ptr() as *mut u8,
+            len: bytes.len(),
+            cap: VOW_CAP_RODATA,
+        };
+        let pinned = unsafe { __vow_string_pin_to_root(&source as *const VowVec as *const u8) };
+        let pv = unsafe { &*(pinned as *const VowVec) };
+        assert_eq!(pv.len, 6);
+        assert_eq!(pv.cap, 6, "pinning must return a mutable root copy");
+        assert_ne!(pv.ptr, bytes.as_ptr() as *mut u8);
+        let pinned_bytes = unsafe { std::slice::from_raw_parts(pv.ptr, pv.len) };
+        assert_eq!(pinned_bytes, b"rooted");
+    }
+
+    #[test]
+    fn string_from_raw_parts_copy_copies_bytes() {
+        unsafe { ensure_root_arena() };
+        let bytes: &[u8] = b"raw";
+        let copied = unsafe {
+            __vow_string_from_raw_parts_copy(&raw mut __vow_root_arena, bytes.as_ptr(), bytes.len())
+        };
+        let cv = unsafe { &*(copied as *const VowVec) };
+        assert_eq!(cv.len, 3);
+        assert!(cv.cap >= 3);
+        assert_ne!(cv.ptr, bytes.as_ptr() as *mut u8);
+        let copied_bytes = unsafe { std::slice::from_raw_parts(cv.ptr, cv.len) };
+        assert_eq!(copied_bytes, b"raw");
+    }
+
+    #[test]
+    fn vec_from_raw_parts_copy_val_copies_slots() {
+        unsafe { ensure_root_arena() };
+        let raw = [11_i64, 22_i64, 33_i64];
+        let copied = unsafe {
+            __vow_vec_from_raw_parts_copy_val(&raw mut __vow_root_arena, raw.as_ptr(), raw.len())
+        };
+        let cv = unsafe { &*(copied as *const VowVec) };
+        assert_eq!(cv.len, 3);
+        assert!(cv.cap >= 3);
+        assert_ne!(cv.ptr, raw.as_ptr() as *mut u8);
+        let copied_vals = unsafe { std::slice::from_raw_parts(cv.ptr as *const i64, cv.len) };
+        assert_eq!(copied_vals, &[11, 22, 33]);
+    }
+
+    #[test]
+    fn vec_pin_to_root_val_copies_slots() {
+        unsafe { ensure_root_arena() };
+        let raw = [7_i64, 8_i64];
+        let source = unsafe {
+            __vow_vec_from_raw_parts_copy_val(&raw mut __vow_root_arena, raw.as_ptr(), raw.len())
+        };
+        let pinned = unsafe { __vow_vec_pin_to_root_val(source) };
+        unsafe { __vow_vec_push_val(source, 9) };
+        let pv = unsafe { &*(pinned as *const VowVec) };
+        assert_eq!(pv.len, 2);
+        let pinned_vals = unsafe { std::slice::from_raw_parts(pv.ptr as *const i64, pv.len) };
+        assert_eq!(pinned_vals, &[7, 8]);
     }
 
     #[test]

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -42,6 +42,47 @@ fn suggest_similar(name: &str, candidates: &[String], max_distance: usize) -> Op
     best.map(|(_, s)| s.to_string())
 }
 
+fn is_flat_slot_ty(ty: &Ty) -> bool {
+    matches!(
+        ty,
+        Ty::I8
+            | Ty::I16
+            | Ty::I32
+            | Ty::I64
+            | Ty::I128
+            | Ty::U8
+            | Ty::U16
+            | Ty::U32
+            | Ty::U64
+            | Ty::U128
+            | Ty::F32
+            | Ty::F64
+            | Ty::Bool
+    )
+}
+
+fn is_flat_vec_ty(ty: &Ty) -> bool {
+    match ty {
+        Ty::Applied(base, args) if matches!(base.as_ref(), Ty::Struct(name) if name == "Vec") => {
+            args.first().is_some_and(is_flat_slot_ty)
+        }
+        _ => false,
+    }
+}
+
+fn is_supported_pin_ty(ty: &Ty) -> bool {
+    matches!(ty, Ty::Str) || is_flat_vec_ty(ty)
+}
+
+fn is_vec_raw_parts_copy_expr(expr: &vow_syntax::ast::Expr) -> bool {
+    matches!(
+        &expr.kind,
+        ExprKind::EnumConstruct { path, .. }
+            if path.first().is_some_and(|p| p == "Vec")
+                && path.get(1).is_some_and(|p| p == "from_raw_parts_copy")
+    )
+}
+
 pub struct Checker<'e> {
     pub(crate) env: TypeEnv,
     pub(crate) current_return_ty: Ty,
@@ -538,6 +579,18 @@ impl<'e> Checker<'e> {
                                     )],
                                 );
                             }
+                            if is_vec_raw_parts_copy_expr(init) && !is_flat_vec_ty(&ann_ty) {
+                                self.emit_error_with_hints(
+                                    ErrorCode::TypeMismatch,
+                                    format!(
+                                        "Vec::from_raw_parts_copy requires a flat scalar Vec<T>, found `{ann_ty}`"
+                                    ),
+                                    ann.span(),
+                                    vec![
+                                        "pointer-containing Vec payloads need a hand-written deep-copy wrapper".to_string(),
+                                    ],
+                                );
+                            }
                             ann_ty
                         }
                         Err(msg) => {
@@ -721,6 +774,35 @@ impl<'e> Checker<'e> {
                         return Ty::Unit;
                     }
                 };
+                if name == "pin_to_root" {
+                    if args.len() != 1 {
+                        self.emit_error_with_hints(
+                            ErrorCode::TypeMismatch,
+                            format!(
+                                "function `pin_to_root` expects 1 argument but got {}",
+                                args.len()
+                            ),
+                            expr.span,
+                            vec!["expected signature: (heap_value)".to_string()],
+                        );
+                        for arg in args {
+                            self.check_expr(arg);
+                        }
+                        return Ty::Unit;
+                    }
+                    let arg_ty = self.check_expr(&args[0]);
+                    if !is_supported_pin_ty(&arg_ty) && arg_ty != Ty::Never {
+                        self.emit_error_with_hints(
+                            ErrorCode::TypeMismatch,
+                            format!("pin_to_root does not support `{arg_ty}`"),
+                            args[0].span,
+                            vec![
+                                "supported forms are String and Vec<T> where T is a flat scalar slot; pointer-containing values need a hand-written deep-copy wrapper".to_string(),
+                            ],
+                        );
+                    }
+                    return arg_ty;
+                }
                 let (param_tys, return_ty) = match self.env.lookup_fn(name) {
                     Some(sig) => (sig.params.clone(), sig.return_ty.clone()),
                     None => {
@@ -1361,6 +1443,39 @@ impl<'e> Checker<'e> {
                         }
                         return Ty::Str;
                     }
+                    ("String", "from_raw_parts_copy") => {
+                        if fields.len() != 2 {
+                            self.emit_error_with_hints(
+                                ErrorCode::TypeMismatch,
+                                format!(
+                                    "String::from_raw_parts_copy expects 2 arguments but got {}",
+                                    fields.len()
+                                ),
+                                expr.span,
+                                vec![
+                                    "expected signature: (ptr: i64, len: i64) -> String"
+                                        .to_string(),
+                                ],
+                            );
+                        }
+                        for field in fields {
+                            let arg_ty = self.check_expr(field);
+                            if arg_ty != Ty::I64 && arg_ty != Ty::I32 && arg_ty != Ty::Never {
+                                self.emit_error_with_hints(
+                                    ErrorCode::TypeMismatch,
+                                    format!(
+                                        "String::from_raw_parts_copy argument has type `{arg_ty}` but expects `i64`"
+                                    ),
+                                    field.span,
+                                    vec![
+                                        "raw pointers and lengths cross the FFI boundary as i64"
+                                            .to_string(),
+                                    ],
+                                );
+                            }
+                        }
+                        return Ty::Str;
+                    }
                     ("String", "new") => {
                         return Ty::Str;
                     }
@@ -1404,6 +1519,39 @@ impl<'e> Checker<'e> {
                     }
                     ("Vec", "new") => {
                         // Vec::new() returns Vec<T> with unknown element type (Never)
+                        return Ty::Never;
+                    }
+                    ("Vec", "from_raw_parts_copy") => {
+                        if fields.len() != 2 {
+                            self.emit_error_with_hints(
+                                ErrorCode::TypeMismatch,
+                                format!(
+                                    "Vec::from_raw_parts_copy expects 2 arguments but got {}",
+                                    fields.len()
+                                ),
+                                expr.span,
+                                vec![
+                                    "expected signature: (ptr: i64, len: i64) -> Vec<T>"
+                                        .to_string(),
+                                ],
+                            );
+                        }
+                        for field in fields {
+                            let arg_ty = self.check_expr(field);
+                            if arg_ty != Ty::I64 && arg_ty != Ty::I32 && arg_ty != Ty::Never {
+                                self.emit_error_with_hints(
+                                    ErrorCode::TypeMismatch,
+                                    format!(
+                                        "Vec::from_raw_parts_copy argument has type `{arg_ty}` but expects `i64`"
+                                    ),
+                                    field.span,
+                                    vec![
+                                        "raw pointers and lengths cross the FFI boundary as i64"
+                                            .to_string(),
+                                    ],
+                                );
+                            }
+                        }
                         return Ty::Never;
                     }
                     _ => {}

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -99,7 +99,13 @@ fn collect_typed_vars(func: &Function, creator: &str, prefix: &str) -> HashSet<u
             if inst.opcode == Opcode::Call
                 && let InstData::CallExtern(ref name) = inst.data
             {
-                if name == creator {
+                let is_alt_creator = (prefix == "__vow_vec_"
+                    && (name == "__vow_vec_from_raw_parts_copy_val"
+                        || name == "__vow_vec_pin_to_root_val"))
+                    || (prefix == "__vow_string_"
+                        && (name == "__vow_string_from_raw_parts_copy"
+                            || name == "__vow_string_pin_to_root"));
+                if name == creator || is_alt_creator {
                     vars.insert(inst.id.0);
                 } else if name.starts_with(prefix) && !inst.args.is_empty() {
                     vars.insert(inst.args[0].0);
@@ -182,10 +188,14 @@ fn is_known_builtin(name: &str) -> bool {
         "__vow_vec_new"
             | "__vow_vec_push_val"
             | "__vow_vec_get_val"
+            | "__vow_vec_from_raw_parts_copy_val"
+            | "__vow_vec_pin_to_root_val"
             | "__vow_vec_len"
             | "__vow_vec_pop"
             | "__vow_vec_set_val"
             | "__vow_string_from_cstr"
+            | "__vow_string_from_raw_parts_copy"
+            | "__vow_string_pin_to_root"
             | "__vow_string_len"
             | "__vow_string_push_str"
             | "__vow_string_push_byte"
@@ -703,6 +713,17 @@ fn emit_inst(
                     "__vow_vec_new" => {
                         out.push_str(&format!("  v{id}.len = 0;\n"));
                     }
+                    "__vow_vec_from_raw_parts_copy_val" => {
+                        let len = inst.args[1].0;
+                        let vec_max = limits.vec_max;
+                        out.push_str(&format!(
+                            "  __ESBMC_assume(v{len} >= 0 && v{len} < {vec_max});\n  v{id}.len = v{len};\n"
+                        ));
+                    }
+                    "__vow_vec_pin_to_root_val" => {
+                        let source = inst.args[0].0;
+                        out.push_str(&format!("  v{id} = v{source};\n"));
+                    }
                     "__vow_vec_push_val" => {
                         let vec = inst.args[0].0;
                         let val = inst.args[1].0;
@@ -754,6 +775,17 @@ fn emit_inst(
                             "  v{id}.len = __VERIFIER_nondet_long();\n\
                              \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {string_max});\n",
                         ));
+                    }
+                    "__vow_string_from_raw_parts_copy" => {
+                        let len = inst.args[1].0;
+                        let string_max = limits.string_max;
+                        out.push_str(&format!(
+                            "  __ESBMC_assume(v{len} >= 0 && v{len} < {string_max});\n  v{id}.len = v{len};\n"
+                        ));
+                    }
+                    "__vow_string_pin_to_root" => {
+                        let source = inst.args[0].0;
+                        out.push_str(&format!("  v{id} = v{source};\n"));
                     }
                     "__vow_string_len" => {
                         let s = inst.args[0].0;

--- a/vow/src/cache.rs
+++ b/vow/src/cache.rs
@@ -8,9 +8,9 @@ use vow_verify::Counterexample;
 use crate::frontend::DependencyManifest;
 
 // Bump this whenever generated object files are no longer ABI-compatible with
-// existing cached artifacts. Phase 4 adds the root-arena argument to
-// __vow_arena_alloc, so pre-cutover objects must not be reused.
-const COMPILE_CACHE_ABI_VERSION: &str = "arena-phase4-region-alloc-v1";
+// existing cached artifacts. Phase 7 adds FFI wrapper stdlib intrinsics and
+// runtime helper imports, so pre-cutover objects must not be reused.
+const COMPILE_CACHE_ABI_VERSION: &str = "arena-phase7-ffi-wrapper-v1";
 
 pub struct CompileCache {
     dir: PathBuf,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1016,6 +1016,7 @@ fn skill_json() -> String {
       "unsafe"
     ],
     "builtins": {
+      "pin_to_root": "fn(value: String) -> String and fn<T>(value: Vec<T>) -> Vec<T> for flat scalar T []",
       "print_str": "fn(s: String) -> () [io]",
       "print_i64": "fn(v: i64) -> () [io]",
       "print_u64": "fn(v: u64) -> () [io]",
@@ -1158,6 +1159,7 @@ fn skill_json() -> String {
     "methods": {
       "Vec<T>": [
         "Vec::new()",
+        "Vec::from_raw_parts_copy(ptr, len)",
         ".push(val)",
         ".pop()",
         ".len()",
@@ -1169,6 +1171,7 @@ fn skill_json() -> String {
       "String": [
         "String::from(lit)",
         "String::new()",
+        "String::from_raw_parts_copy(ptr, len)",
         ".len()",
         ".byte_at(i)",
         ".push_byte(b)",
@@ -1341,9 +1344,9 @@ LANGUAGE SUMMARY
 
 TYPES     : i32  i64  u8  u64  f32  f64  bool  ()  !  Vec<T>  Option<T>  Result<T, E>  String  HashMap<K, V>
 EFFECTS   : io  read  write  panic  unsafe
-BUILTINS  : print_str: fn(s: String) -> () [io]   print_i64: fn(v: i64) -> () [io]   print_u64: fn(v: u64) -> () [io]
-            eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   num_cpus: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]
-METHODS   : Vec: Vec::new/push/pop/len/clear/truncate/v[i]/v[i] = val   String: String::from/String::new/len/byte_at/push_byte/push_str/clear/contains/eq/substring/parse_i64/parse_u64
+BUILTINS  : pin_to_root: fn(value: String) -> String and fn<T>(value: Vec<T>) -> Vec<T> for flat scalar T []   print_str: fn(s: String) -> () [io]   print_i64: fn(v: i64) -> () [io]
+            print_u64: fn(v: u64) -> () [io]   eprintln_str: fn(s: String) -> () [io]   debug_str: fn(s: String) -> () []   debug_i64: fn(v: i64) -> () []   debug_u64: fn(v: u64) -> () []   fs_read: fn(path: String) -> String [read]   fs_write: fn(path: String, data: String) -> i64 [write]   fs_exists: fn(path: String) -> i64 [read]   fs_mkdir: fn(path: String) -> i64 [io]   fs_listdir: fn(path: String) -> Vec<String> [read]   fs_remove: fn(path: String) -> i64 [io]   fs_remove_dir: fn(path: String) -> i64 [io]   fs_is_dir: fn(path: String) -> i64 [read]   fs_rename: fn(old: String, new: String) -> i64 [io]   string_substr: fn(s: String, start: i64, len: i64) -> String []   string_split: fn(s: String, delim: String) -> Vec<String> []   string_starts_with: fn(s: String, prefix: String) -> i64 []   string_ends_with: fn(s: String, suffix: String) -> i64 []   string_trim: fn(s: String) -> String []   string_to_upper: fn(s: String) -> String []   string_to_lower: fn(s: String) -> String []   string_replace: fn(s: String, from: String, to: String) -> String []   string_join: fn(parts: Vec<String>, sep: String) -> String []   parse_i64: fn(s: String) -> i64 []   i64_to_string: fn(v: i64) -> String []   vec_sort: fn(v: Vec<i64>) -> Vec<i64> []   time_unix: fn() -> i64 [io]   time_unix_ms: fn() -> i64 [io]   num_cpus: fn() -> i64 [io]   hex_encode: fn(data: Vec<u8>) -> String []   hex_decode: fn(s: String) -> Vec<u8> []   args: fn() -> Vec<String> [read]   stdin_read: fn() -> String [read]   stdin_read_line: fn() -> String [read]   stdin_ready: fn() -> bool [read]   process_exit: fn(code: i64) -> ! [io]   process_run: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_get_stdout: fn() -> String [io]   process_get_stderr: fn() -> String [io]   process_start: fn(cmd: String, args: Vec<String>) -> i64 [io]   process_wait: fn(pid: i64) -> i64 [io]   process_wait_timeout: fn(pid: i64, timeout_ms: i64) -> i64 [io]   process_kill: fn(pid: i64) -> i64 [io]   process_stdout_for: fn(pid: i64) -> String [io]   process_stderr_for: fn(pid: i64) -> String [io]
+METHODS   : Vec: Vec::new/Vec::from_raw_parts_copy/push/pop/len/clear/truncate/v[i]/v[i] = val   String: String::from/String::new/String::from_raw_parts_copy/len/byte_at/push_byte/push_str/clear/contains/eq/substring/parse_i64/parse_u64
             HashMap: HashMap::new/insert/get/contains_key/remove/len   Option: unwrap
 OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?
 
@@ -1950,6 +1953,7 @@ m.contains_key(k)
 | Method         | Signature                        |
 |----------------|----------------------------------|
 | `Vec::new()`   | `() -> Vec<T>`                   |
+| `Vec::from_raw_parts_copy(ptr, len)` | `(i64, i64) -> Vec<T>` for flat scalar `T` |
 | `.push(val)`   | `(T) -> ()`                      |
 | `.pop()`       | `() -> ()`                       |
 | `.len()`       | `() -> i64`                      |
@@ -1964,6 +1968,7 @@ m.contains_key(k)
 |---------------------|-----------------------------|
 | `String::from(lit)` | `(&str) -> String`          |
 | `String::new()`     | `() -> String`              |
+| `String::from_raw_parts_copy(ptr, len)` | `(i64, i64) -> String` |
 | `.len()`            | `() -> i64`                 |
 | `.byte_at(i)`       | `(i64) -> i64`              |
 | `.push_byte(b)`     | `(i64) -> ()`               |
@@ -2073,6 +2078,18 @@ If `caller` omitted `[io]`, the type checker would emit `EffectViolation`.
 Contract expressions (`requires`, `ensures`, `invariant`) must be pure — they cannot call effectful functions.
 
 ### Builtin Function Signatures
+
+#### FFI Wrapper Intrinsics
+
+| Function         | Signature                                  | Effects    |
+|------------------|--------------------------------------------|------------|
+| `pin_to_root`    | `fn(value: String) -> String` and `fn<T>(value: Vec<T>) -> Vec<T>` for flat scalar `T` | `[]` |
+
+`pin_to_root` is a compiler intrinsic, not a user-defined generic. Each call site is monomorphised from the argument type. It always deep-copies the supported heap value into root storage; it does not inspect descriptor tags and does not claim idempotency. The current supported forms are `String` and `Vec<T>` where `T` is a flat scalar slot type (`i*`, `u*`, `f32`, `f64`, `bool`). Pointer-containing payloads, user structs, enums, and maps require hand-written deep-copy wrappers at the FFI boundary.
+
+`String::from_raw_parts_copy(ptr: i64, len: i64)` copies `len` bytes from a raw C pointer into a fresh `String`. `Vec::from_raw_parts_copy(ptr: i64, len: i64)` copies `len` flat scalar slots into a fresh `Vec<T>`. The surface length type is `i64`; the code generator converts pointer and length values to the platform pointer-sized ABI type at the FFI boundary. Both helpers have a `FreshInCaller` return summary.
+
+For pointer-containing C payloads, a wrapper must be written per type: call the extern, recursively copy every Vow-owned heap subobject into the target region, free every C-owned pointer according to the extern's ownership contract, then return the Vow-placed value. A bytewise copy of a pointer-containing payload is unsound because it preserves stale pointers into C-owned storage.
 
 #### Print / IO
 


### PR DESCRIPTION
## Summary
- add Phase 7 FFI wrapper intrinsics: `pin_to_root`, `String::from_raw_parts_copy`, and flat-slot `Vec::from_raw_parts_copy`
- route raw-copy returns through FreshInCaller regions across Rust and self-hosted compiler paths, codegen, verifier models, and runtime
- update spec/help output and add run/error fixtures for supported and rejected payloads

## Notes
- `Vec::from_raw_parts_copy` and `pin_to_root` accept flat scalar-slot `Vec<T>` payloads and reject pointer-containing payloads such as `Vec<String>`
- rebuilt the self-hosted fixed point manually with `--verify-jobs 4` because the stock bootstrap script still serializes verification with `--verify-jobs 1`

## Validation
- `cargo test --all`
- `cargo build --release -p vow`
- `uv run python scripts/check_help_coverage.py docs/spec/grammar.md "$(target/release/vow --help)"`
- `./target/release/vow build --verify-jobs 4 compiler/main.vow -o build/vowc`
- `build/vowc build --verify-jobs 4 compiler/main.vow -o build/vowc2`
- `build/vowc2 build --verify-jobs 4 compiler/main.vow -o build/vowc3`
- `sha256sum build/vowc2 build/vowc3` matched: `fb23786583d93c85ca4536149f2b5a40cd70857dfa35b70587d39e2b2f1c8fb2`
- `tests/run_tests.sh --no-bootstrap --no-verify` (97 passed, 0 failed, 1 skipped)

Closes #202