### PR TITLE
fix(verify): invalidate __vow_string_eq cache on string mutations + model __vow_string_clear

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -104,6 +104,7 @@ fn is_known_builtin(name: String) -> bool {
     || name == String::from("__vow_string_len")
     || name == String::from("__vow_string_push_str")
     || name == String::from("__vow_string_push_byte")
+    || name == String::from("__vow_string_clear")
     || name == String::from("__vow_string_byte_at")
     || name == String::from("__vow_string_eq")
     || name == String::from("__vow_string_contains")
@@ -664,6 +665,7 @@ fn emit_cmp(out: String, id: i64, a: i64, b: i64, op: String) {
 
 fn emit_inst(out: String, inst: IrInst, vec_vars: Vec<i64>, string_vars: Vec<i64>,
              hashmap_vars: Vec<i64>, const_fn_indices: Vec<i64>, modelable_fi_set: Vec<i64>, m: IrModule,
+             eq_lo: Vec<i64>, eq_hi: Vec<i64>,
              vec_max: i64, string_max: i64, hashmap_max: i64) {
     let id: i64 = inst.id;
     let op: i64 = inst.op;
@@ -903,7 +905,7 @@ fn emit_inst(out: String, inst: IrInst, vec_vars: Vec<i64>, string_vars: Vec<i64
                 return;
             }
             if str_starts_with(ds, String::from("__vow_string_")) {
-                emit_string_op(out, inst, string_max);
+                emit_string_op(out, inst, string_max, eq_lo, eq_hi);
                 return;
             }
             if str_starts_with(ds, String::from("__vow_map_")) {
@@ -1078,7 +1080,66 @@ fn emit_vec_op(out: String, inst: IrInst, vec_max: i64) {
     emit_unmodelled(out, inst);
 }
 
-fn emit_string_op(out: String, inst: IrInst, string_max: i64) {
+// Walk every instruction in the function and append each unordered (lo, hi)
+// __vow_string_eq operand pair into the parallel `eq_lo`/`eq_hi` arrays, in
+// IR-traversal order with linear deduplication. Mirrors the Rust emitter's
+// `compute_string_eq_pairs`.
+fn compute_string_eq_pairs(blocks: Vec<IrBlock>, eq_lo: Vec<i64>, eq_hi: Vec<i64>) {
+    let n_blocks: i64 = blocks.len();
+    let mut bi: i64 = 0;
+    while bi < n_blocks {
+        let blk: IrBlock = blocks[bi];
+        let insts: Vec<IrInst> = blk.insts;
+        let mut ii: i64 = 0;
+        while ii < insts.len() {
+            let inst: IrInst = insts[ii];
+            if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN()
+                && inst.ds == String::from("__vow_string_eq") {
+                let ea: Vec<i64> = inst.args;
+                if ea.len() == 2 {
+                    let a: i64 = ea[0];
+                    let b: i64 = ea[1];
+                    if a != b {
+                        let lo: i64 = if a < b { a } else { b };
+                        let hi: i64 = if a < b { b } else { a };
+                        let mut found: bool = false;
+                        let mut pi: i64 = 0;
+                        while pi < eq_lo.len() {
+                            if eq_lo[pi] == lo && eq_hi[pi] == hi { found = true; }
+                            pi = pi + 1;
+                        }
+                        if !found {
+                            eq_lo.push(lo);
+                            eq_hi.push(hi);
+                        }
+                    }
+                }
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+}
+
+// Re-sample every cached `__str_eq_<lo>_<hi>` whose pair touches `operand`.
+// Called immediately after each modeled string mutation so the verifier
+// cannot prove a stale equality across the mutation.
+fn emit_string_eq_invalidate(out: String, operand: i64, eq_lo: Vec<i64>, eq_hi: Vec<i64>) {
+    let n: i64 = eq_lo.len();
+    let mut i: i64 = 0;
+    while i < n {
+        let lo: i64 = eq_lo[i];
+        let hi: i64 = eq_hi[i];
+        if lo == operand || hi == operand {
+            out.push_str(str5(String::from("  __str_eq_"), i64_to_str(lo),
+                String::from("_"), i64_to_str(hi),
+                String::from(" = __VERIFIER_nondet_bool();\n")));
+        }
+        i = i + 1;
+    }
+}
+
+fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, eq_hi: Vec<i64>) {
     let id: i64 = inst.id;
     let ds: String = inst.ds;
     let iargs: Vec<i64> = inst.args;
@@ -1118,6 +1179,7 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64) {
         let src: i64 = iargs[1];
         out.push_str(str5(String::from("  v"), i64_to_str(dest),
             String::from(".len += v"), i64_to_str(src), String::from(".len;\n")));
+        emit_string_eq_invalidate(out, dest, eq_lo, eq_hi);
         return;
     }
     if ds == String::from("__vow_string_push_byte") {
@@ -1129,6 +1191,13 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64) {
         out.push_str(str6(String::from("  v"), ss, String::from(".data[v"), ss,
             String::from(".len] = (int8_t)v"), str2(i64_to_str(byte), String::from(";\n"))));
         out.push_str(str3(String::from("  v"), ss, String::from(".len++;\n")));
+        emit_string_eq_invalidate(out, s, eq_lo, eq_hi);
+        return;
+    }
+    if ds == String::from("__vow_string_clear") {
+        let s: i64 = iargs[0];
+        out.push_str(str3(String::from("  v"), i64_to_str(s), String::from(".len = 0;\n")));
+        emit_string_eq_invalidate(out, s, eq_lo, eq_hi);
         return;
     }
     if ds == String::from("__vow_string_byte_at") {
@@ -1469,42 +1538,11 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
 
     // Per-pair nondet cache for abstract __vow_string_eq. Mirrors the Rust
     // emitter: one shared _Bool per unordered (a, b) pair ensures repeated
-    // comparisons of the same pair agree.
+    // comparisons of the same pair agree, and emit_string_eq_invalidate
+    // re-samples the entry after each modeled mutation on either operand.
     let eq_lo: Vec<i64> = Vec::new();
     let eq_hi: Vec<i64> = Vec::new();
-    bi = 0;
-    while bi < n_blocks {
-        let blk: IrBlock = blocks[bi];
-        let insts: Vec<IrInst> = blk.insts;
-        let mut ii: i64 = 0;
-        while ii < insts.len() {
-            let inst: IrInst = insts[ii];
-            if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN()
-                && inst.ds == String::from("__vow_string_eq") {
-                let ea: Vec<i64> = inst.args;
-                if ea.len() == 2 {
-                    let a: i64 = ea[0];
-                    let b: i64 = ea[1];
-                    if a != b {
-                        let lo: i64 = if a < b { a } else { b };
-                        let hi: i64 = if a < b { b } else { a };
-                        let mut found: bool = false;
-                        let mut pi: i64 = 0;
-                        while pi < eq_lo.len() {
-                            if eq_lo[pi] == lo && eq_hi[pi] == hi { found = true; }
-                            pi = pi + 1;
-                        }
-                        if !found {
-                            eq_lo.push(lo);
-                            eq_hi.push(hi);
-                        }
-                    }
-                }
-            }
-            ii = ii + 1;
-        }
-        bi = bi + 1;
-    }
+    compute_string_eq_pairs(blocks, eq_lo, eq_hi);
     let mut ei: i64 = 0;
     while ei < eq_lo.len() {
         out.push_str(str5(String::from("  _Bool __str_eq_"), i64_to_str(eq_lo[ei]),
@@ -1568,7 +1606,7 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
         let mut ri: i64 = 0;
         while ri < regular.len() {
             let inst: IrInst = insts[regular[ri]];
-            emit_inst(out, inst, vec_vars, string_vars, hashmap_vars, const_fn_indices, modelable_fi_set, m, vec_max, string_max, hashmap_max);
+            emit_inst(out, inst, vec_vars, string_vars, hashmap_vars, const_fn_indices, modelable_fi_set, m, eq_lo, eq_hi, vec_max, string_max, hashmap_max);
             ri = ri + 1;
         }
 
@@ -1592,7 +1630,7 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
 
         if terminal_idx >= 0 {
             let term: IrInst = insts[terminal_idx];
-            emit_inst(out, term, vec_vars, string_vars, hashmap_vars, const_fn_indices, modelable_fi_set, m, vec_max, string_max, hashmap_max);
+            emit_inst(out, term, vec_vars, string_vars, hashmap_vars, const_fn_indices, modelable_fi_set, m, eq_lo, eq_hi, vec_max, string_max, hashmap_max);
         }
 
         bi = bi + 1;

--- a/tests/verify/string_clear_resets_len.vow
+++ b/tests/verify/string_clear_resets_len.vow
@@ -1,0 +1,18 @@
+// Pin: issue #256 — __vow_string_clear must be modeled as `len = 0`,
+// not silently elided. Before this fix the call fell through to the
+// unmodelled handler, leaving `len` symbolic and breaking any contract
+// that reasoned about the post-clear length.
+module StringClearResetsLen
+
+fn clear_makes_empty() -> i64 vow {
+  ensures: result == 0
+} {
+  let s: String = String::from("hello");
+  s.clear();
+  s.len()
+}
+
+fn main() -> i32 [io] {
+  print_i64(clear_makes_empty());
+  0
+}

--- a/tests/verify/string_clear_resets_len.vow
+++ b/tests/verify/string_clear_resets_len.vow
@@ -1,7 +1,6 @@
-// Pin: issue #256 — __vow_string_clear must be modeled as `len = 0`,
-// not silently elided. Before this fix the call fell through to the
-// unmodelled handler, leaving `len` symbolic and breaking any contract
-// that reasoned about the post-clear length.
+// __vow_string_clear must be modeled as `len = 0`. Without the model
+// the call is elided and `s.len()` after a clear is symbolic, so any
+// contract reasoning about the post-clear length silently weakens.
 module StringClearResetsLen
 
 fn clear_makes_empty() -> i64 vow {

--- a/tests/verify/string_eq_idempotent.vow
+++ b/tests/verify/string_eq_idempotent.vow
@@ -1,0 +1,23 @@
+// Pin: issue #256 — repeated `__vow_string_eq` on the same operand pair
+// must agree within a path. The per-pair `_Bool __str_eq_<lo>_<hi>` cache
+// (cdbdef7) is what makes this true; PR #231 would have replaced it with
+// independent nondets and broken this property.
+//
+// Note: we use locally-constructed strings rather than parameters because
+// `collect_typed_vars` does not yet detect the args[1] of __vow_string_eq
+// as a string operand — that's a separate issue and out of scope here.
+module StringEqIdempotent
+
+fn eq_is_idempotent() -> bool vow {
+  ensures: result == true
+} {
+  let a: String = String::from("hello");
+  let b: String = String::from("hello");
+  let first: bool = a.eq(b);
+  let second: bool = a.eq(b);
+  first == second
+}
+
+fn main() -> i32 [io] {
+  if eq_is_idempotent() { 0 } else { 1 }
+}

--- a/tests/verify/string_eq_idempotent.vow
+++ b/tests/verify/string_eq_idempotent.vow
@@ -1,11 +1,13 @@
-// Pin: issue #256 — repeated `__vow_string_eq` on the same operand pair
-// must agree within a path. The per-pair `_Bool __str_eq_<lo>_<hi>` cache
-// (cdbdef7) is what makes this true; PR #231 would have replaced it with
-// independent nondets and broken this property.
+// `collect_typed_vars` only detects args[0] of `__vow_string_eq` as a
+// string operand, so this test uses locally-constructed strings (which
+// are detected via the `__vow_string_from_cstr` creator path) instead of
+// parameters — broadening the detector is a separate concern.
 //
-// Note: we use locally-constructed strings rather than parameters because
-// `collect_typed_vars` does not yet detect the args[1] of __vow_string_eq
-// as a string operand — that's a separate issue and out of scope here.
+// The property under test: repeated `__vow_string_eq` on the same operand
+// pair must agree within a path. The shared `_Bool __str_eq_<lo>_<hi>`
+// cache is what makes this true; replacing it with independent nondets
+// would let ESBMC pick different values for the same pair on the same
+// path and falsify any `requires a.eq(b); ensures a.eq(b)` contract.
 module StringEqIdempotent
 
 fn eq_is_idempotent() -> bool vow {

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -199,6 +199,7 @@ fn is_known_builtin(name: &str) -> bool {
             | "__vow_string_len"
             | "__vow_string_push_str"
             | "__vow_string_push_byte"
+            | "__vow_string_clear"
             | "__vow_string_byte_at"
             | "__vow_string_eq"
             | "__vow_string_contains"
@@ -536,6 +537,7 @@ fn emit_inst(
     option_vars: &HashSet<u32>,
     const_fns: &HashMap<FuncId, ConstantValue>,
     modelable_fns: &HashSet<FuncId>,
+    eq_pairs: &[(u32, u32)],
     module: &Module,
     limits: &VerifyLimits,
 ) {
@@ -880,6 +882,7 @@ fn emit_inst(
                         let dest = inst.args[0].0;
                         let src = inst.args[1].0;
                         out.push_str(&format!("  v{dest}.len += v{src}.len;\n"));
+                        emit_string_eq_invalidate(dest, eq_pairs, out);
                     }
                     "__vow_string_push_byte" => {
                         let s = inst.args[0].0;
@@ -889,6 +892,12 @@ fn emit_inst(
                             "  __ESBMC_assert(v{s}.len < {string_max}, \"string capacity\");\n\
                              \x20 v{s}.data[v{s}.len] = (int8_t)v{byte};\n  v{s}.len++;\n",
                         ));
+                        emit_string_eq_invalidate(s, eq_pairs, out);
+                    }
+                    "__vow_string_clear" => {
+                        let s = inst.args[0].0;
+                        out.push_str(&format!("  v{s}.len = 0;\n"));
+                        emit_string_eq_invalidate(s, eq_pairs, out);
                     }
                     "__vow_string_byte_at" => {
                         let s = inst.args[0].0;
@@ -1144,6 +1153,46 @@ fn emit_unmodelled(inst: &Inst, out: &mut String) {
     }
 }
 
+/// Collect every unordered (lo, hi) operand pair appearing as arguments to
+/// `__vow_string_eq`, in IR-traversal order with linear deduplication. The
+/// caller emits one shared `_Bool __str_eq_<lo>_<hi>` per pair, and re-samples
+/// it whenever a modeled mutation touches `lo` or `hi`.
+fn compute_string_eq_pairs(func: &Function) -> Vec<(u32, u32)> {
+    let mut eq_pairs: Vec<(u32, u32)> = Vec::new();
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if inst.opcode == Opcode::Call
+                && let InstData::CallExtern(ref name) = inst.data
+                && name == "__vow_string_eq"
+                && inst.args.len() == 2
+            {
+                let a = inst.args[0].0;
+                let b = inst.args[1].0;
+                if a != b {
+                    let pair = (a.min(b), a.max(b));
+                    if !eq_pairs.contains(&pair) {
+                        eq_pairs.push(pair);
+                    }
+                }
+            }
+        }
+    }
+    eq_pairs
+}
+
+/// Emit `__str_eq_<lo>_<hi> = __VERIFIER_nondet_bool();` for every cached pair
+/// involving `operand`. Called immediately after each modeled string mutation
+/// so the verifier cannot prove a stale equality across a mutation.
+fn emit_string_eq_invalidate(operand: u32, eq_pairs: &[(u32, u32)], out: &mut String) {
+    for &(lo, hi) in eq_pairs {
+        if lo == operand || hi == operand {
+            out.push_str(&format!(
+                "  __str_eq_{lo}_{hi} = __VERIFIER_nondet_bool();\n"
+            ));
+        }
+    }
+}
+
 /// Sentinel `vow_id` reported when ESBMC fails on an
 /// `emit_unsupported_for_verification` assertion. Reserved so the diagnostic
 /// pipeline can distinguish a verifier-limitation failure from a real vow
@@ -1367,33 +1416,13 @@ pub fn emit_c_function_full(
     // __VERIFIER_nondet_bool() on every call would let ESBMC pick different
     // values for the same (a,b) pair, breaking determinism (e.g. body proves
     // `a.eq(b)` then `ensures: a.eq(b)` fails). Declare one shared bool per
-    // unordered pair (min, max) and reuse it at every call site.
-    {
-        let mut eq_pairs: Vec<(u32, u32)> = Vec::new();
-        for block in &func.blocks {
-            for inst in &block.insts {
-                if inst.opcode == Opcode::Call
-                    && let InstData::CallExtern(ref name) = inst.data
-                    && name == "__vow_string_eq"
-                    && inst.args.len() == 2
-                {
-                    let a = inst.args[0].0;
-                    let b = inst.args[1].0;
-                    if a != b {
-                        let pair = (a.min(b), a.max(b));
-                        if !eq_pairs.contains(&pair) {
-                            eq_pairs.push(pair);
-                        }
-                    }
-                }
-            }
-        }
-        eq_pairs.sort();
-        for (lo, hi) in eq_pairs {
-            out.push_str(&format!(
-                "  _Bool __str_eq_{lo}_{hi} = __VERIFIER_nondet_bool();\n"
-            ));
-        }
+    // unordered pair (min, max) and reuse it at every call site, then
+    // re-sample after each modeled mutation on either operand.
+    let eq_pairs = compute_string_eq_pairs(func);
+    for &(lo, hi) in &eq_pairs {
+        out.push_str(&format!(
+            "  _Bool __str_eq_{lo}_{hi} = __VERIFIER_nondet_bool();\n"
+        ));
     }
 
     // Block-visit tracking variables
@@ -1443,6 +1472,7 @@ pub fn emit_c_function_full(
                 &option_vars,
                 const_fns,
                 modelable_fns,
+                &eq_pairs,
                 module,
                 limits,
             );
@@ -1466,6 +1496,7 @@ pub fn emit_c_function_full(
                 &option_vars,
                 const_fns,
                 modelable_fns,
+                &eq_pairs,
                 module,
                 limits,
             );
@@ -3473,6 +3504,347 @@ mod tests {
     }
 
     #[test]
+    fn emit_string_eq_invalidates_on_push_byte() {
+        // After `__vow_string_push_byte(a, ...)` mutates `a`, every cached
+        // pair touching `a` must be re-sampled with __VERIFIER_nondet_bool().
+        // The cache itself stays — the pair is still shared by call sites
+        // before and after the mutation — but its value can change.
+        use vow_ir::InstId;
+        let func = make_func(
+            "push_then_compare",
+            vec![],
+            Ty::Bool,
+            vec![
+                inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                Inst {
+                    id: InstId(1),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(0)],
+                    data: InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(2, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(1)),
+                Inst {
+                    id: InstId(3),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(2)],
+                    data: InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(4),
+                    opcode: Opcode::Call,
+                    ty: Ty::Bool,
+                    args: vec![InstId(1), InstId(3)],
+                    data: InstData::CallExtern("__vow_string_eq".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(5, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(65)),
+                Inst {
+                    id: InstId(6),
+                    opcode: Opcode::Call,
+                    ty: Ty::Unit,
+                    args: vec![InstId(1), InstId(5)],
+                    data: InstData::CallExtern("__vow_string_push_byte".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(7),
+                    opcode: Opcode::Call,
+                    ty: Ty::Bool,
+                    args: vec![InstId(1), InstId(3)],
+                    data: InstData::CallExtern("__vow_string_eq".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(8, Opcode::Return, Ty::Unit, vec![7], InstData::None),
+            ],
+        );
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        // Exactly one shared declaration for the (1, 3) pair.
+        let decls = c
+            .matches("_Bool __str_eq_1_3 = __VERIFIER_nondet_bool();")
+            .count();
+        assert_eq!(decls, 1, "expected exactly one shared decl: {c}");
+        // Both reads share the cached name.
+        assert!(
+            c.contains("v4 = (v1.len == v3.len) ? __str_eq_1_3 : 0"),
+            "first eq call must use cached nondet: {c}"
+        );
+        assert!(
+            c.contains("v7 = (v1.len == v3.len) ? __str_eq_1_3 : 0"),
+            "second eq call must reuse cached nondet: {c}"
+        );
+        // Re-sample line follows the mutation (`v1.len++;`) and precedes the
+        // second read.
+        let resample = "__str_eq_1_3 = __VERIFIER_nondet_bool();";
+        let len_inc_pos = c.find("v1.len++;").expect("push_byte must emit len++");
+        let resample_pos = c[len_inc_pos..]
+            .find(resample)
+            .map(|p| p + len_inc_pos)
+            .expect(&format!("re-sample must follow v1.len++: {c}"));
+        let second_read_pos = c
+            .find("v7 = (v1.len == v3.len)")
+            .expect("second read must exist");
+        assert!(
+            resample_pos < second_read_pos,
+            "re-sample must precede second read: {c}"
+        );
+    }
+
+    #[test]
+    fn emit_string_eq_invalidates_on_push_str() {
+        // `__vow_string_push_str(dest, src)` mutates dest's len; src is
+        // read-only. Cached pairs touching dest must be re-sampled; pairs
+        // not touching dest must not.
+        use vow_ir::InstId;
+        let func = make_func(
+            "push_str_then_compare",
+            vec![],
+            Ty::Bool,
+            vec![
+                inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                Inst {
+                    id: InstId(1),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(0)],
+                    data: InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(2, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(1)),
+                Inst {
+                    id: InstId(3),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(2)],
+                    data: InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(4),
+                    opcode: Opcode::Call,
+                    ty: Ty::Bool,
+                    args: vec![InstId(1), InstId(3)],
+                    data: InstData::CallExtern("__vow_string_eq".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(5),
+                    opcode: Opcode::Call,
+                    ty: Ty::Unit,
+                    args: vec![InstId(1), InstId(3)],
+                    data: InstData::CallExtern("__vow_string_push_str".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(6),
+                    opcode: Opcode::Call,
+                    ty: Ty::Bool,
+                    args: vec![InstId(1), InstId(3)],
+                    data: InstData::CallExtern("__vow_string_eq".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(7, Opcode::Return, Ty::Unit, vec![6], InstData::None),
+            ],
+        );
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        // Cache shared across both reads.
+        let decls = c
+            .matches("_Bool __str_eq_1_3 = __VERIFIER_nondet_bool();")
+            .count();
+        assert_eq!(decls, 1, "expected exactly one shared decl: {c}");
+        // Re-sample line follows v1.len += v3.len; (the push_str body) and
+        // precedes the second read.
+        let push_pos = c
+            .find("v1.len += v3.len;")
+            .expect("push_str must emit `dest.len += src.len;`");
+        let resample = "__str_eq_1_3 = __VERIFIER_nondet_bool();";
+        let resample_pos = c[push_pos..]
+            .find(resample)
+            .map(|p| p + push_pos)
+            .expect(&format!("re-sample must follow push_str body: {c}"));
+        let second_read_pos = c
+            .find("v6 = (v1.len == v3.len)")
+            .expect("second read must exist");
+        assert!(
+            resample_pos < second_read_pos,
+            "re-sample must precede second read: {c}"
+        );
+    }
+
+    #[test]
+    fn emit_string_clear_emits_len_zero_and_invalidates() {
+        // `__vow_string_clear` was previously elided as unmodelled, which
+        // both lost the `len = 0` post-condition and skipped cache
+        // invalidation. The new model must emit both.
+        use vow_ir::InstId;
+        let func = make_func(
+            "clear_then_compare",
+            vec![],
+            Ty::Bool,
+            vec![
+                inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                Inst {
+                    id: InstId(1),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(0)],
+                    data: InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(2, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(1)),
+                Inst {
+                    id: InstId(3),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(2)],
+                    data: InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(4),
+                    opcode: Opcode::Call,
+                    ty: Ty::Bool,
+                    args: vec![InstId(1), InstId(3)],
+                    data: InstData::CallExtern("__vow_string_eq".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(5),
+                    opcode: Opcode::Call,
+                    ty: Ty::Unit,
+                    args: vec![InstId(1)],
+                    data: InstData::CallExtern("__vow_string_clear".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(6),
+                    opcode: Opcode::Call,
+                    ty: Ty::Bool,
+                    args: vec![InstId(1), InstId(3)],
+                    data: InstData::CallExtern("__vow_string_eq".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(7, Opcode::Return, Ty::Unit, vec![6], InstData::None),
+            ],
+        );
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        // Clear must NOT fall through to the unmodelled handler.
+        assert!(
+            !c.contains("/* opcode Call not modelled */"),
+            "clear must be modeled, not unmodelled: {c}"
+        );
+        // The new model emits `len = 0`.
+        let zero_pos = c
+            .find("v1.len = 0;")
+            .expect(&format!("clear must emit `v1.len = 0;`: {c}"));
+        // Re-sample for the (1, 3) pair follows the clear and precedes the
+        // second read.
+        let resample = "__str_eq_1_3 = __VERIFIER_nondet_bool();";
+        let resample_pos = c[zero_pos..]
+            .find(resample)
+            .map(|p| p + zero_pos)
+            .expect(&format!("re-sample must follow clear: {c}"));
+        let second_read_pos = c
+            .find("v6 = (v1.len == v3.len)")
+            .expect("second read must exist");
+        assert!(
+            resample_pos < second_read_pos,
+            "re-sample must precede second read: {c}"
+        );
+    }
+
+    #[test]
+    fn emit_string_eq_no_invalidation_for_unrelated_operand() {
+        // The cache key is the (lo, hi) operand pair. A mutation on a string
+        // that is NOT in any cached pair must emit no re-sample.
+        use vow_ir::InstId;
+        let func = make_func(
+            "mutate_unrelated",
+            vec![],
+            Ty::Bool,
+            vec![
+                inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                Inst {
+                    id: InstId(1),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(0)],
+                    data: InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(2, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(1)),
+                Inst {
+                    id: InstId(3),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(2)],
+                    data: InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(4, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(2)),
+                Inst {
+                    id: InstId(5),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(4)],
+                    data: InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(6),
+                    opcode: Opcode::Call,
+                    ty: Ty::Bool,
+                    args: vec![InstId(1), InstId(3)],
+                    data: InstData::CallExtern("__vow_string_eq".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(7, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(65)),
+                Inst {
+                    id: InstId(8),
+                    opcode: Opcode::Call,
+                    ty: Ty::Unit,
+                    args: vec![InstId(5), InstId(7)],
+                    data: InstData::CallExtern("__vow_string_push_byte".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(9, Opcode::Return, Ty::Unit, vec![6], InstData::None),
+            ],
+        );
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        // Cached pair is (1, 3); the push_byte is on operand 5.
+        // Cache decl is the only place __str_eq_1_3 is assigned; no re-sample.
+        let assignments = c.matches("__str_eq_1_3").count();
+        // Two occurrences expected: the decl line and the read at v6.
+        assert_eq!(
+            assignments, 2,
+            "no re-sample for unrelated operand (decl + 1 read = 2): {c}"
+        );
+    }
+
+    #[test]
     fn emit_string_contains() {
         use vow_ir::InstId;
         let func = make_func(
@@ -4113,6 +4485,7 @@ mod tests {
             &HashSet::new(),
             &const_fns,
             &HashSet::new(),
+            &[],
             &empty_module,
             &VerifyLimits::default(),
         );
@@ -4148,6 +4521,7 @@ mod tests {
             &HashSet::new(),
             &HashMap::new(),
             &HashSet::new(),
+            &[],
             &empty_module,
             &VerifyLimits::default(),
         );


### PR DESCRIPTION
Closes #256.

## Summary
- Keep cdbdef7's per-pair `_Bool __str_eq_<lo>_<hi>` cache and re-sample it via `__VERIFIER_nondet_bool()` after every modeled string mutation (`push_byte`, `push_str`, `clear`) on either operand.
- Add a verifier model for `__vow_string_clear` (`v{s}.len = 0;`) — previously elided as unmodelled, silently weakening any contract reasoning about `s.len()` after a clear.
- Mirror byte-for-byte in the self-hosted emitter; bootstrap fixed point preserved.

## Why this approach
PR #231 (closed) tried to remove the cache to address staleness across mutations. That direction reintroduces a real regression — ESBMC can pick different values for the same pair on the same path, falsifying ensures the body just established. Keeping the cache and invalidating it on mutation is the soundness-preserving fix; see issue #256 for the full reasoning and the closed-PR thread.

## Files
- `vow-verify/src/c_emitter.rs` — new helpers `compute_string_eq_pairs` and `emit_string_eq_invalidate`; new `__vow_string_clear` arm in the string-ops dispatch; `eq_pairs` plumbed through `emit_inst`. Drops the `eq_pairs.sort()` that was a no-op given IR-traversal order, to match the self-hosted (insertion-order) policy.
- `compiler/c_emitter.vow` — same shape, parallel `eq_lo`/`eq_hi` arrays.
- `tests/verify/string_eq_idempotent.vow` `[new]` — pin: repeated `eq` calls on the same path agree.
- `tests/verify/string_clear_resets_len.vow` `[new]` — pin: clear's new model end-to-end.
- `vow-verify/src/c_emitter.rs` test module — 4 new emit-shape unit tests (push_byte, push_str, clear invalidation; unrelated-operand regression).

## Test plan
- [x] `cargo test --all` — green (103/103 in `vow-verify`)
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `scripts/bootstrap.sh --skip-cargo` — binary fixed point preserved (stage-2 == stage-3)
- [x] `scripts/full_test.sh` — 306 passed, 6 failed, 1 skipped. The 6 failures (`search`, `sum_range`, `vec_fill`, `gc`, `math` verify; `cmdloop` runtime) reproduce on `main` unchanged — pre-existing ESBMC integration issues unrelated to this fix.
- [x] `/codex:review --background --scope branch` — no actionable issues.

## Out of scope (flagged for follow-up)
- `collect_typed_vars` only inspects `args[0]` of `__vow_string_eq`, so the issue body's literal `fn check(a: String, b: String)` contract still won't verify after this fix. The integration test was rewritten with locally-constructed strings to pin the cache property without tripping the param-detection bug.
- Acceptance criterion (b) "spurious counterexample no longer arises" cannot be tested end-to-end today: every modeled string mutation changes `len`, so the existing length-equality short-circuit catches any test scenario regardless of the new invalidation. Emit-shape unit tests are the tightest available signal until a length-preserving mutation lands.
- Pre-existing modelable-list divergence: Rust includes `__vow_string_substring` / `parse_i64_opt` / `parse_u64_opt`; self-hosted does not. Untouched here.

## Merge instructions
Per project policy, merge via `gh pr merge --merge` — do not squash or rebase.