### PR TITLE
[codex] install self-hosted toolchain to prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,7 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "tempfile",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ For project design details, see [docs/vow_design.md](docs/vow_design.md).
 ```bash
 # Bootstrap (one-time)
 cargo build --all --release
-scripts/bootstrap.sh --no-verify
+scripts/bootstrap.sh --skip-cargo
+
+# Install the self-hosted toolchain to a user prefix
+scripts/install-toolchain.sh --prefix "$HOME/.local"
+export PATH="$HOME/.local/bin:$PATH"
+vowc build --no-verify examples/hello.vow -o /tmp/vow_hello
 
 # Day-to-day usage
 ulimit -v 2000000; build/vowc build examples/divide.vow              # compile + verify

--- a/scripts/install-toolchain.sh
+++ b/scripts/install-toolchain.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PREFIX="${HOME:?}/.local"
+SKIP_BOOTSTRAP=false
+
+usage() {
+    echo "Usage: $0 [--prefix <path>] [--skip-bootstrap] [--help|-h]"
+    echo ""
+    echo "Install the self-hosted Vow toolchain into a prefix."
+    echo ""
+    echo "Installs:"
+    echo "  <prefix>/bin/vowc"
+    echo "  <prefix>/bin/vow"
+    echo "  <prefix>/lib/vow/libvow_runtime.a"
+    echo "  <prefix>/lib/vow/libvow_clif_shim.a"
+    echo ""
+    echo "Options:"
+    echo "  --prefix <path>    Installation prefix (default: \$HOME/.local)"
+    echo "  --skip-bootstrap   Require existing build artifacts; do not run bootstrap"
+    echo "  -h, --help         Show this help"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --prefix)
+            if [ "$#" -lt 2 ]; then
+                echo "Error: --prefix requires a path" >&2
+                exit 1
+            fi
+            PREFIX="$2"
+            shift 2
+            ;;
+        --skip-bootstrap)
+            SKIP_BOOTSTRAP=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+VOWC="build/vowc"
+RUNTIME_LIB="target/release/libvow_runtime.a"
+SHIM_LIB="target/release/libvow_clif_shim.a"
+
+artifacts_ready() {
+    [ -x "$VOWC" ] && [ -f "$RUNTIME_LIB" ] && [ -f "$SHIM_LIB" ]
+}
+
+if ! artifacts_ready; then
+    if [ "$SKIP_BOOTSTRAP" = true ]; then
+        echo "Error: missing toolchain artifacts." >&2
+        echo "Run: scripts/bootstrap.sh" >&2
+        exit 1
+    fi
+    scripts/bootstrap.sh
+fi
+
+if ! artifacts_ready; then
+    echo "Error: bootstrap completed but required artifacts are still missing." >&2
+    exit 1
+fi
+
+BIN_DIR="$PREFIX/bin"
+LIB_DIR="$PREFIX/lib/vow"
+mkdir -p "$BIN_DIR" "$LIB_DIR"
+
+install -m 0755 "$VOWC" "$BIN_DIR/vowc"
+if ln -sfn "vowc" "$BIN_DIR/vow" 2>/dev/null; then
+    :
+else
+    install -m 0755 "$VOWC" "$BIN_DIR/vow"
+fi
+
+install -m 0644 "$RUNTIME_LIB" "$LIB_DIR/libvow_runtime.a"
+install -m 0644 "$SHIM_LIB" "$LIB_DIR/libvow_clif_shim.a"
+
+echo "Installed Vow toolchain to $PREFIX"
+echo "Add $BIN_DIR to PATH if it is not already present."

--- a/vow-clif-shim/Cargo.toml
+++ b/vow-clif-shim/Cargo.toml
@@ -12,3 +12,6 @@ cranelift-frontend = "0.131"
 cranelift-module = "0.131"
 cranelift-object = "0.131"
 cranelift-native = "0.131"
+
+[dev-dependencies]
+tempfile = "3"

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2118,28 +2118,35 @@ pub unsafe extern "C" fn __vow_clif_link(obj_path_ptr: i64, output_path_ptr: i64
 // ---------------------------------------------------------------------------
 
 fn find_lib(name: &str) -> Option<String> {
-    let exe = std::env::current_exe().ok()?;
-    find_lib_for_exe(
-        name,
-        if name.contains("runtime") {
-            "VOW_RUNTIME_PATH"
-        } else {
-            "VOW_CLIF_SHIM_PATH"
-        },
-        &exe,
-    )
+    let env_key = if name.contains("runtime") {
+        "VOW_RUNTIME_PATH"
+    } else {
+        "VOW_CLIF_SHIM_PATH"
+    };
+    let exe = std::env::current_exe().ok();
+    find_lib_from_parts(name, std::env::var_os(env_key), exe.as_deref())
 }
 
-fn find_lib_for_exe(name: &str, env_key: &str, exe: &std::path::Path) -> Option<String> {
-    // Check env var
-    if let Ok(p) = std::env::var(env_key)
-        && std::path::Path::new(&p).exists()
-    {
-        return Some(p);
+fn find_lib_from_parts(
+    name: &str,
+    env_value: Option<std::ffi::OsString>,
+    exe: Option<&std::path::Path>,
+) -> Option<String> {
+    if let Some(p) = env_value {
+        let path = std::path::PathBuf::from(p);
+        if path.exists() {
+            return Some(path.to_string_lossy().into_owned());
+        }
     }
 
-    // Adjacent to current exe
+    find_lib_for_exe(name, exe?)
+}
+
+fn find_lib_for_exe(name: &str, exe: &std::path::Path) -> Option<String> {
     if let Some(dir) = exe.parent() {
+        // Preserve the legacy adjacent-to-exe lookup before prefix paths so
+        // manual installs that co-locate the static libraries with vowc keep
+        // working.
         let p = dir.join(name);
         if p.exists() {
             return Some(p.to_string_lossy().into_owned());
@@ -2712,19 +2719,11 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
 mod tests {
     use super::*;
 
-    fn unique_dir(name: &str) -> std::path::PathBuf {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        std::env::temp_dir().join(format!("vow-clif-shim-{name}-{nanos}"))
-    }
-
     #[test]
     fn finds_lib_in_installed_lib_vow_dir() {
-        let root = unique_dir("lib-vow");
-        let bin_dir = root.join("bin");
-        let lib_dir = root.join("lib").join("vow");
+        let root = tempfile::TempDir::new().unwrap();
+        let bin_dir = root.path().join("bin");
+        let lib_dir = root.path().join("lib").join("vow");
         std::fs::create_dir_all(&bin_dir).unwrap();
         std::fs::create_dir_all(&lib_dir).unwrap();
         let exe = bin_dir.join("vowc");
@@ -2732,17 +2731,16 @@ mod tests {
         std::fs::write(&exe, b"").unwrap();
         std::fs::write(&lib, b"").unwrap();
 
-        let found = find_lib_for_exe("libvow_runtime.a", "VOW_TEST_RUNTIME_PATH", &exe);
-        assert_eq!(found.as_deref(), Some(lib.to_string_lossy().as_ref()));
-
-        std::fs::remove_dir_all(root).unwrap();
+        let found = find_lib_for_exe("libvow_runtime.a", &exe);
+        let expected = lib.to_string_lossy().into_owned();
+        assert_eq!(found.as_deref(), Some(expected.as_str()));
     }
 
     #[test]
     fn finds_lib_in_installed_lib_dir() {
-        let root = unique_dir("lib");
-        let bin_dir = root.join("bin");
-        let lib_dir = root.join("lib");
+        let root = tempfile::TempDir::new().unwrap();
+        let bin_dir = root.path().join("bin");
+        let lib_dir = root.path().join("lib");
         std::fs::create_dir_all(&bin_dir).unwrap();
         std::fs::create_dir_all(&lib_dir).unwrap();
         let exe = bin_dir.join("vowc");
@@ -2750,9 +2748,20 @@ mod tests {
         std::fs::write(&exe, b"").unwrap();
         std::fs::write(&lib, b"").unwrap();
 
-        let found = find_lib_for_exe("libvow_runtime.a", "VOW_TEST_RUNTIME_PATH", &exe);
-        assert_eq!(found.as_deref(), Some(lib.to_string_lossy().as_ref()));
+        let found = find_lib_for_exe("libvow_runtime.a", &exe);
+        let expected = lib.to_string_lossy().into_owned();
+        assert_eq!(found.as_deref(), Some(expected.as_str()));
+    }
 
-        std::fs::remove_dir_all(root).unwrap();
+    #[test]
+    fn env_override_does_not_require_current_exe() {
+        let root = tempfile::TempDir::new().unwrap();
+        let lib = root.path().join("libvow_runtime.a");
+        std::fs::write(&lib, b"").unwrap();
+
+        let found =
+            find_lib_from_parts("libvow_runtime.a", Some(lib.clone().into_os_string()), None);
+        let expected = lib.to_string_lossy().into_owned();
+        assert_eq!(found.as_deref(), Some(expected.as_str()));
     }
 }

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2132,6 +2132,16 @@ fn find_lib_from_parts(
     env_value: Option<std::ffi::OsString>,
     exe: Option<&std::path::Path>,
 ) -> Option<String> {
+    let target_dir = cargo_target_dir();
+    find_lib_from_parts_with_target_dir(name, env_value, exe, &target_dir)
+}
+
+fn find_lib_from_parts_with_target_dir(
+    name: &str,
+    env_value: Option<std::ffi::OsString>,
+    exe: Option<&std::path::Path>,
+    target_dir: &std::path::Path,
+) -> Option<String> {
     if let Some(p) = env_value {
         let path = std::path::PathBuf::from(p);
         if path.exists() {
@@ -2139,10 +2149,16 @@ fn find_lib_from_parts(
         }
     }
 
-    find_lib_for_exe(name, exe?)
+    if let Some(exe) = exe
+        && let Some(path) = find_installed_lib_for_exe(name, exe)
+    {
+        return Some(path);
+    }
+
+    find_lib_in_cargo_target(name, target_dir)
 }
 
-fn find_lib_for_exe(name: &str, exe: &std::path::Path) -> Option<String> {
+fn find_installed_lib_for_exe(name: &str, exe: &std::path::Path) -> Option<String> {
     if let Some(dir) = exe.parent() {
         // Preserve the legacy adjacent-to-exe lookup before prefix paths so
         // manual installs that co-locate the static libraries with vowc keep
@@ -2163,16 +2179,18 @@ fn find_lib_for_exe(name: &str, exe: &std::path::Path) -> Option<String> {
         }
     }
 
-    // Cargo target directories (for development)
+    None
+}
+
+fn cargo_target_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../target"))
+}
+
+fn find_lib_in_cargo_target(name: &str, target_dir: &std::path::Path) -> Option<String> {
     for profile in &["release", "debug"] {
-        let p = format!(
-            "{}/../target/{}/{}",
-            env!("CARGO_MANIFEST_DIR"),
-            profile,
-            name
-        );
-        if std::path::Path::new(&p).exists() {
-            return Some(p);
+        let p = target_dir.join(profile).join(name);
+        if p.exists() {
+            return Some(p.to_string_lossy().into_owned());
         }
     }
 
@@ -2731,7 +2749,12 @@ mod tests {
         std::fs::write(&exe, b"").unwrap();
         std::fs::write(&lib, b"").unwrap();
 
-        let found = find_lib_for_exe("libvow_runtime.a", &exe);
+        let found = find_lib_from_parts_with_target_dir(
+            "libvow_runtime.a",
+            None,
+            Some(&exe),
+            &root.path().join("target"),
+        );
         let expected = lib.to_string_lossy().into_owned();
         assert_eq!(found.as_deref(), Some(expected.as_str()));
     }
@@ -2748,7 +2771,12 @@ mod tests {
         std::fs::write(&exe, b"").unwrap();
         std::fs::write(&lib, b"").unwrap();
 
-        let found = find_lib_for_exe("libvow_runtime.a", &exe);
+        let found = find_lib_from_parts_with_target_dir(
+            "libvow_runtime.a",
+            None,
+            Some(&exe),
+            &root.path().join("target"),
+        );
         let expected = lib.to_string_lossy().into_owned();
         assert_eq!(found.as_deref(), Some(expected.as_str()));
     }
@@ -2761,6 +2789,20 @@ mod tests {
 
         let found =
             find_lib_from_parts("libvow_runtime.a", Some(lib.clone().into_os_string()), None);
+        let expected = lib.to_string_lossy().into_owned();
+        assert_eq!(found.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn cargo_target_fallback_does_not_require_current_exe() {
+        let root = tempfile::TempDir::new().unwrap();
+        let release_dir = root.path().join("release");
+        std::fs::create_dir_all(&release_dir).unwrap();
+        let lib = release_dir.join("libvow_runtime.a");
+        std::fs::write(&lib, b"").unwrap();
+
+        let found =
+            find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, root.path());
         let expected = lib.to_string_lossy().into_owned();
         assert_eq!(found.as_deref(), Some(expected.as_str()));
     }

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2118,12 +2118,20 @@ pub unsafe extern "C" fn __vow_clif_link(obj_path_ptr: i64, output_path_ptr: i64
 // ---------------------------------------------------------------------------
 
 fn find_lib(name: &str) -> Option<String> {
+    let exe = std::env::current_exe().ok()?;
+    find_lib_for_exe(
+        name,
+        if name.contains("runtime") {
+            "VOW_RUNTIME_PATH"
+        } else {
+            "VOW_CLIF_SHIM_PATH"
+        },
+        &exe,
+    )
+}
+
+fn find_lib_for_exe(name: &str, env_key: &str, exe: &std::path::Path) -> Option<String> {
     // Check env var
-    let env_key = if name.contains("runtime") {
-        "VOW_RUNTIME_PATH"
-    } else {
-        "VOW_CLIF_SHIM_PATH"
-    };
     if let Ok(p) = std::env::var(env_key)
         && std::path::Path::new(&p).exists()
     {
@@ -2131,12 +2139,20 @@ fn find_lib(name: &str) -> Option<String> {
     }
 
     // Adjacent to current exe
-    if let Ok(exe) = std::env::current_exe()
-        && let Some(dir) = exe.parent()
-    {
+    if let Some(dir) = exe.parent() {
         let p = dir.join(name);
         if p.exists() {
             return Some(p.to_string_lossy().into_owned());
+        }
+        if let Some(prefix) = dir.parent() {
+            let p = prefix.join("lib").join("vow").join(name);
+            if p.exists() {
+                return Some(p.to_string_lossy().into_owned());
+            }
+            let p = prefix.join("lib").join(name);
+            if p.exists() {
+                return Some(p.to_string_lossy().into_owned());
+            }
         }
     }
 
@@ -2690,4 +2706,53 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         }
     }
     sig
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_dir(name: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("vow-clif-shim-{name}-{nanos}"))
+    }
+
+    #[test]
+    fn finds_lib_in_installed_lib_vow_dir() {
+        let root = unique_dir("lib-vow");
+        let bin_dir = root.join("bin");
+        let lib_dir = root.join("lib").join("vow");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        let exe = bin_dir.join("vowc");
+        let lib = lib_dir.join("libvow_runtime.a");
+        std::fs::write(&exe, b"").unwrap();
+        std::fs::write(&lib, b"").unwrap();
+
+        let found = find_lib_for_exe("libvow_runtime.a", "VOW_TEST_RUNTIME_PATH", &exe);
+        assert_eq!(found.as_deref(), Some(lib.to_string_lossy().as_ref()));
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn finds_lib_in_installed_lib_dir() {
+        let root = unique_dir("lib");
+        let bin_dir = root.join("bin");
+        let lib_dir = root.join("lib");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        let exe = bin_dir.join("vowc");
+        let lib = lib_dir.join("libvow_runtime.a");
+        std::fs::write(&exe, b"").unwrap();
+        std::fs::write(&lib, b"").unwrap();
+
+        let found = find_lib_for_exe("libvow_runtime.a", "VOW_TEST_RUNTIME_PATH", &exe);
+        assert_eq!(found.as_deref(), Some(lib.to_string_lossy().as_ref()));
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/vow-codegen/src/linker.rs
+++ b/vow-codegen/src/linker.rs
@@ -17,6 +17,11 @@ pub fn find_shim_lib() -> Option<PathBuf> {
 }
 
 fn find_lib(name: &str, env_var: &str) -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    find_lib_for_exe(name, env_var, &exe)
+}
+
+fn find_lib_for_exe(name: &str, env_var: &str, exe: &Path) -> Option<PathBuf> {
     if let Ok(p) = std::env::var(env_var) {
         let path = PathBuf::from(p);
         if path.exists() {
@@ -24,10 +29,12 @@ fn find_lib(name: &str, env_var: &str) -> Option<PathBuf> {
         }
     }
 
+    let exe_dir = exe.parent();
+    let prefix_dir = exe_dir.and_then(|dir| dir.parent());
     let candidates = [
-        std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent().map(|d| d.join(name))),
+        exe_dir.map(|dir| dir.join(name)),
+        prefix_dir.map(|prefix| prefix.join("lib").join("vow").join(name)),
+        prefix_dir.map(|prefix| prefix.join("lib").join(name)),
         Some(PathBuf::from(format!(
             "{}/{name}",
             concat!(env!("CARGO_MANIFEST_DIR"), "/../target/debug")
@@ -80,6 +87,38 @@ pub fn link(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn finds_lib_in_installed_lib_vow_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let bin_dir = dir.path().join("bin");
+        let lib_dir = dir.path().join("lib").join("vow");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        let exe = bin_dir.join("vowc");
+        let lib = lib_dir.join("libvow_runtime.a");
+        std::fs::write(&exe, b"").unwrap();
+        std::fs::write(&lib, b"").unwrap();
+
+        let found = find_lib_for_exe("libvow_runtime.a", "VOW_TEST_RUNTIME_PATH", &exe);
+        assert_eq!(found.as_deref(), Some(lib.as_path()));
+    }
+
+    #[test]
+    fn finds_lib_in_installed_lib_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let bin_dir = dir.path().join("bin");
+        let lib_dir = dir.path().join("lib");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::create_dir_all(&lib_dir).unwrap();
+        let exe = bin_dir.join("vowc");
+        let lib = lib_dir.join("libvow_runtime.a");
+        std::fs::write(&exe, b"").unwrap();
+        std::fs::write(&lib, b"").unwrap();
+
+        let found = find_lib_for_exe("libvow_runtime.a", "VOW_TEST_RUNTIME_PATH", &exe);
+        assert_eq!(found.as_deref(), Some(lib.as_path()));
+    }
 
     #[test]
     fn find_runtime_returns_some_in_dev_build() {

--- a/vow-codegen/src/linker.rs
+++ b/vow-codegen/src/linker.rs
@@ -26,6 +26,16 @@ fn find_lib_from_parts(
     env_value: Option<std::ffi::OsString>,
     exe: Option<&Path>,
 ) -> Option<PathBuf> {
+    let target_dir = cargo_target_dir();
+    find_lib_from_parts_with_target_dir(name, env_value, exe, &target_dir)
+}
+
+fn find_lib_from_parts_with_target_dir(
+    name: &str,
+    env_value: Option<std::ffi::OsString>,
+    exe: Option<&Path>,
+    target_dir: &Path,
+) -> Option<PathBuf> {
     if let Some(p) = env_value {
         let path = PathBuf::from(p);
         if path.exists() {
@@ -33,10 +43,16 @@ fn find_lib_from_parts(
         }
     }
 
-    find_lib_for_exe(name, exe?)
+    if let Some(exe) = exe
+        && let Some(path) = find_installed_lib_for_exe(name, exe)
+    {
+        return Some(path);
+    }
+
+    find_lib_in_cargo_target(name, target_dir)
 }
 
-fn find_lib_for_exe(name: &str, exe: &Path) -> Option<PathBuf> {
+fn find_installed_lib_for_exe(name: &str, exe: &Path) -> Option<PathBuf> {
     let exe_dir = exe.parent();
     let prefix_dir = exe_dir.and_then(|dir| dir.parent());
     // Preserve the legacy adjacent-to-exe lookup before prefix paths so manual
@@ -45,19 +61,22 @@ fn find_lib_for_exe(name: &str, exe: &Path) -> Option<PathBuf> {
         exe_dir.map(|dir| dir.join(name)),
         prefix_dir.map(|prefix| prefix.join("lib").join("vow").join(name)),
         prefix_dir.map(|prefix| prefix.join("lib").join(name)),
-        Some(PathBuf::from(format!(
-            "{}/{name}",
-            concat!(env!("CARGO_MANIFEST_DIR"), "/../target/debug")
-        ))),
-        Some(PathBuf::from(format!(
-            "{}/{name}",
-            concat!(env!("CARGO_MANIFEST_DIR"), "/../target/release")
-        ))),
     ];
 
     candidates
         .into_iter()
         .flatten()
+        .find(|candidate| candidate.exists())
+}
+
+fn cargo_target_dir() -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../target"))
+}
+
+fn find_lib_in_cargo_target(name: &str, target_dir: &Path) -> Option<PathBuf> {
+    ["debug", "release"]
+        .into_iter()
+        .map(|profile| target_dir.join(profile).join(name))
         .find(|candidate| candidate.exists())
 }
 
@@ -110,7 +129,12 @@ mod tests {
         std::fs::write(&exe, b"").unwrap();
         std::fs::write(&lib, b"").unwrap();
 
-        let found = find_lib_for_exe("libvow_runtime.a", &exe);
+        let found = find_lib_from_parts_with_target_dir(
+            "libvow_runtime.a",
+            None,
+            Some(&exe),
+            &dir.path().join("target"),
+        );
         assert_eq!(found.as_deref(), Some(lib.as_path()));
     }
 
@@ -126,7 +150,12 @@ mod tests {
         std::fs::write(&exe, b"").unwrap();
         std::fs::write(&lib, b"").unwrap();
 
-        let found = find_lib_for_exe("libvow_runtime.a", &exe);
+        let found = find_lib_from_parts_with_target_dir(
+            "libvow_runtime.a",
+            None,
+            Some(&exe),
+            &dir.path().join("target"),
+        );
         assert_eq!(found.as_deref(), Some(lib.as_path()));
     }
 
@@ -138,6 +167,18 @@ mod tests {
 
         let found =
             find_lib_from_parts("libvow_runtime.a", Some(lib.clone().into_os_string()), None);
+        assert_eq!(found.as_deref(), Some(lib.as_path()));
+    }
+
+    #[test]
+    fn cargo_target_fallback_does_not_require_current_exe() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let debug_dir = dir.path().join("debug");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        let lib = debug_dir.join("libvow_runtime.a");
+        std::fs::write(&lib, b"").unwrap();
+
+        let found = find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, dir.path());
         assert_eq!(found.as_deref(), Some(lib.as_path()));
     }
 

--- a/vow-codegen/src/linker.rs
+++ b/vow-codegen/src/linker.rs
@@ -17,20 +17,30 @@ pub fn find_shim_lib() -> Option<PathBuf> {
 }
 
 fn find_lib(name: &str, env_var: &str) -> Option<PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    find_lib_for_exe(name, env_var, &exe)
+    let exe = std::env::current_exe().ok();
+    find_lib_from_parts(name, std::env::var_os(env_var), exe.as_deref())
 }
 
-fn find_lib_for_exe(name: &str, env_var: &str, exe: &Path) -> Option<PathBuf> {
-    if let Ok(p) = std::env::var(env_var) {
+fn find_lib_from_parts(
+    name: &str,
+    env_value: Option<std::ffi::OsString>,
+    exe: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(p) = env_value {
         let path = PathBuf::from(p);
         if path.exists() {
             return Some(path);
         }
     }
 
+    find_lib_for_exe(name, exe?)
+}
+
+fn find_lib_for_exe(name: &str, exe: &Path) -> Option<PathBuf> {
     let exe_dir = exe.parent();
     let prefix_dir = exe_dir.and_then(|dir| dir.parent());
+    // Preserve the legacy adjacent-to-exe lookup before prefix paths so manual
+    // installs that co-locate the static libraries with vowc keep working.
     let candidates = [
         exe_dir.map(|dir| dir.join(name)),
         prefix_dir.map(|prefix| prefix.join("lib").join("vow").join(name)),
@@ -100,7 +110,7 @@ mod tests {
         std::fs::write(&exe, b"").unwrap();
         std::fs::write(&lib, b"").unwrap();
 
-        let found = find_lib_for_exe("libvow_runtime.a", "VOW_TEST_RUNTIME_PATH", &exe);
+        let found = find_lib_for_exe("libvow_runtime.a", &exe);
         assert_eq!(found.as_deref(), Some(lib.as_path()));
     }
 
@@ -116,7 +126,18 @@ mod tests {
         std::fs::write(&exe, b"").unwrap();
         std::fs::write(&lib, b"").unwrap();
 
-        let found = find_lib_for_exe("libvow_runtime.a", "VOW_TEST_RUNTIME_PATH", &exe);
+        let found = find_lib_for_exe("libvow_runtime.a", &exe);
+        assert_eq!(found.as_deref(), Some(lib.as_path()));
+    }
+
+    #[test]
+    fn env_override_does_not_require_current_exe() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let lib = dir.path().join("libvow_runtime.a");
+        std::fs::write(&lib, b"").unwrap();
+
+        let found =
+            find_lib_from_parts("libvow_runtime.a", Some(lib.clone().into_os_string()), None);
         assert_eq!(found.as_deref(), Some(lib.as_path()));
     }
 

--- a/vow/tests/agent_level1.rs
+++ b/vow/tests/agent_level1.rs
@@ -12,6 +12,42 @@ fn examples_dir() -> PathBuf {
         .join("examples")
 }
 
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn support_lib(name: &str) -> PathBuf {
+    if let Some(path) = find_support_lib(name) {
+        return path;
+    }
+
+    let status = Command::new("cargo")
+        .args(["build", "-p", "vow-runtime", "-p", "vow-clif-shim"])
+        .status()
+        .expect("failed to invoke cargo to build support libraries");
+    assert!(
+        status.success(),
+        "cargo build -p vow-runtime -p vow-clif-shim failed"
+    );
+
+    find_support_lib(name)
+        .unwrap_or_else(|| panic!("missing {name} after building support libraries"))
+}
+
+fn find_support_lib(name: &str) -> Option<PathBuf> {
+    let root = workspace_root();
+    for profile in ["debug", "release"] {
+        let path = root.join("target").join(profile).join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
 #[test]
 fn help_json_valid() {
     let out = Command::new(vow_bin())
@@ -36,6 +72,56 @@ fn build_help_json_valid() {
     let json: serde_json::Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|e| panic!("invalid JSON from build --help: {e}\nstdout: {stdout}"));
     assert!(json.get("tool").is_some(), "expected 'tool' key in JSON");
+}
+
+#[test]
+fn installed_prefix_can_build_and_run_program_without_env_paths() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let prefix = dir.path().join("prefix");
+    let bin_dir = prefix.join("bin");
+    let lib_dir = prefix.join("lib").join("vow");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    std::fs::create_dir_all(&lib_dir).unwrap();
+
+    let installed_vowc = bin_dir.join("vowc");
+    std::fs::copy(vow_bin(), &installed_vowc).unwrap();
+    std::fs::copy(
+        support_lib("libvow_runtime.a"),
+        lib_dir.join("libvow_runtime.a"),
+    )
+    .unwrap();
+    std::fs::copy(
+        support_lib("libvow_clif_shim.a"),
+        lib_dir.join("libvow_clif_shim.a"),
+    )
+    .unwrap();
+
+    let out_path = dir.path().join("hello");
+    let result = Command::new(&installed_vowc)
+        .args([
+            "build",
+            "--no-verify",
+            "--no-cache",
+            examples_dir().join("hello.vow").to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+        ])
+        .env_remove("VOW_RUNTIME_PATH")
+        .env_remove("VOW_CLIF_SHIM_PATH")
+        .output()
+        .expect("failed to run installed vowc");
+    assert_eq!(
+        result.status.code(),
+        Some(0),
+        "expected installed vowc build to succeed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let run = Command::new(&out_path)
+        .output()
+        .expect("failed to run installed-compiler output");
+    assert_eq!(run.status.code(), Some(0), "compiled binary should exit 0");
 }
 
 #[test]

--- a/vow/tests/agent_level1.rs
+++ b/vow/tests/agent_level1.rs
@@ -24,6 +24,8 @@ fn support_lib(name: &str) -> PathBuf {
         return path;
     }
 
+    // Build the support libraries on demand so this integration test can run
+    // in isolation without requiring the caller to pre-build the workspace.
     let status = Command::new("cargo")
         .args(["build", "-p", "vow-runtime", "-p", "vow-clif-shim"])
         .status()


### PR DESCRIPTION
## Summary

- add `scripts/install-toolchain.sh` to install `build/vowc`, `vow`, and support static libraries into a user prefix
- teach both Rust and self-hosted linker paths to find installed support libraries under `<prefix>/lib/vow` or `<prefix>/lib` without env vars
- add installed-prefix smoke coverage and document the `$HOME/.local` workflow

## Validation

- `bash -n scripts/install-toolchain.sh`
- `cargo test -p vow-codegen`
- `cargo test -p vow-clif-shim`
- `cargo test -p vow --test agent_level1`
- `cargo test --all`
- `cargo clippy --all -- -D warnings`
- `cargo build --all --release`
- `scripts/bootstrap.sh --skip-cargo` fixed point: `e687e010dbeb02cb325a1f07c4b8af4e45d4599856c1c8daa582f37ba3fc6128`
- install smoke with env vars unset: `/tmp/vow-prefix-default/bin/vowc build --no-verify --no-cache examples/hello.vow -o /tmp/vow-hello-default` and `/tmp/vow-hello-default`

## Note

`tests/run_tests.sh --no-bootstrap --no-verify` still has an unrelated existing failure in `vmod_region_roundtrip`: both `build/vowc` and `target/release/vow` report that the fixture calls `ir_function_new` with 4 args while the live signature expects 5.