### PR TITLE
[codex] Unify support library target fallback order

### DIFF
--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2822,6 +2822,20 @@ mod tests {
     #[test]
     fn cargo_target_fallback_does_not_require_current_exe() {
         let root = tempfile::TempDir::new().unwrap();
+        let debug_dir = root.path().join("debug");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        let lib = debug_dir.join("libvow_runtime.a");
+        std::fs::write(&lib, b"").unwrap();
+
+        let found =
+            find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, root.path());
+        let expected = lib.to_string_lossy().into_owned();
+        assert_eq!(found.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn cargo_target_fallback_accepts_release_when_debug_missing() {
+        let root = tempfile::TempDir::new().unwrap();
         let release_dir = root.path().join("release");
         std::fs::create_dir_all(&release_dir).unwrap();
         let lib = release_dir.join("libvow_runtime.a");

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2187,7 +2187,10 @@ fn cargo_target_dir() -> std::path::PathBuf {
 }
 
 fn find_lib_in_cargo_target(name: &str, target_dir: &std::path::Path) -> Option<String> {
-    for profile in &["release", "debug"] {
+    // Development fallback only: env overrides and installed-prefix libraries
+    // are checked first, so prefer plain cargo build/test artifacts here while
+    // still accepting release bootstrap artifacts.
+    for profile in &["debug", "release"] {
         let p = target_dir.join(profile).join(name);
         if p.exists() {
             return Some(p.to_string_lossy().into_owned());
@@ -2827,6 +2830,24 @@ mod tests {
         let found =
             find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, root.path());
         let expected = lib.to_string_lossy().into_owned();
+        assert_eq!(found.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn cargo_target_fallback_prefers_debug_before_release() {
+        let root = tempfile::TempDir::new().unwrap();
+        let debug_dir = root.path().join("debug");
+        let release_dir = root.path().join("release");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        std::fs::create_dir_all(&release_dir).unwrap();
+        let debug_lib = debug_dir.join("libvow_runtime.a");
+        let release_lib = release_dir.join("libvow_runtime.a");
+        std::fs::write(&debug_lib, b"debug").unwrap();
+        std::fs::write(&release_lib, b"release").unwrap();
+
+        let found =
+            find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, root.path());
+        let expected = debug_lib.to_string_lossy().into_owned();
         assert_eq!(found.as_deref(), Some(expected.as_str()));
     }
 }

--- a/vow-codegen/src/linker.rs
+++ b/vow-codegen/src/linker.rs
@@ -186,6 +186,18 @@ mod tests {
     }
 
     #[test]
+    fn cargo_target_fallback_accepts_release_when_debug_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let release_dir = dir.path().join("release");
+        std::fs::create_dir_all(&release_dir).unwrap();
+        let lib = release_dir.join("libvow_runtime.a");
+        std::fs::write(&lib, b"").unwrap();
+
+        let found = find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, dir.path());
+        assert_eq!(found.as_deref(), Some(lib.as_path()));
+    }
+
+    #[test]
     fn cargo_target_fallback_prefers_debug_before_release() {
         let dir = tempfile::TempDir::new().unwrap();
         let debug_dir = dir.path().join("debug");

--- a/vow-codegen/src/linker.rs
+++ b/vow-codegen/src/linker.rs
@@ -74,6 +74,9 @@ fn cargo_target_dir() -> PathBuf {
 }
 
 fn find_lib_in_cargo_target(name: &str, target_dir: &Path) -> Option<PathBuf> {
+    // Development fallback only: env overrides and installed-prefix libraries
+    // are checked first, so prefer plain cargo build/test artifacts here while
+    // still accepting release bootstrap artifacts.
     ["debug", "release"]
         .into_iter()
         .map(|profile| target_dir.join(profile).join(name))
@@ -180,6 +183,22 @@ mod tests {
 
         let found = find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, dir.path());
         assert_eq!(found.as_deref(), Some(lib.as_path()));
+    }
+
+    #[test]
+    fn cargo_target_fallback_prefers_debug_before_release() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let debug_dir = dir.path().join("debug");
+        let release_dir = dir.path().join("release");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        std::fs::create_dir_all(&release_dir).unwrap();
+        let debug_lib = debug_dir.join("libvow_runtime.a");
+        let release_lib = release_dir.join("libvow_runtime.a");
+        std::fs::write(&debug_lib, b"debug").unwrap();
+        std::fs::write(&release_lib, b"release").unwrap();
+
+        let found = find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, dir.path());
+        assert_eq!(found.as_deref(), Some(debug_lib.as_path()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Make the Cranelift shim Cargo target fallback prefer `target/debug` before `target/release`, matching `vow-codegen`.
- Document that Cargo target lookup is only the development fallback after env overrides and installed-prefix libraries.
- Add matching regression tests in both helper modules for the both-debug-and-release-present case.

## Root Cause

Issue #277 tracked a pre-existing inconsistency: `vow-codegen` checked debug before release, while `vow-clif-shim` checked release before debug. Installed-prefix lookup was already separate and remains unchanged.

Fixes #277.

## Validation

- `cargo test -p vow-clif-shim cargo_target_fallback_prefers_debug_before_release` (RED before the fix, GREEN after)
- `cargo test -p vow-codegen cargo_target_fallback_prefers_debug_before_release`
- `cargo fmt --all`
- `cargo build -p vow-runtime`
- `cargo test -p vow-codegen -p vow-clif-shim`
- `git diff --check`