### PR TITLE
[codex] Bound stdin_read_line memory

### DIFF
--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1076,6 +1076,9 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
             if fn_name == String::from("hex_encode") {
                 lctx_tag(ctx, result, String::from("String"));
             }
+            if fn_name == String::from("process_get_stdout") || fn_name == String::from("process_get_stderr") || fn_name == String::from("process_stdout_for") || fn_name == String::from("process_stderr_for") {
+                lctx_tag(ctx, result, String::from("String"));
+            }
             if fn_name == String::from("vec_sort") || fn_name == String::from("hex_decode") {
                 lctx_tag(ctx, result, String::from("Vec"));
             }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1025,6 +1025,8 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                     }
                     return result;
                 }
+                // pin_to_root relies on lowering-time String/Vec tags. Keep builtin result
+                // tags in sync with the Rust lowerer, or pin_to_root(expr) becomes a no-op here.
                 return source_id;
             }
         }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1057,6 +1057,7 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
                 ai = ai + 1;
             }
             let result: i64 = lctx_emit(ctx, IOP_CALL(), ret_ty, call_args, IDATA_CALL_EXTERN(), 0, 0, ext);
+            // Keep these builtin result tags in sync with tag_builtin_result in the Rust lowerer.
             if fn_name == String::from("fs_read") || fn_name == String::from("stdin_read") || fn_name == String::from("stdin_read_line") {
                 lctx_tag(ctx, result, String::from("String"));
             }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3014,10 +3014,10 @@ fn skill_full() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("**`process_kill`:** `process_kill(pid)` sends a kill signal to a running process and waits for it to exit. Returns 0 on success, -1 on error. No-op (returns 0) if the process has already completed.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `\"\"` (empty string) at EOF. Use `stdin_read_line` for line-at-a-time processing with bounded memory:\n"));
+    r.push_str(String::from("**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `\"\"` (empty string) at EOF. The returned String is runtime scratch storage valid until the next `stdin_read_line()` call. Process each line before reading the next one for bounded memory; use `pin_to_root(line)` before the next read when a line must be stored, returned, mutated, or otherwise retained. The direct scratch line is read-only.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("```vow\n"));
-    r.push_str(String::from("let line: String = stdin_read_line();\n"));
+    r.push_str(String::from("let mut line: String = stdin_read_line();\n"));
     r.push_str(String::from("while str_len(line) > 0 {\n"));
     r.push_str(String::from("    // process line (has trailing \\n)\n"));
     r.push_str(String::from("    line = stdin_read_line();\n"));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3020,7 +3020,7 @@ fn skill_full() -> String {
     r.push_str(String::from("let lines: Vec<String> = Vec::new();\n"));
     r.push_str(String::from("let mut line: String = stdin_read_line();\n"));
     r.push_str(String::from("while str_len(line) > 0 {\n"));
-    r.push_str(String::from("    // WRONG: lines.push(line) stores the scratch alias, not a copy.\n"));
+    r.push_str(String::from("    // Without pin_to_root, lines.push(line) would store the scratch alias, not a copy.\n"));
     r.push_str(String::from("    lines.push(pin_to_root(line));\n"));
     r.push_str(String::from("    line = stdin_read_line();\n"));
     r.push_str(String::from("}\n"));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3014,7 +3014,17 @@ fn skill_full() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("**`process_kill`:** `process_kill(pid)` sends a kill signal to a running process and waits for it to exit. Returns 0 on success, -1 on error. No-op (returns 0) if the process has already completed.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `\"\"` (empty string) at EOF. The returned String is runtime scratch storage valid until the next `stdin_read_line()` call. Process each line before reading the next one for bounded memory; use `pin_to_root(line)` before the next read when a line must be stored, returned, mutated, or otherwise retained. The direct scratch line is read-only.\n"));
+    r.push_str(String::from("**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `\"\"` (empty string) at EOF. The returned String is runtime scratch storage valid until the next `stdin_read_line()` call. Process each line before reading the next one for bounded memory; use `pin_to_root(line)` before the next read when a line must be stored, returned, passed to a function that may store it, mutated, or otherwise retained. The direct scratch line is read-only. The scratch buffer keeps the largest line capacity seen so far, so memory is bounded by maximum line length rather than total input, but one very large line can retain that capacity for the process lifetime.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("```vow\n"));
+    r.push_str(String::from("let lines: Vec<String> = Vec::new();\n"));
+    r.push_str(String::from("let mut line: String = stdin_read_line();\n"));
+    r.push_str(String::from("while str_len(line) > 0 {\n"));
+    r.push_str(String::from("    // WRONG: lines.push(line) stores the scratch alias, not a copy.\n"));
+    r.push_str(String::from("    lines.push(pin_to_root(line));\n"));
+    r.push_str(String::from("    line = stdin_read_line();\n"));
+    r.push_str(String::from("}\n"));
+    r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("```vow\n"));
     r.push_str(String::from("let mut line: String = stdin_read_line();\n"));

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -804,7 +804,7 @@ For pointer-containing C payloads, a wrapper must be written per type: call the 
 let lines: Vec<String> = Vec::new();
 let mut line: String = stdin_read_line();
 while str_len(line) > 0 {
-    // WRONG: lines.push(line) stores the scratch alias, not a copy.
+    // Without pin_to_root, lines.push(line) would store the scratch alias, not a copy.
     lines.push(pin_to_root(line));
     line = stdin_read_line();
 }

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -798,10 +798,10 @@ For pointer-containing C payloads, a wrapper must be written per type: call the 
 
 **`process_kill`:** `process_kill(pid)` sends a kill signal to a running process and waits for it to exit. Returns 0 on success, -1 on error. No-op (returns 0) if the process has already completed.
 
-**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `""` (empty string) at EOF. Use `stdin_read_line` for line-at-a-time processing with bounded memory:
+**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `""` (empty string) at EOF. The returned String is runtime scratch storage valid until the next `stdin_read_line()` call. Process each line before reading the next one for bounded memory; use `pin_to_root(line)` before the next read when a line must be stored, returned, mutated, or otherwise retained. The direct scratch line is read-only.
 
 ```vow
-let line: String = stdin_read_line();
+let mut line: String = stdin_read_line();
 while str_len(line) > 0 {
     // process line (has trailing \n)
     line = stdin_read_line();

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -798,7 +798,17 @@ For pointer-containing C payloads, a wrapper must be written per type: call the 
 
 **`process_kill`:** `process_kill(pid)` sends a kill signal to a running process and waits for it to exit. Returns 0 on success, -1 on error. No-op (returns 0) if the process has already completed.
 
-**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `""` (empty string) at EOF. The returned String is runtime scratch storage valid until the next `stdin_read_line()` call. Process each line before reading the next one for bounded memory; use `pin_to_root(line)` before the next read when a line must be stored, returned, mutated, or otherwise retained. The direct scratch line is read-only.
+**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `""` (empty string) at EOF. The returned String is runtime scratch storage valid until the next `stdin_read_line()` call. Process each line before reading the next one for bounded memory; use `pin_to_root(line)` before the next read when a line must be stored, returned, passed to a function that may store it, mutated, or otherwise retained. The direct scratch line is read-only. The scratch buffer keeps the largest line capacity seen so far, so memory is bounded by maximum line length rather than total input, but one very large line can retain that capacity for the process lifetime.
+
+```vow
+let lines: Vec<String> = Vec::new();
+let mut line: String = stdin_read_line();
+while str_len(line) > 0 {
+    // WRONG: lines.push(line) stores the scratch alias, not a copy.
+    lines.push(pin_to_root(line));
+    line = stdin_read_line();
+}
+```
 
 ```vow
 let mut line: String = stdin_read_line();

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -154,7 +154,7 @@ else:
 }
 
 compare_runtime() {
-    local label="$1" rust_bin="$2" self_bin="$3"
+    local label="$1" rust_bin="$2" self_bin="$3" stdin_file="${4:-}"
 
     if [ ! -x "$rust_bin" ] || [ ! -x "$self_bin" ]; then
         skip "$label" "binary not found"
@@ -162,8 +162,13 @@ compare_runtime() {
     fi
 
     local rust_out="" self_out="" rust_exit=0 self_exit=0
-    rust_out=$("$rust_bin" </dev/null 2>/dev/null) || rust_exit=$?
-    self_out=$(run_self_bin "$self_bin" </dev/null 2>/dev/null) || self_exit=$?
+    if [ -n "$stdin_file" ]; then
+        rust_out=$("$rust_bin" < "$stdin_file" 2>/dev/null) || rust_exit=$?
+        self_out=$(run_self_bin "$self_bin" < "$stdin_file" 2>/dev/null) || self_exit=$?
+    else
+        rust_out=$("$rust_bin" </dev/null 2>/dev/null) || rust_exit=$?
+        self_out=$(run_self_bin "$self_bin" </dev/null 2>/dev/null) || self_exit=$?
+    fi
 
     local errors=()
     if [ "$rust_exit" != "$self_exit" ]; then
@@ -177,6 +182,24 @@ compare_runtime() {
         pass "$label"
     else
         fail "$label" "$(IFS='; '; echo "${errors[*]}")"
+    fi
+}
+
+run_stdout_with_optional_stdin() {
+    local bin="$1" stdin_file="${2:-}"
+    if [ -n "$stdin_file" ]; then
+        "$bin" < "$stdin_file" 2>/dev/null
+    else
+        "$bin" </dev/null 2>/dev/null
+    fi
+}
+
+run_discard_with_optional_stdin() {
+    local bin="$1" stdin_file="${2:-}"
+    if [ -n "$stdin_file" ]; then
+        "$bin" < "$stdin_file" >/dev/null 2>/dev/null
+    else
+        "$bin" </dev/null >/dev/null 2>/dev/null
     fi
 }
 
@@ -339,13 +362,23 @@ for vow_file in tests/run/*.vow; do
         continue
     fi
 
+    test_stdin=$(sed -n 's|^// TEST: stdin "\(.*\)"$|\1|p' "$vow_file" | head -1)
+    test_stdin_file=$(sed -n 's|^// TEST: stdin-file \(.*\)$|\1|p' "$vow_file" | head -1)
+    stdin_path=""
+    if [ -n "$test_stdin_file" ]; then
+        stdin_path="$(dirname "$vow_file")/$test_stdin_file"
+    elif [ -n "$test_stdin" ]; then
+        stdin_path="$TMPDIR/stdin_${name}.txt"
+        printf '%b' "$test_stdin" > "$stdin_path"
+    fi
+
     # Compare runtime output between compilers
-    compare_runtime "${name}/test-run" "$TMPDIR/test_rust_${name}" "$TMPDIR/test_self_${name}"
+    compare_runtime "${name}/test-run" "$TMPDIR/test_rust_${name}" "$TMPDIR/test_self_${name}" "$stdin_path"
 
     # Validate against // TEST: stdout directive if present
     expected=$(sed -n 's|^// TEST: stdout "\(.*\)"$|\1|p' "$vow_file" | head -1)
     if [ -n "$expected" ]; then
-        actual=$("$TMPDIR/test_rust_${name}" </dev/null 2>/dev/null) || true
+        actual=$(run_stdout_with_optional_stdin "$TMPDIR/test_rust_${name}" "$stdin_path") || true
         # Interpret \n escapes in expected string
         expected_decoded=$(printf '%b' "$expected")
         if [ "$actual" = "$expected_decoded" ]; then
@@ -359,7 +392,7 @@ for vow_file in tests/run/*.vow; do
     expected_exit=$(sed -n 's|^// TEST: exit \([0-9]*\)$|\1|p' "$vow_file" | head -1)
     if [ -n "$expected_exit" ]; then
         actual_exit=0
-        "$TMPDIR/test_rust_${name}" </dev/null >/dev/null 2>/dev/null || actual_exit=$?
+        run_discard_with_optional_stdin "$TMPDIR/test_rust_${name}" "$stdin_path" || actual_exit=$?
         if [ "$actual_exit" = "$expected_exit" ]; then
             pass "${name}/test-exit"
         else

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -367,6 +367,10 @@ for vow_file in tests/run/*.vow; do
     stdin_path=""
     if [ -n "$test_stdin_file" ]; then
         stdin_path="$(dirname "$vow_file")/$test_stdin_file"
+        if [ ! -f "$stdin_path" ]; then
+            fail "${name}/test-run" "stdin fixture not found: $stdin_path"
+            continue
+        fi
     elif [ -n "$test_stdin" ]; then
         stdin_path="$TMPDIR/stdin_${name}.txt"
         printf '%b' "$test_stdin" > "$stdin_path"

--- a/tests/run/stdin_read_line_pin_to_root.vow
+++ b/tests/run/stdin_read_line_pin_to_root.vow
@@ -1,0 +1,11 @@
+// TEST: stdin "alpha\nbeta\n"
+// TEST: stdout "alpha\nbeta\n"
+module StdinReadLinePinToRoot
+
+fn main() -> i32 [read, io] {
+    let first: String = pin_to_root(stdin_read_line());
+    let second: String = stdin_read_line();
+    print_str(first);
+    print_str(second);
+    0
+}

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -824,6 +824,9 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     }
                     return result;
                 }
+                // pin_to_root relies on lowering-time String/Vec tags. Keep
+                // tag_builtin_result in sync for heap-returning builtins, or a
+                // direct pin_to_root(builtin_call()) becomes a no-op here.
                 return source_id;
             }
             let call_info = ctx.func_index.get(&callee_name).cloned();

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -87,6 +87,8 @@ fn vow_builtin_to_runtime(name: &str) -> Option<(&'static str, Ty)> {
     }
 }
 
+// Keep this list in sync with the builtin result tags in compiler/lower.vow.
+// pin_to_root depends on these heap tags for direct builtin call results.
 fn tag_builtin_result(ctx: &mut LowerCtx, name: &str, result: InstId) {
     match name {
         "fs_read" | "stdin_read" | "stdin_read_line" | "string_substr" | "string_trim"

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -93,7 +93,8 @@ fn tag_builtin_result(ctx: &mut LowerCtx, name: &str, result: InstId) {
     match name {
         "fs_read" | "stdin_read" | "stdin_read_line" | "string_substr" | "string_trim"
         | "string_to_upper" | "string_to_lower" | "string_replace" | "string_join"
-        | "i64_to_string" | "hex_encode" => {
+        | "i64_to_string" | "hex_encode" | "process_get_stdout" | "process_get_stderr"
+        | "process_stdout_for" | "process_stderr_for" => {
             ctx.inst_struct_type.insert(result, "String".to_string());
         }
         "args" | "fs_listdir" | "string_split" | "vec_sort" | "hex_decode" => {
@@ -3440,6 +3441,13 @@ mod tests {
         }
     }
 
+    fn string_ty() -> Type {
+        Type::Named {
+            name: "String".to_string(),
+            span: sp(),
+        }
+    }
+
     fn int_expr(v: i128) -> Expr {
         Expr {
             kind: ExprKind::Lit(Lit::Int(v)),
@@ -3457,6 +3465,16 @@ mod tests {
     fn ident_expr(name: &str) -> Expr {
         Expr {
             kind: ExprKind::Ident(name.to_string()),
+            span: sp(),
+        }
+    }
+
+    fn call_expr(callee: &str, args: Vec<Expr>) -> Expr {
+        Expr {
+            kind: ExprKind::Call {
+                callee: Box::new(ident_expr(callee)),
+                args,
+            },
             span: sp(),
         }
     }
@@ -3707,6 +3725,53 @@ mod tests {
         let ret = all_insts.iter().find(|i| i.opcode == Opcode::Return);
         assert!(ret.is_some(), "expected Return instruction");
         assert_eq!(func.return_ty, Ty::Unit);
+    }
+
+    #[test]
+    fn pin_to_root_process_stdout_lowers_to_string_pin() {
+        let body = Block {
+            stmts: vec![],
+            trailing_expr: Some(Box::new(call_expr(
+                "pin_to_root",
+                vec![call_expr("process_get_stdout", vec![])],
+            ))),
+            span: sp(),
+        };
+        let fn_def = make_fn(
+            "pin_process_stdout",
+            vec![],
+            string_ty(),
+            body,
+            vec![Effect::IO],
+        );
+        let (func, _, _) = lower_function(
+            &fn_def,
+            "",
+            &HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        let all_insts: Vec<_> = func.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+        assert!(
+            all_insts
+                .iter()
+                .any(|inst| inst.data
+                    == InstData::CallExtern("__vow_process_get_stdout".to_string())),
+            "expected process_get_stdout extern call"
+        );
+        assert!(
+            all_insts
+                .iter()
+                .any(|inst| inst.data
+                    == InstData::CallExtern("__vow_string_pin_to_root".to_string())),
+            "direct pin_to_root(process_get_stdout()) must lower to string pin"
+        );
     }
 
     #[test]

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -87,6 +87,20 @@ fn vow_builtin_to_runtime(name: &str) -> Option<(&'static str, Ty)> {
     }
 }
 
+fn tag_builtin_result(ctx: &mut LowerCtx, name: &str, result: InstId) {
+    match name {
+        "fs_read" | "stdin_read" | "stdin_read_line" | "string_substr" | "string_trim"
+        | "string_to_upper" | "string_to_lower" | "string_replace" | "string_join"
+        | "i64_to_string" | "hex_encode" => {
+            ctx.inst_struct_type.insert(result, "String".to_string());
+        }
+        "args" | "fs_listdir" | "string_split" | "vec_sort" | "hex_decode" => {
+            ctx.inst_struct_type.insert(result, "Vec".to_string());
+        }
+        _ => {}
+    }
+}
+
 fn lower_ty_with_linear(ast_ty: &AstType, linear_struct_names: &HashSet<String>) -> Ty {
     match ast_ty {
         AstType::Named { name, .. } => match name.as_str() {
@@ -837,13 +851,15 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                     span,
                 )
             } else if let Some((sym, ret_ty)) = vow_builtin_to_runtime(&callee_name) {
-                ctx.emit(
+                let result = ctx.emit(
                     Opcode::Call,
                     ret_ty,
                     arg_ids,
                     InstData::CallExtern(sym.to_string()),
                     span,
-                )
+                );
+                tag_builtin_result(ctx, &callee_name, result);
+                result
             } else {
                 ctx.emit(
                     Opcode::Call,

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -4,8 +4,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::{CStr, c_char};
 use std::io::Write as _;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 thread_local! {
     static LAST_STDOUT: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
@@ -836,6 +836,57 @@ pub struct VowVec {
     pub ptr: *mut u8,
     pub len: usize,
     pub cap: usize,
+}
+
+struct StdinLineScratch {
+    desc: VowVec,
+    bytes: Vec<u8>,
+}
+
+// SAFETY: access is serialized by STDIN_LINE_SCRATCH's Mutex, and desc.ptr is
+// either dangling for len=0 or points into bytes owned by the same scratch.
+unsafe impl Send for StdinLineScratch {}
+
+impl StdinLineScratch {
+    fn new() -> Self {
+        Self {
+            desc: VowVec {
+                ptr: std::ptr::dangling_mut::<u8>(),
+                len: 0,
+                cap: VOW_CAP_RODATA,
+            },
+            bytes: Vec::new(),
+        }
+    }
+}
+
+static STDIN_LINE_SCRATCH: OnceLock<Mutex<StdinLineScratch>> = OnceLock::new();
+
+fn stdin_line_scratch() -> &'static Mutex<StdinLineScratch> {
+    STDIN_LINE_SCRATCH.get_or_init(|| Mutex::new(StdinLineScratch::new()))
+}
+
+fn read_stdin_line_into_scratch<R: std::io::BufRead>(
+    reader: &mut R,
+    scratch: &mut StdinLineScratch,
+) -> *mut u8 {
+    scratch.bytes.clear();
+    let bytes_read = match reader.read_until(b'\n', &mut scratch.bytes) {
+        Ok(n) => n,
+        Err(_) => {
+            scratch.bytes.clear();
+            0
+        }
+    };
+    if bytes_read == 0 {
+        scratch.desc.ptr = std::ptr::dangling_mut::<u8>();
+        scratch.desc.len = 0;
+    } else {
+        scratch.desc.ptr = scratch.bytes.as_mut_ptr();
+        scratch.desc.len = scratch.bytes.len();
+    }
+    scratch.desc.cap = VOW_CAP_RODATA;
+    &mut scratch.desc as *mut VowVec as *mut u8
 }
 
 const VEC_INITIAL_CAP: usize = 8;
@@ -1834,16 +1885,10 @@ pub extern "C" fn __vow_stdin_read() -> *mut u8 {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __vow_stdin_read_line() -> *mut u8 {
-    use std::io::BufRead;
     let stdin = std::io::stdin();
     let mut handle = stdin.lock();
-    let mut line = String::new();
-    let bytes_read = handle.read_line(&mut line).unwrap_or(0);
-    if bytes_read == 0 {
-        unsafe { __vow_string_new(std::ptr::null(), 0) }
-    } else {
-        unsafe { __vow_string_new(line.as_ptr() as *const i8, line.len()) }
-    }
+    let mut scratch = stdin_line_scratch().lock().unwrap();
+    read_stdin_line_into_scratch(&mut handle, &mut scratch)
 }
 
 #[unsafe(no_mangle)]
@@ -2963,6 +3008,64 @@ mod tests {
         assert_ne!(pv.ptr, bytes.as_ptr() as *mut u8);
         let pinned_bytes = unsafe { std::slice::from_raw_parts(pv.ptr, pv.len) };
         assert_eq!(pinned_bytes, b"rooted");
+    }
+
+    #[test]
+    fn stdin_read_line_scratch_reuses_capacity_for_many_lines() {
+        let line_len = 4096;
+        let line_count = 512;
+        let mut input = Vec::with_capacity((line_len + 1) * line_count);
+        for _ in 0..line_count {
+            input.extend(std::iter::repeat_n(b'x', line_len));
+            input.push(b'\n');
+        }
+
+        let mut reader = std::io::Cursor::new(input);
+        let mut scratch = StdinLineScratch::new();
+        for _ in 0..line_count {
+            let ptr = read_stdin_line_into_scratch(&mut reader, &mut scratch);
+            let line = unsafe { &*(ptr as *const VowVec) };
+            assert_eq!(line.len, line_len + 1);
+            assert_eq!(line.cap, VOW_CAP_RODATA);
+        }
+
+        assert!(
+            scratch.bytes.capacity() < (line_len + 1) * line_count / 4,
+            "scratch capacity should track max line size, not total input"
+        );
+    }
+
+    #[test]
+    fn stdin_read_line_scratch_descriptor_is_reused_and_read_only() {
+        let mut reader = std::io::Cursor::new(b"first\nsecond\n".as_slice());
+        let mut scratch = StdinLineScratch::new();
+
+        let first = read_stdin_line_into_scratch(&mut reader, &mut scratch);
+        let first_desc = unsafe { &*(first as *const VowVec) };
+        let first_bytes = unsafe { std::slice::from_raw_parts(first_desc.ptr, first_desc.len) };
+        assert_eq!(first_bytes, b"first\n");
+        assert_eq!(first_desc.cap, VOW_CAP_RODATA);
+
+        let second = read_stdin_line_into_scratch(&mut reader, &mut scratch);
+        assert_eq!(first, second, "stdin scratch descriptor should be stable");
+        let second_desc = unsafe { &*(second as *const VowVec) };
+        let second_bytes = unsafe { std::slice::from_raw_parts(second_desc.ptr, second_desc.len) };
+        assert_eq!(second_bytes, b"second\n");
+        assert_eq!(second_desc.cap, VOW_CAP_RODATA);
+    }
+
+    #[test]
+    fn stdin_read_line_pin_to_root_preserves_previous_line() {
+        let mut reader = std::io::Cursor::new(b"alpha\nbeta\n".as_slice());
+        let mut scratch = StdinLineScratch::new();
+
+        let first = read_stdin_line_into_scratch(&mut reader, &mut scratch);
+        let pinned = unsafe { __vow_string_pin_to_root(first) };
+        let _second = read_stdin_line_into_scratch(&mut reader, &mut scratch);
+
+        let pinned_desc = unsafe { &*(pinned as *const VowVec) };
+        let pinned_bytes = unsafe { std::slice::from_raw_parts(pinned_desc.ptr, pinned_desc.len) };
+        assert_eq!(pinned_bytes, b"alpha\n");
     }
 
     #[test]

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -844,12 +844,10 @@ struct StdinLineScratch {
 }
 
 // SAFETY: desc.ptr is either dangling for len=0 or points into bytes owned by
-// the same scratch value. Moving StdinLineScratch keeps that internal pointer
-// valid because Vec backing storage does not move with the struct. The pointer
-// returned from stdin_read_line points at scratch.desc, whose address is stable
-// because STDIN_LINE_SCRATCH lives in a static OnceLock. The mutex serializes
-// mutation; after the lock is dropped, soundness relies on Vow programs calling
-// stdin_read_line from one thread.
+// the same scratch value. The pointer returned from stdin_read_line points at
+// scratch.desc, whose address is stable because STDIN_LINE_SCRATCH lives in a
+// static OnceLock. The mutex serializes mutation; after the lock is dropped,
+// soundness relies on Vow programs calling stdin_read_line from one thread.
 unsafe impl Send for StdinLineScratch {}
 
 impl StdinLineScratch {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -843,8 +843,10 @@ struct StdinLineScratch {
     bytes: Vec<u8>,
 }
 
-// SAFETY: access is serialized by STDIN_LINE_SCRATCH's Mutex, and desc.ptr is
-// either dangling for len=0 or points into bytes owned by the same scratch.
+// SAFETY: mutation is serialized by STDIN_LINE_SCRATCH's Mutex, and desc.ptr is
+// either dangling for len=0 or points into bytes owned by the same scratch. The
+// returned pointer stays sound because Vow programs call stdin_read_line on one
+// thread; concurrent calls would alias scratch storage after the lock is dropped.
 unsafe impl Send for StdinLineScratch {}
 
 impl StdinLineScratch {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -878,6 +878,8 @@ fn read_stdin_line_into_scratch<R: std::io::BufRead>(
     // clear preserves capacity: scratch memory follows the largest line seen,
     // not total input, and may retain that high-water mark for process lifetime.
     scratch.bytes.clear();
+    // Vow strings are byte strings: accept arbitrary stdin bytes, including
+    // invalid UTF-8, while still splitting on newline bytes.
     let bytes_read = match reader.read_until(b'\n', &mut scratch.bytes) {
         Ok(n) => n,
         Err(_) => {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -187,10 +187,12 @@ fn oom_trap(operation: &'static str) -> ! {
 
 fn region_literal_mutation_trap(operation: &'static str) -> ! {
     use std::io::Write;
+    // VOW_CAP_RODATA marks read-only descriptors, including literals and
+    // stdin_read_line scratch storage. Keep the hint useful for both origins.
     let hint: &[u8] = if operation.starts_with("String::") {
-        b"hint: use String::from(literal) to obtain a mutable copy\n"
+        b"hint: use String::from(literal) for literals; use pin_to_root(value) for read-only scratch strings\n"
     } else if operation.starts_with("Vec::") {
-        b"hint: use Vec::from(literal) to obtain a mutable copy\n"
+        b"hint: use Vec::from(literal) for literals; use pin_to_root(value) for read-only vectors\n"
     } else if operation.starts_with("HashMap::") {
         b"hint: construct a mutable HashMap and copy entries before mutating\n"
     } else {
@@ -892,6 +894,10 @@ fn read_stdin_line_into_scratch<R: std::io::BufRead>(
         scratch.desc.len = scratch.bytes.len();
     }
     scratch.desc.cap = VOW_CAP_RODATA;
+    // SAFETY: this raw pointer escapes the RefCell borrow in
+    // __vow_stdin_read_line, but it targets this thread's stable thread-local
+    // descriptor. The descriptor remains live for the thread lifetime; its
+    // contents are semantically invalidated by the next call on this thread.
     &mut scratch.desc as *mut VowVec as *mut u8
 }
 
@@ -3318,6 +3324,12 @@ mod tests {
                 || stderr.contains("hint: construct a mutable HashMap"),
             "stderr missing hint line:\n{stderr}"
         );
+        if expected_op_in_json.starts_with("String::") || expected_op_in_json.starts_with("Vec::") {
+            assert!(
+                stderr.contains("pin_to_root(value)"),
+                "stderr missing pin_to_root hint for read-only heap value:\n{stderr}"
+            );
+        }
     }
 
     #[test]

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -843,10 +843,13 @@ struct StdinLineScratch {
     bytes: Vec<u8>,
 }
 
-// SAFETY: mutation is serialized by STDIN_LINE_SCRATCH's Mutex, and desc.ptr is
-// either dangling for len=0 or points into bytes owned by the same scratch. The
-// returned pointer stays sound because Vow programs call stdin_read_line on one
-// thread; concurrent calls would alias scratch storage after the lock is dropped.
+// SAFETY: desc.ptr is either dangling for len=0 or points into bytes owned by
+// the same scratch value. Moving StdinLineScratch keeps that internal pointer
+// valid because Vec backing storage does not move with the struct. The pointer
+// returned from stdin_read_line points at scratch.desc, whose address is stable
+// because STDIN_LINE_SCRATCH lives in a static OnceLock. The mutex serializes
+// mutation; after the lock is dropped, soundness relies on Vow programs calling
+// stdin_read_line from one thread.
 unsafe impl Send for StdinLineScratch {}
 
 impl StdinLineScratch {

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -4,8 +4,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::{CStr, c_char};
 use std::io::Write as _;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
 
 thread_local! {
     static LAST_STDOUT: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
@@ -843,13 +843,6 @@ struct StdinLineScratch {
     bytes: Vec<u8>,
 }
 
-// SAFETY: desc.ptr is either dangling for len=0 or points into bytes owned by
-// the same scratch value. The pointer returned from stdin_read_line points at
-// scratch.desc, whose address is stable because STDIN_LINE_SCRATCH lives in a
-// static OnceLock. The mutex serializes mutation; after the lock is dropped,
-// soundness relies on Vow programs calling stdin_read_line from one thread.
-unsafe impl Send for StdinLineScratch {}
-
 impl StdinLineScratch {
     fn new() -> Self {
         Self {
@@ -863,10 +856,12 @@ impl StdinLineScratch {
     }
 }
 
-static STDIN_LINE_SCRATCH: OnceLock<Mutex<StdinLineScratch>> = OnceLock::new();
-
-fn stdin_line_scratch() -> &'static Mutex<StdinLineScratch> {
-    STDIN_LINE_SCRATCH.get_or_init(|| Mutex::new(StdinLineScratch::new()))
+thread_local! {
+    // Each OS thread owns one stable descriptor. The returned pointer remains
+    // valid until that same thread's next stdin_read_line call, and concurrent
+    // callers never share descriptor or backing-buffer state.
+    static STDIN_LINE_SCRATCH: RefCell<StdinLineScratch> =
+        RefCell::new(StdinLineScratch::new());
 }
 
 fn read_stdin_line_into_scratch<R: std::io::BufRead>(
@@ -1898,8 +1893,10 @@ pub extern "C" fn __vow_stdin_read() -> *mut u8 {
 pub extern "C" fn __vow_stdin_read_line() -> *mut u8 {
     let stdin = std::io::stdin();
     let mut handle = stdin.lock();
-    let mut scratch = stdin_line_scratch().lock().unwrap();
-    read_stdin_line_into_scratch(&mut handle, &mut scratch)
+    STDIN_LINE_SCRATCH.with(|cell| {
+        let mut scratch = cell.borrow_mut();
+        read_stdin_line_into_scratch(&mut handle, &mut scratch)
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -3041,9 +3038,44 @@ mod tests {
         }
 
         assert!(
-            scratch.bytes.capacity() < (line_len + 1) * line_count / 4,
+            scratch.bytes.capacity() <= 2 * (line_len + 1),
             "scratch capacity should track max line size, not total input"
         );
+    }
+
+    #[test]
+    fn stdin_read_line_scratch_descriptor_is_thread_local() {
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut handles = Vec::new();
+
+        for byte in [b'a', b'b'] {
+            let barrier = std::sync::Arc::clone(&barrier);
+            let tx = tx.clone();
+            handles.push(std::thread::spawn(move || {
+                let input = [byte, b'\n'];
+                let mut reader = std::io::Cursor::new(input.as_slice());
+                let ptr = STDIN_LINE_SCRATCH.with(|cell| {
+                    let mut scratch = cell.borrow_mut();
+                    read_stdin_line_into_scratch(&mut reader, &mut scratch) as usize
+                });
+                tx.send(ptr).unwrap();
+                barrier.wait();
+            }));
+        }
+        drop(tx);
+
+        let first = rx.recv().unwrap();
+        let second = rx.recv().unwrap();
+        assert_ne!(
+            first, second,
+            "stdin scratch descriptor should be per-thread"
+        );
+        barrier.wait();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
     }
 
     #[test]

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -872,6 +872,8 @@ fn read_stdin_line_into_scratch<R: std::io::BufRead>(
     reader: &mut R,
     scratch: &mut StdinLineScratch,
 ) -> *mut u8 {
+    // clear preserves capacity: scratch memory follows the largest line seen,
+    // not total input, and may retain that high-water mark for process lifetime.
     scratch.bytes.clear();
     let bytes_read = match reader.read_until(b'\n', &mut scratch.bytes) {
         Ok(n) => n,
@@ -881,6 +883,9 @@ fn read_stdin_line_into_scratch<R: std::io::BufRead>(
             0
         }
     };
+    // bytes may reallocate while reading a longer line. Vow callers hold this
+    // stable descriptor address, so refresh ptr/len after each read; unpinned
+    // old values then observe the current scratch line instead of freed memory.
     if bytes_read == 0 {
         scratch.desc.ptr = std::ptr::dangling_mut::<u8>();
         scratch.desc.len = 0;

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -874,6 +874,7 @@ fn read_stdin_line_into_scratch<R: std::io::BufRead>(
     let bytes_read = match reader.read_until(b'\n', &mut scratch.bytes) {
         Ok(n) => n,
         Err(_) => {
+            // Preserve the historical stdin_read_line contract: IO errors look like EOF.
             scratch.bytes.clear();
             0
         }

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2290,7 +2290,17 @@ For pointer-containing C payloads, a wrapper must be written per type: call the 
 
 **`process_kill`:** `process_kill(pid)` sends a kill signal to a running process and waits for it to exit. Returns 0 on success, -1 on error. No-op (returns 0) if the process has already completed.
 
-**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `""` (empty string) at EOF. The returned String is runtime scratch storage valid until the next `stdin_read_line()` call. Process each line before reading the next one for bounded memory; use `pin_to_root(line)` before the next read when a line must be stored, returned, mutated, or otherwise retained. The direct scratch line is read-only.
+**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `""` (empty string) at EOF. The returned String is runtime scratch storage valid until the next `stdin_read_line()` call. Process each line before reading the next one for bounded memory; use `pin_to_root(line)` before the next read when a line must be stored, returned, passed to a function that may store it, mutated, or otherwise retained. The direct scratch line is read-only. The scratch buffer keeps the largest line capacity seen so far, so memory is bounded by maximum line length rather than total input, but one very large line can retain that capacity for the process lifetime.
+
+```vow
+let lines: Vec<String> = Vec::new();
+let mut line: String = stdin_read_line();
+while str_len(line) > 0 {
+    // WRONG: lines.push(line) stores the scratch alias, not a copy.
+    lines.push(pin_to_root(line));
+    line = stdin_read_line();
+}
+```
 
 ```vow
 let mut line: String = stdin_read_line();

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2290,10 +2290,10 @@ For pointer-containing C payloads, a wrapper must be written per type: call the 
 
 **`process_kill`:** `process_kill(pid)` sends a kill signal to a running process and waits for it to exit. Returns 0 on success, -1 on error. No-op (returns 0) if the process has already completed.
 
-**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `""` (empty string) at EOF. Use `stdin_read_line` for line-at-a-time processing with bounded memory:
+**`stdin_read` vs `stdin_read_line`:** `stdin_read()` reads the entire stdin stream into a single String (unbounded memory). `stdin_read_line()` reads one line at a time, including the trailing newline. Returns `""` (empty string) at EOF. The returned String is runtime scratch storage valid until the next `stdin_read_line()` call. Process each line before reading the next one for bounded memory; use `pin_to_root(line)` before the next read when a line must be stored, returned, mutated, or otherwise retained. The direct scratch line is read-only.
 
 ```vow
-let line: String = stdin_read_line();
+let mut line: String = stdin_read_line();
 while str_len(line) > 0 {
     // process line (has trailing \n)
     line = stdin_read_line();

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2296,7 +2296,7 @@ For pointer-containing C payloads, a wrapper must be written per type: call the 
 let lines: Vec<String> = Vec::new();
 let mut line: String = stdin_read_line();
 while str_len(line) > 0 {
-    // WRONG: lines.push(line) stores the scratch alias, not a copy.
+    // Without pin_to_root, lines.push(line) would store the scratch alias, not a copy.
     lines.push(pin_to_root(line));
     line = stdin_read_line();
 }

--- a/vow/tests/agent_level1.rs
+++ b/vow/tests/agent_level1.rs
@@ -1,6 +1,9 @@
+#[cfg(target_os = "linux")]
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::Command;
+#[cfg(target_os = "linux")]
+use std::process::Stdio;
 use std::sync::OnceLock;
 
 static SUPPORT_LIBS_BUILT: OnceLock<()> = OnceLock::new();
@@ -158,6 +161,7 @@ fn compile_success() {
     assert_eq!(run.status.code(), Some(0), "compiled binary should exit 0");
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn stdin_read_line_processes_large_stream_under_memory_cap() {
     build_support_libs();

--- a/vow/tests/agent_level1.rs
+++ b/vow/tests/agent_level1.rs
@@ -1,5 +1,9 @@
+use std::io::Write;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+
+static SUPPORT_LIBS_BUILT: OnceLock<()> = OnceLock::new();
 
 fn vow_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_vow"))
@@ -20,23 +24,23 @@ fn workspace_root() -> PathBuf {
 }
 
 fn support_lib(name: &str) -> PathBuf {
-    if let Some(path) = find_support_lib(name) {
-        return path;
-    }
-
-    // Build the support libraries on demand so this integration test can run
-    // in isolation without requiring the caller to pre-build the workspace.
-    let status = Command::new("cargo")
-        .args(["build", "-p", "vow-runtime", "-p", "vow-clif-shim"])
-        .status()
-        .expect("failed to invoke cargo to build support libraries");
-    assert!(
-        status.success(),
-        "cargo build -p vow-runtime -p vow-clif-shim failed"
-    );
+    build_support_libs();
 
     find_support_lib(name)
         .unwrap_or_else(|| panic!("missing {name} after building support libraries"))
+}
+
+fn build_support_libs() {
+    SUPPORT_LIBS_BUILT.get_or_init(|| {
+        let status = Command::new("cargo")
+            .args(["build", "-p", "vow-runtime", "-p", "vow-clif-shim"])
+            .status()
+            .expect("failed to invoke cargo to build support libraries");
+        assert!(
+            status.success(),
+            "cargo build -p vow-runtime -p vow-clif-shim failed"
+        );
+    });
 }
 
 fn find_support_lib(name: &str) -> Option<PathBuf> {
@@ -152,6 +156,82 @@ fn compile_success() {
         .output()
         .expect("failed to run compiled binary");
     assert_eq!(run.status.code(), Some(0), "compiled binary should exit 0");
+}
+
+#[test]
+fn stdin_read_line_processes_large_stream_under_memory_cap() {
+    build_support_libs();
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let src_path = dir.path().join("stdin_large.vow");
+    let out_path = dir.path().join("stdin_large");
+    let src = r#"module StdinLarge
+
+fn main() -> i32 [read, io] {
+    let mut count: u64 = 0;
+    let mut line: String = stdin_read_line();
+    while line.len() > 0 {
+        count = count + 1;
+        line = stdin_read_line();
+    }
+    print_str(String::from("total: "));
+    print_u64(count);
+    print_str(String::from("\n"));
+    0
+}
+"#;
+    std::fs::write(&src_path, src).unwrap();
+
+    let result = Command::new(vow_bin())
+        .args([
+            "build",
+            "--no-verify",
+            "--no-cache",
+            src_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run vow");
+    assert_eq!(
+        result.status.code(),
+        Some(0),
+        "expected build success\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg("ulimit -v 131072; exec \"$1\"")
+        .arg("sh")
+        .arg(out_path.to_str().unwrap())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to run compiled binary under memory cap");
+
+    {
+        let stdin = child.stdin.as_mut().expect("child stdin");
+        let payload = vec![b'x'; 128 * 1024 - 1];
+        for _ in 0..2000 {
+            stdin
+                .write_all(&payload)
+                .expect("failed to write line payload");
+            stdin.write_all(b"\n").expect("failed to write newline");
+        }
+    }
+
+    let run = child.wait_with_output().expect("failed to wait for child");
+    assert_eq!(
+        run.status.code(),
+        Some(0),
+        "expected bounded line processing to finish\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "total: 2000\n");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #282.

`stdin_read_line()` no longer copies every returned line into the append-only root arena. The runtime now reads into a reusable stdin scratch buffer and returns read-only scratch storage that is valid until the next `stdin_read_line()` call. Callers that need to keep a line across the next read can use `pin_to_root(line)`.

This also aligns the spec/help text with the lifetime contract and fixes Rust/self-hosted IR lowering so builtin `String`/`Vec` results are tagged consistently, allowing nested calls such as `pin_to_root(stdin_read_line())` and `pin_to_root(process_get_stdout())` to retain the value correctly.

## Changes

- Add reusable runtime scratch storage for `stdin_read_line()`.
- Tag lowered builtin results for `String` and `Vec` parity across the Rust and self-hosted lowerers, including process stdout/stderr result builtins.
- Document the scratch lifetime, aliasing/storage footgun, and high-water capacity behavior in `docs/spec/grammar.md`, then regenerate embedded help/skill output.
- Fix the `stdin_read_line()` docs example to use `let mut line`, correcting the latent reassignment error in the published example.
- Add runtime/unit coverage, a large-stream memory-cap integration regression, a direct process-output pinning lowerer regression, and a run-test for retaining a pinned line across the next read.
- Teach `scripts/full_test.sh` run tests to honor `// TEST: stdin` and `// TEST: stdin-file` annotations.

## Validation

- `git diff --check`
- `uv run python scripts/generate_help.py --check`
- `cargo fmt --all --check`
- `cargo test -p vow-runtime stdin_read_line -- --nocapture`
- `cargo test -p vow-ir pin_to_root_process_stdout_lowers_to_string_pin -- --nocapture`
- `cargo test -p vow --test agent_level1 stdin_read_line_processes_large_stream_under_memory_cap -- --nocapture`
- `cargo test --all`
- `cargo clippy --all -- -D warnings`
- `cargo build --release -p vow`
- `cargo build --release -p vow-runtime -p vow-clif-shim`
- `scripts/bootstrap.sh --skip-cargo`
- `tests/run_tests.sh --no-bootstrap --filter stdin_read_line_pin_to_root`
- `tests/run_tests.sh --no-bootstrap --filter pin_to_root`
- `tests/run_tests.sh --no-bootstrap --filter cmdloop`
- Automated Linux memory-cap regression: process 2000 x 128 KiB lines (~250 MiB total stdin) under a 128 MiB virtual-memory cap.
- Manual issue-style repro: read more than 1 GiB of stdin under a 1 GiB virtual-memory cap without `OutOfMemory`.

Note: `scripts/full_test.sh` improved from 326 passed / 7 failed / 1 skipped to 328 passed / 5 failed / 1 skipped after the stdin harness fix. The remaining failures are unrelated verifier-counterexample failures in `search`, `sum_range`, `vec_fill`, `gc`, and `math`.
