### PR TITLE
[codex] Complete arena Phase 9 performance pass

### DIFF
--- a/compiler/frontend.vow
+++ b/compiler/frontend.vow
@@ -162,7 +162,8 @@ fn frontend_lower_path(path: String) -> LoweredFrontend [io] {
             // in place; emits any RegionConflict diagnostics through dctx so
             // they reach the existing CompileFailed JSON path.
             let lowered: IrModule = lower_module_vow(prep.merged, prep.str_eids, checked.path);
-            infer_regions_module(lowered, checked.dctx, checked.path)
+            let inferred: IrModule = infer_regions_module(lowered, checked.dctx, checked.path);
+            insert_region_markers_module(inferred)
         }
     };
     // Refresh n_errors so any region diagnostics emitted above propagate to

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -753,6 +753,14 @@ fn check_region_store_conflicts_module(
 fn check_store_effects_at_call(
     flat: Vec<i64>, call_inst: IrInst, id_to_inst: Vec<IrInst>, dctx: DiagCtx, path: String
 ) {
+    // Divergence note: the Rust path (`vow-ir/src/region.rs::handle_inst`,
+    // `Opcode::Call` arm) adds a `VirtualCaller` marker on the target arg
+    // for `RSUM_KIND_FRESH_IN_CALLER` store effects, routing the target
+    // toward `Caller(0)`. The self-hosted compiler has no `VirtualCaller`
+    // marker mechanism — targets of FreshInCaller store effects stay at
+    // their default `Root`. No diagnostic effect (region routing only),
+    // but worth promoting to true parity once hidden-caller-region
+    // plumbing for `IOP_REGION_ALLOC` lands in `vow-clif-shim`.
     let mut i: i64 = 0;
     while i < flat.len() {
         let target: i64 = flat[i];

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1711,6 +1711,33 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
     while fi < n_funcs {
         let f: IrFunction = m.functions[fi];
 
+        // Idempotency guard (mirrors the Rust `debug_assert!` at
+        // `vow-ir/src/region.rs:443-451`). This pass is non-idempotent —
+        // a second invocation would insert duplicate `IOP_REGION_OPEN` /
+        // `IOP_REGION_CLOSE` pairs because the scan only looks at
+        // `REGION_KIND_BLOCK` heap producers and would not notice its
+        // own previously-inserted markers. The pipeline calls this once
+        // today; if a future reorder causes a double call, skip the
+        // function rather than corrupt its IR.
+        let mut already_has_markers: bool = false;
+        let mut bi_g: i64 = 0;
+        while bi_g < f.blocks.len() {
+            let blk_g: IrBlock = f.blocks[bi_g];
+            let mut ii_g: i64 = 0;
+            while ii_g < blk_g.insts.len() {
+                let op_g: i64 = blk_g.insts[ii_g].op;
+                if op_g == IOP_REGION_OPEN() || op_g == IOP_REGION_CLOSE() {
+                    already_has_markers = true;
+                }
+                ii_g = ii_g + 1;
+            }
+            bi_g = bi_g + 1;
+        }
+        if already_has_markers {
+            fi = fi + 1;
+            continue;
+        }
+
         // Find the largest existing inst id so we can mint fresh ones.
         let mut max_id: i64 = 0;
         let mut bi: i64 = 0;

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -785,6 +785,9 @@ fn check_store_effects_at_call(
                 );
             }
         } else if kind == RSUM_KIND_ALIAS_OF_ANY() {
+            // FIXME: align with Rust `_ => {}` before enabling AliasOfAny
+            // origin tracing.
+            //
             // Unreachable on today's pipeline: `trace_origin_shallow` only ever
             // produces `AliasOf`, `FreshInCaller`, or `ConstantGlobal`, so
             // store_effects with `AliasOfAny` source cannot currently be generated.

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -909,18 +909,19 @@ fn analyze_function(
     }
 
     // Tag local heap-producing instructions with block regions when all direct
-    // uses stay in the defining block. This is the self-hosted Phase 9 subset
-    // that the shim can lower today: `IOP_REGION_ALLOC` and FreshInCaller
-    // extern wrappers can route through `REGION_KIND_BLOCK`; caller-routed
-    // internal function returns remain Root because the shim still rejects
-    // `REGION_KIND_CALLER` for `IOP_REGION_ALLOC`.
+    // uses stay in the defining block. The self-hosted Phase 9 subset routes
+    // three cases through `REGION_KIND_BLOCK`: `IOP_REGION_ALLOC`, FreshInCaller
+    // extern wrappers, and `IOP_CALL` + `IDATA_CALL_TARGET` whose callee
+    // summary is `FRESH_IN_CALLER`. The block-region tag uses
+    // `REGION_KIND_BLOCK`, not `REGION_KIND_CALLER`, so the shim's pending
+    // hidden-caller-region work is irrelevant here.
     let mut rbi: i64 = 0;
     while rbi < n_bks {
         let rb: IrBlock = bks[rbi];
         let mut rii: i64 = 0;
         while rii < rb.insts.len() {
             let rinst: IrInst = rb.insts[rii];
-            if is_heap_producing_for_block_region(rinst)
+            if is_heap_producing_for_block_region(rinst, int_kinds)
                 && value_used_only_in_block(f, rinst.id, rb.id)
             {
                 put_inst_region(
@@ -977,11 +978,17 @@ fn analyze_function(
     false
 }
 
-fn is_heap_producing_for_block_region(inst: IrInst) -> bool {
+fn is_heap_producing_for_block_region(inst: IrInst, int_kinds: Vec<i64>) -> bool {
     if inst.op == IOP_REGION_ALLOC() {
         return true;
     }
     if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() && extern_fresh_in_caller(inst.ds) {
+        return true;
+    }
+    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_TARGET()
+        && inst.dv >= 0 && inst.dv < int_kinds.len()
+        && int_kinds[inst.dv] == RSUM_KIND_FRESH_IN_CALLER()
+    {
         return true;
     }
     false

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -12,7 +12,7 @@ use diag
 //   `rsum_return_kind` field always carries one of the four published
 //   `RSUM_KIND_*` discriminants after `infer_regions_module` returns.
 // - `AliasOfAny` aliases vec is ascending + deduplicated (canonical).
-// - `store_effects` are sorted by `target_param` ascending (canonical).
+// - `store_effects` are sorted by `(target_param, source_constraint)` (canonical).
 //
 // Internal Uninit state lives only in this module's local arrays
 // (`int_kinds: Vec<i64>` keyed by function index). Sentinel value
@@ -231,6 +231,8 @@ fn infer_regions_module(m: IrModule, dctx: DiagCtx, path: String) -> IrModule {
         m.functions[fi] = new_f;
         fi = fi + 1;
     }
+
+    check_region_store_conflicts_module(m, id_to_inst_per_fn, dctx, path);
 
     // Commit per-inst regions.
     let mut fi2: i64 = 0;
@@ -542,6 +544,36 @@ fn linear_vec_eq(a: Vec<i64>, b: Vec<i64>) -> bool {
     true
 }
 
+fn clone_i64_vec(src: Vec<i64>) -> Vec<i64> {
+    let out: Vec<i64> = Vec::new();
+    let mut i: i64 = 0;
+    while i < src.len() {
+        out.push(src[i]);
+        i = i + 1;
+    }
+    out
+}
+
+fn clone_i64_vec_vec(src: Vec<Vec<i64>>) -> Vec<Vec<i64>> {
+    let out: Vec<Vec<i64>> = Vec::new();
+    let mut i: i64 = 0;
+    while i < src.len() {
+        out.push(clone_i64_vec(src[i]));
+        i = i + 1;
+    }
+    out
+}
+
+fn i64_vec_vec_eq(a: Vec<Vec<i64>>, b: Vec<Vec<i64>>) -> bool {
+    if a.len() != b.len() { return false; }
+    let mut i: i64 = 0;
+    while i < a.len() {
+        if !linear_vec_eq(a[i], b[i]) { return false; }
+        i = i + 1;
+    }
+    true
+}
+
 // ---- Lookup helper for parallel inst-region arrays ----
 
 fn lookup_inst_region(keys: Vec<i64>, vals: Vec<i64>, id: i64) -> i64 {
@@ -591,11 +623,12 @@ fn canonicalize_store_effects(
         perm.push(pi);
         pi = pi + 1;
     }
-    // Insertion sort perm by targets[perm[i]] ascending.
+    // Insertion sort perm by Rust's BTreeSet key order:
+    // target, then RegionConstraint discriminant, then payload.
     let mut a: i64 = 1;
     while a < n {
         let mut b: i64 = a;
-        while b > 0 && targets[perm[b - 1]] > targets[perm[b]] {
+        while b > 0 && store_effect_less(targets, kinds, aux, aliases, perm[b], perm[b - 1]) {
             let tmp: i64 = perm[b - 1];
             perm[b - 1] = perm[b];
             perm[b] = tmp;
@@ -627,6 +660,180 @@ fn canonicalize_store_effects(
     out
 }
 
+fn store_effect_less(
+    targets: Vec<i64>, kinds: Vec<i64>, auxs: Vec<i64>, aliases: Vec<Vec<i64>>,
+    a: i64, b: i64
+) -> bool {
+    if targets[a] != targets[b] {
+        return targets[a] < targets[b];
+    }
+    if kinds[a] != kinds[b] {
+        return kinds[a] < kinds[b];
+    }
+    if kinds[a] == RSUM_KIND_ALIAS_OF() && auxs[a] != auxs[b] {
+        return auxs[a] < auxs[b];
+    }
+    if kinds[a] == RSUM_KIND_ALIAS_OF_ANY() {
+        return i64_vec_lex_less(aliases[a], aliases[b]);
+    }
+    false
+}
+
+fn i64_vec_lex_less(a: Vec<i64>, b: Vec<i64>) -> bool {
+    let mut i: i64 = 0;
+    while i < a.len() && i < b.len() {
+        if a[i] != b[i] {
+            return a[i] < b[i];
+        }
+        i = i + 1;
+    }
+    a.len() < b.len()
+}
+
+fn add_store_effect(
+    targets: Vec<i64>, kinds: Vec<i64>, auxs: Vec<i64>, aliases_list: Vec<Vec<i64>>,
+    target: i64, kind: i64, aux: i64, aliases: Vec<i64>
+) {
+    let mut i: i64 = 0;
+    while i < targets.len() {
+        if targets[i] == target && kinds[i] == kind {
+            if kind == RSUM_KIND_ALIAS_OF() {
+                if auxs[i] == aux {
+                    return;
+                }
+            } else if kind == RSUM_KIND_ALIAS_OF_ANY() {
+                if linear_vec_eq(aliases_list[i], aliases) {
+                    return;
+                }
+            } else {
+                return;
+            }
+        }
+        i = i + 1;
+    }
+    targets.push(target);
+    kinds.push(kind);
+    auxs.push(aux);
+    aliases_list.push(clone_i64_vec(aliases));
+}
+
+fn check_region_store_conflicts_module(
+    m: IrModule, id_to_inst_per_fn: Vec<Vec<IrInst>>, dctx: DiagCtx, path: String
+) {
+    let mut fi: i64 = 0;
+    while fi < m.functions.len() {
+        let f: IrFunction = m.functions[fi];
+        let id_to_inst: Vec<IrInst> = id_to_inst_per_fn[fi];
+        let mut bi: i64 = 0;
+        while bi < f.blocks.len() {
+            let blk: IrBlock = f.blocks[bi];
+            let mut ii: i64 = 0;
+            while ii < blk.insts.len() {
+                let inst: IrInst = blk.insts[ii];
+                if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_TARGET() {
+                    let callee_idx: i64 = inst.dv;
+                    if callee_idx >= 0 && callee_idx < m.functions.len() {
+                        check_store_effects_at_call(
+                            m.functions[callee_idx].rsum_store_effects,
+                            inst,
+                            id_to_inst,
+                            dctx,
+                            path,
+                        );
+                    }
+                }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        fi = fi + 1;
+    }
+}
+
+fn check_store_effects_at_call(
+    flat: Vec<i64>, call_inst: IrInst, id_to_inst: Vec<IrInst>, dctx: DiagCtx, path: String
+) {
+    let mut i: i64 = 0;
+    while i < flat.len() {
+        let target: i64 = flat[i];
+        i = i + 1;
+        if i >= flat.len() { return; }
+        let kind: i64 = flat[i];
+        i = i + 1;
+        if kind == RSUM_KIND_ALIAS_OF() {
+            if i >= flat.len() { return; }
+            let source_param: i64 = flat[i];
+            i = i + 1;
+            if target >= 0 && target < call_inst.args.len()
+                && source_param >= 0 && source_param < call_inst.args.len()
+            {
+                check_store_conflict(
+                    path,
+                    call_inst.args[target],
+                    call_inst.args[source_param],
+                    call_inst,
+                    id_to_inst,
+                    dctx,
+                );
+            }
+        } else if kind == RSUM_KIND_ALIAS_OF_ANY() {
+            if i >= flat.len() { return; }
+            let n: i64 = flat[i];
+            i = i + 1;
+            let mut ai: i64 = 0;
+            while ai < n && i < flat.len() {
+                let source_param: i64 = flat[i];
+                if target >= 0 && target < call_inst.args.len()
+                    && source_param >= 0 && source_param < call_inst.args.len()
+                {
+                    check_store_conflict(
+                        path,
+                        call_inst.args[target],
+                        call_inst.args[source_param],
+                        call_inst,
+                        id_to_inst,
+                        dctx,
+                    );
+                }
+                i = i + 1;
+                ai = ai + 1;
+            }
+        }
+    }
+}
+
+fn check_store_conflict(
+    path: String, target_arg_id: i64, source_arg_id: i64, call_inst: IrInst,
+    id_to_inst: Vec<IrInst>, dctx: DiagCtx
+) {
+    let source: DeepRet = trace_origin_shallow(id_to_inst, source_arg_id);
+    if source.kind != RSUM_KIND_FRESH_IN_CALLER() {
+        return;
+    }
+    let target_param: i64 = trace_param_shallow(id_to_inst, target_arg_id);
+    if target_param < 0 {
+        return;
+    }
+
+    let source_inst: IrInst = lookup_inst_or_default(id_to_inst, source_arg_id);
+    let span_start: i64 = if source_inst.id >= 0 && source_inst.olen > 0 { source_inst.ostart } else { call_inst.ostart };
+    let span_len: i64 = if source_inst.id >= 0 && source_inst.olen > 0 { source_inst.olen } else { call_inst.olen };
+    let d: Diagnostic = diag_new(
+        SEV_ERROR(),
+        EC_REGION_CONFLICT(),
+        String::from("value's region cannot satisfy target container's region: block-local allocation stored into a parameter region"),
+        path,
+        span_start,
+        span_len,
+        DIAG_BLAME_CALLEE()
+    );
+    diag_add_hint(
+        d,
+        String::from("hoist the allocation to a wider scope, copy the value into the outer arena, or restructure the return flow so the value escapes to the caller")
+    );
+    diag_ctx_emit(dctx, d);
+}
+
 // ---- Per-function analysis ----
 
 // Returns true if the function's internal summary changed.
@@ -645,6 +852,10 @@ fn analyze_function(
     let prev_kind: i64 = int_kinds[fidx];
     let prev_aux: i64 = int_auxs[fidx];
     let prev_aliases: Vec<i64> = int_aliases_list[fidx];
+    let prev_se_targets: Vec<i64> = clone_i64_vec(int_se_targets[fidx]);
+    let prev_se_src_kinds: Vec<i64> = clone_i64_vec(int_se_src_kinds[fidx]);
+    let prev_se_src_aux: Vec<i64> = clone_i64_vec(int_se_src_aux[fidx]);
+    let prev_se_src_aliases: Vec<Vec<i64>> = clone_i64_vec_vec(int_se_src_aliases[fidx]);
 
     // 1. Compute return-region contribution by deep-walking the Return arg
     //    through Pizlo Phi/Upsilon arms and Call summaries.
@@ -674,36 +885,71 @@ fn analyze_function(
                 acc_aux = join_aux(acc_kind, acc_aux, ret_kind, ret_aux, joined_kind);
                 acc_kind = joined_kind;
             }
-            // Tag heap-producing insts with Caller(0) when they flow into a
-            // Return; for Phase 3 we conservatively tag every RegionAlloc
-            // that escapes via Return to Caller(0). All other RegionAllocs
-            // remain at their Phase 2 default (Root).
+            if (inst.op == IOP_STORE() || inst.op == IOP_FIELD_SET()) && inst.args.len() >= 2 {
+                let target_id: i64 = inst.args[0];
+                let source_id: i64 = inst.args[1];
+                let target_param: i64 = trace_param_shallow(id_to_inst, target_id);
+                if target_param >= 0 {
+                    let source: DeepRet = trace_origin_shallow(id_to_inst, source_id);
+                    add_store_effect(
+                        int_se_targets[fidx],
+                        int_se_src_kinds[fidx],
+                        int_se_src_aux[fidx],
+                        int_se_src_aliases[fidx],
+                        target_param,
+                        source.kind,
+                        source.aux,
+                        source.aliases,
+                    );
+                }
+            }
             ii = ii + 1;
         }
         bi = bi + 1;
     }
 
-    // Tag RegionAlloc instructions that escape to virtual caller.
+    // Tag local heap-producing instructions with block regions when all direct
+    // uses stay in the defining block. This is the self-hosted Phase 9 subset
+    // that the shim can lower today: `IOP_REGION_ALLOC` and FreshInCaller
+    // extern wrappers can route through `REGION_KIND_BLOCK`; caller-routed
+    // internal function returns remain Root because the shim still rejects
+    // `REGION_KIND_CALLER` for `IOP_REGION_ALLOC`.
+    let mut rbi: i64 = 0;
+    while rbi < n_bks {
+        let rb: IrBlock = bks[rbi];
+        let mut rii: i64 = 0;
+        while rii < rb.insts.len() {
+            let rinst: IrInst = rb.insts[rii];
+            if is_heap_producing_for_block_region(rinst)
+                && value_used_only_in_block(f, rinst.id, rb.id)
+            {
+                put_inst_region(
+                    region_keys[fidx],
+                    region_vals[fidx],
+                    rinst.id,
+                    region_pack(REGION_KIND_BLOCK(), rb.id)
+                );
+            }
+            rii = rii + 1;
+        }
+        rbi = rbi + 1;
+    }
+
+    // Escaping RegionAlloc instructions still deliberately stay Root.
     //
-    // Phase 3 minimum: the self-hosted Cranelift shim in
-    // `vow-clif-shim/src/lib.rs` (IOP_REGION_ALLOC path) currently only
-    // accepts `REGION_KIND_ROOT`; any `Caller` or `Block` region makes
-    // `fn_end` return -1 ("hidden-arena routing lands in a follow-up").
-    // Emitting `region_caller0()` here would break self-hosted codegen for
-    // any program with an escaping allocation. We therefore leave escaping
-    // allocations at their Phase-2 default (Root) in self-hosted IR until
-    // the shim learns hidden-arena plumbing. The summary itself is still
-    // set to FreshInCaller where appropriate so the metadata remains
-    // correct for downstream consumers; only the per-inst region tag is
-    // degraded for codegen compatibility.
+    // Phase 9 status: the self-hosted Cranelift shim can lower block regions,
+    // but `IOP_REGION_ALLOC` still has no hidden-caller-region plumbing.
+    // Emitting `region_caller0()` here would break self-hosted codegen for any
+    // program with an escaping allocation. We therefore leave escaping
+    // allocations at their Phase-2 default (Root). The summary itself is still
+    // set to FreshInCaller where appropriate so the metadata remains correct
+    // for downstream consumers; only the per-inst region tag is degraded for
+    // codegen compatibility.
     //
     // Rust codegen accepts Caller(0) via `cranelift_backend.rs` + Phase 4's
-    // hidden-arena projection, so the Rust pass emits `Caller(0)` on
-    // escaping allocs. This is an intentional divergence between the two
-    // compilers until the self-hosted shim catches up. Helpers
-    // `collect_escaping_allocs` and `region_caller0` remain in this module
-    // so the port is ready to drop in as a one-line change once the shim
-    // supports hidden-arena routing.
+    // hidden-arena projection, so the Rust pass emits `Caller(0)` on escaping
+    // allocs. This is the remaining intentional divergence between the two
+    // compilers until the self-hosted shim catches up.
 
     let new_kind: i64 = acc_kind;
     let new_aux: i64 = acc_aux;
@@ -712,29 +958,6 @@ fn analyze_function(
     int_kinds[fidx] = new_kind;
     int_auxs[fidx] = new_aux;
     int_aliases_list[fidx] = new_aliases;
-
-    // For Phase 3 minimal we don't infer store_effects in self-hosted yet.
-    // The Rust pass also defers full store-effect inference (see step 5
-    // "Phase 3 minimum" comment in vow-ir/src/region.rs). Both compilers
-    // converge on empty store_effects for now, satisfying the differential
-    // gate.
-    //
-    // TODO(#204, Phase 9): when store-effect INFERENCE lands here, the
-    // companion `check_store_conflict` equivalent (currently Rust-only,
-    // see `vow-ir/src/region.rs::check_store_conflict`) MUST land in the
-    // same touch. Inference without conflict emission would let the
-    // self-hosted compiler silently accept programs the Rust compiler
-    // rejects, breaking the differential gate without any visible signal.
-    //
-    // The Phase-9 implementation must also mirror the per-iteration
-    // diagnostics buffering pattern from `vow-ir/src/region.rs`'s
-    // `iter_diagnostics` (the SCC fixed-point loop runs `analyze_function`
-    // multiple times, so a diagnostic emitted directly via `diag_ctx_emit`
-    // would fire once per round). The Rust pass keeps a Vec per iteration
-    // and extends `diagnostics` only on convergence (or alongside the ICE
-    // marker on iteration-bound exceeded). Without this, a single real
-    // conflict will be reported `iters` times, breaking the
-    // `conflicts.len() == 1` invariant the Rust tests assert.
 
     // Return whether the summary changed.
     if new_kind != prev_kind { return true; }
@@ -747,38 +970,59 @@ fn analyze_function(
             k = k + 1;
         }
     }
-    // TODO(Phase 5 / issue #200): self-hosted needs TWO additions here,
-    // not just the convergence check.
-    //
-    // (1) Store-effect INFERENCE itself is missing. The Rust pass'
-    // `handle_inst` (vow-ir/src/region.rs `Opcode::Store | Opcode::FieldSet`
-    // arm) calls `trace_origin` + `origin_to_constraint` and inserts
-    // into `summary.store_effects`. The self-hosted port has no
-    // equivalent — `int_se_targets[fidx]` etc. are always left empty.
-    // Functions that store one parameter into another currently
-    // produce empty `store_effects` from the self-hosted compiler
-    // even when the Rust compiler produces a non-empty result.
-    //
-    // (2) Once (1) lands, add the convergence comparison here so a
-    // round where only store_effects grow will set `changed = true`:
-    // compare int_se_targets[fidx] / int_se_src_kinds[fidx] /
-    // int_se_src_aux[fidx] / int_se_src_aliases[fidx] against their
-    // prev_* snapshots. Without this, the SCC fixed-point will
-    // declare convergence one iteration too early.
-    //
-    // Both gaps are harmless today (both compilers produce empty
-    // store_effects), but both must land together to keep the
-    // differential gate working.
+    if !linear_vec_eq(prev_se_targets, int_se_targets[fidx]) { return true; }
+    if !linear_vec_eq(prev_se_src_kinds, int_se_src_kinds[fidx]) { return true; }
+    if !linear_vec_eq(prev_se_src_aux, int_se_src_aux[fidx]) { return true; }
+    if !i64_vec_vec_eq(prev_se_src_aliases, int_se_src_aliases[fidx]) { return true; }
     false
 }
 
+fn is_heap_producing_for_block_region(inst: IrInst) -> bool {
+    if inst.op == IOP_REGION_ALLOC() {
+        return true;
+    }
+    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() && extern_fresh_in_caller(inst.ds) {
+        return true;
+    }
+    false
+}
+
+fn value_used_only_in_block(f: IrFunction, id: i64, defining_block: i64) -> bool {
+    let bks: Vec<IrBlock> = f.blocks;
+    let mut bi: i64 = 0;
+    while bi < bks.len() {
+        let blk: IrBlock = bks[bi];
+        let mut ii: i64 = 0;
+        while ii < blk.insts.len() {
+            let inst: IrInst = blk.insts[ii];
+            let mut ai: i64 = 0;
+            while ai < inst.args.len() {
+                if inst.args[ai] == id {
+                    if blk.id != defining_block {
+                        return false;
+                    }
+                    if inst.op == IOP_RETURN()
+                        || inst.op == IOP_UPSILON()
+                        || inst.op == IOP_CALL()
+                        || inst.op == IOP_STORE()
+                        || inst.op == IOP_FIELD_SET()
+                    {
+                        return false;
+                    }
+                }
+                ai = ai + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    true
+}
+
 // Currently unused (intentional scaffolding). Becomes live once the
-// `vow-clif-shim` learns hidden-arena routing for `IOP_REGION_ALLOC`
-// (tracked alongside Phase 5 wiring, issue #200). Keeping this and
-// `collect_escaping_allocs` ready avoids a second touch of the file
-// when the shim is updated. Until then, escaping allocations stay at
-// the Phase-2 default (Root) — see the comment in `analyze_function`
-// where these would otherwise be wired.
+// `vow-clif-shim` learns hidden-caller-region routing for `IOP_REGION_ALLOC`.
+// Until then, escaping allocations stay at the Phase-2 default (Root) — see
+// the comment in `analyze_function` where these would otherwise be wired.
 fn region_caller0() -> i64 {
     // RegionId::Caller(HiddenRegionIdx(0)) packed: kind=CALLER, val=0.
     region_pack(REGION_KIND_CALLER(), 0)
@@ -899,6 +1143,38 @@ fn extern_fresh_in_caller(sym: String) -> bool {
 
 fn deep_ret_uninit() -> DeepRet {
     DeepRet { kind: RSUM_INTERNAL_UNINIT(), aux: 0, aliases: Vec::new() }
+}
+
+fn lookup_inst_or_default(id_to_inst: Vec<IrInst>, id: i64) -> IrInst {
+    if id >= 0 && id < id_to_inst.len() {
+        return id_to_inst[id];
+    }
+    ir_inst_new(-1, 0, 0, Vec::new(), 0, 0, 0, String::from(""))
+}
+
+fn trace_origin_shallow(id_to_inst: Vec<IrInst>, id: i64) -> DeepRet {
+    let inst: IrInst = lookup_inst_or_default(id_to_inst, id);
+    if inst.id < 0 {
+        return deep_ret_const_global();
+    }
+    if inst.op == IOP_GET_ARG() {
+        return DeepRet { kind: RSUM_KIND_ALIAS_OF(), aux: inst.dv, aliases: Vec::new() };
+    }
+    if inst.op == IOP_REGION_ALLOC() {
+        return DeepRet { kind: RSUM_KIND_FRESH_IN_CALLER(), aux: 0, aliases: Vec::new() };
+    }
+    if is_const_op(inst.op) {
+        return deep_ret_const_global();
+    }
+    deep_ret_const_global()
+}
+
+fn trace_param_shallow(id_to_inst: Vec<IrInst>, id: i64) -> i64 {
+    let inst: IrInst = lookup_inst_or_default(id_to_inst, id);
+    if inst.id >= 0 && inst.op == IOP_GET_ARG() {
+        return inst.dv;
+    }
+    -1
 }
 
 fn deep_origin(
@@ -1166,15 +1442,6 @@ fn resolve_uninit_return_kind(m: IrModule, fidx: i64, id_to_inst: Vec<IrInst>, p
     acc_kind
 }
 
-// TODO(#204): Pre-existing limitation — bails on the *first* `IOP_RETURN`
-// it finds and returns its `aux`. If a function has multiple Return sites
-// both typed `AliasOf` but aliasing different parameters,
-// `resolve_uninit_return_kind` (which joins across all Returns) can settle
-// on `AliasOf(N)` while this returns `aux` from whichever Return appears
-// first in block order — potentially a different index. Today this is
-// unreachable (the only callers feed in functions whose internal kind is
-// already `Uninit`, which is rare on the corpus), but Phase 9 should join
-// across all Returns the same way `resolve_uninit_return_kind` does.
 fn resolve_uninit_return_aux(m: IrModule, fidx: i64, kind: i64, id_to_inst: Vec<IrInst>, phi_arms: Vec<Vec<i64>>) -> i64 {
     if kind != RSUM_KIND_ALIAS_OF() {
         return 0;
@@ -1184,6 +1451,9 @@ fn resolve_uninit_return_aux(m: IrModule, fidx: i64, kind: i64, id_to_inst: Vec<
     let int_kinds_empty: Vec<i64> = Vec::new();
     let int_auxs_empty: Vec<i64> = Vec::new();
     let int_aliases_empty: Vec<Vec<i64>> = Vec::new();
+    let mut acc_kind: i64 = RSUM_INTERNAL_UNINIT();
+    let mut acc_aux: i64 = 0;
+    let mut acc_aliases: Vec<i64> = Vec::new();
     let mut bi: i64 = 0;
     while bi < bks.len() {
         let blk: IrBlock = bks[bi];
@@ -1193,11 +1463,22 @@ fn resolve_uninit_return_aux(m: IrModule, fidx: i64, kind: i64, id_to_inst: Vec<
             if inst.op == IOP_RETURN() && inst.args.len() > 0 {
                 let visiting: Vec<i64> = Vec::new();
                 let dr: DeepRet = deep_origin_inner(id_to_inst, phi_arms, inst.args[0], int_kinds_empty, int_auxs_empty, int_aliases_empty, visiting);
-                return dr.aux;
+                let arm_kind: i64 = dr.kind;
+                let arm_aux: i64 = dr.aux;
+                let arm_aliases: Vec<i64> = dr.aliases;
+                let nk: i64 = join_kinds(acc_kind, acc_aux, acc_aliases, arm_kind, arm_aux, arm_aliases);
+                let nl: Vec<i64> = join_aliases(acc_kind, acc_aux, acc_aliases, arm_kind, arm_aux, arm_aliases, nk);
+                let na: i64 = join_aux(acc_kind, acc_aux, arm_kind, arm_aux, nk);
+                acc_kind = nk;
+                acc_aux = na;
+                acc_aliases = nl;
             }
             ii = ii + 1;
         }
         bi = bi + 1;
+    }
+    if acc_kind == RSUM_KIND_ALIAS_OF() {
+        return acc_aux;
     }
     0
 }
@@ -1221,14 +1502,12 @@ fn region_vec_contains_i64(v: Vec<i64>, x: i64) -> bool {
 }
 
 // Currently unused — same scaffolding rationale as `region_caller0` above.
-// Becomes live once the clif-shim accepts non-Root regions on
-// `IOP_REGION_ALLOC` (issue #200, Phase 5).
+// Becomes live once the clif-shim accepts hidden caller regions on
+// `IOP_REGION_ALLOC`.
 fn collect_escaping_allocs(m: IrModule, f: IrFunction) -> Vec<i64> {
-    // Phase 3 minimal: a RegionAlloc inst escapes if its id appears as the
-    // sole arg of any Return in the same function (transitively through
-    // simple GetArg/Phi edges — covered by deep_kind path returning
-    // FreshInCaller). For a tracer-bullet, mark an alloc as escaping only
-    // if a Return reaches it directly (not via Phi chains).
+    // Conservative helper: a RegionAlloc inst escapes if its id appears as
+    // the sole arg of any Return in the same function. Full transitive
+    // handling happens in the return-summary walk above.
     let escaping: Vec<i64> = Vec::new();
     let bks: Vec<IrBlock> = f.blocks;
     // Pass 1: collect Return arg ids.
@@ -1402,39 +1681,20 @@ fn tarjan_sccs(cg: Vec<Vec<i64>>, n: i64) -> Vec<Vec<i64>> {
 
 // ---------------------------------------------------------------------------
 // Block-region marker insertion (mirror of vow-ir/src/region.rs
-// `insert_region_markers`). Tags every non-escaping `IOP_REGION_ALLOC` with
-// `Block(defining_block)` and brackets the containing block with
-// `IOP_REGION_OPEN` / `IOP_REGION_CLOSE` markers per spec §3.5 criterion 1.
+// `insert_region_markers`). Brackets blocks that already contain a
+// `REGION_KIND_BLOCK` heap-producing instruction with `IOP_REGION_OPEN` /
+// `IOP_REGION_CLOSE` markers per spec §3.5 criterion 1.
 //
-// Phase 4 status: this function is a NO-OP (the body returns the module
-// unchanged) because:
-//   1. The Rust pass equivalent (`vow-ir/src/region.rs::lub_to_region_id`)
-//      defers `Block(_)` emission to Phase 9 (#204) until `must_outlive`
-//      tracks every use of a heap-typed value (regular `FieldGet`/`Load`,
-//      non-store-effect call args, Phi-merged values).
-//   2. To stay aligned with the Rust pass, the self-hosted equivalent must
-//      defer the same way. The implementation below remains as scaffolding
-//      so Phase 9 can flip a single switch.
-//   3. The shim rejects `REGION_KIND_CALLER` with `k > 0` (S1
-//      vow-clif-shim/src/lib.rs); escaping allocs continue to route to
-//      `Root` until full hidden-region plumbing lands.
-//
-// `frontend.vow` therefore does NOT call this function in Phase 4. The
-// body below is unreachable (the early `return m;` short-circuits it) and
-// remains only as Phase 9 scaffolding — it is NOT exercised by any test
-// today. When Phase 9 lifts the `Block(_)` deferral in `region.rs`, drop
-// the early return here, wire the call from `frontend.vow`, and add a
-// differential test against the Rust pass.
+// Phase 9 status: this is live for safe local block regions. It intentionally
+// does not retag `IOP_REGION_ALLOC` by itself; inference decides which values
+// are safe to place in a block region, and this pass only materializes markers.
 // ---------------------------------------------------------------------------
 
 fn insert_region_markers_module(m: IrModule) -> IrModule {
-    // No-op for Phase 4 — see header comment for rationale.
-    return m;
     let n_funcs: i64 = m.functions.len();
     let mut fi: i64 = 0;
     while fi < n_funcs {
         let f: IrFunction = m.functions[fi];
-        let escaping_ids: Vec<i64> = collect_escaping_allocs(m, f);
 
         // Find the largest existing inst id so we can mint fresh ones.
         let mut max_id: i64 = 0;
@@ -1452,26 +1712,7 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
         }
         let mut next_id: i64 = max_id + 1;
 
-        // Pass 1: tag non-escaping RegionAlloc insts with Block(defining_block).
-        let mut bi2: i64 = 0;
-        while bi2 < f.blocks.len() {
-            let blk: IrBlock = f.blocks[bi2];
-            let mut ii2: i64 = 0;
-            while ii2 < blk.insts.len() {
-                let inst: IrInst = blk.insts[ii2];
-                if inst.op == IOP_REGION_ALLOC()
-                    && !region_vec_contains_i64(escaping_ids, inst.id)
-                {
-                    let block_region: i64 = region_pack(REGION_KIND_BLOCK(), blk.id);
-                    blk.insts[ii2] = ir_inst_set_region(inst, block_region);
-                }
-                ii2 = ii2 + 1;
-            }
-            f.blocks[bi2] = blk;
-            bi2 = bi2 + 1;
-        }
-
-        // Pass 2: collect blocks that now contain a Block-tagged alloc.
+        // Pass 1: collect blocks that contain a Block-tagged heap producer.
         let block_regions: Vec<i64> = Vec::new();
         let mut bi3: i64 = 0;
         while bi3 < f.blocks.len() {
@@ -1491,7 +1732,7 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
             bi3 = bi3 + 1;
         }
 
-        // Pass 3: insert RegionOpen at start of marked blocks and
+        // Pass 2: insert RegionOpen at start of marked blocks and
         // RegionClose just before the terminator.
         let mut bi4: i64 = 0;
         while bi4 < f.blocks.len() {

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -785,15 +785,15 @@ fn check_store_effects_at_call(
                 );
             }
         } else if kind == RSUM_KIND_ALIAS_OF_ANY() {
-            // Unreachable on today's pipeline (kept for forward compat).
-            // `trace_origin_shallow` only ever produces `AliasOf`,
-            // `FreshInCaller`, or `ConstantGlobal` source constraints, so
-            // store_effects with `AliasOfAny` source cannot be generated.
-            // The Rust `handle_inst` Call arm also skips this case
-            // (`_ => {}` at vow-ir/src/region.rs). Even if a future origin
-            // tracer produces `AliasOfAny`, `check_store_conflict` early-
-            // returns unless the source is `FreshInCaller`, which a
-            // parameter-alias source can't be — so no false positive.
+            // Unreachable on today's pipeline: `trace_origin_shallow` only ever
+            // produces `AliasOf`, `FreshInCaller`, or `ConstantGlobal`, so
+            // store_effects with `AliasOfAny` source cannot currently be generated.
+            // DIVERGENCE: the Rust `handle_inst` Call arm skips `AliasOfAny`
+            // (`_ => {}` at vow-ir/src/region.rs). If a future origin tracer
+            // produces `AliasOfAny`, the self-hosted compiler would emit a
+            // RegionConflict for each alias element where the caller passes
+            // a fresh allocation, while Rust emits none. When AliasOfAny store
+            // effects land, align the two paths first.
             if i >= flat.len() { return; }
             let n: i64 = flat[i];
             i = i + 1;
@@ -1749,10 +1749,10 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
         // function rather than corrupt its IR.
         let mut already_has_markers: bool = false;
         let mut bi_g: i64 = 0;
-        while bi_g < f.blocks.len() {
+        while bi_g < f.blocks.len() && !already_has_markers {
             let blk_g: IrBlock = f.blocks[bi_g];
             let mut ii_g: i64 = 0;
-            while ii_g < blk_g.insts.len() {
+            while ii_g < blk_g.insts.len() && !already_has_markers {
                 let op_g: i64 = blk_g.insts[ii_g].op;
                 if op_g == IOP_REGION_OPEN() || op_g == IOP_REGION_CLOSE() {
                     already_has_markers = true;

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -785,36 +785,22 @@ fn check_store_effects_at_call(
                 );
             }
         } else if kind == RSUM_KIND_ALIAS_OF_ANY() {
-            // FIXME: align with Rust `_ => {}` before enabling AliasOfAny
-            // origin tracing.
-            //
             // Unreachable on today's pipeline: `trace_origin_shallow` only ever
             // produces `AliasOf`, `FreshInCaller`, or `ConstantGlobal`, so
             // store_effects with `AliasOfAny` source cannot currently be generated.
-            // DIVERGENCE: the Rust `handle_inst` Call arm skips `AliasOfAny`
-            // (`_ => {}` at vow-ir/src/region.rs). If a future origin tracer
-            // produces `AliasOfAny`, the self-hosted compiler would emit a
-            // RegionConflict for each alias element where the caller passes
-            // a fresh allocation, while Rust emits none. When AliasOfAny store
-            // effects land, align the two paths first.
+            // The flat-array cursor `i` must still consume the `n` alias entries
+            // to stay aligned for the next effect, but no conflict check fires —
+            // matching the Rust `handle_inst` Call arm's `_ => {}` at
+            // vow-ir/src/region.rs.
+            //
+            // FIXME: when AliasOfAny store effects land (e.g. after
+            // `trace_origin_shallow` is extended), align the two paths before
+            // re-introducing any diagnostic here.
             if i >= flat.len() { return; }
             let n: i64 = flat[i];
             i = i + 1;
             let mut ai: i64 = 0;
             while ai < n && i < flat.len() {
-                let source_param: i64 = flat[i];
-                if target >= 0 && target < call_inst.args.len()
-                    && source_param >= 0 && source_param < call_inst.args.len()
-                {
-                    check_store_conflict(
-                        path,
-                        call_inst.args[target],
-                        call_inst.args[source_param],
-                        call_inst,
-                        id_to_inst,
-                        dctx,
-                    );
-                }
                 i = i + 1;
                 ai = ai + 1;
             }

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -785,6 +785,15 @@ fn check_store_effects_at_call(
                 );
             }
         } else if kind == RSUM_KIND_ALIAS_OF_ANY() {
+            // Unreachable on today's pipeline (kept for forward compat).
+            // `trace_origin_shallow` only ever produces `AliasOf`,
+            // `FreshInCaller`, or `ConstantGlobal` source constraints, so
+            // store_effects with `AliasOfAny` source cannot be generated.
+            // The Rust `handle_inst` Call arm also skips this case
+            // (`_ => {}` at vow-ir/src/region.rs). Even if a future origin
+            // tracer produces `AliasOfAny`, `check_store_conflict` early-
+            // returns unless the source is `FreshInCaller`, which a
+            // parameter-alias source can't be — so no false positive.
             if i >= flat.len() { return; }
             let n: i64 = flat[i];
             i = i + 1;
@@ -826,6 +835,14 @@ fn check_store_conflict(
     let source_inst: IrInst = lookup_inst_or_default(id_to_inst, source_arg_id);
     let span_start: i64 = if source_inst.id >= 0 && source_inst.olen > 0 { source_inst.ostart } else { call_inst.ostart };
     let span_len: i64 = if source_inst.id >= 0 && source_inst.olen > 0 { source_inst.olen } else { call_inst.olen };
+    // Diagnostic shape divergence from the Rust pass: the Rust
+    // `check_store_conflict` (vow-ir/src/region.rs) emits a primary span
+    // (the source alloc) plus two secondary spans (target container span
+    // and call-site span) so the user can see the full alloc → store →
+    // container chain. The self-hosted `Diagnostic` in `compiler/diag.vow`
+    // currently models a single span + hints only; secondary spans need a
+    // structural extension to `diag_new` and the JSON / human emitters.
+    // Tracked alongside the other self-hosted diagnostic-infra gaps.
     let d: Diagnostic = diag_new(
         SEV_ERROR(),
         EC_REGION_CONFLICT(),
@@ -1002,6 +1019,17 @@ fn is_heap_producing_for_block_region(inst: IrInst, int_kinds: Vec<i64>) -> bool
     false
 }
 
+// TODO(scalability, follow-up to #204): this is O(blocks × insts × args)
+// per call, and `analyze_function` invokes it once per heap-producing
+// inst. Rough total per function: O(h × n) where h = heap producers,
+// n = total insts. The Rust pass achieves the same effect in O(n) by
+// folding all uses into a `must_outlive` map in a single forward sweep
+// (`collect_regular_use_markers` at vow-ir/src/region.rs:909-926) and
+// then reading per-id markers in O(markers) per producer. That refactor
+// is structural — it would change the analyze_function signature and
+// touch the bootstrap fixed point — and is intentionally deferred so
+// this PR stays scoped to Phase 9 routing. See CLAUDE.md "Scalability is
+// a requirement" for the long-term direction.
 fn value_used_only_in_block(f: IrFunction, id: i64, defining_block: i64) -> bool {
     let bks: Vec<IrBlock> = f.blocks;
     let mut bi: i64 = 0;

--- a/docs/design/arena_phase9_profile.md
+++ b/docs/design/arena_phase9_profile.md
@@ -1,0 +1,69 @@
+# Arena Phase 9 Profile Report
+
+Date: 2026-04-29
+
+Issue: #204, final arena-per-scope performance pass for epic #195.
+
+## Scope
+
+Measured the original Vow benchmark suite references: 36 non-Stretch E/M/H benchmarks from `benchmarks/manifest.toml`.
+
+Baseline is a clean detached `main` worktree at `dc8db24`. The current measurement is the `issue204-arenas-phase-9-performance-pass` branch at the same base commit plus the Phase 9 working-tree changes.
+
+Important caveat: current `main` already contains the arena cutover, so this is a pre-optimization vs post-optimization comparison, not a historical pre-arena comparison. The benchmark `main()` bodies are also very short; runtime differences are around process-startup noise. Treat runtime deltas as smoke signals and RSS deltas as coarse peak-memory checks.
+
+## Method
+
+- Built both worktrees with `cargo build --release --all`.
+- For each benchmark reference:
+  - compiled with `vow build --no-cache --no-verify`;
+  - ran the produced executable 30 times and recorded median wall time using `time.perf_counter`;
+  - recorded peak run RSS with `/usr/bin/time -f "%M"` during executable runs.
+- Excluded HumanEval benchmarks and Stretch benchmarks to match the original suite named in the arena PRD.
+
+Raw measurement artifact for this run: `/tmp/arena_phase9_profile/profile.json`.
+
+## Runtime Regressions
+
+Top 5 by median executable wall-time delta:
+
+| Benchmark | Baseline | Current | Delta |
+| --- | ---: | ---: | ---: |
+| M13 gcd | 1.200 ms | 1.254 ms | +4.48% |
+| H08 interval_overlap | 1.206 ms | 1.259 ms | +4.40% |
+| M14 selection_min | 1.219 ms | 1.267 ms | +3.90% |
+| E02 max_of_two | 1.228 ms | 1.270 ms | +3.46% |
+| M06 vec_max | 1.218 ms | 1.257 ms | +3.27% |
+
+Median runtime delta across the suite: -0.19%.
+
+The largest observed runtime regression is about 0.054 ms absolute, below a meaningful threshold for these process-sized benchmark runs.
+
+## Peak RSS Regressions
+
+Top 5 by executable peak RSS delta:
+
+| Benchmark | Baseline | Current | Delta |
+| --- | ---: | ---: | ---: |
+| H01 stack_push_pop | 2804 KB | 2996 KB | +192 KB (+6.85%) |
+| M05 vec_count | 2808 KB | 2924 KB | +116 KB (+4.13%) |
+| E03 min_of_two | 2740 KB | 2852 KB | +112 KB (+4.09%) |
+| H03 bounded_queue | 2760 KB | 2868 KB | +108 KB (+3.91%) |
+| E02 max_of_two | 2872 KB | 2976 KB | +104 KB (+3.62%) |
+
+Median peak RSS delta across the suite: +0.63%.
+
+The largest RSS increase is 192 KB. No benchmark showed a multi-megabyte regression.
+
+## Applied Optimizations
+
+- Block-local heap producers now route to `Block(defining_block)` when all direct uses stay in that block.
+- `FreshInCaller` call results can route to a caller block when their uses are local.
+- Marker insertion remains elided for blocks with no block-region heap producer.
+- Self-hosted region inference now inserts block markers from inferred regions instead of retagging allocations independently.
+
+## Correctness Hardening
+
+While closing Phase 9, the self-hosted compiler had a remaining store-effect parity gap: it did not publish direct `Store` / `FieldSet` effects and therefore could not emit the Rust-side `RegionConflict` for alloc-into-param-via-callee. That gap is now covered by a source-level regression fixture.
+
+Remaining known limitation: full region-conflict detection for cross-parameter, Phi-mixed, and complete block-tree LUB cases is still outside the current partial checker. The implemented checker covers the source-visible alloc-into-param-via-callee shape already documented in the Rust pass.

--- a/tests/error/region_conflict_store_effect.vow
+++ b/tests/error/region_conflict_store_effect.vow
@@ -1,0 +1,23 @@
+// TEST: error-code RegionConflict
+module RegionConflictStoreEffect
+
+struct Box {
+    value: Payload,
+}
+
+struct Payload {
+    n: i64,
+}
+
+fn put(target: Box, value: Payload) {
+    target.value = value;
+}
+
+fn caller(target: Box) {
+    let value: Payload = Payload { n: 1 };
+    put(target, value);
+}
+
+fn main() -> i32 {
+    0
+}

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -715,6 +715,9 @@ fn analyze_function(
         }
     }
 
+    collect_regular_use_markers(func, &mut must_outlive);
+    propagate_alias_markers(func, summaries, &phi_arms, &mut must_outlive);
+
     // Compute return-region contributions in a deep pass, walking Phi/Call
     // origins with the current summaries fixed. This is the canonical
     // path; the in-handle_inst Return shortcut only flags virtual-caller
@@ -724,7 +727,7 @@ fn analyze_function(
     // Compute LUB-derived RegionId for every heap-producing inst.
     for block in &func.blocks {
         for inst in &block.insts {
-            if !is_heap_producing(inst) {
+            if !is_heap_producing(inst, summaries) {
                 continue;
             }
             let markers = must_outlive.get(&inst.id).cloned().unwrap_or_default();
@@ -743,11 +746,19 @@ fn extern_fresh_in_caller(sym: &str) -> bool {
     )
 }
 
-fn is_heap_producing(inst: &Inst) -> bool {
+fn is_heap_producing(inst: &Inst, summaries: &[InternalSummary]) -> bool {
     matches!(inst.opcode, Opcode::RegionAlloc)
         || matches!(
             (&inst.opcode, &inst.data),
             (Opcode::Call, InstData::CallExtern(sym)) if extern_fresh_in_caller(sym)
+        )
+        || matches!(
+            (&inst.opcode, &inst.data),
+            (Opcode::Call, InstData::CallTarget(callee_id))
+                if summaries
+                    .get(callee_id.0 as usize)
+                    .is_some_and(|s| s.return_region
+                        == InternalReturnRegion::Published(RegionConstraint::FreshInCaller))
         )
 }
 
@@ -895,37 +906,96 @@ fn add_marker(
     must_outlive.entry(inst_id).or_default().insert(marker);
 }
 
-/// After a call returns AliasOf(j), the result inst is *the same value* as
-/// arg[j] from the must_outlive standpoint: any marker on the result must
-/// also apply to arg[j], and vice versa.
-///
-/// **Currently inert in the forward sweep.** `handle_inst` invokes this at
-/// the point a `Call` is processed, but no downstream consumer (e.g., a
-/// `Return` that marks the call result `VirtualCaller`) has run yet — so
-/// `must_outlive[result_id]` is always empty here and the function returns
-/// without doing anything. The return-region summary is correctly
-/// computed by the separate `compute_return_region` deep pass below, so
-/// this no-op does not affect Phase 3 outputs.
-///
-/// TODO(Phase 5 / issue #200): once store-effect propagation lands, run
-/// `propagate_alias` either as a backward sweep after the must_outlive
-/// forward pass completes, or as a dedicated pass that walks
-/// `Opcode::Call` results once their downstream uses are visible. Either
-/// approach makes the function load-bearing for AliasOf-driven
-/// arena-routing decisions on call results.
+fn collect_regular_use_markers(
+    func: &Function,
+    must_outlive: &mut BTreeMap<InstId, BTreeSet<MustOutliveMarker>>,
+) {
+    for block in &func.blocks {
+        for inst in &block.insts {
+            for &arg_id in &inst.args {
+                add_marker(must_outlive, arg_id, MustOutliveMarker::Block(block.id));
+                if matches!(
+                    inst.opcode,
+                    Opcode::Call | Opcode::Store | Opcode::FieldSet | Opcode::Upsilon
+                ) {
+                    add_marker(must_outlive, arg_id, MustOutliveMarker::Root);
+                }
+            }
+        }
+    }
+}
+
+fn propagate_alias_markers(
+    func: &Function,
+    summaries: &[InternalSummary],
+    phi_arms: &BTreeMap<InstId, Vec<InstId>>,
+    must_outlive: &mut BTreeMap<InstId, BTreeSet<MustOutliveMarker>>,
+) {
+    let mut alias_edges: Vec<(InstId, InstId)> = Vec::new();
+    for (phi_id, arms) in phi_arms {
+        for &arm_id in arms {
+            alias_edges.push((*phi_id, arm_id));
+        }
+    }
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if inst.opcode != Opcode::Call {
+                continue;
+            }
+            let InstData::CallTarget(callee_id) = &inst.data else {
+                continue;
+            };
+            let Some(summary) = summaries.get(callee_id.0 as usize) else {
+                continue;
+            };
+            match &summary.return_region {
+                InternalReturnRegion::Published(RegionConstraint::AliasOf(j)) => {
+                    let j_idx = *j as usize;
+                    if j_idx < inst.args.len() {
+                        alias_edges.push((inst.id, inst.args[j_idx]));
+                    }
+                }
+                InternalReturnRegion::Published(RegionConstraint::AliasOfAny(js)) => {
+                    for j in js {
+                        let j_idx = *j as usize;
+                        if j_idx < inst.args.len() {
+                            alias_edges.push((inst.id, inst.args[j_idx]));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut changed = true;
+    let mut iters = 0usize;
+    let bound = alias_edges.len().saturating_add(func.blocks.len()).max(8);
+    while changed && iters <= bound {
+        changed = false;
+        iters += 1;
+        for &(result_id, arg_id) in &alias_edges {
+            changed |= propagate_alias(must_outlive, result_id, arg_id);
+        }
+    }
+}
+
+/// After a Phi or call returns an alias, the result inst is the same value as
+/// its arm/arg from the must_outlive standpoint: markers on the result must
+/// also apply to the origin.
 fn propagate_alias(
     must_outlive: &mut BTreeMap<InstId, BTreeSet<MustOutliveMarker>>,
     result_id: InstId,
     arg_id: InstId,
-) {
+) -> bool {
     let result_markers = must_outlive.get(&result_id).cloned().unwrap_or_default();
     if result_markers.is_empty() {
-        return;
+        return false;
     }
-    must_outlive
-        .entry(arg_id)
-        .or_default()
-        .extend(result_markers);
+    let entry = must_outlive.entry(arg_id).or_default();
+    let before = entry.len();
+    entry.extend(result_markers);
+    entry.len() != before
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -969,30 +1039,14 @@ fn lub_to_region_id(markers: &BTreeSet<MustOutliveMarker>, defining_block: Block
     if has_caller {
         return RegionId::Caller(HiddenRegionIdx(0));
     }
-    // ── Phase 4 (CURRENT BEHAVIOUR) ────────────────────────────────────
-    // All pure-block-marker / empty-set cases are routed to `Root`.
-    // The classification logic below (Phase 9 target) is NOT active
-    // yet — we cannot safely emit `Block(_)` until the `must_outlive`
-    // pass tracks every use of the value (regular `FieldGet`/`Load`,
-    // non-store-effect call args, Pizlo-Phi uses). An untracked read
-    // in a sibling block would consume freed memory after
-    // `RegionClose`. `Root` is conservatively safe — process-lifetime
-    // storage strictly outlives any concrete block LUB.
-    //
-    // ── Phase 9 (#204) target classification, FOR REFERENCE ────────────
-    // Once `must_outlive` is complete, the bullets below describe the
-    // intended behaviour:
-    //   - Empty set → defining block (its narrowest possible region).
-    //   - Single marker == defining block → that block.
-    //   - Anything else (different single block, multiple blocks) →
-    //     `Root` (no block-tree dominance info; returning
-    //     `Block(other)` for an alloc in a different basic block
-    //     would risk use-after-free when `other`'s arena closes).
-    //
-    // The match below is the Phase 9 dispatch, retained as a
-    // structural placeholder; for now we discard `blocks` and return
-    // `Root` unconditionally.
-    let _ = (blocks, defining_block);
+    blocks.sort_unstable();
+    blocks.dedup();
+    if blocks.is_empty() || (blocks.len() == 1 && blocks[0] == defining_block) {
+        return RegionId::Block(defining_block);
+    }
+    // Conservative Phase 9 rule: a concrete-block use outside the defining
+    // block needs full block-tree dominance/LUB to place safely. Until that
+    // exists, Root outlives all blocks without risking a premature close.
     RegionId::Root
 }
 
@@ -1251,15 +1305,11 @@ fn origin_to_constraint(origin: &ValueOrigin) -> RegionConstraint {
 
 /// Phase 5 partial conflict detection (spec §4.4).
 ///
-/// **Self-hosted gap (#204):** the self-hosted `compiler/region.vow` has
-/// no equivalent of this function today. The gap is currently masked
-/// because the self-hosted port also defers store-effect *inference*
-/// (see `compiler/region.vow` `analyze_function`'s "Phase 3 minimal"
-/// note), so `store_effects` is always empty on the self-hosted path
-/// and no call site reaches this check. Both pieces — the inference
-/// and the conflict emission — must land together on the self-hosted
-/// side before the differential gate stays meaningful for programs
-/// that exercise this diagnostic.
+/// The self-hosted `compiler/region.vow` mirrors this in two phases: it
+/// publishes direct `Store`/`FieldSet` effects during fixed-point iteration,
+/// then checks call sites once after summaries converge. Keeping diagnostic
+/// emission outside the SCC loop avoids duplicate reports while preserving the
+/// same source-visible rejection as this Rust path.
 ///
 /// Called during the forward sweep when an `Opcode::Call` site processes
 /// a callee store-effect of shape `(target_param, AliasOf(p))`: the callee
@@ -1283,7 +1333,7 @@ fn origin_to_constraint(origin: &ValueOrigin) -> RegionConstraint {
 ///   hoist the alloc, copy via `pin_to_root`, or restructure the return
 ///   flow per §4.4 + issue #200.
 ///
-/// Deferred to Phase 9 (#204):
+/// Still outside this partial checker:
 ///   * Full block-tree LUB requires a dominator tree (`lub_to_region_id`
 ///     currently routes undecidable block-marker sets to `Root` — the
 ///     pre-existing §4.4 compliance gap shipped with Phase 4).
@@ -2019,9 +2069,9 @@ mod tests {
         let mut m = module(vec![f]);
         infer_regions(&mut m, "test.vow");
         let inst0 = &m.functions[0].blocks[0].insts[0];
-        // The alloc has no must_outlive contributions in Phase 3 minimal —
-        // it falls back to Root. This is conservative; Phase 4 will tighten.
-        assert!(matches!(inst0.region, RegionId::Root | RegionId::Block(_)));
+        // A heap value with no escaping uses can be scoped to its defining
+        // block; this is the no-alloc-block elision prerequisite from #204.
+        assert_eq!(inst0.region, RegionId::Block(BlockId(0)));
         assert_eq!(
             m.functions[0].summary.return_region,
             RegionConstraint::ConstantGlobal,
@@ -2032,9 +2082,8 @@ mod tests {
     #[test]
     fn markers_inserted_for_non_empty_block_region() {
         // The marker insertion pass keys off `inst.region == Block(_)`. We
-        // hand-tag the alloc to exercise the marker pass directly — the
-        // region pass's own `Block(_)` emission is currently disabled (see
-        // `local_alloc_assigned_to_root_until_use_set_is_complete`).
+        // hand-tag the alloc to exercise the marker pass directly without
+        // depending on the inference pass shape.
         let mut alloc = inst(
             0,
             Opcode::RegionAlloc,
@@ -2108,13 +2157,7 @@ mod tests {
     }
 
     #[test]
-    fn local_alloc_assigned_to_root_until_use_set_is_complete() {
-        // Phase 4 / S3 (deferred to Phase 9 / #204): non-escaping local
-        // allocs would ideally land in `Block(defining_block)`, but
-        // `must_outlive` currently misses `FieldGet` / `Load` / non-store-
-        // effect call args. Without a complete use-set we cannot safely
-        // close the block's arena while uses might survive. The pass falls
-        // back to `Root` until `must_outlive` is extended.
+    fn local_alloc_used_only_in_defining_block_routes_to_block_region() {
         let insts = vec![
             inst(
                 0,
@@ -2123,14 +2166,91 @@ mod tests {
                 vec![],
                 InstData::AllocSize { size: 16, align: 8 },
             ),
-            inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(1, Opcode::Load, Ty::I64, vec![0], InstData::None),
             inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
         ];
         let f = function(0, "local", vec![], Ty::I64, vec![block(0, insts)]);
         let mut m = module(vec![f]);
         infer_regions(&mut m, "test.vow");
         let inst0 = &m.functions[0].blocks[0].insts[0];
-        assert_eq!(inst0.region, RegionId::Root);
+        assert_eq!(inst0.region, RegionId::Block(BlockId(0)));
+        insert_region_markers(&mut m);
+        assert_eq!(
+            m.functions[0].blocks[0].insts[0].opcode,
+            Opcode::RegionOpen,
+            "non-empty block region should open at block entry"
+        );
+        assert!(
+            m.functions[0].blocks[0]
+                .insts
+                .iter()
+                .any(|i| i.opcode == Opcode::RegionClose),
+            "non-empty block region should close before the terminator"
+        );
+    }
+
+    #[test]
+    fn alloc_used_from_another_block_stays_root() {
+        let b0_insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                1,
+                Opcode::Jump,
+                Ty::Unit,
+                vec![],
+                InstData::JumpTarget(BlockId(1)),
+            ),
+        ];
+        let b1_insts = vec![
+            inst(2, Opcode::Load, Ty::I64, vec![0], InstData::None),
+            inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+        ];
+        let f = function(
+            0,
+            "cross_block",
+            vec![],
+            Ty::I64,
+            vec![block(0, b0_insts), block(1, b1_insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m, "test.vow");
+        let inst0 = &m.functions[0].blocks[0].insts[0];
+        assert_eq!(
+            inst0.region,
+            RegionId::Root,
+            "uses outside the defining block must stay conservative"
+        );
+    }
+
+    #[test]
+    fn fresh_in_caller_call_result_used_locally_routes_to_block_region() {
+        let callee = build_returning_alloc();
+        let caller_insts = vec![
+            inst(
+                10,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![],
+                InstData::CallTarget(FuncId(0)),
+            ),
+            inst(11, Opcode::Load, Ty::I64, vec![10], InstData::None),
+            inst(12, Opcode::Return, Ty::Unit, vec![11], InstData::None),
+        ];
+        let caller = function(1, "caller", vec![], Ty::I64, vec![block(0, caller_insts)]);
+        let mut m = module(vec![callee, caller]);
+        infer_regions(&mut m, "test.vow");
+        let call = &m.functions[1].blocks[0].insts[0];
+        assert_eq!(
+            call.region,
+            RegionId::Block(BlockId(0)),
+            "FreshInCaller call result should allocate in the caller's local block"
+        );
     }
 
     #[test]

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -978,6 +978,15 @@ fn propagate_alias_markers(
             changed |= propagate_alias(must_outlive, result_id, arg_id);
         }
     }
+    // The marker lattice is finite and `bound` accounts for the worst-case
+    // propagation chain, so non-convergence is unreachable on valid IR.
+    // A regression that breaks monotonicity would silently under-propagate
+    // markers and could let a block-local alloc qualify for block-region
+    // placement when it shouldn't — catch it loudly in debug builds.
+    debug_assert!(
+        !changed,
+        "propagate_alias_markers did not converge within {bound} iterations"
+    );
 }
 
 /// After a Phi or call returns an alias, the result inst is the same value as

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -38,7 +38,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use vow_diag::Severity;
-use vow_ir::{decode_module, encode_module, RegionConstraint};
+use vow_ir::{RegionConstraint, decode_module, encode_module};
 
 /// Assert canonical-form invariants on every function's summary.
 fn assert_canonical_summaries(module: &vow_ir::Module) {
@@ -150,8 +150,8 @@ fn small_module_uninit_never_leaks_after_round_trip() {
     // run the pass, encode + decode via the public .vmod path, and
     // assert canonical-form invariants survive the round trip.
     use vow_ir::{
-        infer_regions, BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData,
-        InstId, Module, Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId,
+        BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData, InstId, Module,
+        Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId, infer_regions,
     };
     use vow_syntax::ast::Effect;
     use vow_syntax::span::Span;

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -287,50 +287,47 @@ fn small_module_uninit_never_leaks_after_round_trip() {
     }
 }
 
-/// Documents the **Rust ↔ self-hosted divergence** on the
-/// alloc→param-via-callee shape (Phase 5 partial RegionConflict
-/// detection, issue #200).
-///
-/// Today's behaviour:
-/// - `vow-ir/src/region.rs::check_store_conflict` (the Rust frontend)
-///   emits `RegionConflict { blame: Callee }` for this shape.
-/// - `compiler/region.vow` has no equivalent. The gap is masked
-///   because the self-hosted side also defers store-effect *inference*
-///   (`compiler/region.vow:436`-style "Phase 3 minimal" comment), so
-///   `store_effects` is always empty and no call site reaches the
-///   conflict check.
-///
-/// The differential gate in `scripts/full_test.sh` therefore can't
-/// validate this code path: both sides emit no `RegionConflict` (Rust
-/// because the input doesn't trigger it on today's corpus,
-/// self-hosted because it can never trigger).
-///
-/// **This `#[ignore]` test makes that gap visibly load-bearing in the
-/// suite.** When #204 lands store-effect inference + the
-/// `check_store_conflict` equivalent on the self-hosted path, this
-/// test must:
-/// 1. drop the `#[ignore]` annotation;
-/// 2. construct a `.vow` program exercising the alloc→param-via-callee
-///    shape (the same logical shape the inline
-///    `region_conflict_alloc_into_param_via_callee_store_effect` test
-///    in `vow-ir/src/region.rs` exercises at the IR level);
-/// 3. assert both compilers emit exactly one `RegionConflict` with
-///    `blame: Callee` on the same source span;
-/// 4. fail loudly if only one side emits.
-///
-/// Until #204 lands, this test fails with `todo!()` if accidentally
-/// run, preventing #204 from merging without implementing the parity
-/// check it's tracking.
+/// Source-level regression for the same logical shape as the inline
+/// `region_conflict_alloc_into_param_via_callee_store_effect` IR test:
+/// a callee stores arg1 into arg0, and a caller passes a parameter container
+/// plus a fresh block-local allocation. The checked-in `tests/error/` fixture
+/// is also consumed by the self-hosted shell suite after bootstrap.
 #[test]
-#[ignore = "tracks #204 (Phase 9): self-hosted check_store_conflict equivalent"]
 fn parity_alloc_into_param_via_callee_emits_region_conflict() {
-    todo!(
-        "Implement when #204 (Phase 9 self-hosted store-effect inference + \
-         check_store_conflict equivalent) lands. Construct a .vow program \
-         exercising the alloc→param-via-callee shape (mirrors the inline \
-         region_conflict_alloc_into_param_via_callee_store_effect test in \
-         vow-ir/src/region.rs::tests), run it through both ./target/release/vow \
-         and build/vowc, and assert both emit exactly one RegionConflict \
-         with blame: Callee on the same source span."
-    )
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let fixture = root
+        .join("tests")
+        .join("error")
+        .join("region_conflict_store_effect.vow");
+    let out = Command::new(env!("CARGO_BIN_EXE_vow"))
+        .args(["build", "--no-verify"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run vow");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "fixture should fail with RegionConflict\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("failed to parse vow stdout as JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+    });
+    assert_eq!(parsed["status"].as_str(), Some("CompileFailed"));
+    let diagnostics = parsed["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array");
+    let conflicts: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["error_code"].as_str() == Some("RegionConflict"))
+        .collect();
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "expected exactly one RegionConflict diagnostic\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(conflicts[0]["blame"].as_str(), Some("callee"));
 }

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -38,7 +38,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use vow_diag::Severity;
-use vow_ir::{RegionConstraint, decode_module, encode_module};
+use vow_ir::{decode_module, encode_module, RegionConstraint};
 
 /// Assert canonical-form invariants on every function's summary.
 fn assert_canonical_summaries(module: &vow_ir::Module) {
@@ -150,8 +150,8 @@ fn small_module_uninit_never_leaks_after_round_trip() {
     // run the pass, encode + decode via the public .vmod path, and
     // assert canonical-form invariants survive the round trip.
     use vow_ir::{
-        BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData, InstId, Module,
-        Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId, infer_regions,
+        infer_regions, BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData,
+        InstId, Module, Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId,
     };
     use vow_syntax::ast::Effect;
     use vow_syntax::span::Span;
@@ -290,10 +290,12 @@ fn small_module_uninit_never_leaks_after_round_trip() {
 /// Source-level regression for the same logical shape as the inline
 /// `region_conflict_alloc_into_param_via_callee_store_effect` IR test:
 /// a callee stores arg1 into arg0, and a caller passes a parameter container
-/// plus a fresh block-local allocation. The checked-in `tests/error/` fixture
-/// is also consumed by the self-hosted shell suite after bootstrap.
+/// plus a fresh block-local allocation. Exercises only the Rust frontend
+/// here; the same fixture is picked up by the self-hosted shell suite via
+/// its `// TEST: error-code RegionConflict` annotation, which runs
+/// `build/vowc` on it after bootstrap.
 #[test]
-fn parity_alloc_into_param_via_callee_emits_region_conflict() {
+fn rust_alloc_into_param_via_callee_emits_region_conflict() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()


### PR DESCRIPTION
## Summary

Completes issue #204, the final arena-per-scope Phase 9 performance pass for epic #195.

- routes safe block-local heap producers and FreshInCaller call results to block regions in the Rust region pass
- wires the self-hosted compiler to insert inferred block-region markers
- closes the self-hosted store-effect parity gap for the alloc-into-param-via-callee RegionConflict path
- adds a source-level regression fixture consumed by both Rust and self-hosted test paths
- adds the Phase 9 profile report under docs/design/arena_phase9_profile.md

## Profile Notes

The report compares a clean detached main worktree at dc8db24 against this branch. Current main already includes the arena cutover, so this is a pre-optimization vs post-optimization comparison rather than a historical pre-arena comparison.

Measured 36 original E/M/H non-Stretch benchmark references:

- median executable runtime delta: -0.19%
- largest runtime increase: about 0.054 ms absolute
- median peak RSS delta: +0.63%
- largest peak RSS increase: 192 KB

The benchmark programs are very short, so runtime deltas are process-startup-scale smoke signals rather than stable microbenchmarks.

## Known Limits

Full region-conflict detection for cross-parameter, Phi-mixed, and complete block-tree LUB cases is still outside the current partial checker. The implemented checker covers the source-visible alloc-into-param-via-callee shape already documented by the Rust pass.

Closes #204.

## Validation

- scripts/bootstrap.sh --skip-cargo
- cargo test --all
- tests/run_tests.sh --no-bootstrap --no-verify
- git diff --check