### PR TITLE
fix(verify): skip non-modelable vowed functions instead of failing closed inline

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -245,6 +245,110 @@ fn is_modelable(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>, modelabl
     true
 }
 
+// Mirror of `vow_verify::c_emitter::non_modelable_reason`. Returns a
+// human-readable explanation for why the verifier cannot model this
+// function (used as a Warning diagnostic + skip-the-function gate).
+// Empty string means the function IS modelable.
+fn iop_unsupported_name(op: i64) -> String {
+    if op == IOP_REM_F32() { return String::from("RemF32"); }
+    if op == IOP_REM_F64() { return String::from("RemF64"); }
+    if op == IOP_LOAD() { return String::from("Load"); }
+    if op == IOP_STORE() { return String::from("Store"); }
+    if op == IOP_REGION_ALLOC() { return String::from("RegionAlloc"); }
+    if op == IOP_REGION_OPEN() { return String::from("RegionOpen"); }
+    if op == IOP_REGION_CLOSE() { return String::from("RegionClose"); }
+    if op == IOP_LINEAR_CONSUME() { return String::from("LinearConsume"); }
+    if op == IOP_LINEAR_BORROW() { return String::from("LinearBorrow"); }
+    if op == IOP_FIELD_SET() { return String::from("FieldSet"); }
+    String::from("")
+}
+
+fn first_unsupported_opcode_name(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>) -> String {
+    let blocks: Vec<IrBlock> = f.blocks;
+    let mut bi: i64 = 0;
+    while bi < blocks.len() {
+        let blk: IrBlock = blocks[bi];
+        let insts: Vec<IrInst> = blk.insts;
+        let mut ii: i64 = 0;
+        while ii < insts.len() {
+            let inst: IrInst = insts[ii];
+            let op: i64 = inst.op;
+            let name: String = iop_unsupported_name(op);
+            if name.len() > 0 {
+                return name;
+            }
+            if op == IOP_CALL() {
+                if inst.dk == IDATA_CALL_EXTERN() {
+                    if !is_known_builtin(inst.ds) {
+                        return str3(String::from("Call extern `"), inst.ds, String::from("`"));
+                    }
+                } else if inst.dk == IDATA_CALL_TARGET() {
+                    let target_fi: i64 = inst.dv;
+                    if !vec_contains_i64(const_fn_indices, target_fi) {
+                        let fns: Vec<IrFunction> = m.functions;
+                        let mut found_modelable: bool = false;
+                        let mut callee_name: String = String::from("");
+                        let mut fi: i64 = 0;
+                        while fi < fns.len() {
+                            let callee: IrFunction = fns[fi];
+                            if callee.id == target_fi {
+                                callee_name = callee.name;
+                                let cache_ids: Vec<i64> = Vec::new();
+                                let cache_vals: Vec<i64> = Vec::new();
+                                found_modelable = is_modelable(callee, m, const_fn_indices, cache_ids, cache_vals);
+                                fi = fns.len();
+                            }
+                            fi = fi + 1;
+                        }
+                        if !found_modelable {
+                            if callee_name.len() == 0 {
+                                callee_name = str2(String::from("FuncId("), str2(i64_to_str(target_fi), String::from(")")));
+                            }
+                            return str3(String::from("Call target `"), callee_name, String::from("`"));
+                        }
+                    }
+                }
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    String::from("")
+}
+
+fn non_modelable_reason(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>) -> String {
+    if is_reserved_verifier_symbol(f.name) {
+        return str3(String::from("function `"), f.name, String::from("` shadows a reserved verifier symbol"));
+    }
+    if f.effects != 0 {
+        return str3(
+            String::from("function `"),
+            f.name,
+            String::from("` has effects; the verifier model is restricted to pure functions"),
+        );
+    }
+    let cache_ids: Vec<i64> = Vec::new();
+    let cache_vals: Vec<i64> = Vec::new();
+    if is_modelable(f, m, const_fn_indices, cache_ids, cache_vals) {
+        return String::from("");
+    }
+    let offender: String = first_unsupported_opcode_name(f, m, const_fn_indices);
+    let detail: String = {
+        if offender.len() > 0 {
+            str3(String::from("contains unsupported opcode `"), offender, String::from("`"))
+        } else {
+            String::from("calls a non-modelable callee")
+        }
+    };
+    str5(
+        String::from("function `"),
+        f.name,
+        String::from("` is not modelable in the verifier ("),
+        detail,
+        String::from(")"),
+    )
+}
+
 fn collect_callees_dfs(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>,
                        modelable_cache_ids: Vec<i64>, modelable_cache_vals: Vec<i64>,
                        visited: Vec<i64>, order: Vec<i64>) {

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -307,6 +307,8 @@ fn first_unsupported_opcode_name(f: IrFunction, m: IrModule, const_fn_indices: V
                             return str3(String::from("Call target `"), callee_name, String::from("`"));
                         }
                     }
+                } else {
+                    return str3(String::from("Call (dk="), i64_to_str(inst.dk), String::from(")"));
                 }
             }
             ii = ii + 1;

--- a/compiler/diag.vow
+++ b/compiler/diag.vow
@@ -28,6 +28,9 @@ fn EC_CONTRACT_TYPE_MISMATCH() -> i64 vow { ensures: result >= 0 } { 16 }
 fn EC_ESBMC_NOT_FOUND() -> i64 vow { ensures: result >= 0 } { 17 }
 fn EC_REGION_CONFLICT() -> i64 vow { ensures: result >= 0 } { 18 }
 fn EC_REGION_LINEAR() -> i64 vow { ensures: result >= 0 } { 19 }
+// Emitted as a Warning when a vowed function's body cannot be modeled by
+// the verifier. Mirrors `vow_diag::ErrorCode::VerificationSkipped`.
+fn EC_VERIFICATION_SKIPPED() -> i64 vow { ensures: result >= 0 } { 20 }
 
 struct Diagnostic {
     severity: i64,
@@ -216,8 +219,11 @@ fn ec_name(code: i64) -> String {
     if code == EC_REGION_LINEAR() {
         String::from("RegionLinear")
     } else {
+    if code == EC_VERIFICATION_SKIPPED() {
+        String::from("VerificationSkipped")
+    } else {
         String::from("IoError")
-    }}}}}}}}}}}}}}}}}}}
+    }}}}}}}}}}}}}}}}}}}}
 }
 
 fn sev_name_lower(s: i64) -> String {

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -216,7 +216,33 @@ fn emit_ce_vars(vr: VerifyResult) [io] {
     }
 }
 
-fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
+// Modelability gate (mirror of `vow_verify::c_emitter::non_modelable_reason`).
+// Vowed functions whose bodies the C emitter cannot model — most importantly
+// struct constructors that lower to RegionAlloc + FieldSet — must be skipped
+// here. Verifying them inline would emit `__ESBMC_assert(0,
+// "vow:UNSUPPORTED_OP_VOW_ID")` defense-in-depth traps and fail closed,
+// breaking the bootstrap (issue #195 regression).
+//
+// Returns true (and emits a Warning diagnostic) when the function is
+// non-modelable; the caller skips ESBMC for it.
+fn skip_if_non_modelable(f: IrFunction, ir_mod: IrModule, const_fn_indices: Vec<i64>, dctx: DiagCtx) -> bool [io] {
+    let reason: String = non_modelable_reason(f, ir_mod, const_fn_indices);
+    if reason.len() == 0 {
+        return false;
+    }
+    eprintln_str(str3(String::from("  "), f.name, String::from(": SKIPPED (non-modelable in verifier)")));
+    let msg: String = str3(
+        String::from("skipped verification of `"),
+        f.name,
+        str2(String::from("`: "), reason),
+    );
+    let d: Diagnostic = diag_new(SEV_WARNING(), EC_VERIFICATION_SKIPPED(), msg, String::from(""), 0, 0, DIAG_BLAME_NONE());
+    diag_add_hint(d, String::from("the contract is documentary; runtime checks still apply in --mode debug"));
+    diag_ctx_emit(dctx, d);
+    true
+}
+
+fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec<i64>, dctx: DiagCtx, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
                    vec_max: i64, string_max: i64, hashmap_max: i64, jobs: i64) -> i64 [io] {
     let mut all_proven: i64 = 1;
     // Bounded pool: ≤ jobs ESBMC processes in flight, FIFO drain. See #175.
@@ -240,10 +266,14 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, path: String, ces: Ve
                 }
             }
             if all_proven == 1 {
-                eprintln_str(str3(String::from("Verifying "), f.name, String::from("...")));
-                let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
-                in_flight_h.push(h);
-                in_flight_fi.push(fi);
+                if skip_if_non_modelable(f, ir_mod, const_fn_indices, dctx) {
+                    // Skipped: do not enqueue ESBMC. Build/run continues with the warning.
+                } else {
+                    eprintln_str(str3(String::from("Verifying "), f.name, String::from("...")));
+                    let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
+                    in_flight_h.push(h);
+                    in_flight_fi.push(fi);
+                }
             }
         }
         fi = fi + 1;
@@ -429,7 +459,8 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     emit_ir_warnings(ir_mod, dctx);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
-    let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, jobs);
+    let const_fn_indices: Vec<i64> = detect_const_fns(ir_mod);
+    let all_proven: i64 = run_verify_loop(fns, ir_mod, const_fn_indices, dctx, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, jobs);
     let status_str: String = {
         if all_proven == 1 {
             String::from("Verified")
@@ -519,6 +550,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     // Bounded pool: ≤ jobs ESBMC processes in flight, FIFO drain. See #175.
     let in_flight_h: Vec<i64> = Vec::new();
     let in_flight_fi: Vec<i64> = Vec::new();
+    let const_fn_indices: Vec<i64> = detect_const_fns(ir_mod);
     if do_verify {
         let mut fi: i64 = 0;
         while fi < fns.len() {
@@ -538,10 +570,14 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
                     }
                 }
                 if all_proven == 1 {
-                    eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
-                    let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
-                    in_flight_h.push(h);
-                    in_flight_fi.push(fi);
+                    if skip_if_non_modelable(f, ir_mod, const_fn_indices, dctx) {
+                        // Skipped: do not enqueue ESBMC. Build continues with the warning.
+                    } else {
+                        eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
+                        let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max);
+                        in_flight_h.push(h);
+                        in_flight_fi.push(fi);
+                    }
                 }
             }
             fi = fi + 1;
@@ -964,7 +1000,8 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             let ces: Vec<VerifyCE> = Vec::new();
             let use_cache_leg: bool = !has_flag(argv, String::from("--no-cache"));
             let jobs_leg: i64 = resolve_verify_jobs(argv);
-            let all_proven: i64 = run_verify_loop(fns, ir_mod, path, ces, max_k_step, use_cache_leg, String::from(""), String::from(""), String::from(""), vec_max_leg, string_max_leg, hashmap_max_leg, jobs_leg);
+            let const_fn_indices_leg: Vec<i64> = detect_const_fns(ir_mod);
+            let all_proven: i64 = run_verify_loop(fns, ir_mod, const_fn_indices_leg, dctx, path, ces, max_k_step, use_cache_leg, String::from(""), String::from(""), String::from(""), vec_max_leg, string_max_leg, hashmap_max_leg, jobs_leg);
             let status_str: String = {
                 if all_proven == 1 {
                     String::from("Verified")
@@ -1122,7 +1159,7 @@ fn skill_json() -> String {
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--no-cache\",\n"));
-    r.push_str(String::from("          \"description\": \"Disable compile and verify caching\",\n"));
+    r.push_str(String::from("          \"description\": \"Disable verification result caching, and (for --no-verify builds) the compile-object cache. See \\\"Compile-object cache behavior\\\" below\",\n"));
     r.push_str(String::from("          \"long\": \"--no-cache\",\n"));
     r.push_str(String::from("          \"value_kind\": \"flag\"\n"));
     r.push_str(String::from("        },\n"));
@@ -1563,7 +1600,7 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--no-verify\": \"Skip ESBMC static verification\",\n"));
     r.push_str(String::from("    \"--dump-ir\": \"Print IR text to stdout and exit (no JSON output, no codegen)\",\n"));
     r.push_str(String::from("    \"--debug-trace <off|calls|full>\": \"Emit JSON trace lines to stderr at runtime (default: off)\",\n"));
-    r.push_str(String::from("    \"--no-cache\": \"Disable compile and verify caching\",\n"));
+    r.push_str(String::from("    \"--no-cache\": \"Disable verification result caching, and (for --no-verify builds) the compile-object cache. See \\\"Compile-object cache behavior\\\" below\",\n"));
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
@@ -1955,7 +1992,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  --no-verify             Skip ESBMC static verification\n"));
     r.push_str(String::from("  --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)\n"));
     r.push_str(String::from("  --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)\n"));
-    r.push_str(String::from("  --no-cache              Disable compile and verify caching\n"));
+    r.push_str(String::from("  --no-cache              Disable verification result caching, and (for --no-verify builds) the compile-object cache. See \"Compile-object cache behavior\" below\n"));
     r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
@@ -2961,7 +2998,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--no-verify`     | (off)       | Skip ESBMC static verification            |\n"));
     r.push_str(String::from("| `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |\n"));
     r.push_str(String::from("| `--debug-trace <off\\|calls\\|full>` | `off` | Emit JSON trace lines to stderr at runtime |\n"));
-    r.push_str(String::from("| `--no-cache`    | (off)       | Disable compile and verify caching           |\n"));
+    r.push_str(String::from("| `--no-cache`    | (off)       | Disable verification result caching, and (for `--no-verify` builds) the compile-object cache. See \"Compile-object cache behavior\" below |\n"));
     r.push_str(String::from("| `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
@@ -2970,6 +3007,8 @@ fn skill_full() -> String {
     r.push_str(String::from("| `--string-max <N>` | `256`    | Max String capacity for verification model   |\n"));
     r.push_str(String::from("| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Compile-object cache behavior.** The on-disk compile-object cache (`$VOW_CACHE_DIR` or `~/.cache/vow/`, where each entry is a `<key>.o` artifact keyed by a content hash of all dependencies, mode, and trace settings) is automatically disabled whenever ESBMC verification is active. This guarantees the linked binary always comes from the same codegen run whose IR was verified, closing the integrity gap where a stale or attacker-supplied `.o` could be linked against freshly-verified IR. Concretely the cache only activates on `vow build --no-verify` invocations; it is bypassed on the default `vow build` path. `--no-cache` additionally disables the cache for `--no-verify` builds.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow verify`\n"));
     r.push_str(String::from("\n"));
@@ -3136,7 +3175,7 @@ fn skill_full() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("| Status          | Meaning                                     |\n"));
     r.push_str(String::from("|-----------------|---------------------------------------------|\n"));
-    r.push_str(String::from("| `Verified`      | Compiled + all contracts proved by ESBMC     |\n"));
+    r.push_str(String::from("| `Verified`      | Compiled + all contracts proved by ESBMC. Functions whose bodies the verifier cannot model (`RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, effectful) are reported as a `VerificationSkipped` *Warning* in `diagnostics[]` and the build still succeeds -- their contracts are documentary, runtime-checked under `--mode debug`. |\n"));
     r.push_str(String::from("| `Unverified`    | Compiled with `--no-verify` (ESBMC skipped)  |\n"));
     r.push_str(String::from("| `CompileFailed` | Parse error, type error, module load error, or link failure |\n"));
     r.push_str(String::from("| `VerifyFailed`  | ESBMC found a counterexample, timed out, errored, or was not found |\n"));
@@ -3279,6 +3318,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `unknown`       | Another contract in the same function failed; this one was not individually checked |\n"));
     r.push_str(String::from("| `timeout`       | ESBMC timed out on the containing function (BV and -- when applicable -- IR fallback both timed out) |\n"));
     r.push_str(String::from("| `error`         | ESBMC error or tool not found                        |\n"));
+    r.push_str(String::from("| `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]`. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Trace Output (stderr, --debug-trace)\n"));
     r.push_str(String::from("\n"));
@@ -3982,6 +4022,26 @@ fn skill_full() -> String {
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("**Fix:** Move the allocation to a wider scope, or copy the value into the target region (e.g., `String::from(s)` into the outer arena). The compiler does NOT silently promote values to the root region -- see `docs/design/arena_memory.md` §4.4.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("### VerificationSkipped\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Phase:** Verification (Warning, not Error -- does not fail the build)\n"));
+    r.push_str(String::from("**Meaning:** The function carries a `vow {}` block but its body uses opcodes the verifier's C model cannot represent -- most commonly `RegionAlloc` and `FieldSet` produced by struct construction, also `Load`/`Store`, `RemF*`, and the `Linear*` family. The function is skipped before any C is emitted or ESBMC is invoked. The contract becomes documentary: runtime checks still apply in `--mode debug`, but no static proof is attempted.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("```json\n"));
+    r.push_str(String::from("{\n"));
+    r.push_str(String::from("  \"error_code\": \"VerificationSkipped\",\n"));
+    r.push_str(String::from("  \"severity\": \"warning\",\n"));
+    r.push_str(String::from("  \"message\": \"skipped verification of `ir_inst_set_region`: function `ir_inst_set_region` is not modelable in the verifier (contains unsupported opcode `RegionAlloc`)\",\n"));
+    r.push_str(String::from("  \"hints\": [\n"));
+    r.push_str(String::from("    \"the contract is documentary; runtime checks still apply in --mode debug\"\n"));
+    r.push_str(String::from("  ]\n"));
+    r.push_str(String::from("}\n"));
+    r.push_str(String::from("```\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Why this isn't a failure.** Per `CLAUDE.md`'s \"Contract Authoring\" guidance, contracts express semantic correctness and must not be weakened to fit the verifier. When the verifier's bounded model checker cannot represent a function's body, the right response is to skip with a structured warning, not to fail closed inline (which historically tripped a defense-in-depth `__ESBMC_assert(0, \"vow:UNSUPPORTED_OP_VOW_ID\")` and broke the bootstrap on every vowed struct-builder).\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Fix:** None required for the build to pass. If you want static verification of the contract, refactor the function so its body uses only modelable opcodes -- typically by splitting allocation/initialisation away from the contract-bearing computation.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Runtime Errors\n"));
     r.push_str(String::from("\n"));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -216,15 +216,7 @@ fn emit_ce_vars(vr: VerifyResult) [io] {
     }
 }
 
-// Modelability gate (mirror of `vow_verify::c_emitter::non_modelable_reason`).
-// Vowed functions whose bodies the C emitter cannot model — most importantly
-// struct constructors that lower to RegionAlloc + FieldSet — must be skipped
-// here. Verifying them inline would emit `__ESBMC_assert(0,
-// "vow:UNSUPPORTED_OP_VOW_ID")` defense-in-depth traps and fail closed,
-// breaking the bootstrap (issue #195 regression).
-//
-// Returns true (and emits a Warning diagnostic) when the function is
-// non-modelable; the caller skips ESBMC for it.
+// Skip non-modelable vowed functions before ESBMC runs; otherwise the C emitter emits __ESBMC_assert(0) traps and the build fails closed.
 fn skip_if_non_modelable(f: IrFunction, ir_mod: IrModule, const_fn_indices: Vec<i64>, dctx: DiagCtx) -> bool [io] {
     let reason: String = non_modelable_reason(f, ir_mod, const_fn_indices);
     if reason.len() == 0 {
@@ -3272,7 +3264,7 @@ fn skill_full() -> String {
     r.push_str(String::from("      \"status\": \"not_verified\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1 }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0 }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -3291,7 +3283,7 @@ fn skill_full() -> String {
     r.push_str(String::from("      \"status\": \"proven\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0 }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0 }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -3305,7 +3297,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| `description` | string  | Full contract text                                       |\n"));
     r.push_str(String::from("| `blame`       | string  | `\"Caller\"` (requires) or `\"Callee\"` (ensures/invariant)  |\n"));
     r.push_str(String::from("| `source`      | object  | `{ \"file\": string, \"offset\": integer }`                  |\n"));
-    r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, or `\"not_verified\"` |\n"));
+    r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, `\"not_verified\"`, or `\"skipped\"` |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Status Values\n"));
     r.push_str(String::from("\n"));
@@ -4653,7 +4645,7 @@ fn skill_full() -> String {
     r.push_str(String::from("          },\n"));
     r.push_str(String::from("          \"status\": {\n"));
     r.push_str(String::from("            \"type\": \"string\",\n"));
-    r.push_str(String::from("            \"enum\": [\"proven\", \"proven-ir\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\"],\n"));
+    r.push_str(String::from("            \"enum\": [\"proven\", \"proven-ir\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\", \"skipped\"],\n"));
     r.push_str(String::from("            \"description\": \"Verification status\"\n"));
     r.push_str(String::from("          }\n"));
     r.push_str(String::from("        },\n"));
@@ -4662,7 +4654,7 @@ fn skill_full() -> String {
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"summary\": {\n"));
     r.push_str(String::from("      \"type\": \"object\",\n"));
-    r.push_str(String::from("      \"required\": [\"total\", \"proven\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\"],\n"));
+    r.push_str(String::from("      \"required\": [\"total\", \"proven\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\", \"skipped\"],\n"));
     r.push_str(String::from("      \"properties\": {\n"));
     r.push_str(String::from("        \"total\": { \"type\": \"integer\" },\n"));
     r.push_str(String::from("        \"proven\": { \"type\": \"integer\" },\n"));
@@ -4670,7 +4662,8 @@ fn skill_full() -> String {
     r.push_str(String::from("        \"unknown\": { \"type\": \"integer\" },\n"));
     r.push_str(String::from("        \"timeout\": { \"type\": \"integer\" },\n"));
     r.push_str(String::from("        \"error\": { \"type\": \"integer\" },\n"));
-    r.push_str(String::from("        \"not_verified\": { \"type\": \"integer\" }\n"));
+    r.push_str(String::from("        \"not_verified\": { \"type\": \"integer\" },\n"));
+    r.push_str(String::from("        \"skipped\": { \"type\": \"integer\" }\n"));
     r.push_str(String::from("      },\n"));
     r.push_str(String::from("      \"additionalProperties\": false\n"));
     r.push_str(String::from("    }\n"));
@@ -5060,32 +5053,44 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
             eprintln_str(String::from("error: ESBMC not found; install ESBMC to run verification"));
             return 1;
         }
+        let const_fn_indices_c: Vec<i64> = detect_const_fns(ir_mod);
         fi = 0;
         while fi < nf {
             let func: IrFunction = ir_mod.functions[fi];
             if func.vows.len() > 0 {
-                let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max_c, string_max_c, hashmap_max_c);
-                let st: i64 = vr.status;
-                let mut ei: i64 = 0;
-                while ei < e_func_ids.len() {
-                    if e_func_ids[ei] == func.id {
-                        if st == VERIFY_PROVEN() {
-                            e_statuses[ei] = String::from("proven");
-                        } else if st == VERIFY_PROVEN_IR() {
-                            e_statuses[ei] = String::from("proven-ir");
-                        } else if st == VERIFY_FAILED() {
-                            if vr.vow_id == e_vow_ids[ei] {
-                                e_statuses[ei] = String::from("failed");
-                            } else {
-                                e_statuses[ei] = String::from("unknown");
-                            }
-                        } else if st == VERIFY_TIMEOUT() {
-                            e_statuses[ei] = String::from("timeout");
-                        } else {
-                            e_statuses[ei] = String::from("error");
+                let skip_reason: String = non_modelable_reason(func, ir_mod, const_fn_indices_c);
+                if skip_reason.len() > 0 {
+                    let mut ei: i64 = 0;
+                    while ei < e_func_ids.len() {
+                        if e_func_ids[ei] == func.id {
+                            e_statuses[ei] = String::from("skipped");
                         }
+                        ei = ei + 1;
                     }
-                    ei = ei + 1;
+                } else {
+                    let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max_c, string_max_c, hashmap_max_c);
+                    let st: i64 = vr.status;
+                    let mut ei: i64 = 0;
+                    while ei < e_func_ids.len() {
+                        if e_func_ids[ei] == func.id {
+                            if st == VERIFY_PROVEN() {
+                                e_statuses[ei] = String::from("proven");
+                            } else if st == VERIFY_PROVEN_IR() {
+                                e_statuses[ei] = String::from("proven-ir");
+                            } else if st == VERIFY_FAILED() {
+                                if vr.vow_id == e_vow_ids[ei] {
+                                    e_statuses[ei] = String::from("failed");
+                                } else {
+                                    e_statuses[ei] = String::from("unknown");
+                                }
+                            } else if st == VERIFY_TIMEOUT() {
+                                e_statuses[ei] = String::from("timeout");
+                            } else {
+                                e_statuses[ei] = String::from("error");
+                            }
+                        }
+                        ei = ei + 1;
+                    }
                 }
             }
             fi = fi + 1;
@@ -5127,6 +5132,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let n_timeout: i64 = 0;
     let n_error: i64 = 0;
     let n_not_verified: i64 = 0;
+    let n_skipped: i64 = 0;
     let mut si: i64 = 0;
     while si < total {
         let s: String = e_statuses[si];
@@ -5140,6 +5146,8 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
             n_timeout = n_timeout + 1;
         } else if s == String::from("error") {
             n_error = n_error + 1;
+        } else if s == String::from("skipped") {
+            n_skipped = n_skipped + 1;
         } else {
             n_not_verified = n_not_verified + 1;
         }
@@ -5160,6 +5168,8 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     json.push_str(i64_to_str(n_error));
     json.push_str(String::from(",\"not_verified\":"));
     json.push_str(i64_to_str(n_not_verified));
+    json.push_str(String::from(",\"skipped\":"));
+    json.push_str(i64_to_str(n_skipped));
     json.push_str(String::from("}}"));
     print_str(json);
     0

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -197,7 +197,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 
 | Status          | Meaning                                     |
 |-----------------|---------------------------------------------|
-| `Verified`      | Compiled + all contracts proved by ESBMC     |
+| `Verified`      | Compiled + all contracts proved by ESBMC. Functions whose bodies the verifier cannot model (`RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, effectful) are reported as a `VerificationSkipped` *Warning* in `diagnostics[]` and the build still succeeds — their contracts are documentary, runtime-checked under `--mode debug`. |
 | `Unverified`    | Compiled with `--no-verify` (ESBMC skipped)  |
 | `CompileFailed` | Parse error, type error, module load error, or link failure |
 | `VerifyFailed`  | ESBMC found a counterexample, timed out, errored, or was not found |
@@ -340,6 +340,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `unknown`       | Another contract in the same function failed; this one was not individually checked |
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
+| `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]`. |
 
 ## Trace Output (stderr, --debug-trace)
 

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -294,7 +294,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
       "status": "not_verified"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1 }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0 }
 }
 ```
 
@@ -313,7 +313,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
       "status": "proven"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0 }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0 }
 }
 ```
 
@@ -327,7 +327,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `description` | string  | Full contract text                                       |
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
-| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, or `"not_verified"` |
+| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
 
 ### Status Values
 

--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -246,6 +246,26 @@ fn store_into(out: Vec<String>, prefix: String) [io] {
 
 **Fix:** Move the allocation to a wider scope, or copy the value into the target region (e.g., `String::from(s)` into the outer arena). The compiler does NOT silently promote values to the root region — see `docs/design/arena_memory.md` §4.4.
 
+### VerificationSkipped
+
+**Phase:** Verification (Warning, not Error — does not fail the build)
+**Meaning:** The function carries a `vow {}` block but its body uses opcodes the verifier's C model cannot represent — most commonly `RegionAlloc` and `FieldSet` produced by struct construction, also `Load`/`Store`, `RemF*`, and the `Linear*` family. The function is skipped before any C is emitted or ESBMC is invoked. The contract becomes documentary: runtime checks still apply in `--mode debug`, but no static proof is attempted.
+
+```json
+{
+  "error_code": "VerificationSkipped",
+  "severity": "warning",
+  "message": "skipped verification of `ir_inst_set_region`: function `ir_inst_set_region` is not modelable in the verifier (contains unsupported opcode `RegionAlloc`)",
+  "hints": [
+    "the contract is documentary; runtime checks still apply in --mode debug"
+  ]
+}
+```
+
+**Why this isn't a failure.** Per `CLAUDE.md`'s "Contract Authoring" guidance, contracts express semantic correctness and must not be weakened to fit the verifier. When the verifier's bounded model checker cannot represent a function's body, the right response is to skip with a structured warning, not to fail closed inline (which historically tripped a defense-in-depth `__ESBMC_assert(0, "vow:UNSUPPORTED_OP_VOW_ID")` and broke the bootstrap on every vowed struct-builder).
+
+**Fix:** None required for the build to pass. If you want static verification of the contract, refactor the function so its body uses only modelable opcodes — typically by splitting allocation/initialisation away from the contract-bearing computation.
+
 ## Runtime Errors
 
 These are emitted to stderr as JSON when a compiled program runs (debug mode for VowViolation).

--- a/vow-diag/src/lib.rs
+++ b/vow-diag/src/lib.rs
@@ -66,6 +66,11 @@ pub enum ErrorCode {
     // Region inference (arena-per-scope, Phase 3)
     RegionConflict,
     RegionLinear,
+    // Emitted as a Warning when a vowed function's body cannot be modeled
+    // by the verifier (e.g. uses RegionAlloc/FieldSet/Linear*/Load/Store).
+    // The build still succeeds; the contract is documentary, not statically
+    // checked. Runtime checks still apply in --mode debug.
+    VerificationSkipped,
 }
 
 pub trait DiagnosticEmitter {

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -394,15 +394,7 @@ pub fn is_modelable(
     true
 }
 
-/// If `func` cannot be precisely modeled by the C emitter, return a
-/// human-readable explanation suitable for a `VerificationResult::Skipped`
-/// reason. Returns `None` when the function IS modelable.
-///
-/// This is the gate that prevents the verifier from emitting fail-closed
-/// `__ESBMC_assert(0, "vow:UNSUPPORTED_OP_VOW_ID")` traps inline in a
-/// function body — those traps remain as defense-in-depth, but should be
-/// unreachable in practice once this gate is consulted at the verify-driver
-/// entry point.
+/// Gate: if `func` is non-modelable, return a human-readable reason; `None` means modelable. Mirror of `compiler/c_emitter.vow::non_modelable_reason`; must stay in sync.
 pub fn non_modelable_reason(
     func: &Function,
     module: &Module,

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -453,23 +453,13 @@ fn first_unsupported_opcode(
                     }
                     InstData::CallTarget(fid) => {
                         if !const_fns.contains_key(fid) {
-                            let modelable = module
-                                .functions
-                                .iter()
-                                .find(|f| f.id == *fid)
-                                .map(|callee| {
-                                    let mut cache = HashMap::new();
-                                    is_modelable(callee, module, const_fns, &mut cache)
-                                })
-                                .unwrap_or(false);
-                            if !modelable {
-                                let name = module
-                                    .functions
-                                    .iter()
-                                    .find(|f| f.id == *fid)
-                                    .map(|f| f.name.clone())
-                                    .unwrap_or_else(|| format!("FuncId({})", fid.0));
-                                return Some(format!("Call target `{name}`"));
+                            if let Some(callee) = module.functions.iter().find(|f| f.id == *fid) {
+                                let mut cache = HashMap::new();
+                                if !is_modelable(callee, module, const_fns, &mut cache) {
+                                    return Some(format!("Call target `{}`", callee.name));
+                                }
+                            } else {
+                                return Some(format!("Call target `FuncId({})`", fid.0));
                             }
                         }
                     }

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -394,6 +394,102 @@ pub fn is_modelable(
     true
 }
 
+/// If `func` cannot be precisely modeled by the C emitter, return a
+/// human-readable explanation suitable for a `VerificationResult::Skipped`
+/// reason. Returns `None` when the function IS modelable.
+///
+/// This is the gate that prevents the verifier from emitting fail-closed
+/// `__ESBMC_assert(0, "vow:UNSUPPORTED_OP_VOW_ID")` traps inline in a
+/// function body — those traps remain as defense-in-depth, but should be
+/// unreachable in practice once this gate is consulted at the verify-driver
+/// entry point.
+pub fn non_modelable_reason(
+    func: &Function,
+    module: &Module,
+    const_fns: &HashMap<FuncId, ConstantValue>,
+) -> Option<String> {
+    if is_reserved_verifier_symbol(&func.name) {
+        return Some(format!(
+            "function `{}` shadows a reserved verifier symbol",
+            func.name
+        ));
+    }
+    if !func.effects.is_empty() {
+        return Some(format!(
+            "function `{}` has effects; the verifier model is restricted to pure functions",
+            func.name
+        ));
+    }
+    let mut cache = HashMap::new();
+    if is_modelable(func, module, const_fns, &mut cache) {
+        return None;
+    }
+    let offender = first_unsupported_opcode(func, module, const_fns);
+    let detail = match offender {
+        Some(name) => format!("contains unsupported opcode `{name}`"),
+        None => "calls a non-modelable callee".to_string(),
+    };
+    Some(format!(
+        "function `{}` is not modelable in the verifier ({detail})",
+        func.name
+    ))
+}
+
+fn first_unsupported_opcode(
+    func: &Function,
+    module: &Module,
+    const_fns: &HashMap<FuncId, ConstantValue>,
+) -> Option<String> {
+    for block in &func.blocks {
+        for inst in &block.insts {
+            match inst.opcode {
+                Opcode::RemF32
+                | Opcode::RemF64
+                | Opcode::Load
+                | Opcode::Store
+                | Opcode::RegionAlloc
+                | Opcode::RegionOpen
+                | Opcode::RegionClose
+                | Opcode::LinearConsume
+                | Opcode::LinearBorrow
+                | Opcode::FieldSet => return Some(format!("{:?}", inst.opcode)),
+                Opcode::Call => match &inst.data {
+                    InstData::CallExtern(name) => {
+                        if !is_known_builtin(name) {
+                            return Some(format!("Call extern `{name}`"));
+                        }
+                    }
+                    InstData::CallTarget(fid) => {
+                        if !const_fns.contains_key(fid) {
+                            let modelable = module
+                                .functions
+                                .iter()
+                                .find(|f| f.id == *fid)
+                                .map(|callee| {
+                                    let mut cache = HashMap::new();
+                                    is_modelable(callee, module, const_fns, &mut cache)
+                                })
+                                .unwrap_or(false);
+                            if !modelable {
+                                let name = module
+                                    .functions
+                                    .iter()
+                                    .find(|f| f.id == *fid)
+                                    .map(|f| f.name.clone())
+                                    .unwrap_or_else(|| format!("FuncId({})", fid.0));
+                                return Some(format!("Call target `{name}`"));
+                            }
+                        }
+                    }
+                    _ => return Some(format!("Call ({:?})", inst.data)),
+                },
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
 /// Collect all modelable callees reachable from `func`, excluding constant
 /// functions (which are inlined). Returns FuncIds in topological order
 /// (callees before callers).

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -42,7 +42,9 @@ pub enum VerificationResult {
     /// invoked. Build drivers should treat this as a structured warning
     /// (vow contract is documentary, not statically checked) — never as a
     /// failure.
-    Skipped { reason: String },
+    Skipped {
+        reason: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -1558,9 +1560,7 @@ VERIFICATION FAILED";
                     "skip reason should mention the cause: {reason}"
                 );
             }
-            other => panic!(
-                "expected Skipped (gate must run before find_esbmc), got {other:?}"
-            ),
+            other => panic!("expected Skipped (gate must run before find_esbmc), got {other:?}"),
         }
     }
 }

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -11,7 +11,7 @@ use crate::solver_strategy::{SolverConfig, run_with_fallback};
 
 use crate::c_emitter::{
     ConstantValue, VerifyLimits, collect_modelable_callees, detect_constant_functions,
-    emit_c_module, emit_c_module_with_callees,
+    emit_c_module, emit_c_module_with_callees, non_modelable_reason,
 };
 
 // ---------------------------------------------------------------------------
@@ -36,6 +36,13 @@ pub enum VerificationResult {
     Timeout,
     ToolNotFound,
     ToolError(String),
+    /// The function's body contains opcodes the C emitter cannot faithfully
+    /// model (e.g. `RegionAlloc`, `FieldSet`, `Load`/`Store`, `RemF*`, linear
+    /// ops) or it has effects. Verification was not attempted; ESBMC was not
+    /// invoked. Build drivers should treat this as a structured warning
+    /// (vow contract is documentary, not statically checked) — never as a
+    /// failure.
+    Skipped { reason: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -296,6 +303,10 @@ pub fn verify_function_with_module_and_const_fns_configured(
     config: &SolverConfig,
     limits: &VerifyLimits,
 ) -> VerificationResult {
+    if let Some(reason) = non_modelable_reason(func, module, const_fns) {
+        return VerificationResult::Skipped { reason };
+    }
+
     let esbmc = match find_esbmc() {
         Some(p) => p,
         None => return VerificationResult::ToolNotFound,
@@ -1471,6 +1482,85 @@ VERIFICATION FAILED";
                 eprintln!("SKIP: esbmc not found");
             }
             other => panic!("expected Failed or ToolNotFound, got {other:?}"),
+        }
+    }
+
+    // --- Non-modelable function skip gate ---
+    //
+    // A vowed function whose body contains opcodes the verifier cannot model
+    // (RegionAlloc, FieldSet, RegionOpen/Close, Linear*, Load, Store, RemFxx)
+    // must be diagnosed as Skipped *before* any C is emitted or ESBMC is
+    // invoked. The fail-closed `__ESBMC_assert(0, "vow:UNSUPPORTED_OP_VOW_ID")`
+    // emitted by the C emitter for these opcodes is defense-in-depth — it
+    // should be unreachable in practice once the gate is in place.
+
+    fn vowed_with_region_alloc() -> Function {
+        // fn alloc_thing(rgn: i64) -> Ptr requires: rgn >= 0 { /* RegionAlloc */ }
+        Function {
+            id: FuncId(0),
+            name: "alloc_thing".to_string(),
+            params: vec![Ty::I64],
+            param_names: vec!["rgn".to_string()],
+            return_ty: Ty::Ptr,
+            effects: vec![],
+            vows: vec![VowEntry {
+                id: VowId(0),
+                description: "rgn >= 0".to_string(),
+                blame: Blame::Caller,
+                bindings: vec![("rgn".to_string(), InstId(0))],
+                file: String::new(),
+                offset: 0,
+            }],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                    inst(
+                        1,
+                        Opcode::RegionAlloc,
+                        Ty::Ptr,
+                        vec![],
+                        InstData::AllocSize { size: 8, align: 8 },
+                    ),
+                    inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+        }
+    }
+
+    #[test]
+    fn vowed_function_with_region_alloc_returns_skipped() {
+        let func = vowed_with_region_alloc();
+        let module = Module {
+            name: "test".to_string(),
+            functions: vec![func.clone()],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+            warnings: vec![],
+        };
+        let result = verify_function_with_module_and_const_fns_configured(
+            &func,
+            &module,
+            &HashMap::new(),
+            10,
+            &SolverConfig::default_config(),
+            &VerifyLimits::default(),
+        );
+        match result {
+            VerificationResult::Skipped { reason } => {
+                assert!(
+                    reason.contains("RegionAlloc")
+                        || reason.contains("not modelable")
+                        || reason.contains("unsupported"),
+                    "skip reason should mention the cause: {reason}"
+                );
+            }
+            other => panic!(
+                "expected Skipped (gate must run before find_esbmc), got {other:?}"
+            ),
         }
     }
 }

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -36,12 +36,7 @@ pub enum VerificationResult {
     Timeout,
     ToolNotFound,
     ToolError(String),
-    /// The function's body contains opcodes the C emitter cannot faithfully
-    /// model (e.g. `RegionAlloc`, `FieldSet`, `Load`/`Store`, `RemF*`, linear
-    /// ops) or it has effects. Verification was not attempted; ESBMC was not
-    /// invoked. Build drivers should treat this as a structured warning
-    /// (vow contract is documentary, not statically checked) — never as a
-    /// failure.
+    /// Function's body contains non-modelable opcodes or effects; ESBMC not invoked. Treat as warning, not failure.
     Skipped {
         reason: String,
     },
@@ -1486,15 +1481,6 @@ VERIFICATION FAILED";
             other => panic!("expected Failed or ToolNotFound, got {other:?}"),
         }
     }
-
-    // --- Non-modelable function skip gate ---
-    //
-    // A vowed function whose body contains opcodes the verifier cannot model
-    // (RegionAlloc, FieldSet, RegionOpen/Close, Linear*, Load, Store, RemFxx)
-    // must be diagnosed as Skipped *before* any C is emitted or ESBMC is
-    // invoked. The fail-closed `__ESBMC_assert(0, "vow:UNSUPPORTED_OP_VOW_ID")`
-    // emitted by the C emitter for these opcodes is defense-in-depth — it
-    // should be unreachable in practice once the gate is in place.
 
     fn vowed_with_region_alloc() -> Function {
         // fn alloc_thing(rgn: i64) -> Ptr requires: rgn >= 0 { /* RegionAlloc */ }

--- a/vow-verify/src/lib.rs
+++ b/vow-verify/src/lib.rs
@@ -4,6 +4,7 @@ pub mod solver_strategy;
 
 pub use c_emitter::{
     ConstantValue, UNSUPPORTED_OP_VOW_ID, VerifyLimits, detect_constant_functions,
+    non_modelable_reason,
 };
 pub use esbmc::{
     Counterexample, DEFAULT_MAX_K_STEP, VerificationResult, emit_verify_c_source, find_esbmc,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -5181,14 +5181,12 @@ fn run_verification_sync(
                     ) {
                         PerFuncResult::Ok => {}
                         PerFuncResult::Skipped(s) => {
-                            let mut guard = skipped_acc
-                                .lock()
-                                .expect("verify skipped mutex poisoned");
+                            let mut guard =
+                                skipped_acc.lock().expect("verify skipped mutex poisoned");
                             guard[idx] = Some(s);
                         }
                         PerFuncResult::Halt(out) => {
-                            let mut guard =
-                                halts.lock().expect("verify halts mutex poisoned");
+                            let mut guard = halts.lock().expect("verify halts mutex poisoned");
                             guard[idx] = Some(out);
                             drop(guard);
                             // Release pairs with sibling threads' stop.load(Acquire) to propagate early-exit.
@@ -5200,9 +5198,7 @@ fn run_verification_sync(
         }
     });
 
-    let halts = halts
-        .into_inner()
-        .expect("verify halts mutex poisoned");
+    let halts = halts.into_inner().expect("verify halts mutex poisoned");
     let outcome = halts
         .into_iter()
         .flatten()
@@ -5251,10 +5247,7 @@ fn verify_outcome_to_output_with_skipped(
         diagnostics.push(Diagnostic {
             severity: Severity::Warning,
             code: vow_diag::ErrorCode::VerificationSkipped,
-            message: format!(
-                "skipped verification of `{}`: {}",
-                s.function, s.reason
-            ),
+            message: format!("skipped verification of `{}`: {}", s.function, s.reason),
             primary: vow_diag::SourceLocation {
                 file: String::new(),
                 byte_offset: 0,
@@ -8804,15 +8797,16 @@ fn main() -> i32 {
             BuildStatus::CompileFailed { message } => {
                 panic!("unexpected compile failure: {message}");
             }
-            other => panic!(
-                "expected Verified/Unverified for non-modelable vowed fn, got {other:?}"
-            ),
+            other => {
+                panic!("expected Verified/Unverified for non-modelable vowed fn, got {other:?}")
+            }
         }
         assert!(
-            result.diagnostics.iter().any(|d| matches!(
-                d.severity,
-                vow_diag::Severity::Warning
-            ) && d.message.contains("make_foo")),
+            result
+                .diagnostics
+                .iter()
+                .any(|d| matches!(d.severity, vow_diag::Severity::Warning)
+                    && d.message.contains("make_foo")),
             "expected a Warning diagnostic naming `make_foo`, got diagnostics: {:?}",
             result.diagnostics
         );

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -8787,23 +8787,27 @@ fn main() -> i32 {
         let result =
             run_verify_only_inner(&source, true, &limits, 1, &SolverConfig::default_config());
         match &result.status {
-            BuildStatus::Verified | BuildStatus::Unverified => {}
+            BuildStatus::Verified => {
+                assert!(
+                    result
+                        .diagnostics
+                        .iter()
+                        .any(|d| matches!(d.severity, vow_diag::Severity::Warning)
+                            && d.message.contains("make_foo")),
+                    "expected a Warning diagnostic naming `make_foo`, got: {:?}",
+                    result.diagnostics
+                );
+            }
+            BuildStatus::VerifyFailed { description, .. }
+                if description.contains("ESBMC not found") =>
+            {
+                eprintln!("SKIP: esbmc not found");
+            }
             BuildStatus::CompileFailed { message } => {
                 panic!("unexpected compile failure: {message}");
             }
-            other => {
-                panic!("expected Verified/Unverified for non-modelable vowed fn, got {other:?}")
-            }
+            other => panic!("expected Verified for non-modelable vowed fn, got {other:?}"),
         }
-        assert!(
-            result
-                .diagnostics
-                .iter()
-                .any(|d| matches!(d.severity, vow_diag::Severity::Warning)
-                    && d.message.contains("make_foo")),
-            "expected a Warning diagnostic naming `make_foo`, got diagnostics: {:?}",
-            result.diagnostics
-        );
     }
 
     #[test]

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2537,7 +2537,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
       "status": "not_verified"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1 }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0 }
 }
 ```
 
@@ -2556,7 +2556,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
       "status": "proven"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0 }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0 }
 }
 ```
 
@@ -2570,7 +2570,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `description` | string  | Full contract text                                       |
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
-| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, or `"not_verified"` |
+| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
 
 ### Status Values
 
@@ -3918,7 +3918,7 @@ When stdin is exhausted, `stdin_read_line()` returns `""` (length 0), the `while
           },
           "status": {
             "type": "string",
-            "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified"],
+            "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
             "description": "Verification status"
           }
         },
@@ -3927,7 +3927,7 @@ When stdin is exhausted, `stdin_read_line()` returns `""` (length 0), the `while
     },
     "summary": {
       "type": "object",
-      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified"],
+      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
       "properties": {
         "total": { "type": "integer" },
         "proven": { "type": "integer" },
@@ -3935,7 +3935,8 @@ When stdin is exhausted, `stdin_read_line()` returns `""` (length 0), the `while
         "unknown": { "type": "integer" },
         "timeout": { "type": "integer" },
         "error": { "type": "integer" },
-        "not_verified": { "type": "integer" }
+        "not_verified": { "type": "integer" },
+        "skipped": { "type": "integer" }
       },
       "additionalProperties": false
     }
@@ -4296,19 +4297,14 @@ enum VerifyOutcome {
     ToolNotFound,
 }
 
-/// Reason a single vowed function was skipped by the verifier (e.g. its body
-/// uses opcodes the C emitter cannot model, like `RegionAlloc`/`FieldSet`).
-/// Surfaces in `BuildOutput.diagnostics` as a Warning — the build still
-/// succeeds.
+/// A vowed function the verifier skipped; surfaces as a Warning in `BuildOutput.diagnostics`.
 #[derive(Debug, Clone)]
 struct SkippedFunction {
     function: String,
     reason: String,
 }
 
-/// Per-function verification verdict, distinguishing "all good" from
-/// "skip with warning" from "halt the run". Avoids overloading
-/// `Option<VerifyOutcome>` (where `None` ambiguously meant either).
+/// Per-function verdict: continue, skip-with-warning, or halt.
 enum PerFuncResult {
     Ok,
     Skipped(SkippedFunction),
@@ -4444,6 +4440,7 @@ pub struct ContractsSummaryJson {
     pub timeout: u32,
     pub error: u32,
     pub not_verified: u32,
+    pub skipped: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -4985,12 +4982,7 @@ fn verify_one_function(
     limits: &VerifyLimits,
     config: &SolverConfig,
 ) -> PerFuncResult {
-    // Modelability gate (issue #195 regression fix). A vowed function whose
-    // body contains opcodes the C emitter cannot model — most importantly
-    // `RegionAlloc` and `FieldSet`, which struct construction lowers to —
-    // would otherwise hit the `__ESBMC_assert(0, "vow:UNSUPPORTED_OP_VOW_ID")`
-    // defense-in-depth trap inline in the C model and fail closed. Skip such
-    // functions here so the build continues with a structured warning.
+    // Non-modelable vowed functions must be skipped here; the C emitter would emit __ESBMC_assert(0) traps for them.
     if let Some(reason) = non_modelable_reason(func, ir_module, const_fns) {
         return PerFuncResult::Skipped(SkippedFunction {
             function: func.name.clone(),
@@ -6142,6 +6134,7 @@ fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJso
         timeout: 0,
         error: 0,
         not_verified: 0,
+        skipped: 0,
     };
     for e in entries {
         match e.status.as_str() {
@@ -6150,6 +6143,7 @@ fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJso
             "unknown" => summary.unknown += 1,
             "timeout" => summary.timeout += 1,
             "error" => summary.error += 1,
+            "skipped" => summary.skipped += 1,
             _ => summary.not_verified += 1,
         }
     }
@@ -6166,6 +6160,15 @@ fn update_contract_statuses(
     let const_fns = detect_constant_functions(ir_module);
     for func in &ir_module.functions {
         if func.vows.is_empty() {
+            continue;
+        }
+
+        if non_modelable_reason(func, ir_module, &const_fns).is_some() {
+            for entry in entries.iter_mut() {
+                if entry.function_id == func.id.0 {
+                    entry.status = "skipped".to_string();
+                }
+            }
             continue;
         }
 
@@ -8766,15 +8769,6 @@ fn main() -> i32 {
         }
     }
 
-    // A vowed function whose body the verifier cannot model (here: a struct
-    // constructor that lowers to RegionAlloc + FieldSet) must NOT cause a
-    // VerifyFailed build. The build succeeds; a structured warning
-    // diagnostic identifies the skipped function and the reason.
-    //
-    // Regression test for the bootstrap regression on `ir_inst_set_region`
-    // observed under issue #195: commit 882a6bc made the C emitter fail
-    // closed on unsupported opcodes, which turned every vowed struct-builder
-    // into a hard build break.
     #[test]
     fn vowed_struct_builder_is_skipped_not_failed() {
         let dir = TempDir::new().unwrap();

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -19,7 +19,7 @@ use vow_diag::{Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
 use vow_verify::{
     ConstantValue, Counterexample, DEFAULT_MAX_K_STEP, Encoding, Solver, SolverConfig,
     UNSUPPORTED_OP_VOW_ID, VerificationResult, VerifyLimits, detect_constant_functions,
-    emit_verify_c_source, find_esbmc, run_with_fallback,
+    emit_verify_c_source, find_esbmc, non_modelable_reason, run_with_fallback,
     verify_function_with_module_and_const_fns_configured,
 };
 
@@ -424,7 +424,7 @@ fn skill_json() -> String {
         },
         {
           "form": "--no-cache",
-          "description": "Disable compile and verify caching",
+          "description": "Disable verification result caching, and (for --no-verify builds) the compile-object cache. See \"Compile-object cache behavior\" below",
           "long": "--no-cache",
           "value_kind": "flag"
         },
@@ -865,7 +865,7 @@ fn skill_json() -> String {
     "--no-verify": "Skip ESBMC static verification",
     "--dump-ir": "Print IR text to stdout and exit (no JSON output, no codegen)",
     "--debug-trace <off|calls|full>": "Emit JSON trace lines to stderr at runtime (default: off)",
-    "--no-cache": "Disable compile and verify caching",
+    "--no-cache": "Disable verification result caching, and (for --no-verify builds) the compile-object cache. See \"Compile-object cache behavior\" below",
     "--max-k-step <N>": "ESBMC incremental BMC max iterations (default: 50)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
@@ -1257,7 +1257,7 @@ BUILD OPTIONS
   --no-verify             Skip ESBMC static verification
   --dump-ir               Print IR text to stdout and exit (no JSON output, no codegen)
   --debug-trace <off|calls|full>  Emit JSON trace lines to stderr at runtime (default: off)
-  --no-cache              Disable compile and verify caching
+  --no-cache              Disable verification result caching, and (for --no-verify builds) the compile-object cache. See "Compile-object cache behavior" below
   --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
@@ -2263,7 +2263,7 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--no-verify`     | (off)       | Skip ESBMC static verification            |
 | `--dump-ir`       | (off)       | Print IR text to stdout and exit (no JSON output, no codegen) |
 | `--debug-trace <off\|calls\|full>` | `off` | Emit JSON trace lines to stderr at runtime |
-| `--no-cache`    | (off)       | Disable compile and verify caching           |
+| `--no-cache`    | (off)       | Disable verification result caching, and (for `--no-verify` builds) the compile-object cache. See "Compile-object cache behavior" below |
 | `--max-k-step <N>` | `50`     | ESBMC incremental BMC max iterations          |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
@@ -2272,6 +2272,8 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--string-max <N>` | `256`    | Max String capacity for verification model   |
 | `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
+
+**Compile-object cache behavior.** The on-disk compile-object cache (`$VOW_CACHE_DIR` or `~/.cache/vow/`, where each entry is a `<key>.o` artifact keyed by a content hash of all dependencies, mode, and trace settings) is automatically disabled whenever ESBMC verification is active. This guarantees the linked binary always comes from the same codegen run whose IR was verified, closing the integrity gap where a stale or attacker-supplied `.o` could be linked against freshly-verified IR. Concretely the cache only activates on `vow build --no-verify` invocations; it is bypassed on the default `vow build` path. `--no-cache` additionally disables the cache for `--no-verify` builds.
 
 ### `vow verify`
 
@@ -2438,7 +2440,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 
 | Status          | Meaning                                     |
 |-----------------|---------------------------------------------|
-| `Verified`      | Compiled + all contracts proved by ESBMC     |
+| `Verified`      | Compiled + all contracts proved by ESBMC. Functions whose bodies the verifier cannot model (`RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, effectful) are reported as a `VerificationSkipped` *Warning* in `diagnostics[]` and the build still succeeds — their contracts are documentary, runtime-checked under `--mode debug`. |
 | `Unverified`    | Compiled with `--no-verify` (ESBMC skipped)  |
 | `CompileFailed` | Parse error, type error, module load error, or link failure |
 | `VerifyFailed`  | ESBMC found a counterexample, timed out, errored, or was not found |
@@ -2581,6 +2583,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `unknown`       | Another contract in the same function failed; this one was not individually checked |
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
+| `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]`. |
 
 ## Trace Output (stderr, --debug-trace)
 
@@ -3284,6 +3287,26 @@ fn store_into(out: Vec<String>, prefix: String) [io] {
 ```
 
 **Fix:** Move the allocation to a wider scope, or copy the value into the target region (e.g., `String::from(s)` into the outer arena). The compiler does NOT silently promote values to the root region — see `docs/design/arena_memory.md` §4.4.
+
+### VerificationSkipped
+
+**Phase:** Verification (Warning, not Error — does not fail the build)
+**Meaning:** The function carries a `vow {}` block but its body uses opcodes the verifier's C model cannot represent — most commonly `RegionAlloc` and `FieldSet` produced by struct construction, also `Load`/`Store`, `RemF*`, and the `Linear*` family. The function is skipped before any C is emitted or ESBMC is invoked. The contract becomes documentary: runtime checks still apply in `--mode debug`, but no static proof is attempted.
+
+```json
+{
+  "error_code": "VerificationSkipped",
+  "severity": "warning",
+  "message": "skipped verification of `ir_inst_set_region`: function `ir_inst_set_region` is not modelable in the verifier (contains unsupported opcode `RegionAlloc`)",
+  "hints": [
+    "the contract is documentary; runtime checks still apply in --mode debug"
+  ]
+}
+```
+
+**Why this isn't a failure.** Per `CLAUDE.md`'s "Contract Authoring" guidance, contracts express semantic correctness and must not be weakened to fit the verifier. When the verifier's bounded model checker cannot represent a function's body, the right response is to skip with a structured warning, not to fail closed inline (which historically tripped a defense-in-depth `__ESBMC_assert(0, "vow:UNSUPPORTED_OP_VOW_ID")` and broke the bootstrap on every vowed struct-builder).
+
+**Fix:** None required for the build to pass. If you want static verification of the contract, refactor the function so its body uses only modelable opcodes — typically by splitting allocation/initialisation away from the contract-bearing computation.
 
 ## Runtime Errors
 
@@ -4273,6 +4296,25 @@ enum VerifyOutcome {
     ToolNotFound,
 }
 
+/// Reason a single vowed function was skipped by the verifier (e.g. its body
+/// uses opcodes the C emitter cannot model, like `RegionAlloc`/`FieldSet`).
+/// Surfaces in `BuildOutput.diagnostics` as a Warning — the build still
+/// succeeds.
+#[derive(Debug, Clone)]
+struct SkippedFunction {
+    function: String,
+    reason: String,
+}
+
+/// Per-function verification verdict, distinguishing "all good" from
+/// "skip with warning" from "halt the run". Avoids overloading
+/// `Option<VerifyOutcome>` (where `None` ambiguously meant either).
+enum PerFuncResult {
+    Ok,
+    Skipped(SkippedFunction),
+    Halt(VerifyOutcome),
+}
+
 #[derive(Debug)]
 pub struct BuildOutput {
     pub status: BuildStatus,
@@ -4942,7 +4984,20 @@ fn verify_one_function(
     verify_cache: Option<&VerifyCache>,
     limits: &VerifyLimits,
     config: &SolverConfig,
-) -> Option<VerifyOutcome> {
+) -> PerFuncResult {
+    // Modelability gate (issue #195 regression fix). A vowed function whose
+    // body contains opcodes the C emitter cannot model — most importantly
+    // `RegionAlloc` and `FieldSet`, which struct construction lowers to —
+    // would otherwise hit the `__ESBMC_assert(0, "vow:UNSUPPORTED_OP_VOW_ID")`
+    // defense-in-depth trap inline in the C model and fail closed. Skip such
+    // functions here so the build continues with a structured warning.
+    if let Some(reason) = non_modelable_reason(func, ir_module, const_fns) {
+        return PerFuncResult::Skipped(SkippedFunction {
+            function: func.name.clone(),
+            reason,
+        });
+    }
+
     // Resolve Auto solver via heuristic (Phase B).
     // Skip heuristic when encoding is Ir — that forces Z3 via resolve().
     let func_config = if config.solver == Solver::Auto && config.encoding != Encoding::Ir {
@@ -4974,7 +5029,7 @@ fn verify_one_function(
         } else {
             let esbmc = match find_esbmc() {
                 Some(p) => p,
-                None => return Some(VerifyOutcome::ToolNotFound),
+                None => return PerFuncResult::Halt(VerifyOutcome::ToolNotFound),
             };
             let (res, resolved_config) =
                 run_with_fallback(&esbmc, &c_src, limits.max_k_step, &func.name, &func_config);
@@ -5014,21 +5069,28 @@ fn verify_one_function(
     match result {
         VerificationResult::Failed(ce) => {
             let sce = build_structured_counterexample(func, &ce, file, call_site_index);
-            Some(VerifyOutcome::Failed {
+            PerFuncResult::Halt(VerifyOutcome::Failed {
                 function: func.name.clone(),
                 description: ce.description.clone(),
                 counterexamples: vec![sce],
             })
         }
-        VerificationResult::ToolError(e) => Some(VerifyOutcome::Error {
+        VerificationResult::ToolError(e) => PerFuncResult::Halt(VerifyOutcome::Error {
             function: func.name.clone(),
             message: e,
         }),
-        VerificationResult::Timeout => Some(VerifyOutcome::Timeout {
+        VerificationResult::Timeout => PerFuncResult::Halt(VerifyOutcome::Timeout {
             function: func.name.clone(),
         }),
-        VerificationResult::Proven | VerificationResult::ProvenIr => None,
-        VerificationResult::ToolNotFound => Some(VerifyOutcome::ToolNotFound),
+        VerificationResult::Proven | VerificationResult::ProvenIr => PerFuncResult::Ok,
+        VerificationResult::ToolNotFound => PerFuncResult::Halt(VerifyOutcome::ToolNotFound),
+        // The verifier-side gate already short-circuits this path; the
+        // emit-and-run code above never returns Skipped today. Treat any
+        // future Skipped from those entry points the same way.
+        VerificationResult::Skipped { reason } => PerFuncResult::Skipped(SkippedFunction {
+            function: func.name.clone(),
+            reason,
+        }),
     }
 }
 
@@ -5041,7 +5103,7 @@ fn run_verification_sync(
     limits: &VerifyLimits,
     jobs: usize,
     config: &SolverConfig,
-) -> VerifyOutcome {
+) -> (VerifyOutcome, Vec<SkippedFunction>) {
     let const_fns = detect_constant_functions(ir_module);
 
     let vowed: Vec<&vow_ir::Function> = ir_module
@@ -5051,13 +5113,14 @@ fn run_verification_sync(
         .collect();
 
     if vowed.is_empty() {
-        return VerifyOutcome::Proven;
+        return (VerifyOutcome::Proven, Vec::new());
     }
 
     let jobs = jobs.max(1).min(vowed.len());
     if jobs == 1 {
+        let mut skipped = Vec::new();
         for func in &vowed {
-            if let Some(outcome) = verify_one_function(
+            match verify_one_function(
                 func,
                 ir_module,
                 &const_fns,
@@ -5067,23 +5130,30 @@ fn run_verification_sync(
                 limits,
                 config,
             ) {
-                return outcome;
+                PerFuncResult::Ok => {}
+                PerFuncResult::Skipped(s) => skipped.push(s),
+                PerFuncResult::Halt(out) => return (out, skipped),
             }
         }
-        return VerifyOutcome::Proven;
+        return (VerifyOutcome::Proven, skipped);
     }
 
-    // Stop after first failure; return lowest-indexed outcome for deterministic reporting.
+    // Stop after first halt-class outcome (Failed/Error/Timeout/ToolNotFound);
+    // return lowest-indexed halt for deterministic reporting. Skipped
+    // functions never halt — they're aggregated and reported as warnings.
     let next = AtomicUsize::new(0);
     let stop = AtomicBool::new(false);
-    let outcomes: StdMutex<Vec<Option<VerifyOutcome>>> =
+    let halts: StdMutex<Vec<Option<VerifyOutcome>>> =
+        StdMutex::new((0..vowed.len()).map(|_| None).collect());
+    let skipped_acc: StdMutex<Vec<Option<SkippedFunction>>> =
         StdMutex::new((0..vowed.len()).map(|_| None).collect());
 
     thread::scope(|scope| {
         for _ in 0..jobs {
             let next = &next;
             let stop = &stop;
-            let outcomes = &outcomes;
+            let halts = &halts;
+            let skipped_acc = &skipped_acc;
             let vowed = &vowed;
             let const_fns = &const_fns;
             scope.spawn(move || {
@@ -5095,11 +5165,11 @@ fn run_verification_sync(
                     if idx >= vowed.len() {
                         break;
                     }
-                    // Always finish what we've claimed so `outcomes[idx]` reflects
-                    // its true verdict — otherwise lowest-index failure reporting
+                    // Always finish what we've claimed so `halts[idx]` reflects
+                    // its true verdict — otherwise lowest-index halt reporting
                     // becomes timing-dependent. The pre-check already avoids claims
-                    // in the common post-failure case.
-                    let outcome = verify_one_function(
+                    // in the common post-halt case.
+                    match verify_one_function(
                         vowed[idx],
                         ir_module,
                         const_fns,
@@ -5108,27 +5178,43 @@ fn run_verification_sync(
                         verify_cache,
                         limits,
                         config,
-                    );
-                    if let Some(out) = outcome {
-                        let mut guard = outcomes.lock().expect("verify outcomes mutex poisoned");
-                        guard[idx] = Some(out);
-                        drop(guard);
-                        // Release pairs with sibling threads' stop.load(Acquire) to propagate early-exit.
-                        stop.store(true, Ordering::Release);
+                    ) {
+                        PerFuncResult::Ok => {}
+                        PerFuncResult::Skipped(s) => {
+                            let mut guard = skipped_acc
+                                .lock()
+                                .expect("verify skipped mutex poisoned");
+                            guard[idx] = Some(s);
+                        }
+                        PerFuncResult::Halt(out) => {
+                            let mut guard =
+                                halts.lock().expect("verify halts mutex poisoned");
+                            guard[idx] = Some(out);
+                            drop(guard);
+                            // Release pairs with sibling threads' stop.load(Acquire) to propagate early-exit.
+                            stop.store(true, Ordering::Release);
+                        }
                     }
                 }
             });
         }
     });
 
-    let results = outcomes
+    let halts = halts
         .into_inner()
-        .expect("verify outcomes mutex poisoned");
-    results
+        .expect("verify halts mutex poisoned");
+    let outcome = halts
         .into_iter()
         .flatten()
         .next()
-        .unwrap_or(VerifyOutcome::Proven)
+        .unwrap_or(VerifyOutcome::Proven);
+    let skipped: Vec<SkippedFunction> = skipped_acc
+        .into_inner()
+        .expect("verify skipped mutex poisoned")
+        .into_iter()
+        .flatten()
+        .collect();
+    (outcome, skipped)
 }
 
 fn blame_to_error_code(blame: &str) -> vow_diag::ErrorCode {
@@ -5149,9 +5235,39 @@ fn blame_to_diag_blame(blame: &str) -> vow_diag::Blame {
 
 fn verify_outcome_to_output(
     outcome: VerifyOutcome,
-    mut diagnostics: Vec<Diagnostic>,
+    diagnostics: Vec<Diagnostic>,
     executable: Option<PathBuf>,
 ) -> BuildOutput {
+    verify_outcome_to_output_with_skipped(outcome, diagnostics, &[], executable)
+}
+
+fn verify_outcome_to_output_with_skipped(
+    outcome: VerifyOutcome,
+    mut diagnostics: Vec<Diagnostic>,
+    skipped: &[SkippedFunction],
+    executable: Option<PathBuf>,
+) -> BuildOutput {
+    for s in skipped {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Warning,
+            code: vow_diag::ErrorCode::VerificationSkipped,
+            message: format!(
+                "skipped verification of `{}`: {}",
+                s.function, s.reason
+            ),
+            primary: vow_diag::SourceLocation {
+                file: String::new(),
+                byte_offset: 0,
+                byte_len: 0,
+            },
+            secondary: vec![],
+            blame: vow_diag::Blame::None,
+            hints: vec![
+                "the contract is documentary; runtime checks still apply in --mode debug"
+                    .to_string(),
+            ],
+        });
+    }
     let (status, counterexamples, verify_status, verify_message) = match outcome {
         VerifyOutcome::Failed {
             function,
@@ -5317,7 +5433,7 @@ fn run_verify_only_inner(
     let verify_cache = if no_cache { None } else { VerifyCache::new() };
     let file = source.to_string_lossy().to_string();
     let call_site_index = build_call_site_index(ir_module, &file);
-    let outcome = run_verification_sync(
+    let (outcome, skipped) = run_verification_sync(
         ir_module,
         &file,
         &call_site_index,
@@ -5326,7 +5442,7 @@ fn run_verify_only_inner(
         jobs,
         config,
     );
-    verify_outcome_to_output(outcome, all_diagnostics, None)
+    verify_outcome_to_output_with_skipped(outcome, all_diagnostics, &skipped, None)
 }
 
 // ---------------------------------------------------------------------------
@@ -5452,9 +5568,9 @@ fn run_pipeline_from_frontend(
     };
     let verify_limits = *limits;
     let verify_config = *config;
-    let verify_handle = thread::spawn(move || -> VerifyOutcome {
+    let verify_handle = thread::spawn(move || -> (VerifyOutcome, Vec<SkippedFunction>) {
         if no_verify {
-            return VerifyOutcome::Skipped;
+            return (VerifyOutcome::Skipped, Vec::new());
         }
         run_verification_sync(
             &module_for_verify,
@@ -5496,8 +5612,15 @@ fn run_pipeline_from_frontend(
         && std::fs::copy(&cached_obj, &obj_path).is_ok()
     {
         let exe_path = link_obj(&obj_path, &output_path);
-        let verify_outcome = verify_handle.join().unwrap_or(VerifyOutcome::Skipped);
-        return verify_outcome_to_output(verify_outcome, all_diagnostics, exe_path);
+        let (verify_outcome, skipped) = verify_handle
+            .join()
+            .unwrap_or((VerifyOutcome::Skipped, Vec::new()));
+        return verify_outcome_to_output_with_skipped(
+            verify_outcome,
+            all_diagnostics,
+            &skipped,
+            exe_path,
+        );
     }
 
     // Codegen
@@ -5546,8 +5669,10 @@ fn run_pipeline_from_frontend(
 
     let exe_path = link_obj(&obj_path, &output_path);
 
-    let verify_outcome = verify_handle.join().unwrap_or(VerifyOutcome::Skipped);
-    verify_outcome_to_output(verify_outcome, all_diagnostics, exe_path)
+    let (verify_outcome, skipped) = verify_handle
+        .join()
+        .unwrap_or((VerifyOutcome::Skipped, Vec::new()));
+    verify_outcome_to_output_with_skipped(verify_outcome, all_diagnostics, &skipped, exe_path)
 }
 
 // ---------------------------------------------------------------------------
@@ -6132,6 +6257,9 @@ fn update_contract_statuses(
                     }
                     VerificationResult::ToolError(_) | VerificationResult::ToolNotFound => {
                         entry.status = "error".to_string();
+                    }
+                    VerificationResult::Skipped { .. } => {
+                        entry.status = "skipped".to_string();
                     }
                 }
             }
@@ -8643,6 +8771,51 @@ fn main() -> i32 {
             }
             other => panic!("unexpected status: {other:?}"),
         }
+    }
+
+    // A vowed function whose body the verifier cannot model (here: a struct
+    // constructor that lowers to RegionAlloc + FieldSet) must NOT cause a
+    // VerifyFailed build. The build succeeds; a structured warning
+    // diagnostic identifies the skipped function and the reason.
+    //
+    // Regression test for the bootstrap regression on `ir_inst_set_region`
+    // observed under issue #195: commit 882a6bc made the C emitter fail
+    // closed on unsupported opcodes, which turned every vowed struct-builder
+    // into a hard build break.
+    #[test]
+    fn vowed_struct_builder_is_skipped_not_failed() {
+        let dir = TempDir::new().unwrap();
+        let src = r#"module SkipDemo
+struct Foo { x: i64, rgn: i64 }
+fn make_foo(x: i64, rgn: i64) -> Foo vow {
+  requires: rgn >= 0
+} {
+  Foo { x: x, rgn: rgn }
+}
+fn main() -> i32 {
+  0
+}"#;
+        let source = write_source(&dir, "skip_demo.vow", src);
+        let limits = VerifyLimits::default();
+        let result =
+            run_verify_only_inner(&source, true, &limits, 1, &SolverConfig::default_config());
+        match &result.status {
+            BuildStatus::Verified | BuildStatus::Unverified => {}
+            BuildStatus::CompileFailed { message } => {
+                panic!("unexpected compile failure: {message}");
+            }
+            other => panic!(
+                "expected Verified/Unverified for non-modelable vowed fn, got {other:?}"
+            ),
+        }
+        assert!(
+            result.diagnostics.iter().any(|d| matches!(
+                d.severity,
+                vow_diag::Severity::Warning
+            ) && d.message.contains("make_foo")),
+            "expected a Warning diagnostic naming `make_foo`, got diagnostics: {:?}",
+            result.diagnostics
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes the bootstrap regression on `main` (#195 Phase 5 gate) where every vowed function whose body lowers to `RegionAlloc`/`FieldSet` (e.g. `compiler/ir.vow:331 ir_inst_set_region`) failed verification at Stage 1 with a synthetic `vow:UNSUPPORTED_OP_VOW_ID` counterexample.
- Adds a function-level modelability gate in both compilers: vowed functions whose bodies the verifier cannot model are now skipped with a structured `VerificationSkipped` Warning instead of fail-closed inline. Build status stays `Verified`; contracts remain runtime-checked under `--mode debug`.
- Re-establishes the binary fixed point: `sha256(vowc2) == sha256(vowc3) == f94198133be8f2d13b66224151ed47cb85942be1d14a397f7f9bc0da28c3a797`.

## Why this is the right shape

`__ESBMC_assert(0, "vow:UNSUPPORTED_OP_VOW_ID")` (added in `882a6bc fix(vow-verify): fail closed on unsupported side-effecting ops`) is meant as defense-in-depth — _"if we ever try to model an unsupported opcode, fail loudly"_. The actual gate ("don't try in the first place") was never wired up; the existing `is_modelable` predicate was only consulted for callees, never for the function under verification. Before `882a6bc` the silent-nondet fallback masked this gap; the fail-closed change exposed it as a hard build break on every vowed struct-builder.

Per `CLAUDE.md` Contract Authoring guidance — _"If ESBMC can't prove a correct contract, that's ESBMC's problem. Mark the function as unverifiable or skip it in the verification pass."_ — the right response is the upstream gate, not weakening the contracts.

## What changed

| Layer | Change |
|---|---|
| `vow-verify/src/c_emitter.rs` | New `non_modelable_reason` + `first_unsupported_opcode` helpers. |
| `vow-verify/src/esbmc.rs` | New `VerificationResult::Skipped { reason }`; gate added to `verify_function_with_module_and_const_fns_configured` before `find_esbmc()`. |
| `vow-verify/src/lib.rs` | Re-export `non_modelable_reason`. |
| `vow/src/main.rs` | New `PerFuncResult { Ok / Skipped / Halt }` + `SkippedFunction`. `run_verification_sync` aggregates skips without short-circuiting. `verify_outcome_to_output_with_skipped` emits a Warning per skipped function. |
| `vow-diag/src/lib.rs` | New `ErrorCode::VerificationSkipped`. |
| `compiler/c_emitter.vow` | Mirror `non_modelable_reason` + `first_unsupported_opcode_name` + `iop_unsupported_name`. |
| `compiler/main.vow` | New `skip_if_non_modelable` helper called inline in `run_verify_loop` and the `run_build` verify block; `detect_const_fns(ir_mod)` threaded through. |
| `compiler/diag.vow` | New `EC_VERIFICATION_SKIPPED()` (code 20) + `ec_name` arm. |
| `docs/spec/cli.md` + `docs/spec/errors.md` | Spec sync per `CLAUDE.md`. |

## Test plan

- [x] `cargo test --all` — 0 failures (incl. new `vowed_function_with_region_alloc_returns_skipped` in vow-verify and `vowed_struct_builder_is_skipped_not_failed` in vow build driver)
- [x] `scripts/bootstrap.sh` — Stages 0/1/2/3 succeed
- [x] `sha256(vowc2) == sha256(vowc3)` — binary fixed point re-established
- [x] Stage 1 build output now contains `{"status":"Verified", … "diagnostics":[{"error_code":"VerificationSkipped","severity":"warning","message":"skipped verification of \`ir_inst_set_region\`: function \`ir_inst_set_region\` is not modelable in the verifier (contains unsupported opcode \`RegionAlloc\`)"}]}` instead of `VerifyFailed`.
- [x] `scripts/full_test.sh` — 304 passed / 6 failed / 1 skipped; all 6 failures (`search/verify`, `sum_range/verify`, `vec_fill/verify`, `gc/verify`, `math/verify`, `cmdloop/test-expected`) reproduced on the unmodified `b7a7c12` Rust compiler — pre-existing on `main`, **unrelated to this PR**.

## Closes

This unblocks closing #195 once the per-phase epic checklist is reviewed.
