### PR TITLE
[codex] Fix checked arithmetic result type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
           rm "/tmp/$ESBMC_ZIP"
       - run: echo "$HOME/esbmc/bin" >> "$GITHUB_PATH"
       - run: cargo build --all
+      - name: Build concatenated self-hosted compiler
+        run: |
+          bash scripts/concat_vow.sh clif > /tmp/compiler_clif.vow
+          ulimit -v 2000000
+          ./target/debug/vow build --no-verify --no-cache /tmp/compiler_clif.vow -o /tmp/vowc_concat
+          test -x /tmp/vowc_concat
       - run: cargo llvm-cov --all --lcov --output-path lcov.info
       - run: cargo clippy --all -- -D warnings
       - run: cargo fmt --all -- --check

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -624,10 +624,7 @@ impl<'e> Checker<'e> {
                     | BinOp::SubChecked
                     | BinOp::MulChecked
                     | BinOp::DivChecked
-                    | BinOp::RemChecked => {
-                        let elem_ty = self.check_same_numeric(lhs_ty, rhs_ty, expr.span);
-                        Ty::Applied(Box::new(Ty::Enum("Option".to_string())), vec![elem_ty])
-                    }
+                    | BinOp::RemChecked => self.check_same_numeric(lhs_ty, rhs_ty, expr.span),
                     BinOp::Eq | BinOp::Ne | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge => {
                         let coercible = (lhs_ty == Ty::I32 && rhs_ty.is_integer())
                             || (rhs_ty == Ty::I32 && lhs_ty.is_integer());
@@ -1980,7 +1977,7 @@ mod tests {
     // --- Checked arithmetic ---
 
     #[test]
-    fn checked_add_returns_option() {
+    fn checked_add_returns_integer_type() {
         let mut emitter = TestEmitter(vec![]);
         let mut checker = new_checker(&mut emitter);
         let ty = checker.check_expr(&make_expr(ExprKind::BinaryOp {
@@ -1988,10 +1985,7 @@ mod tests {
             lhs: Box::new(int_lit()),
             rhs: Box::new(int_lit()),
         }));
-        assert_eq!(
-            ty,
-            Ty::Applied(Box::new(Ty::Enum("Option".to_string())), vec![Ty::I32])
-        );
+        assert_eq!(ty, Ty::I32);
         assert!(!checker.has_errors());
     }
 

--- a/vow/tests/agent_level1.rs
+++ b/vow/tests/agent_level1.rs
@@ -67,6 +67,48 @@ fn compile_success() {
 }
 
 #[test]
+fn checked_arithmetic_returns_integer() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let src_path = dir.path().join("checked_arithmetic.vow");
+    let out_path = dir.path().join("checked_arithmetic");
+    let src = r#"module CheckedArithmetic
+
+fn checked_add(a: i64, b: i64) -> i64 {
+    a +! b
+}
+
+fn main() -> i32 {
+    if checked_add(3, 4) != 7 {
+        return 1;
+    }
+    0
+}
+"#;
+    std::fs::write(&src_path, src).unwrap();
+
+    let result = Command::new(vow_bin())
+        .args([
+            "build",
+            "--no-verify",
+            "--no-cache",
+            src_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run vow");
+    assert_eq!(result.status.code(), Some(0), "expected exit 0");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {stdout}"));
+    assert_eq!(json["status"], "Unverified");
+    assert!(
+        json["diagnostics"].as_array().unwrap().is_empty(),
+        "expected no diagnostics, got {stdout}"
+    );
+}
+
+#[test]
 fn compile_type_error() {
     let dir = tempfile::TempDir::new().unwrap();
     let bad_src = "module Bad\nfn main() -> i32 { true }";


### PR DESCRIPTION
## Summary

Fixes #257.

This aligns checked arithmetic type checking with the existing language spec and backend behavior: `+!`, `-!`, `*!`, `/!`, and `%!` now type-check as the numeric operand type instead of `Option<T>`.

## Root Cause

The Rust type checker treated checked arithmetic operators as returning `Option<T>`, while the self-hosted compiler, IR lowering, codegen, and docs model them as trapping numeric operations. That mismatch broke the self-hosted concatenated compiler when `watchdog_ms_for` returned `n *! 1000` from a function declared as `i64`.

## Changes

- Update `vow-types` checked arithmetic typing to return the operand numeric type.
- Add a CLI regression test proving checked arithmetic can be returned from an `i64` function.
- Add a CI gate that builds the concatenated self-hosted compiler after `cargo build --all`.

## Validation

- Reproduced the original concat-bootstrap type error before the fix.
- `cargo test --all`
- `cargo clippy --all -- -D warnings`
- `cargo fmt --all -- --check`
- Local concat CI gate: `cargo build --all && ./target/debug/vow build --no-verify --no-cache <concat> -o <out>`