### PR TITLE
Fix per-destination region markers

### DIFF
--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -88,13 +88,16 @@ fn infer_regions_module(m: IrModule, dctx: DiagCtx) -> IrModule {
     // this cache it drops to ~2s. See #252 for the BTreeMap stdlib that
     // would replace this Vec<IrInst>-indexed-by-id workaround.
     let id_to_inst_per_fn: Vec<Vec<IrInst>> = Vec::new();
+    let id_to_block_per_fn: Vec<Vec<i64>> = Vec::new();
     let phi_arms_per_fn: Vec<Vec<Vec<i64>>> = Vec::new();
     let mut bxi: i64 = 0;
     while bxi < n_funcs {
         let f0: IrFunction = m.functions[bxi];
         let it: Vec<IrInst> = build_id_to_inst(f0);
+        let ib: Vec<i64> = build_id_to_block(f0, it.len());
         let pa: Vec<Vec<i64>> = build_phi_arms(f0, it.len());
         id_to_inst_per_fn.push(it);
+        id_to_block_per_fn.push(ib);
         phi_arms_per_fn.push(pa);
         bxi = bxi + 1;
     }
@@ -131,7 +134,7 @@ fn infer_regions_module(m: IrModule, dctx: DiagCtx) -> IrModule {
                 let fidx: i64 = scc[ii];
                 let did_change: bool = analyze_function(
                     m, fidx,
-                    id_to_inst_per_fn[fidx], phi_arms_per_fn[fidx],
+                    id_to_inst_per_fn[fidx], id_to_block_per_fn[fidx], phi_arms_per_fn[fidx],
                     int_kinds, int_auxs, int_aliases_list,
                     int_se_targets, int_se_src_kinds, int_se_src_aux, int_se_src_aliases,
                     region_keys, region_vals,
@@ -860,7 +863,7 @@ fn check_store_conflict(
 // Returns true if the function's internal summary changed.
 fn analyze_function(
     m: IrModule, fidx: i64,
-    id_to_inst: Vec<IrInst>, phi_arms: Vec<Vec<i64>>,
+    id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>, phi_arms: Vec<Vec<i64>>,
     int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
     int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>,
     int_se_src_aux: Vec<Vec<i64>>, int_se_src_aliases: Vec<Vec<Vec<i64>>>,
@@ -929,21 +932,25 @@ fn analyze_function(
         bi = bi + 1;
     }
 
-    // Tag local heap-producing instructions with block regions when all direct
-    // uses stay in the defining block. The self-hosted Phase 9 subset routes
-    // three cases through `REGION_KIND_BLOCK`: `IOP_REGION_ALLOC`, FreshInCaller
-    // extern wrappers, and `IOP_CALL` + `IDATA_CALL_TARGET` whose callee
-    // summary is `FRESH_IN_CALLER`. The block-region tag uses
-    // `REGION_KIND_BLOCK`, not `REGION_KIND_CALLER`, so the shim's pending
-    // hidden-caller-region work is irrelevant here.
+    // 2. Tag heap-producing instructions whose per-destination marker LUB
+    // stays in the defining block. This mirrors the Rust pass's marker model
+    // without materializing a must_outlive set for every value: for each heap
+    // producer, scan its direct uses plus Phi/call return-alias users and
+    // reject the block placement as soon as any marker would LUB wider than
+    // the defining block. That keeps stage-2 bootstrap from allocating the
+    // full marker lattice inside the self-hosted arena.
     let mut rbi: i64 = 0;
     while rbi < n_bks {
         let rb: IrBlock = bks[rbi];
         let mut rii: i64 = 0;
         while rii < rb.insts.len() {
             let rinst: IrInst = rb.insts[rii];
-            if is_heap_producing_for_block_region(rinst, int_kinds)
-                && value_used_only_in_block(f, rinst.id, rb.id)
+            if is_heap_producing_for_region(rinst, int_kinds)
+                && value_lub_stays_in_block(
+                    f, rinst.id, rb.id, id_to_inst, id_to_block,
+                    int_kinds, int_auxs, int_aliases_list,
+                    int_se_targets, int_se_src_kinds, int_se_src_aux,
+                )
             {
                 put_inst_region(
                     region_keys[fidx],
@@ -999,7 +1006,7 @@ fn analyze_function(
     false
 }
 
-fn is_heap_producing_for_block_region(inst: IrInst, int_kinds: Vec<i64>) -> bool {
+fn is_heap_producing_for_region(inst: IrInst, int_kinds: Vec<i64>) -> bool {
     if inst.op == IOP_REGION_ALLOC() {
         return true;
     }
@@ -1015,18 +1022,57 @@ fn is_heap_producing_for_block_region(inst: IrInst, int_kinds: Vec<i64>) -> bool
     false
 }
 
-// TODO(scalability, follow-up to #204): this is O(blocks × insts × args)
-// per call, and `analyze_function` invokes it once per heap-producing
-// inst. Rough total per function: O(h × n) where h = heap producers,
-// n = total insts. The Rust pass achieves the same effect in O(n) by
-// folding all uses into a `must_outlive` map in a single forward sweep
-// (`collect_regular_use_markers` at vow-ir/src/region.rs:909-926) and
-// then reading per-id markers in O(markers) per producer. That refactor
-// is structural — it would change the analyze_function signature and
-// touch the bootstrap fixed point — and is intentionally deferred so
-// this PR stays scoped to Phase 9 routing. See CLAUDE.md "Scalability is
-// a requirement" for the long-term direction.
-fn value_used_only_in_block(f: IrFunction, id: i64, defining_block: i64) -> bool {
+fn lookup_inst_block(id_to_block: Vec<i64>, id: i64) -> i64 {
+    if id >= 0 && id < id_to_block.len() {
+        return id_to_block[id];
+    }
+    -1
+}
+
+fn value_lub_stays_in_block(
+    f: IrFunction, id: i64, defining_block: i64,
+    id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>,
+    int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
+    int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>
+) -> bool {
+    let work: Vec<i64> = Vec::new();
+    let seen: Vec<i64> = Vec::new();
+    work.push(id);
+    while work.len() > 0 {
+        let cur: i64 = work[work.len() - 1];
+        work.pop();
+        if region_vec_contains_i64(seen, cur) {
+            continue;
+        }
+        seen.push(cur);
+        if !direct_markers_stay_in_block(
+            f,
+            cur,
+            defining_block,
+            id_to_inst,
+            id_to_block,
+            int_kinds,
+            int_auxs,
+            int_aliases_list,
+            int_se_targets,
+            int_se_src_kinds,
+            int_se_src_aux,
+            work,
+            seen
+        ) {
+            return false;
+        }
+    }
+    true
+}
+
+fn direct_markers_stay_in_block(
+    f: IrFunction, id: i64, defining_block: i64,
+    id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>,
+    int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
+    int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>,
+    work: Vec<i64>, seen: Vec<i64>
+) -> bool {
     let bks: Vec<IrBlock> = f.blocks;
     let mut bi: i64 = 0;
     while bi < bks.len() {
@@ -1037,16 +1083,55 @@ fn value_used_only_in_block(f: IrFunction, id: i64, defining_block: i64) -> bool
             let mut ai: i64 = 0;
             while ai < inst.args.len() {
                 if inst.args[ai] == id {
+                    // Every argument use contributes the use-block marker.
                     if blk.id != defining_block {
                         return false;
                     }
-                    if inst.op == IOP_RETURN()
-                        || inst.op == IOP_UPSILON()
-                        || inst.op == IOP_CALL()
-                        || inst.op == IOP_STORE()
-                        || inst.op == IOP_FIELD_SET()
-                    {
+                    if inst.op == IOP_RETURN() {
                         return false;
+                    }
+                    if (inst.op == IOP_STORE() || inst.op == IOP_FIELD_SET()) && ai == 1 {
+                        if !target_marker_is_defining_block(
+                            id_to_inst,
+                            id_to_block,
+                            inst.args[0],
+                            int_kinds,
+                            defining_block
+                        ) {
+                            return false;
+                        }
+                    }
+                    if inst.op == IOP_UPSILON() && ai == 0 && inst.dk == IDATA_PHI_TARGET() {
+                        let phi_block: i64 = lookup_inst_block(id_to_block, inst.dv);
+                        if phi_block != defining_block {
+                            return false;
+                        }
+                        push_region_work(work, seen, inst.dv);
+                    }
+                    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_TARGET() {
+                        let callee_idx: i64 = inst.dv;
+                        if !call_store_effects_keep_source_in_block(
+                            inst,
+                            ai,
+                            id_to_inst,
+                            id_to_block,
+                            int_kinds,
+                            int_se_targets,
+                            int_se_src_kinds,
+                            int_se_src_aux,
+                            defining_block
+                        ) {
+                            return false;
+                        }
+                        if callee_return_aliases_arg(
+                            callee_idx,
+                            ai,
+                            int_kinds,
+                            int_auxs,
+                            int_aliases_list
+                        ) {
+                            push_region_work(work, seen, inst.id);
+                        }
                     }
                 }
                 ai = ai + 1;
@@ -1058,10 +1143,89 @@ fn value_used_only_in_block(f: IrFunction, id: i64, defining_block: i64) -> bool
     true
 }
 
-// Currently unused (intentional scaffolding). Becomes live once the
-// `vow-clif-shim` learns hidden-caller-region routing for `IOP_REGION_ALLOC`.
-// Until then, escaping allocations stay at the Phase-2 default (Root) — see
-// the comment in `analyze_function` where these would otherwise be wired.
+fn push_region_work(work: Vec<i64>, seen: Vec<i64>, id: i64) {
+    if id < 0 {
+        return;
+    }
+    if region_vec_contains_i64(seen, id) {
+        return;
+    }
+    if region_vec_contains_i64(work, id) {
+        return;
+    }
+    work.push(id);
+}
+
+fn target_marker_is_defining_block(
+    id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>, target_id: i64,
+    int_kinds: Vec<i64>, defining_block: i64
+) -> bool {
+    let inst: IrInst = lookup_inst_or_default(id_to_inst, target_id);
+    if inst.id < 0 {
+        return false;
+    }
+    if inst.op == IOP_GET_ARG() {
+        return false;
+    }
+    if is_heap_producing_for_region(inst, int_kinds) {
+        return lookup_inst_block(id_to_block, target_id) == defining_block;
+    }
+    false
+}
+
+fn call_store_effects_keep_source_in_block(
+    call_inst: IrInst, source_arg_pos: i64,
+    id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>, int_kinds: Vec<i64>,
+    int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>,
+    defining_block: i64
+) -> bool {
+    let callee_idx: i64 = call_inst.dv;
+    if callee_idx < 0 || callee_idx >= int_se_targets.len() {
+        return true;
+    }
+    let targets: Vec<i64> = int_se_targets[callee_idx];
+    let kinds: Vec<i64> = int_se_src_kinds[callee_idx];
+    let auxs: Vec<i64> = int_se_src_aux[callee_idx];
+    let mut i: i64 = 0;
+    while i < targets.len() && i < kinds.len() && i < auxs.len() {
+        if kinds[i] == RSUM_KIND_ALIAS_OF() && auxs[i] == source_arg_pos {
+            let target_param: i64 = targets[i];
+            if target_param >= 0 && target_param < call_inst.args.len() {
+                if !target_marker_is_defining_block(
+                    id_to_inst,
+                    id_to_block,
+                    call_inst.args[target_param],
+                    int_kinds,
+                    defining_block
+                ) {
+                    return false;
+                }
+            }
+        } else if kinds[i] == RSUM_KIND_ALIAS_OF_ANY() {
+            return false;
+        }
+        i = i + 1;
+    }
+    true
+}
+
+fn callee_return_aliases_arg(
+    callee_idx: i64, arg_pos: i64,
+    int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>
+) -> bool {
+    if callee_idx < 0 || callee_idx >= int_kinds.len() {
+        return false;
+    }
+    if int_kinds[callee_idx] == RSUM_KIND_ALIAS_OF() {
+        return int_auxs[callee_idx] == arg_pos;
+    }
+    if int_kinds[callee_idx] == RSUM_KIND_ALIAS_OF_ANY() {
+        let aliases: Vec<i64> = int_aliases_list[callee_idx];
+        return region_vec_contains_i64(aliases, arg_pos);
+    }
+    false
+}
+
 fn region_caller0() -> i64 {
     // RegionId::Caller(HiddenRegionIdx(0)) packed: kind=CALLER, val=0.
     region_pack(REGION_KIND_CALLER(), 0)
@@ -1089,6 +1253,7 @@ fn is_scalar_ity(ty: i64) -> bool {
 //
 // `id_to_inst[id]` is the inst with `inst.id == id`, or a sentinel
 // (`inst.id < 0`) when no such inst exists in the function.
+// `id_to_block[id]` is the block containing that inst, or -1 for no inst.
 // `phi_arms[id]` is the list of upsilon-arm value ids targeting the
 // phi with `phi.id == id`; empty for non-phi ids.
 fn build_id_to_inst(f: IrFunction) -> Vec<IrInst> {
@@ -1124,6 +1289,30 @@ fn build_id_to_inst(f: IrFunction) -> Vec<IrInst> {
             ii = ii + 1;
         }
         bi2 = bi2 + 1;
+    }
+    tbl
+}
+
+fn build_id_to_block(f: IrFunction, n_ids: i64) -> Vec<i64> {
+    let tbl: Vec<i64> = Vec::new();
+    let mut i: i64 = 0;
+    while i < n_ids {
+        tbl.push(-1);
+        i = i + 1;
+    }
+    let bks: Vec<IrBlock> = f.blocks;
+    let mut bi: i64 = 0;
+    while bi < bks.len() {
+        let blk: IrBlock = bks[bi];
+        let mut ii: i64 = 0;
+        while ii < blk.insts.len() {
+            let inst: IrInst = blk.insts[ii];
+            if inst.id >= 0 && inst.id < n_ids {
+                tbl[inst.id] = blk.id;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
     }
     tbl
 }

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1100,6 +1100,11 @@ fn direct_markers_stay_in_block(
                         ) {
                             return false;
                         }
+                        // Stored values must follow later widening of their
+                        // target container. The target-marker check above
+                        // handles the target's origin; the work item catches
+                        // use-derived widening such as returning the target.
+                        push_region_work(work, seen, inst.args[0]);
                     }
                     if inst.op == IOP_UPSILON() && ai == 0 && inst.dk == IDATA_PHI_TARGET() {
                         let phi_block: i64 = lookup_inst_block(id_to_block, inst.dv);
@@ -1119,6 +1124,8 @@ fn direct_markers_stay_in_block(
                             int_se_targets,
                             int_se_src_kinds,
                             int_se_src_aux,
+                            work,
+                            seen,
                             defining_block
                         ) {
                             return false;
@@ -1177,6 +1184,7 @@ fn call_store_effects_keep_source_in_block(
     call_inst: IrInst, source_arg_pos: i64,
     id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>, int_kinds: Vec<i64>,
     int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>,
+    work: Vec<i64>, seen: Vec<i64>,
     defining_block: i64
 ) -> bool {
     let callee_idx: i64 = call_inst.dv;
@@ -1200,6 +1208,7 @@ fn call_store_effects_keep_source_in_block(
                 ) {
                     return false;
                 }
+                push_region_work(work, seen, call_inst.args[target_param]);
             }
         } else if kinds[i] == RSUM_KIND_ALIAS_OF_ANY() {
             return false;

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -783,13 +783,9 @@ fn handle_inst(
         Opcode::Store | Opcode::FieldSet
             // Store/FieldSet: source must outlive target's region. We model
             // this as: source's must_outlive includes the region of the
-            // target. For Phase 3 the target's region is approximated by
-            // tracing it back to its definition (parameter, alloc, etc.).
-            //
-            // For now we conservatively add the target's *containing block*
-            // region as a marker on the source, surfacing
-            // RegionConflict only when the source's region statically
-            // strictly outlives the target.
+            // target. Unknown/root-pinned targets still fall back to Root;
+            // local heap targets and parameter targets get their precise
+            // marker.
             if inst.args.len() >= 2 => {
                 // IR convention for Store / FieldSet: args = [target, source].
                 // - Store: codegen emits `store(value=arg!(1), address=arg!(0))`
@@ -800,9 +796,11 @@ fn handle_inst(
                 // source (value being stored).
                 let target_id = inst.args[0];
                 let source_id = inst.args[1];
-                if let Some(target_block) = trace_target_block(target_id, inst_lookup) {
-                    add_marker(must_outlive, source_id, MustOutliveMarker::Block(target_block));
-                }
+                add_marker(
+                    must_outlive,
+                    source_id,
+                    target_region_marker(target_id, inst_lookup, summaries),
+                );
                 // If the target traces to a parameter, record a store_effect.
                 if let Some(target_param) = trace_param(target_id, inst_lookup) {
                     let source_origin = trace_origin(source_id, inst_lookup);
@@ -812,6 +810,18 @@ fn handle_inst(
                         .insert((target_param, InternalReturnRegion::Published(source_constraint)));
                 }
             }
+        Opcode::Upsilon => {
+            if let InstData::PhiTarget(target_phi) = inst.data
+                && let Some(&source_id) = inst.args.first()
+                && let Some((target_block, _)) = inst_lookup.get(&target_phi)
+            {
+                add_marker(
+                    must_outlive,
+                    source_id,
+                    MustOutliveMarker::Block(*target_block),
+                );
+            }
+        }
         Opcode::Call => {
             // Look up callee summary and apply store-effects + return aliasing.
             let callee_summary: Option<&InternalSummary> = if let InstData::CallTarget(callee_id) =
@@ -824,10 +834,10 @@ fn handle_inst(
 
             if let Some(cs) = callee_summary {
                 // Apply store_effects: for each (target, source) effect on
-                // the callee, the caller's argument at position `target`
-                // receives values constrained by `source`. If `source` aliases
-                // a callee parameter, propagate the corresponding caller
-                // argument's must_outlive contribution back to the target arg.
+                // the callee, values constrained by `source` are stored into
+                // the region of argument `target`. If `source` aliases a callee
+                // parameter, make the corresponding caller source argument
+                // inherit the caller target argument's region marker.
                 for (target_param, source_constraint) in &cs.store_effects {
                     let target_idx = *target_param as usize;
                     if target_idx >= inst.args.len() {
@@ -840,6 +850,11 @@ fn handle_inst(
                             let p_idx = *p as usize;
                             if p_idx < inst.args.len() {
                                 let source_arg_id = inst.args[p_idx];
+                                add_marker(
+                                    must_outlive,
+                                    source_arg_id,
+                                    target_region_marker(target_arg_id, inst_lookup, summaries),
+                                );
                                 // target must outlive source — if conflict, emit.
                                 check_store_conflict(
                                     source_file,
@@ -851,12 +866,7 @@ fn handle_inst(
                                 );
                             }
                         }
-                        InternalReturnRegion::Published(RegionConstraint::FreshInCaller) => {
-                            // Callee allocates fresh and stores into target. Caller
-                            // must place the alloc in target's region; mark target
-                            // for downstream LUB.
-                            add_marker(must_outlive, target_arg_id, MustOutliveMarker::VirtualCaller);
-                        }
+                        InternalReturnRegion::Published(RegionConstraint::FreshInCaller) => {}
                         _ => {}
                     }
                 }
@@ -906,12 +916,6 @@ fn collect_regular_use_markers(
         for inst in &block.insts {
             for &arg_id in &inst.args {
                 add_marker(must_outlive, arg_id, MustOutliveMarker::Block(block.id));
-                if matches!(
-                    inst.opcode,
-                    Opcode::Call | Opcode::Store | Opcode::FieldSet | Opcode::Upsilon
-                ) {
-                    add_marker(must_outlive, arg_id, MustOutliveMarker::Root);
-                }
             }
         }
     }
@@ -1272,11 +1276,19 @@ fn trace_origin(id: InstId, inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>) ->
     }
 }
 
-fn trace_target_block(
+fn target_region_marker(
     id: InstId,
     inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>,
-) -> Option<BlockId> {
-    inst_lookup.get(&id).map(|(b, _)| *b)
+    summaries: &[InternalSummary],
+) -> MustOutliveMarker {
+    let Some((block_id, inst)) = inst_lookup.get(&id) else {
+        return MustOutliveMarker::Root;
+    };
+    match inst.opcode {
+        Opcode::GetArg => MustOutliveMarker::VirtualCaller,
+        _ if is_heap_producing(inst, summaries) => MustOutliveMarker::Block(*block_id),
+        _ => MustOutliveMarker::Root,
+    }
 }
 
 fn trace_param(id: InstId, inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>) -> Option<u32> {
@@ -2244,6 +2256,258 @@ mod tests {
             call.region,
             RegionId::Block(BlockId(0)),
             "FreshInCaller call result should allocate in the caller's local block"
+        );
+    }
+
+    #[test]
+    fn field_set_into_local_alloc_keeps_source_in_target_block() {
+        let insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                2,
+                Opcode::FieldSet,
+                Ty::Unit,
+                vec![0, 1],
+                InstData::FieldIndex(0),
+            ),
+            inst(3, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+        ];
+        let f = function(0, "field_store", vec![], Ty::I64, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        let source = &m.functions[0].blocks[0].insts[1];
+        assert_eq!(
+            source.region,
+            RegionId::Block(BlockId(0)),
+            "source stored into a local target should inherit the target's block region"
+        );
+    }
+
+    #[test]
+    fn store_into_local_alloc_keeps_source_in_target_block() {
+        let insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(2, Opcode::Store, Ty::Unit, vec![0, 1], InstData::None),
+            inst(3, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+        ];
+        let f = function(0, "store_local", vec![], Ty::I64, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        let source = &m.functions[0].blocks[0].insts[1];
+        assert_eq!(
+            source.region,
+            RegionId::Block(BlockId(0)),
+            "source stored into a local target should inherit the target's block region"
+        );
+    }
+
+    #[test]
+    fn store_into_param_routes_source_to_caller_region() {
+        let insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(2, Opcode::Store, Ty::Unit, vec![0, 1], InstData::None),
+            inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let f = function(
+            0,
+            "store_param",
+            vec![Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        let source = &m.functions[0].blocks[0].insts[1];
+        assert_eq!(
+            source.region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "source stored into a parameter target must outlive this function"
+        );
+    }
+
+    #[test]
+    fn upsilon_source_inherits_phi_target_block() {
+        let phi_id = 10u32;
+        let b0_insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                1,
+                Opcode::Upsilon,
+                Ty::Unit,
+                vec![0],
+                InstData::PhiTarget(InstId(phi_id)),
+            ),
+            inst(
+                2,
+                Opcode::Jump,
+                Ty::Unit,
+                vec![],
+                InstData::JumpTarget(BlockId(1)),
+            ),
+        ];
+        let b1_insts = vec![
+            inst(phi_id, Opcode::Phi, Ty::Ptr, vec![], InstData::None),
+            inst(11, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(12, Opcode::Return, Ty::Unit, vec![11], InstData::None),
+        ];
+        let f = function(
+            0,
+            "upsilon_target",
+            vec![],
+            Ty::I64,
+            vec![block(0, b0_insts), block(1, b1_insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        let source = &m.functions[0].blocks[0].insts[0];
+        assert_eq!(
+            source.region,
+            RegionId::Root,
+            "source feeding a Phi in another block must inherit the Phi block marker"
+        );
+    }
+
+    #[test]
+    fn store_into_root_pinned_target_routes_source_to_root() {
+        let insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                1,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![0],
+                InstData::CallExtern("__vow_string_pin_to_root".to_string()),
+            ),
+            inst(
+                2,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(3, Opcode::Store, Ty::Unit, vec![1, 2], InstData::None),
+            inst(4, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
+        ];
+        let f = function(0, "store_root", vec![], Ty::I64, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        let source = &m.functions[0].blocks[0].insts[2];
+        assert_eq!(
+            source.region,
+            RegionId::Root,
+            "source stored into a root-pinned target must route to Root"
+        );
+    }
+
+    #[test]
+    fn callee_store_effect_routes_source_arg_to_target_marker() {
+        let callee_insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+            inst(2, Opcode::Store, Ty::Unit, vec![0, 1], InstData::None),
+            inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let callee = function(
+            0,
+            "copy_param",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, callee_insts)],
+        );
+
+        let caller_insts = vec![
+            inst(
+                4,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                5,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![4],
+                InstData::CallExtern("__vow_string_pin_to_root".to_string()),
+            ),
+            inst(
+                6,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                7,
+                Opcode::Call,
+                Ty::Unit,
+                vec![5, 6],
+                InstData::CallTarget(FuncId(0)),
+            ),
+            inst(8, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let caller = function(1, "caller", vec![], Ty::Unit, vec![block(0, caller_insts)]);
+        let mut m = module(vec![callee, caller]);
+        infer_regions(&mut m);
+
+        let source = &m.functions[1].blocks[0].insts[2];
+        assert_eq!(
+            source.region,
+            RegionId::Root,
+            "caller source arg should inherit the callee store-effect target marker"
         );
     }
 

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -935,28 +935,62 @@ fn propagate_alias_markers(
     }
     for block in &func.blocks {
         for inst in &block.insts {
-            if inst.opcode != Opcode::Call {
-                continue;
-            }
-            let InstData::CallTarget(callee_id) = &inst.data else {
-                continue;
-            };
-            let Some(summary) = summaries.get(callee_id.0 as usize) else {
-                continue;
-            };
-            match &summary.return_region {
-                InternalReturnRegion::Published(RegionConstraint::AliasOf(j)) => {
-                    let j_idx = *j as usize;
-                    if j_idx < inst.args.len() {
-                        alias_edges.push((inst.id, inst.args[j_idx]));
-                    }
+            match inst.opcode {
+                Opcode::Store | Opcode::FieldSet if inst.args.len() >= 2 => {
+                    // Stored values must follow later widening of their target
+                    // container. The direct store handler already contributes
+                    // the target's origin marker; this edge catches later
+                    // use-derived markers such as `Return(target)`.
+                    alias_edges.push((inst.args[0], inst.args[1]));
                 }
-                InternalReturnRegion::Published(RegionConstraint::AliasOfAny(js)) => {
-                    for j in js {
-                        let j_idx = *j as usize;
-                        if j_idx < inst.args.len() {
-                            alias_edges.push((inst.id, inst.args[j_idx]));
+                Opcode::Call => {
+                    let InstData::CallTarget(callee_id) = &inst.data else {
+                        continue;
+                    };
+                    let Some(summary) = summaries.get(callee_id.0 as usize) else {
+                        continue;
+                    };
+                    for (target_param, source_constraint) in &summary.store_effects {
+                        let target_idx = *target_param as usize;
+                        if target_idx >= inst.args.len() {
+                            continue;
                         }
+                        let target_arg = inst.args[target_idx];
+                        match source_constraint {
+                            InternalReturnRegion::Published(RegionConstraint::AliasOf(p)) => {
+                                let p_idx = *p as usize;
+                                if p_idx < inst.args.len() {
+                                    alias_edges.push((target_arg, inst.args[p_idx]));
+                                }
+                            }
+                            InternalReturnRegion::Published(RegionConstraint::AliasOfAny(ps)) => {
+                                for p in ps {
+                                    let p_idx = *p as usize;
+                                    if p_idx < inst.args.len() {
+                                        alias_edges.push((target_arg, inst.args[p_idx]));
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    match &summary.return_region {
+                        InternalReturnRegion::Published(RegionConstraint::AliasOf(j)) => {
+                            let j_idx = *j as usize;
+                            if j_idx < inst.args.len() {
+                                alias_edges.push((inst.id, inst.args[j_idx]));
+                            }
+                        }
+                        InternalReturnRegion::Published(RegionConstraint::AliasOfAny(js)) => {
+                            for j in js {
+                                let j_idx = *j as usize;
+                                if j_idx < inst.args.len() {
+                                    alias_edges.push((inst.id, inst.args[j_idx]));
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 _ => {}
@@ -2332,6 +2366,44 @@ mod tests {
     }
 
     #[test]
+    fn store_into_escaping_local_target_widens_source_to_caller_region() {
+        let insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(2, Opcode::Store, Ty::Unit, vec![0, 1], InstData::None),
+            inst(3, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+        ];
+        let f = function(0, "store_escape", vec![], Ty::Ptr, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        let target = &m.functions[0].blocks[0].insts[0];
+        let source = &m.functions[0].blocks[0].insts[1];
+        assert_eq!(
+            target.region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "returned target should be caller-region allocated"
+        );
+        assert_eq!(
+            source.region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "source stored into an escaping target must inherit the target's caller region"
+        );
+    }
+
+    #[test]
     fn store_into_param_routes_source_to_caller_region() {
         let insts = vec![
             inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
@@ -2508,6 +2580,64 @@ mod tests {
             source.region,
             RegionId::Root,
             "caller source arg should inherit the callee store-effect target marker"
+        );
+    }
+
+    #[test]
+    fn callee_store_effect_into_escaping_target_widens_source_to_caller_region() {
+        let callee_insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+            inst(2, Opcode::Store, Ty::Unit, vec![0, 1], InstData::None),
+            inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let callee = function(
+            0,
+            "copy_param",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, callee_insts)],
+        );
+
+        let caller_insts = vec![
+            inst(
+                4,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                5,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                6,
+                Opcode::Call,
+                Ty::Unit,
+                vec![4, 5],
+                InstData::CallTarget(FuncId(0)),
+            ),
+            inst(7, Opcode::Return, Ty::Unit, vec![4], InstData::None),
+        ];
+        let caller = function(1, "caller", vec![], Ty::Ptr, vec![block(0, caller_insts)]);
+        let mut m = module(vec![callee, caller]);
+        infer_regions(&mut m);
+
+        let target = &m.functions[1].blocks[0].insts[0];
+        let source = &m.functions[1].blocks[0].insts[1];
+        assert_eq!(
+            target.region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "returned target should be caller-region allocated"
+        );
+        assert_eq!(
+            source.region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "caller source arg should inherit later escapes from the store-effect target"
         );
     }
 


### PR DESCRIPTION
Fixes #288.

## Summary
- Replace remaining blanket `Root` attribution in Rust region marker collection with destination-derived markers for `Store`, `FieldSet`, `Upsilon`, and callee `store_effects`.
- Add targeted Rust regressions for local destination stores, Phi-target Upsilon markers, callee store-effect propagation, and root-pinned destinations.
- Mirror the marker model in `compiler/region.vow` while preserving the existing self-hosted escaping-caller-region codegen limitation.

## Validation
- `cargo fmt --all`
- `cargo test -p vow-ir`
- `cargo test --all`
- `target/debug/vow build --no-verify compiler/main.vow -o /tmp/vow_main_issue288_prcheck`
- `git diff --check`

## Blocked / Not Run
- `scripts/bootstrap.sh --skip-cargo` is blocked by the Stage 2 arena-memory failure tracked in #298.
- `tests/run_tests.sh --no-bootstrap`, `scripts/full_test.sh`, and `bench/memory/run.sh` were not run because current self-hosted bootstrap validation is blocked by #298.
