### PR TITLE
fix(verify): add capacity assertion for __vow_string_push_str (#271)

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -1177,8 +1177,14 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, e
     if ds == String::from("__vow_string_push_str") {
         let dest: i64 = iargs[0];
         let src: i64 = iargs[1];
-        out.push_str(str5(String::from("  v"), i64_to_str(dest),
-            String::from(".len += v"), i64_to_str(src), String::from(".len;\n")));
+        let dests: String = i64_to_str(dest);
+        let srcs: String = i64_to_str(src);
+        out.push_str(str7(String::from("  __ESBMC_assert(v"), dests,
+            String::from(".len + v"), srcs,
+            String::from(".len <= "), i64_to_str(string_max),
+            String::from(", \"string capacity\");\n")));
+        out.push_str(str5(String::from("  v"), dests,
+            String::from(".len += v"), srcs, String::from(".len;\n")));
         emit_string_eq_invalidate(out, dest, eq_lo, eq_hi);
         return;
     }

--- a/tests/verify-fail/string_push_str_overflow.vow
+++ b/tests/verify-fail/string_push_str_overflow.vow
@@ -1,0 +1,22 @@
+// TEST: counterexample-fn "over"
+// TEST: counterexample-blame none
+// String capacity assertion: a.len + b.len can exceed string_max (both
+// nondet in [0, string_max-1] from from_cstr), and push_str's capacity
+// assertion fires. The check is a raw C-level guard, not a vow block,
+// so blame is "none" (mirrors off_by_one_bounds.vow).
+module StringPushStrOverflow
+
+fn over() -> String vow {
+  ensures: result.len() >= 0
+} {
+  let a: String = String::from("a");
+  let b: String = String::from("b");
+  a.push_str(b);
+  a
+}
+
+fn main() -> i32 [io] {
+  let r: String = over();
+  print_i64(r.len());
+  0
+}

--- a/tests/verify/string_push_str_in_bounds.vow
+++ b/tests/verify/string_push_str_in_bounds.vow
@@ -1,0 +1,14 @@
+module StringPushStrInBounds
+
+fn cat(a: String, b: String) -> i64 vow {
+  requires: a.len() + b.len() <= 256
+} {
+  let mut s: String = a;
+  s.push_str(b);
+  s.len()
+}
+
+fn main() -> i32 [io] {
+  print_i64(cat(String::from("hi"), String::from(" there")));
+  0
+}

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -881,7 +881,11 @@ fn emit_inst(
                     "__vow_string_push_str" => {
                         let dest = inst.args[0].0;
                         let src = inst.args[1].0;
-                        out.push_str(&format!("  v{dest}.len += v{src}.len;\n"));
+                        let string_max = limits.string_max;
+                        out.push_str(&format!(
+                            "  __ESBMC_assert(v{dest}.len + v{src}.len <= {string_max}, \"string capacity\");\n\
+                             \x20 v{dest}.len += v{src}.len;\n",
+                        ));
                         emit_string_eq_invalidate(dest, eq_pairs, out);
                     }
                     "__vow_string_push_byte" => {
@@ -3349,7 +3353,15 @@ mod tests {
             ],
         );
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
-        assert!(c.contains("v1.len += v3.len;"), "push_str: {c}");
+        assert!(
+            c.contains("string capacity"),
+            "push_str must have capacity assertion: {c}"
+        );
+        assert!(
+            c.contains("v1.len + v3.len <= 256"),
+            "push_str capacity expression: {c}"
+        );
+        assert!(c.contains("v1.len += v3.len;"), "push_str mutation: {c}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Mirror `push_byte`'s `string capacity` ESBMC assertion in the `__vow_string_push_str` arm of both verifier C emitters (Rust + self-hosted), so the model no longer accepts states where `dest.len + src.len > string_max`.
- Add a regression test under `tests/verify-fail/` (status flips from `Verified` to `VerifyFailed` once the guard fires) and a positive boundary test under `tests/verify/`.

Closes #271.

## Why

Without the guard, the verifier silently allowed string length to grow past capacity, admitting unsafe programs and producing spurious counterexamples downstream when later `push_byte` calls hit their own capacity check on a state the runtime would never produce.

The bound is `<=` (post-mutation) where `push_byte` uses `<` (pre-write index): `push_byte`'s check guards `data[len]` before incrementing, while `push_str`'s check guards the post-append length against the typedef capacity invariant.

## Test plan

- [x] Extended `vow-verify` unit test `emit_string_push_str` asserting the new `"string capacity"` text and `v1.len + v3.len <= 256` expression.
- [x] `tests/verify-fail/string_push_str_overflow.vow` — both compilers report `VerifyFailed` (counterexample at `len=254 + len=254 > 256`).
- [x] `tests/verify/string_push_str_in_bounds.vow` — both compilers report `Verified` when `requires: a.len() + b.len() <= 256`.
- [x] `cargo test --all` — all green.
- [x] `cargo clippy --all -- -D warnings`, `cargo fmt --all --check` — clean.
- [x] `scripts/bootstrap.sh --skip-cargo` — Stage 1 ↔ Stage 2 SHA-256 fixed point holds.
- [x] `scripts/full_test.sh` — new tests pass; pre-existing 6 failures (unrelated to this change, confirmed by stashing the fix and reproducing identical failures in 5/5 verify cases).