### PR TITLE
docs(spec): list push_str in modeled String operations table

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3458,7 +3458,7 @@ fn skill_full() -> String {
     r.push_str(String::from("| Type              | Default Max Capacity | CLI Flag | Supported Operations |\n"));
     r.push_str(String::from("|-------------------|---------------------|----------|----------------------------------------------|\n"));
     r.push_str(String::from("| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |\n"));
-    r.push_str(String::from("| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `byte_at`        |\n"));
+    r.push_str(String::from("| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `push_str`, `byte_at` |\n"));
     r.push_str(String::from("| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("These support the same operations as the runtime but with bounded storage. `String::from` produces a nondeterministic length (0 to max-1) in verification.\n"));

--- a/docs/spec/contracts.md
+++ b/docs/spec/contracts.md
@@ -27,7 +27,7 @@ ESBMC uses bounded models for collection types. Defaults are shown below; overri
 | Type              | Default Max Capacity | CLI Flag | Supported Operations |
 |-------------------|---------------------|----------|----------------------------------------------|
 | `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |
-| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `byte_at`        |
+| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `push_str`, `byte_at` |
 | `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|
 
 These support the same operations as the runtime but with bounded storage. `String::from` produces a nondeterministic length (0 to max-1) in verification.

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2731,7 +2731,7 @@ ESBMC uses bounded models for collection types. Defaults are shown below; overri
 | Type              | Default Max Capacity | CLI Flag | Supported Operations |
 |-------------------|---------------------|----------|----------------------------------------------|
 | `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |
-| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `byte_at`        |
+| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `push_str`, `byte_at` |
 | `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|
 
 These support the same operations as the runtime but with bounded storage. `String::from` produces a nondeterministic length (0 to max-1) in verification.


### PR DESCRIPTION
## Context

The `__vow_string_push_str` capacity assertion fix that originally motivated this PR landed independently as #271 / #273 while I was working on it. Rebasing onto current `main` collapses my code change to a no-op (byte-identical to what's already merged) and leaves only the documentation update that the merged fix missed.

## Summary

- `docs/spec/contracts.md`: list `push_str` alongside `push_byte` in the modeled `String` operations table — `push_str` is now modeled by ESBMC (per #271/#273) but the spec table still listed only `push_byte`.
- `compiler/main.vow` and `vow/src/main.rs`: regenerate the embedded copies of that table so `--help` output and the embedded skill match the spec.

## Test plan

- [x] `cargo test -p vow-verify` — 102 pass (no test changes; sanity check)
- [x] `uv run python scripts/generate_help.py --check` — generated JSON valid

Closes #272 (already addressed by #273; this PR adds the missing doc update).