### PR TITLE
Handle extern container store regions

### DIFF
--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -927,6 +927,35 @@ fn analyze_function(
                     );
                 }
             }
+            if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
+                let mut edge_idx: i64 = 0;
+                let edge_count: i64 = extern_store_edge_count(inst.ds);
+                while edge_idx < edge_count {
+                    let target_pos: i64 = extern_store_target_pos(inst.ds, edge_idx);
+                    let source_pos: i64 = extern_store_source_pos(inst.ds, edge_idx);
+                    if target_pos >= 0 && target_pos < inst.args.len()
+                        && source_pos >= 0 && source_pos < inst.args.len()
+                    {
+                        let target_id2: i64 = inst.args[target_pos];
+                        let source_id2: i64 = inst.args[source_pos];
+                        let target_param2: i64 = trace_param_shallow(id_to_inst, target_id2);
+                        if target_param2 >= 0 {
+                            let source2: DeepRet = trace_origin_shallow(id_to_inst, source_id2);
+                            add_store_effect(
+                                int_se_targets[fidx],
+                                int_se_src_kinds[fidx],
+                                int_se_src_aux[fidx],
+                                int_se_src_aliases[fidx],
+                                target_param2,
+                                source2.kind,
+                                source2.aux,
+                                source2.aliases,
+                            );
+                        }
+                    }
+                    edge_idx = edge_idx + 1;
+                }
+            }
             ii = ii + 1;
         }
         bi = bi + 1;
@@ -1138,6 +1167,21 @@ fn direct_markers_stay_in_block(
                             int_aliases_list
                         ) {
                             push_region_work(work, seen, inst.id);
+                        }
+                    }
+                    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
+                        let target_pos2: i64 = extern_store_target_for_source(inst.ds, ai);
+                        if target_pos2 >= 0 && target_pos2 < inst.args.len() {
+                            if !target_marker_is_defining_block(
+                                id_to_inst,
+                                id_to_block,
+                                inst.args[target_pos2],
+                                int_kinds,
+                                defining_block
+                            ) {
+                                return false;
+                            }
+                            push_region_work(work, seen, inst.args[target_pos2]);
                         }
                     }
                 }
@@ -1376,6 +1420,49 @@ fn deep_ret_const_global() -> DeepRet {
 fn extern_fresh_in_caller(sym: String) -> bool {
     sym == String::from("__vow_string_from_raw_parts_copy")
         || sym == String::from("__vow_vec_from_raw_parts_copy_val")
+}
+
+fn extern_store_edge_count(sym: String) -> i64 {
+    if sym == String::from("__vow_vec_push_val") { return 1; }
+    if sym == String::from("__vow_vec_set_val") { return 1; }
+    if sym == String::from("__vow_map_insert") { return 2; }
+    if sym == String::from("__vow_btreemap_insert") { return 2; }
+    0
+}
+
+fn extern_store_target_pos(sym: String, edge_idx: i64) -> i64 {
+    if edge_idx < 0 || edge_idx >= extern_store_edge_count(sym) {
+        return -1;
+    }
+    0
+}
+
+fn extern_store_source_pos(sym: String, edge_idx: i64) -> i64 {
+    if sym == String::from("__vow_vec_push_val") && edge_idx == 0 { return 1; }
+    if sym == String::from("__vow_vec_set_val") && edge_idx == 0 { return 2; }
+    if (sym == String::from("__vow_map_insert") || sym == String::from("__vow_btreemap_insert"))
+        && edge_idx == 0
+    {
+        return 1;
+    }
+    if (sym == String::from("__vow_map_insert") || sym == String::from("__vow_btreemap_insert"))
+        && edge_idx == 1
+    {
+        return 2;
+    }
+    -1
+}
+
+fn extern_store_target_for_source(sym: String, source_pos: i64) -> i64 {
+    let mut i: i64 = 0;
+    let n: i64 = extern_store_edge_count(sym);
+    while i < n {
+        if extern_store_source_pos(sym, i) == source_pos {
+            return extern_store_target_pos(sym, i);
+        }
+        i = i + 1;
+    }
+    -1
 }
 
 fn deep_ret_uninit() -> DeepRet {

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -738,6 +738,18 @@ fn extern_fresh_in_caller(sym: &str) -> bool {
     )
 }
 
+fn for_each_extern_store_edge(sym: &str, args: &[InstId], mut visit: impl FnMut(InstId, InstId)) {
+    match sym {
+        "__vow_vec_push_val" if args.len() >= 2 => visit(args[0], args[1]),
+        "__vow_vec_set_val" if args.len() >= 3 => visit(args[0], args[2]),
+        "__vow_map_insert" | "__vow_btreemap_insert" if args.len() >= 3 => {
+            visit(args[0], args[1]);
+            visit(args[0], args[2]);
+        }
+        _ => {}
+    }
+}
+
 fn is_heap_producing(inst: &Inst, summaries: &[InternalSummary]) -> bool {
     matches!(inst.opcode, Opcode::RegionAlloc)
         || matches!(
@@ -823,6 +835,24 @@ fn handle_inst(
             }
         }
         Opcode::Call => {
+            if let InstData::CallExtern(sym) = &inst.data {
+                for_each_extern_store_edge(sym, &inst.args, |target_id, source_id| {
+                    add_marker(
+                        must_outlive,
+                        source_id,
+                        target_region_marker(target_id, inst_lookup, summaries),
+                    );
+                    if let Some(target_param) = trace_param(target_id, inst_lookup) {
+                        let source_origin = trace_origin(source_id, inst_lookup);
+                        let source_constraint = origin_to_constraint(&source_origin);
+                        summary.store_effects.insert((
+                            target_param,
+                            InternalReturnRegion::Published(source_constraint),
+                        ));
+                    }
+                });
+            }
+
             // Look up callee summary and apply store-effects + return aliasing.
             let callee_summary: Option<&InternalSummary> = if let InstData::CallTarget(callee_id) =
                 &inst.data
@@ -943,56 +973,63 @@ fn propagate_alias_markers(
                     // use-derived markers such as `Return(target)`.
                     alias_edges.push((inst.args[0], inst.args[1]));
                 }
-                Opcode::Call => {
-                    let InstData::CallTarget(callee_id) = &inst.data else {
-                        continue;
-                    };
-                    let Some(summary) = summaries.get(callee_id.0 as usize) else {
-                        continue;
-                    };
-                    for (target_param, source_constraint) in &summary.store_effects {
-                        let target_idx = *target_param as usize;
-                        if target_idx >= inst.args.len() {
+                Opcode::Call => match &inst.data {
+                    InstData::CallExtern(sym) => {
+                        for_each_extern_store_edge(sym, &inst.args, |target_id, source_id| {
+                            alias_edges.push((target_id, source_id));
+                        });
+                    }
+                    InstData::CallTarget(callee_id) => {
+                        let Some(summary) = summaries.get(callee_id.0 as usize) else {
                             continue;
-                        }
-                        let target_arg = inst.args[target_idx];
-                        match source_constraint {
-                            InternalReturnRegion::Published(RegionConstraint::AliasOf(p)) => {
-                                let p_idx = *p as usize;
-                                if p_idx < inst.args.len() {
-                                    alias_edges.push((target_arg, inst.args[p_idx]));
-                                }
+                        };
+                        for (target_param, source_constraint) in &summary.store_effects {
+                            let target_idx = *target_param as usize;
+                            if target_idx >= inst.args.len() {
+                                continue;
                             }
-                            InternalReturnRegion::Published(RegionConstraint::AliasOfAny(ps)) => {
-                                for p in ps {
+                            let target_arg = inst.args[target_idx];
+                            match source_constraint {
+                                InternalReturnRegion::Published(RegionConstraint::AliasOf(p)) => {
                                     let p_idx = *p as usize;
                                     if p_idx < inst.args.len() {
                                         alias_edges.push((target_arg, inst.args[p_idx]));
+                                    }
+                                }
+                                InternalReturnRegion::Published(RegionConstraint::AliasOfAny(
+                                    ps,
+                                )) => {
+                                    for p in ps {
+                                        let p_idx = *p as usize;
+                                        if p_idx < inst.args.len() {
+                                            alias_edges.push((target_arg, inst.args[p_idx]));
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+
+                        match &summary.return_region {
+                            InternalReturnRegion::Published(RegionConstraint::AliasOf(j)) => {
+                                let j_idx = *j as usize;
+                                if j_idx < inst.args.len() {
+                                    alias_edges.push((inst.id, inst.args[j_idx]));
+                                }
+                            }
+                            InternalReturnRegion::Published(RegionConstraint::AliasOfAny(js)) => {
+                                for j in js {
+                                    let j_idx = *j as usize;
+                                    if j_idx < inst.args.len() {
+                                        alias_edges.push((inst.id, inst.args[j_idx]));
                                     }
                                 }
                             }
                             _ => {}
                         }
                     }
-
-                    match &summary.return_region {
-                        InternalReturnRegion::Published(RegionConstraint::AliasOf(j)) => {
-                            let j_idx = *j as usize;
-                            if j_idx < inst.args.len() {
-                                alias_edges.push((inst.id, inst.args[j_idx]));
-                            }
-                        }
-                        InternalReturnRegion::Published(RegionConstraint::AliasOfAny(js)) => {
-                            for j in js {
-                                let j_idx = *j as usize;
-                                if j_idx < inst.args.len() {
-                                    alias_edges.push((inst.id, inst.args[j_idx]));
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+                    _ => {}
+                },
                 _ => {}
             }
         }
@@ -2638,6 +2675,56 @@ mod tests {
             source.region,
             RegionId::Caller(HiddenRegionIdx(0)),
             "caller source arg should inherit later escapes from the store-effect target"
+        );
+    }
+
+    #[test]
+    fn extern_vec_push_into_escaping_target_widens_source_to_caller_region() {
+        let insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Unit,
+                vec![0, 1],
+                InstData::CallExtern("__vow_vec_push_val".to_string()),
+            ),
+            inst(3, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+        ];
+        let f = function(
+            0,
+            "extern_vec_push_escape",
+            vec![],
+            Ty::Ptr,
+            vec![block(0, insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        let target = &m.functions[0].blocks[0].insts[0];
+        let source = &m.functions[0].blocks[0].insts[1];
+        assert_eq!(
+            target.region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "returned extern-mutated target should be caller-region allocated"
+        );
+        assert_eq!(
+            source.region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "source stored by an extern container mutator must inherit target escapes"
         );
     }
 


### PR DESCRIPTION
Follow-up to #299.

## Summary
- Treat known extern container mutators (`__vow_vec_push_val`, `__vow_vec_set_val`, `__vow_map_insert`, `__vow_btreemap_insert`) as store edges in Rust region inference.
- Mirror the same extern-store model in `compiler/region.vow` for marker scanning and store-effect publishing.
- Add a regression for `Vec.push` into a target that later escapes so the stored source inherits the target's caller region.

## Validation
- `cargo fmt --all`
- `cargo test -p vow-ir extern_vec_push_into_escaping_target -- --nocapture`
- `cargo test -p vow-ir`
- `cargo test --all`
- `target/debug/vow build --no-verify compiler/main.vow -o /tmp/vow_main_issue288_extern_stores`
- `git diff --check`

## Notes
- `scripts/bootstrap.sh --skip-cargo` remains blocked by the Stage 2 arena-memory issue tracked in #298.
