### PR TITLE
[codex] Implement block-tree region LUB

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -503,6 +503,12 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         else { 0 }
     };
     let ir_mod: IrModule = fr.ir_mod;
+    if has_flag(argv, String::from("--dump-ir")) {
+        emit_ir_warnings(ir_mod, dctx);
+        let ir_text: String = print_module(ir_mod);
+        print_str(ir_text);
+        return 0;
+    }
     emit_ir_warnings(ir_mod, dctx);
     let do_verify: bool = !has_flag(argv, String::from("--no-verify"));
     if do_verify {
@@ -4126,14 +4132,13 @@ fn skill_full() -> String {
     r.push_str(String::from("**Phase:** Region Inference (arena-per-scope, Phase 3)\n"));
     r.push_str(String::from("**Meaning:** A heap-typed value's required lifetime cannot be satisfied by the regions the surrounding code provides. This fires when an interprocedural store-effect constraint is unsatisfiable -- for example, a value allocated in an inner block is stored into a container that outlives that block.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("> **Coverage note (as of Phase 5):** the alloc→param-via-callee shape is\n"));
+    r.push_str(String::from("> **Coverage note (as of issue #289):** the alloc→param-via-callee shape is\n"));
     r.push_str(String::from("> detected and emits this code with `Blame: Callee` and a hint pointing\n"));
     r.push_str(String::from("> at the three resolution strategies (copy into outer arena, hoist the\n"));
     r.push_str(String::from("> allocation, or restructure the data flow). Cross-parameter cases that\n"));
-    r.push_str(String::from("> require a published store-effect, Phi-of-mixed-origins, and the full\n"));
-    r.push_str(String::from("> block-tree LUB stay deferred to Phase 9 (issue #204). The spec shape\n"));
-    r.push_str(String::from("> below is stable; the residual cases above silently promote to a\n"));
-    r.push_str(String::from("> conservative `Root` region today rather than emitting a diagnostic.\n"));
+    r.push_str(String::from("> require a published store-effect and Phi-of-mixed-origins remain partial.\n"));
+    r.push_str(String::from("> Concrete block-marker sets now use the block-tree LUB from spec §4.1\n"));
+    r.push_str(String::from("> step 3; they no longer silently promote to `Root`.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("```vow\n"));
     r.push_str(String::from("fn store_into(out: Vec<String>, prefix: String) [io] {\n"));

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -90,15 +90,21 @@ fn infer_regions_module(m: IrModule, dctx: DiagCtx) -> IrModule {
     let id_to_inst_per_fn: Vec<Vec<IrInst>> = Vec::new();
     let id_to_block_per_fn: Vec<Vec<i64>> = Vec::new();
     let phi_arms_per_fn: Vec<Vec<Vec<i64>>> = Vec::new();
+    let block_parent_per_fn: Vec<Vec<i64>> = Vec::new();
+    let block_depth_per_fn: Vec<Vec<i64>> = Vec::new();
     let mut bxi: i64 = 0;
     while bxi < n_funcs {
         let f0: IrFunction = m.functions[bxi];
         let it: Vec<IrInst> = build_id_to_inst(f0);
         let ib: Vec<i64> = build_id_to_block(f0, it.len());
         let pa: Vec<Vec<i64>> = build_phi_arms(f0, it.len());
+        let bp: Vec<i64> = build_block_parent(f0);
+        let bd: Vec<i64> = build_block_depth(bp);
         id_to_inst_per_fn.push(it);
         id_to_block_per_fn.push(ib);
         phi_arms_per_fn.push(pa);
+        block_parent_per_fn.push(bp);
+        block_depth_per_fn.push(bd);
         bxi = bxi + 1;
     }
 
@@ -135,6 +141,7 @@ fn infer_regions_module(m: IrModule, dctx: DiagCtx) -> IrModule {
                 let did_change: bool = analyze_function(
                     m, fidx,
                     id_to_inst_per_fn[fidx], id_to_block_per_fn[fidx], phi_arms_per_fn[fidx],
+                    block_parent_per_fn[fidx], block_depth_per_fn[fidx],
                     int_kinds, int_auxs, int_aliases_list,
                     int_se_targets, int_se_src_kinds, int_se_src_aux, int_se_src_aliases,
                     region_keys, region_vals,
@@ -864,6 +871,7 @@ fn check_store_conflict(
 fn analyze_function(
     m: IrModule, fidx: i64,
     id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>, phi_arms: Vec<Vec<i64>>,
+    block_parent: Vec<i64>, block_depth: Vec<i64>,
     int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
     int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>,
     int_se_src_aux: Vec<Vec<i64>>, int_se_src_aliases: Vec<Vec<Vec<i64>>>,
@@ -962,43 +970,44 @@ fn analyze_function(
     }
 
     // 2. Tag heap-producing instructions whose per-destination marker LUB
-    // stays in the defining block. This mirrors the Rust pass's marker model
+    // resolves to a concrete block. This mirrors the Rust pass's marker model
     // without materializing a must_outlive set for every value: for each heap
-    // producer, scan its direct uses plus Phi/call return-alias users and
-    // reject the block placement as soon as any marker would LUB wider than
-    // the defining block. That keeps stage-2 bootstrap from allocating the
-    // full marker lattice inside the self-hosted arena.
+    // producer, gather concrete block markers from direct uses plus Phi/call
+    // return-alias users, then compute the cached block-tree LCA.
     let mut rbi: i64 = 0;
     while rbi < n_bks {
         let rb: IrBlock = bks[rbi];
         let mut rii: i64 = 0;
         while rii < rb.insts.len() {
             let rinst: IrInst = rb.insts[rii];
-            if is_heap_producing_for_region(rinst, int_kinds)
-                && value_lub_stays_in_block(
+            if rinst.op == IOP_REGION_ALLOC() {
+                let concrete_lca: i64 = value_lub_concrete_block(
                     f, rinst.id, rb.id, id_to_inst, id_to_block,
+                    block_parent, block_depth,
+                    is_scalar_ity(f.return_ty),
                     int_kinds, int_auxs, int_aliases_list,
                     int_se_targets, int_se_src_kinds, int_se_src_aux,
-                )
-            {
-                put_inst_region(
-                    region_keys[fidx],
-                    region_vals[fidx],
-                    rinst.id,
-                    region_pack(REGION_KIND_BLOCK(), rb.id)
                 );
+                if concrete_lca >= 0 {
+                    put_inst_region(
+                        region_keys[fidx],
+                        region_vals[fidx],
+                        rinst.id,
+                        region_pack(REGION_KIND_BLOCK(), concrete_lca)
+                    );
+                }
             }
             rii = rii + 1;
         }
         rbi = rbi + 1;
     }
 
-    // Escaping RegionAlloc instructions still deliberately stay Root.
+    // Non-concrete RegionAlloc instructions still deliberately stay Root.
     //
-    // Phase 9 status: the self-hosted Cranelift shim can lower block regions,
+    // Current self-hosted status: the Cranelift shim can lower block regions,
     // but `IOP_REGION_ALLOC` still has no hidden-caller-region plumbing.
     // Emitting `region_caller0()` here would break self-hosted codegen for any
-    // program with an escaping allocation. We therefore leave escaping
+    // allocation whose LUB is the virtual caller. We therefore leave those
     // allocations at their Phase-2 default (Root). The summary itself is still
     // set to FreshInCaller where appropriate so the metadata remains correct
     // for downstream consumers; only the per-inst region tag is degraded for
@@ -1058,14 +1067,18 @@ fn lookup_inst_block(id_to_block: Vec<i64>, id: i64) -> i64 {
     -1
 }
 
-fn value_lub_stays_in_block(
+fn value_lub_concrete_block(
     f: IrFunction, id: i64, defining_block: i64,
     id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>,
+    block_parent: Vec<i64>, block_depth: Vec<i64>,
+    return_is_scalar: bool,
     int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
     int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>
-) -> bool {
+) -> i64 {
     let work: Vec<i64> = Vec::new();
     let seen: Vec<i64> = Vec::new();
+    let markers: Vec<i64> = Vec::new();
+    linear_insert_i64(markers, defining_block);
     work.push(id);
     while work.len() > 0 {
         let cur: i64 = work[work.len() - 1];
@@ -1074,12 +1087,13 @@ fn value_lub_stays_in_block(
             continue;
         }
         seen.push(cur);
-        if !direct_markers_stay_in_block(
+        if !direct_markers_collect_concrete_blocks(
             f,
             cur,
-            defining_block,
             id_to_inst,
             id_to_block,
+            markers,
+            return_is_scalar,
             int_kinds,
             int_auxs,
             int_aliases_list,
@@ -1089,15 +1103,18 @@ fn value_lub_stays_in_block(
             work,
             seen
         ) {
-            return false;
+            return -1;
         }
     }
-    true
+    sort_i64_vec_inplace(markers);
+    block_tree_lca_all(block_parent, block_depth, markers)
 }
 
-fn direct_markers_stay_in_block(
-    f: IrFunction, id: i64, defining_block: i64,
+fn direct_markers_collect_concrete_blocks(
+    f: IrFunction, id: i64,
     id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>,
+    markers: Vec<i64>,
+    return_is_scalar: bool,
     int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
     int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>,
     work: Vec<i64>, seen: Vec<i64>
@@ -1113,22 +1130,21 @@ fn direct_markers_stay_in_block(
             while ai < inst.args.len() {
                 if inst.args[ai] == id {
                     // Every argument use contributes the use-block marker.
-                    if blk.id != defining_block {
-                        return false;
-                    }
-                    if inst.op == IOP_RETURN() {
+                    linear_insert_i64(markers, blk.id);
+                    if inst.op == IOP_RETURN() && !return_is_scalar {
                         return false;
                     }
                     if (inst.op == IOP_STORE() || inst.op == IOP_FIELD_SET()) && ai == 1 {
-                        if !target_marker_is_defining_block(
+                        let target_block: i64 = target_marker_concrete_block(
                             id_to_inst,
                             id_to_block,
                             inst.args[0],
-                            int_kinds,
-                            defining_block
-                        ) {
+                            int_kinds
+                        );
+                        if target_block < 0 {
                             return false;
                         }
+                        linear_insert_i64(markers, target_block);
                         // Stored values must follow later widening of their
                         // target container. The target-marker check above
                         // handles the target's origin; the work item catches
@@ -1137,25 +1153,32 @@ fn direct_markers_stay_in_block(
                     }
                     if inst.op == IOP_UPSILON() && ai == 0 && inst.dk == IDATA_PHI_TARGET() {
                         let phi_block: i64 = lookup_inst_block(id_to_block, inst.dv);
-                        if phi_block != defining_block {
+                        if phi_block < 0 {
                             return false;
                         }
+                        linear_insert_i64(markers, phi_block);
                         push_region_work(work, seen, inst.dv);
+                    }
+                    if inst.op == IOP_FIELD_GET() && ai == 0 {
+                        push_region_work(work, seen, inst.id);
+                    }
+                    if inst.op == IOP_LOAD() && ai == 0 && !is_scalar_ity(inst.ty) {
+                        push_region_work(work, seen, inst.id);
                     }
                     if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_TARGET() {
                         let callee_idx: i64 = inst.dv;
-                        if !call_store_effects_keep_source_in_block(
+                        if !call_store_effects_collect_concrete_blocks(
                             inst,
                             ai,
                             id_to_inst,
                             id_to_block,
                             int_kinds,
+                            markers,
                             int_se_targets,
                             int_se_src_kinds,
                             int_se_src_aux,
                             work,
-                            seen,
-                            defining_block
+                            seen
                         ) {
                             return false;
                         }
@@ -1169,21 +1192,22 @@ fn direct_markers_stay_in_block(
                             push_region_work(work, seen, inst.id);
                         }
                     }
-                    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
-                        let target_pos2: i64 = extern_store_target_for_source(inst.ds, ai);
-                        if target_pos2 >= 0 && target_pos2 < inst.args.len() {
-                            if !target_marker_is_defining_block(
-                                id_to_inst,
-                                id_to_block,
-                                inst.args[target_pos2],
-                                int_kinds,
-                                defining_block
-                            ) {
-                                return false;
-                            }
-                            push_region_work(work, seen, inst.args[target_pos2]);
-                        }
-                    }
+	                    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
+	                        let target_pos2: i64 = extern_store_target_for_source(inst.ds, ai);
+	                        if target_pos2 >= 0 && target_pos2 < inst.args.len() {
+	                            let target_block2: i64 = target_marker_concrete_block(
+	                                id_to_inst,
+	                                id_to_block,
+	                                inst.args[target_pos2],
+	                                int_kinds
+	                            );
+	                            if target_block2 < 0 {
+	                                return false;
+	                            }
+	                            linear_insert_i64(markers, target_block2);
+	                            push_region_work(work, seen, inst.args[target_pos2]);
+	                        }
+	                    }
                 }
                 ai = ai + 1;
             }
@@ -1207,29 +1231,29 @@ fn push_region_work(work: Vec<i64>, seen: Vec<i64>, id: i64) {
     work.push(id);
 }
 
-fn target_marker_is_defining_block(
+fn target_marker_concrete_block(
     id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>, target_id: i64,
-    int_kinds: Vec<i64>, defining_block: i64
-) -> bool {
+    int_kinds: Vec<i64>
+) -> i64 {
     let inst: IrInst = lookup_inst_or_default(id_to_inst, target_id);
     if inst.id < 0 {
-        return false;
+        return -1;
     }
     if inst.op == IOP_GET_ARG() {
-        return false;
+        return -1;
     }
     if is_heap_producing_for_region(inst, int_kinds) {
-        return lookup_inst_block(id_to_block, target_id) == defining_block;
+        return lookup_inst_block(id_to_block, target_id);
     }
-    false
+    -1
 }
 
-fn call_store_effects_keep_source_in_block(
+fn call_store_effects_collect_concrete_blocks(
     call_inst: IrInst, source_arg_pos: i64,
     id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>, int_kinds: Vec<i64>,
+    markers: Vec<i64>,
     int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>,
-    work: Vec<i64>, seen: Vec<i64>,
-    defining_block: i64
+    work: Vec<i64>, seen: Vec<i64>
 ) -> bool {
     let callee_idx: i64 = call_inst.dv;
     if callee_idx < 0 || callee_idx >= int_se_targets.len() {
@@ -1243,15 +1267,16 @@ fn call_store_effects_keep_source_in_block(
         if kinds[i] == RSUM_KIND_ALIAS_OF() && auxs[i] == source_arg_pos {
             let target_param: i64 = targets[i];
             if target_param >= 0 && target_param < call_inst.args.len() {
-                if !target_marker_is_defining_block(
+                let target_block: i64 = target_marker_concrete_block(
                     id_to_inst,
                     id_to_block,
                     call_inst.args[target_param],
-                    int_kinds,
-                    defining_block
-                ) {
+                    int_kinds
+                );
+                if target_block < 0 {
                     return false;
                 }
+                linear_insert_i64(markers, target_block);
                 push_region_work(work, seen, call_inst.args[target_param]);
             }
         } else if kinds[i] == RSUM_KIND_ALIAS_OF_ANY() {
@@ -1309,6 +1334,418 @@ fn is_scalar_ity(ty: i64) -> bool {
 // `id_to_block[id]` is the block containing that inst, or -1 for no inst.
 // `phi_arms[id]` is the list of upsilon-arm value ids targeting the
 // phi with `phi.id == id`; empty for non-phi ids.
+// `block_parent[block_id]` is the parent in the DFS-forward dominator
+// block tree, -1 for a virtual-caller child root, and -2 for a
+// missing/nonexistent block id. Back-edges are removed while collecting the
+// forward graph; joins are then parented by their real common dominator
+// instead of whichever branch DFS happened to visit first.
+// `block_depth[block_id]` is the concrete depth from that virtual caller
+// child root, or -1 for missing ids.
+fn build_block_parent(f: IrFunction) -> Vec<i64> {
+    let parent: Vec<i64> = Vec::new();
+    let max_id: i64 = max_block_id(f);
+    let mut i: i64 = 0;
+    while i <= max_id {
+        parent.push(-2);
+        i = i + 1;
+    }
+    if f.blocks.len() == 0 {
+        return parent;
+    }
+
+    let forward: Vec<Vec<i64>> = Vec::new();
+    let component: Vec<i64> = Vec::new();
+    let mut fi: i64 = 0;
+    while fi <= max_id {
+        forward.push(Vec::new());
+        component.push(-1);
+        fi = fi + 1;
+    }
+    let visited: Vec<i64> = Vec::new();
+    let on_stack: Vec<i64> = Vec::new();
+    let roots: Vec<i64> = Vec::new();
+
+    block_tree_visit_root(f, f.blocks[0].id, roots.len(), parent, component, forward, visited, on_stack);
+    roots.push(f.blocks[0].id);
+
+    let mut bi: i64 = 0;
+    while bi < f.blocks.len() {
+        let id: i64 = f.blocks[bi].id;
+        if !region_vec_contains_i64(visited, id) {
+            block_tree_visit_root(f, id, roots.len(), parent, component, forward, visited, on_stack);
+            roots.push(id);
+        }
+        bi = bi + 1;
+    }
+    block_tree_dominance_parent(parent, forward, component, roots);
+    parent
+}
+
+fn max_block_id(f: IrFunction) -> i64 {
+    let mut max_id: i64 = -1;
+    let mut i: i64 = 0;
+    while i < f.blocks.len() {
+        let id: i64 = f.blocks[i].id;
+        if id > max_id {
+            max_id = id;
+        }
+        i = i + 1;
+    }
+    max_id
+}
+
+fn block_tree_visit_root(
+    f: IrFunction, root: i64, comp: i64,
+    parent: Vec<i64>, component: Vec<i64>, forward: Vec<Vec<i64>>,
+    visited: Vec<i64>, on_stack: Vec<i64>
+) {
+    let ids: Vec<i64> = Vec::new();
+    let kinds: Vec<i64> = Vec::new();
+    ids.push(root);
+    kinds.push(0);
+    if root >= 0 && root < parent.len() {
+        parent[root] = -1;
+    }
+
+    while ids.len() > 0 {
+        let top: i64 = ids.len() - 1;
+        let id: i64 = ids[top];
+        let kind: i64 = kinds[top];
+        ids.pop();
+        kinds.pop();
+
+        if kind == 1 {
+            linear_remove_i64(on_stack, id);
+            continue;
+        }
+        if region_vec_contains_i64(visited, id) {
+            continue;
+        }
+        if !block_id_exists(f, id) {
+            continue;
+        }
+
+        visited.push(id);
+        linear_insert_i64(on_stack, id);
+        if id >= 0 && id < component.len() {
+            component[id] = comp;
+        }
+
+        ids.push(id);
+        kinds.push(1);
+
+        let succs: Vec<i64> = block_successors_by_id(f, id);
+        sort_i64_vec_inplace(succs);
+        let mut si: i64 = succs.len();
+        while si > 0 {
+            si = si - 1;
+            let succ: i64 = succs[si];
+            if !block_id_exists(f, succ) {
+                continue;
+            }
+            if region_vec_contains_i64(on_stack, succ) {
+                continue;
+            }
+            if succ >= 0 && succ < component.len() && component[succ] >= 0 && component[succ] != comp {
+                continue;
+            }
+            if id >= 0 && id < forward.len() {
+                linear_insert_i64(forward[id], succ);
+            }
+            if succ >= 0 && succ < parent.len() && parent[succ] == -2 {
+                parent[succ] = id;
+            }
+            if !region_vec_contains_i64(visited, succ) {
+                ids.push(succ);
+                kinds.push(0);
+            }
+        }
+    }
+}
+
+fn block_tree_dominance_parent(
+    parent: Vec<i64>, forward: Vec<Vec<i64>>, component: Vec<i64>, roots: Vec<i64>
+) {
+    let mut ri: i64 = 0;
+    while ri < roots.len() {
+        let root: i64 = roots[ri];
+        if root >= 0 && root < parent.len() {
+            parent[root] = -1;
+        }
+        ri = ri + 1;
+    }
+
+    let bound: i64 = forward.len() * forward.len() + 1;
+    let mut iter: i64 = 0;
+    let mut changed: bool = true;
+    while changed && iter < bound {
+        changed = false;
+        iter = iter + 1;
+        let mut pred: i64 = 0;
+        while pred < forward.len() {
+            let succs: Vec<i64> = forward[pred];
+            let mut si: i64 = 0;
+            while si < succs.len() {
+                let succ: i64 = succs[si];
+                if succ >= 0 && succ < parent.len()
+                    && pred >= 0 && pred < component.len()
+                    && succ < component.len()
+                    && component[pred] == component[succ]
+                    && parent[succ] != -1
+                {
+                    let old_parent: i64 = parent[succ];
+                    let next_parent: i64 = if old_parent == -2 {
+                        pred
+                    } else {
+                        block_tree_parent_lca(parent, old_parent, pred)
+                    };
+                    if next_parent != old_parent {
+                        parent[succ] = next_parent;
+                        changed = true;
+                    }
+                }
+                si = si + 1;
+            }
+            pred = pred + 1;
+        }
+    }
+}
+
+fn block_tree_parent_lca(parent: Vec<i64>, left0: i64, right0: i64) -> i64 {
+    let mut left: i64 = left0;
+    let mut right: i64 = right0;
+    let mut left_depth: i64 = block_parent_depth(parent, left);
+    let mut right_depth: i64 = block_parent_depth(parent, right);
+    if left_depth < 0 || right_depth < 0 {
+        return -1;
+    }
+
+    while left_depth > right_depth {
+        left = block_parent_at(parent, left);
+        left_depth = left_depth - 1;
+    }
+    while right_depth > left_depth {
+        right = block_parent_at(parent, right);
+        right_depth = right_depth - 1;
+    }
+    while left != right {
+        left = block_parent_at(parent, left);
+        right = block_parent_at(parent, right);
+        if left < 0 || right < 0 {
+            return -1;
+        }
+    }
+    left
+}
+
+fn block_parent_depth(parent: Vec<i64>, id: i64) -> i64 {
+    let seen: Vec<i64> = Vec::new();
+    let mut cur: i64 = id;
+    let mut depth: i64 = 0;
+    while cur >= 0 && cur < parent.len() {
+        if region_vec_contains_i64(seen, cur) {
+            return -1;
+        }
+        seen.push(cur);
+        let p: i64 = parent[cur];
+        if p == -1 {
+            return depth;
+        }
+        if p < 0 || p >= parent.len() {
+            return -1;
+        }
+        cur = p;
+        depth = depth + 1;
+    }
+    -1
+}
+
+fn block_id_exists(f: IrFunction, id: i64) -> bool {
+    let mut i: i64 = 0;
+    while i < f.blocks.len() {
+        if f.blocks[i].id == id {
+            return true;
+        }
+        i = i + 1;
+    }
+    false
+}
+
+fn block_successors_by_id(f: IrFunction, id: i64) -> Vec<i64> {
+    let mut i: i64 = 0;
+    while i < f.blocks.len() {
+        let blk: IrBlock = f.blocks[i];
+        if blk.id == id {
+            return linear_successors(blk);
+        }
+        i = i + 1;
+    }
+    Vec::new()
+}
+
+fn build_block_depth(parent: Vec<i64>) -> Vec<i64> {
+    let depth: Vec<i64> = Vec::new();
+    let mut i: i64 = 0;
+    while i < parent.len() {
+        depth.push(-1);
+        i = i + 1;
+    }
+    let mut j: i64 = 0;
+    while j < parent.len() {
+        if parent[j] != -2 {
+            depth[j] = block_depth_for(parent, j);
+        }
+        j = j + 1;
+    }
+    depth
+}
+
+fn block_depth_for(parent: Vec<i64>, id: i64) -> i64 {
+    let seen: Vec<i64> = Vec::new();
+    let mut cur: i64 = id;
+    let mut depth: i64 = 0;
+    while cur >= 0 && cur < parent.len() {
+        if region_vec_contains_i64(seen, cur) {
+            return -1;
+        }
+        seen.push(cur);
+        let p: i64 = parent[cur];
+        if p == -1 {
+            return depth;
+        }
+        if p < 0 || p >= parent.len() {
+            return -1;
+        }
+        cur = p;
+        depth = depth + 1;
+    }
+    -1
+}
+
+fn block_tree_lca_all(parent: Vec<i64>, depth: Vec<i64>, blocks: Vec<i64>) -> i64 {
+    if blocks.len() == 0 {
+        return -1;
+    }
+    let mut acc: i64 = blocks[0];
+    let mut i: i64 = 1;
+    while i < blocks.len() {
+        acc = block_tree_lca(parent, depth, acc, blocks[i]);
+        if acc < 0 {
+            return -1;
+        }
+        i = i + 1;
+    }
+    acc
+}
+
+fn block_tree_lca(parent: Vec<i64>, depth: Vec<i64>, left0: i64, right0: i64) -> i64 {
+    let mut left: i64 = left0;
+    let mut right: i64 = right0;
+    let mut left_depth: i64 = block_depth_at(depth, left);
+    let mut right_depth: i64 = block_depth_at(depth, right);
+    if left_depth < 0 || right_depth < 0 {
+        return -1;
+    }
+
+    while left_depth > right_depth {
+        left = block_parent_at(parent, left);
+        if left < 0 {
+            return -1;
+        }
+        left_depth = left_depth - 1;
+    }
+    while right_depth > left_depth {
+        right = block_parent_at(parent, right);
+        if right < 0 {
+            return -1;
+        }
+        right_depth = right_depth - 1;
+    }
+
+    while left != right {
+        left = block_parent_at(parent, left);
+        right = block_parent_at(parent, right);
+        if left < 0 || right < 0 {
+            return -1;
+        }
+    }
+    left
+}
+
+fn block_tree_is_ancestor(parent: Vec<i64>, ancestor: i64, block: i64) -> bool {
+    let mut cur: i64 = block;
+    while cur >= 0 {
+        if cur == ancestor {
+            return true;
+        }
+        cur = block_parent_at(parent, cur);
+    }
+    false
+}
+
+fn close_regions_for_block(
+    blk: IrBlock, block_regions: Vec<i64>, block_parent: Vec<i64>, block_depth: Vec<i64>
+) -> Vec<i64> {
+    let close_regions: Vec<i64> = Vec::new();
+    let succs: Vec<i64> = linear_successors(blk);
+    let mut i: i64 = 0;
+    while i < block_regions.len() {
+        let region_block: i64 = block_regions[i];
+        if block_tree_is_ancestor(block_parent, region_block, blk.id) {
+            let mut exits_region: bool = succs.len() == 0;
+            let mut si: i64 = 0;
+            while si < succs.len() && !exits_region {
+                if !block_tree_is_ancestor(block_parent, region_block, succs[si]) {
+                    exits_region = true;
+                }
+                si = si + 1;
+            }
+            if exits_region {
+                linear_insert_i64(close_regions, region_block);
+            }
+        }
+        i = i + 1;
+    }
+    sort_block_regions_by_depth(close_regions, block_depth);
+    close_regions
+}
+
+fn sort_block_regions_by_depth(regions: Vec<i64>, depth: Vec<i64>) {
+    let n: i64 = regions.len();
+    let mut i: i64 = 1;
+    while i < n {
+        let mut j: i64 = i;
+        while j > 0 {
+            let left: i64 = regions[j - 1];
+            let right: i64 = regions[j];
+            let left_depth: i64 = block_depth_at(depth, left);
+            let right_depth: i64 = block_depth_at(depth, right);
+            if left_depth > right_depth || (left_depth == right_depth && left > right) {
+                j = 0;
+            } else {
+                regions[j - 1] = right;
+                regions[j] = left;
+                j = j - 1;
+            }
+        }
+        i = i + 1;
+    }
+}
+
+fn block_parent_at(parent: Vec<i64>, id: i64) -> i64 {
+    if id >= 0 && id < parent.len() {
+        return parent[id];
+    }
+    -2
+}
+
+fn block_depth_at(depth: Vec<i64>, id: i64) -> i64 {
+    if id >= 0 && id < depth.len() {
+        return depth[id];
+    }
+    -1
+}
+
 fn build_id_to_inst(f: IrFunction) -> Vec<IrInst> {
     let bks: Vec<IrBlock> = f.blocks;
     let mut max_id: i64 = -1;
@@ -2009,9 +2446,9 @@ fn tarjan_sccs(cg: Vec<Vec<i64>>, n: i64) -> Vec<Vec<i64>> {
 // `REGION_KIND_BLOCK` heap-producing instruction with `IOP_REGION_OPEN` /
 // `IOP_REGION_CLOSE` markers per spec §3.5 criterion 1.
 //
-// Phase 9 status: this is live for safe local block regions. It intentionally
-// does not retag `IOP_REGION_ALLOC` by itself; inference decides which values
-// are safe to place in a block region, and this pass only materializes markers.
+// This intentionally does not retag `IOP_REGION_ALLOC` by itself; inference
+// decides which values are safe to place in a block region, and this pass only
+// materializes markers.
 // ---------------------------------------------------------------------------
 
 fn insert_region_markers_module(m: IrModule) -> IrModule {
@@ -2063,50 +2500,43 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
         }
         let mut next_id: i64 = max_id + 1;
 
-        // Pass 1: collect blocks that contain a Block-tagged heap producer.
+        // Pass 1: collect concrete block regions named by heap producers.
         let block_regions: Vec<i64> = Vec::new();
         let mut bi3: i64 = 0;
         while bi3 < f.blocks.len() {
             let blk2: IrBlock = f.blocks[bi3];
             let mut ii3: i64 = 0;
-            let mut found: bool = false;
             while ii3 < blk2.insts.len() {
                 let inst3: IrInst = blk2.insts[ii3];
                 if region_kind(inst3.rgn) == REGION_KIND_BLOCK() {
-                    found = true;
+                    let rb: i64 = region_val(inst3.rgn);
+                    linear_insert_i64(block_regions, rb);
                 }
                 ii3 = ii3 + 1;
-            }
-            if found {
-                block_regions.push(blk2.id);
             }
             bi3 = bi3 + 1;
         }
 
-        // Pass 2: insert RegionOpen at start of marked blocks and
-        // RegionClose just before the terminator.
+        let block_parent: Vec<i64> = build_block_parent(f);
+        let block_depth: Vec<i64> = build_block_depth(block_parent);
+
+        // Pass 2: insert RegionOpen at each region root and RegionClose
+        // before terminators that leave that region's block-tree subtree.
         let mut bi4: i64 = 0;
         while bi4 < f.blocks.len() {
             let blk3: IrBlock = f.blocks[bi4];
-            if region_vec_contains_i64(block_regions, blk3.id) {
-                let block_rgn: i64 = region_pack(REGION_KIND_BLOCK(), blk3.id);
-
+            let close_regions: Vec<i64> = close_regions_for_block(blk3, block_regions, block_parent, block_depth);
+            let opens_here: bool = region_vec_contains_i64(block_regions, blk3.id);
+            if opens_here || close_regions.len() > 0 {
                 let mut open_inst: IrInst = ir_inst_new(
                     next_id, IOP_REGION_OPEN(), ITY_UNIT(),
                     Vec::new(), 0, 0, 0, String::from(""),
                 );
-                open_inst = ir_inst_set_region(open_inst, block_rgn);
-                next_id = next_id + 1;
+                if opens_here {
+                    open_inst = ir_inst_set_region(open_inst, region_pack(REGION_KIND_BLOCK(), blk3.id));
+                    next_id = next_id + 1;
+                }
 
-                let mut close_inst: IrInst = ir_inst_new(
-                    next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
-                    Vec::new(), 0, 0, 0, String::from(""),
-                );
-                close_inst = ir_inst_set_region(close_inst, block_rgn);
-                next_id = next_id + 1;
-
-                // Find terminator position. The block always has one terminal
-                // inst at the tail; defensive scan covers a missing terminator.
                 let mut term_pos: i64 = blk3.insts.len();
                 let mut k: i64 = 0;
                 while k < blk3.insts.len() {
@@ -2118,20 +2548,46 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                     }
                 }
 
-                // Splice: insert close before terminator first (so the open
-                // insertion at index 0 doesn't shift term_pos).
                 let mut new_insts: Vec<IrInst> = Vec::new();
-                new_insts.push(open_inst);
+                if opens_here {
+                    new_insts.push(open_inst);
+                }
                 let mut copy_i: i64 = 0;
                 while copy_i < blk3.insts.len() {
                     if copy_i == term_pos {
-                        new_insts.push(close_inst);
+                        let mut ci: i64 = 0;
+                        while ci < close_regions.len() {
+                            let mut close_inst: IrInst = ir_inst_new(
+                                next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
+                                Vec::new(), 0, 0, 0, String::from(""),
+                            );
+                            close_inst = ir_inst_set_region(
+                                close_inst,
+                                region_pack(REGION_KIND_BLOCK(), close_regions[ci])
+                            );
+                            next_id = next_id + 1;
+                            new_insts.push(close_inst);
+                            ci = ci + 1;
+                        }
                     }
                     new_insts.push(blk3.insts[copy_i]);
                     copy_i = copy_i + 1;
                 }
                 if term_pos == blk3.insts.len() {
-                    new_insts.push(close_inst);
+                    let mut ci2: i64 = 0;
+                    while ci2 < close_regions.len() {
+                        let mut close_inst2: IrInst = ir_inst_new(
+                            next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
+                            Vec::new(), 0, 0, 0, String::from(""),
+                        );
+                        close_inst2 = ir_inst_set_region(
+                            close_inst2,
+                            region_pack(REGION_KIND_BLOCK(), close_regions[ci2])
+                        );
+                        next_id = next_id + 1;
+                        new_insts.push(close_inst2);
+                        ci2 = ci2 + 1;
+                    }
                 }
                 blk3.insts = new_insts;
                 f.blocks[bi4] = blk3;

--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -258,14 +258,13 @@ fn add(a: i64, b: i64) -> i64 vow {
 **Phase:** Region Inference (arena-per-scope, Phase 3)
 **Meaning:** A heap-typed value's required lifetime cannot be satisfied by the regions the surrounding code provides. This fires when an interprocedural store-effect constraint is unsatisfiable — for example, a value allocated in an inner block is stored into a container that outlives that block.
 
-> **Coverage note (as of Phase 5):** the alloc→param-via-callee shape is
+> **Coverage note (as of issue #289):** the alloc→param-via-callee shape is
 > detected and emits this code with `Blame: Callee` and a hint pointing
 > at the three resolution strategies (copy into outer arena, hoist the
 > allocation, or restructure the data flow). Cross-parameter cases that
-> require a published store-effect, Phi-of-mixed-origins, and the full
-> block-tree LUB stay deferred to Phase 9 (issue #204). The spec shape
-> below is stable; the residual cases above silently promote to a
-> conservative `Root` region today rather than emitting a diagnostic.
+> require a published store-effect and Phi-of-mixed-origins remain partial.
+> Concrete block-marker sets now use the block-tree LUB from spec §4.1
+> step 3; they no longer silently promote to `Root`.
 
 ```vow
 fn store_into(out: Vec<String>, prefix: String) [io] {

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -259,6 +259,65 @@ echo -e "${BOLD}Building self-hosted compiler...${RESET}"
 $RUST --no-verify compiler/main.vow -o "$TMPDIR/vowc_self" >/dev/null 2>/dev/null
 SELF="$TMPDIR/vowc_self"
 
+# ─── Section 0b: Concrete block-region parity ──────────────────────
+
+section_begin "Section 0b: Concrete Block-Region Parity"
+rust_ir="$TMPDIR/compiler_rust.ir"
+self_ir="$TMPDIR/compiler_self.ir"
+rust_ir_err="$TMPDIR/compiler_rust_ir.err"
+self_ir_err="$TMPDIR/compiler_self_ir.err"
+if "$RUST" build --no-verify --dump-ir compiler/main.vow >"$rust_ir" 2>"$rust_ir_err" \
+    && run_self build --no-verify --dump-ir compiler/main.vow >"$self_ir" 2>"$self_ir_err"; then
+    if python3 - "$rust_ir" "$self_ir" <<'PY'
+import re
+import sys
+
+inst_re = re.compile(r'%([0-9]+) = RegionAlloc.*<region=block_([0-9]+)>')
+
+def collect(path):
+    out = {}
+    func = None
+    with open(path, encoding='utf-8') as fh:
+        for line in fh:
+            if line.startswith('fn '):
+                func = line[3:].split('(', 1)[0].strip()
+                continue
+            match = inst_re.search(line)
+            if match and func is not None:
+                out[(func, int(match.group(1)))] = int(match.group(2))
+    return out
+
+rust = collect(sys.argv[1])
+self_hosted = collect(sys.argv[2])
+if rust == self_hosted:
+    print(f'OK ({len(rust)} concrete block placements)')
+    sys.exit(0)
+
+missing = sorted(set(rust) - set(self_hosted))
+extra = sorted(set(self_hosted) - set(rust))
+mismatched = sorted(k for k in set(rust) & set(self_hosted) if rust[k] != self_hosted[k])
+parts = []
+if missing:
+    parts.append('missing in self: ' + ', '.join(f'{f}%{i}->block_{rust[(f, i)]}' for f, i in missing[:8]))
+if extra:
+    parts.append('extra in self: ' + ', '.join(f'{f}%{i}->block_{self_hosted[(f, i)]}' for f, i in extra[:8]))
+if mismatched:
+    parts.append('mismatch: ' + ', '.join(
+        f'{f}%{i}: rust block_{rust[(f, i)]} vs self block_{self_hosted[(f, i)]}'
+        for f, i in mismatched[:8]
+    ))
+print('; '.join(parts))
+sys.exit(1)
+PY
+    then
+        pass "compiler/concrete-block-region-parity"
+    else
+        fail "compiler/concrete-block-region-parity" "concrete block placements differ"
+    fi
+else
+    fail "compiler/concrete-block-region-parity" "failed to dump compiler IR"
+fi
+
 # ─── Section 1: Build --no-verify ─────────────────────────────────
 
 section_begin "Section 1: Build --no-verify"

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -97,6 +97,14 @@ fn ity_to_cranelift(ty: i64) -> Option<types::Type> {
     }
 }
 
+fn signature_return_ty(ret_ty: i64, is_main: bool) -> Option<types::Type> {
+    if is_main && ret_ty == ITY_UNIT {
+        Some(types::I32)
+    } else {
+        ity_to_cranelift(ret_ty)
+    }
+}
+
 const IOP_CONST_I32: i64 = 0;
 const IOP_CONST_I64: i64 = 1;
 const IOP_CONST_F32: i64 = 2;
@@ -521,7 +529,7 @@ pub unsafe extern "C" fn __vow_clif_declare_function(
             sig.params.push(AbiParam::new(cl_ty));
         }
     }
-    if let Some(cl_ty) = ity_to_cranelift(ret_ty) {
+    if let Some(cl_ty) = signature_return_ty(ret_ty, is_main != 0) {
         sig.returns.push(AbiParam::new(cl_ty));
     }
 
@@ -882,7 +890,8 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
             sig.params.push(AbiParam::new(cl_ty));
         }
     }
-    if let Some(cl_ty) = ity_to_cranelift(ret_ty) {
+    let is_main = ctx.func_decls[fi].is_main;
+    if let Some(cl_ty) = signature_return_ty(ret_ty, is_main) {
         sig.returns.push(AbiParam::new(cl_ty));
     }
 
@@ -1650,7 +1659,12 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                         builder.ins().call(se_ref, &[]);
                     }
                     if ret_ty == ITY_UNIT {
-                        builder.ins().return_(&[]);
+                        if is_main {
+                            let zero = builder.ins().iconst(types::I32, 0);
+                            builder.ins().return_(&[zero]);
+                        } else {
+                            builder.ins().return_(&[]);
+                        }
                     } else if alen > 0 {
                         let val_id = all_args[aoff];
                         if let Some(&val) = value_map.get(&val_id) {

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -169,6 +169,14 @@ fn ir_ty_to_cranelift(ty: IrTy) -> Option<types::Type> {
     }
 }
 
+fn signature_return_ty(ir_func: &IrFunction) -> Option<types::Type> {
+    if ir_func.name == "main" && ir_func.return_ty == IrTy::Unit {
+        Some(types::I32)
+    } else {
+        ir_ty_to_cranelift(ir_func.return_ty)
+    }
+}
+
 fn build_signature(ir_func: &IrFunction, call_conv: cranelift_codegen::isa::CallConv) -> Signature {
     let mut sig = Signature::new(call_conv);
     for &param_ty in &ir_func.params {
@@ -179,7 +187,7 @@ fn build_signature(ir_func: &IrFunction, call_conv: cranelift_codegen::isa::Call
     for _ in 0..hidden_region_param_count(ir_func) {
         sig.params.push(AbiParam::new(types::I64));
     }
-    if let Some(cl_ty) = ir_ty_to_cranelift(ir_func.return_ty) {
+    if let Some(cl_ty) = signature_return_ty(ir_func) {
         sig.returns.push(AbiParam::new(cl_ty));
     }
     sig
@@ -888,7 +896,12 @@ fn lower_inst(
                 builder.ins().call(se_ref, &[]);
             }
             if ctx.return_ty == IrTy::Unit {
-                builder.ins().return_(&[]);
+                if ctx.ir_func.name == "main" {
+                    let zero = builder.ins().iconst(types::I32, 0);
+                    builder.ins().return_(&[zero]);
+                } else {
+                    builder.ins().return_(&[]);
+                }
             } else if let Some(&val_id) = inst.args.first() {
                 if let Some(&val) = ctx.value_map.get(&val_id) {
                     // Phase 4 / S5 return materialization (spec §5.1).

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -369,6 +369,281 @@ fn block_successors(block: &crate::types::BasicBlock) -> Vec<BlockId> {
     }
 }
 
+#[derive(Debug, Clone)]
+struct BlockTree {
+    parent: BTreeMap<BlockId, Option<BlockId>>,
+    depth: BTreeMap<BlockId, u32>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BlockDfsFrame {
+    Enter(BlockId, usize),
+    Exit(BlockId),
+}
+
+impl BlockTree {
+    fn from_function(func: &Function) -> Self {
+        let blocks: BTreeMap<BlockId, &crate::types::BasicBlock> =
+            func.blocks.iter().map(|block| (block.id, block)).collect();
+        let mut forward_successors: BTreeMap<BlockId, BTreeSet<BlockId>> = blocks
+            .keys()
+            .copied()
+            .map(|id| (id, BTreeSet::new()))
+            .collect();
+        let mut visited = BTreeSet::new();
+        let mut on_stack = BTreeSet::new();
+        let mut component: BTreeMap<BlockId, usize> = BTreeMap::new();
+        let mut roots: Vec<BlockId> = Vec::new();
+
+        if let Some(entry) = func.blocks.first() {
+            Self::visit_root(
+                entry.id,
+                roots.len(),
+                &blocks,
+                &mut visited,
+                &mut on_stack,
+                &mut component,
+                &mut forward_successors,
+            );
+            roots.push(entry.id);
+        }
+
+        for block in &func.blocks {
+            if !visited.contains(&block.id) {
+                Self::visit_root(
+                    block.id,
+                    roots.len(),
+                    &blocks,
+                    &mut visited,
+                    &mut on_stack,
+                    &mut component,
+                    &mut forward_successors,
+                );
+                roots.push(block.id);
+            }
+        }
+
+        let mut tree = Self {
+            parent: Self::dominance_parent(&blocks, &forward_successors, &component, &roots),
+            depth: BTreeMap::new(),
+        };
+        for &block in blocks.keys() {
+            tree.depth.insert(block, tree.compute_depth(block));
+        }
+        tree
+    }
+
+    fn visit_root(
+        root: BlockId,
+        comp: usize,
+        blocks: &BTreeMap<BlockId, &crate::types::BasicBlock>,
+        visited: &mut BTreeSet<BlockId>,
+        on_stack: &mut BTreeSet<BlockId>,
+        component: &mut BTreeMap<BlockId, usize>,
+        forward_successors: &mut BTreeMap<BlockId, BTreeSet<BlockId>>,
+    ) {
+        let mut stack = vec![BlockDfsFrame::Enter(root, comp)];
+        while let Some(frame) = stack.pop() {
+            match frame {
+                BlockDfsFrame::Enter(id, comp) => {
+                    if visited.contains(&id) {
+                        continue;
+                    }
+                    let Some(block) = blocks.get(&id) else {
+                        continue;
+                    };
+                    visited.insert(id);
+                    on_stack.insert(id);
+                    component.insert(id, comp);
+                    stack.push(BlockDfsFrame::Exit(id));
+
+                    let mut succs = block_successors(block);
+                    succs.sort_unstable();
+                    succs.dedup();
+                    for succ in succs.into_iter().rev() {
+                        if !blocks.contains_key(&succ) {
+                            continue;
+                        }
+                        if on_stack.contains(&succ) {
+                            continue;
+                        }
+                        if component
+                            .get(&succ)
+                            .is_some_and(|&succ_comp| succ_comp != comp)
+                        {
+                            continue;
+                        }
+                        forward_successors.entry(id).or_default().insert(succ);
+                        if !visited.contains(&succ) {
+                            stack.push(BlockDfsFrame::Enter(succ, comp));
+                        }
+                    }
+                }
+                BlockDfsFrame::Exit(id) => {
+                    on_stack.remove(&id);
+                }
+            }
+        }
+    }
+
+    fn dominance_parent(
+        blocks: &BTreeMap<BlockId, &crate::types::BasicBlock>,
+        forward_successors: &BTreeMap<BlockId, BTreeSet<BlockId>>,
+        component: &BTreeMap<BlockId, usize>,
+        roots: &[BlockId],
+    ) -> BTreeMap<BlockId, Option<BlockId>> {
+        let mut predecessors: BTreeMap<BlockId, Vec<BlockId>> =
+            blocks.keys().copied().map(|id| (id, Vec::new())).collect();
+        for (&pred, succs) in forward_successors {
+            for &succ in succs {
+                predecessors.entry(succ).or_default().push(pred);
+            }
+        }
+        for preds in predecessors.values_mut() {
+            preds.sort_unstable();
+            preds.dedup();
+        }
+
+        let mut by_component: BTreeMap<usize, Vec<BlockId>> = BTreeMap::new();
+        for (&block, &comp) in component {
+            by_component.entry(comp).or_default().push(block);
+        }
+
+        let mut parent: BTreeMap<BlockId, Option<BlockId>> = BTreeMap::new();
+        for (comp, mut nodes) in by_component {
+            nodes.sort_unstable();
+            let Some(&root) = roots.get(comp) else {
+                continue;
+            };
+            let all_nodes: BTreeSet<BlockId> = nodes.iter().copied().collect();
+            let mut dom: BTreeMap<BlockId, BTreeSet<BlockId>> = BTreeMap::new();
+            for &node in &nodes {
+                if node == root {
+                    dom.insert(node, BTreeSet::from([node]));
+                } else {
+                    dom.insert(node, all_nodes.clone());
+                }
+            }
+
+            let bound = nodes.len().saturating_mul(nodes.len().max(1)).max(1);
+            for _ in 0..bound {
+                let mut changed = false;
+                for &node in &nodes {
+                    if node == root {
+                        continue;
+                    }
+                    let preds: Vec<BlockId> = predecessors
+                        .get(&node)
+                        .into_iter()
+                        .flat_map(|ps| ps.iter().copied())
+                        .filter(|pred| component.get(pred) == Some(&comp))
+                        .collect();
+                    let mut pred_iter = preds.into_iter();
+                    let mut new_dom = if let Some(first_pred) = pred_iter.next() {
+                        dom.get(&first_pred).cloned().unwrap_or_default()
+                    } else {
+                        BTreeSet::new()
+                    };
+                    for pred in pred_iter {
+                        let pred_dom = dom.get(&pred).cloned().unwrap_or_default();
+                        new_dom = new_dom.intersection(&pred_dom).copied().collect();
+                    }
+                    new_dom.insert(node);
+                    if dom.get(&node) != Some(&new_dom) {
+                        dom.insert(node, new_dom);
+                        changed = true;
+                    }
+                }
+                if !changed {
+                    break;
+                }
+            }
+
+            for &node in &nodes {
+                if node == root {
+                    parent.insert(node, None);
+                    continue;
+                }
+                let mut strict_doms = dom.get(&node).cloned().unwrap_or_default();
+                strict_doms.remove(&node);
+                let idom = strict_doms
+                    .into_iter()
+                    .max_by_key(|candidate| dom.get(candidate).map(|s| s.len()).unwrap_or(0));
+                parent.insert(node, idom);
+            }
+        }
+
+        parent
+    }
+
+    fn compute_depth(&self, block: BlockId) -> u32 {
+        let mut depth = 0u32;
+        let mut seen = BTreeSet::new();
+        let mut cur = block;
+        while seen.insert(cur) {
+            let Some(parent) = self.parent.get(&cur).copied().flatten() else {
+                return depth;
+            };
+            depth = depth.saturating_add(1);
+            cur = parent;
+        }
+        0
+    }
+
+    fn lca_all(&self, blocks: &[BlockId]) -> Option<BlockId> {
+        let (&first, rest) = blocks.split_first()?;
+        let mut acc = first;
+        for &block in rest {
+            acc = self.lca(acc, block)?;
+        }
+        Some(acc)
+    }
+
+    fn lca(&self, mut left: BlockId, mut right: BlockId) -> Option<BlockId> {
+        let mut left_depth = *self.depth.get(&left)?;
+        let mut right_depth = *self.depth.get(&right)?;
+
+        while left_depth > right_depth {
+            left = self.parent.get(&left).copied().flatten()?;
+            left_depth -= 1;
+        }
+        while right_depth > left_depth {
+            right = self.parent.get(&right).copied().flatten()?;
+            right_depth -= 1;
+        }
+
+        while left != right {
+            let left_parent = self.parent.get(&left).copied().flatten();
+            let right_parent = self.parent.get(&right).copied().flatten();
+            match (left_parent, right_parent) {
+                (Some(l), Some(r)) => {
+                    left = l;
+                    right = r;
+                }
+                _ => return None,
+            }
+        }
+
+        Some(left)
+    }
+
+    fn is_ancestor(&self, ancestor: BlockId, mut block: BlockId) -> bool {
+        loop {
+            if ancestor == block {
+                return true;
+            }
+            let Some(parent) = self.parent.get(&block).copied().flatten() else {
+                return false;
+            };
+            block = parent;
+        }
+    }
+
+    fn depth_of(&self, block: BlockId) -> u32 {
+        self.depth.get(&block).copied().unwrap_or(0)
+    }
+}
+
 fn emit_live_linear_errors(
     func: &Function,
     live: &BTreeSet<InstId>,
@@ -417,7 +692,7 @@ fn emit_live_linear_errors(
 ///   `RegionId::Block(B)` on any inst's `region` field within the function.
 /// - For each such `B`, prepend `RegionOpen { region: Block(B) }` to basic
 ///   block `B`'s instruction list and insert `RegionClose { region:
-///   Block(B) }` immediately before the block's terminator.
+///   Block(B) }` before every terminator that exits `B`'s block-tree subtree.
 ///
 /// Spec §3.5 criteria 2 (call store-effects) and 3 (call FreshInCaller
 /// hidden `target_region` routing) are wired in S4 alongside the call-site
@@ -454,53 +729,91 @@ pub fn insert_region_markers(module: &mut Module) {
             continue;
         }
 
+        let block_tree = BlockTree::from_function(func);
+        let mut close_regions_by_block: BTreeMap<BlockId, Vec<BlockId>> = BTreeMap::new();
+        for block in &func.blocks {
+            let succs = block_successors(block);
+            let mut close_regions = Vec::new();
+            for &region_block in &block_regions {
+                if !block_tree.is_ancestor(region_block, block.id) {
+                    continue;
+                }
+                let exits_region = succs.is_empty()
+                    || succs
+                        .iter()
+                        .any(|&succ| !block_tree.is_ancestor(region_block, succ));
+                if exits_region {
+                    close_regions.push(region_block);
+                }
+            }
+            close_regions.sort_by(|a, b| {
+                block_tree
+                    .depth_of(*b)
+                    .cmp(&block_tree.depth_of(*a))
+                    .then_with(|| b.cmp(a))
+            });
+            if !close_regions.is_empty() {
+                close_regions_by_block.insert(block.id, close_regions);
+            }
+        }
+
         let mut next_id = next_inst_id(func);
         for block in &mut func.blocks {
-            if !block_regions.contains(&block.id) {
-                continue;
-            }
-            // Pick a span for the synthesised markers from a real inst in
-            // the block, falling back to the empty span.
-            let span = block
-                .insts
+            let old_insts = std::mem::take(&mut block.insts);
+            let span = old_insts
                 .first()
                 .map(|i| i.origin)
                 .unwrap_or(Span { start: 0, len: 0 });
+            let closes = close_regions_by_block
+                .get(&block.id)
+                .cloned()
+                .unwrap_or_default();
+            let opens_here = block_regions.contains(&block.id);
+            if !opens_here && closes.is_empty() {
+                block.insts = old_insts;
+                continue;
+            }
 
-            let open = Inst {
-                id: InstId(next_id),
-                opcode: Opcode::RegionOpen,
-                ty: Ty::Unit,
-                args: vec![],
-                data: InstData::None,
-                origin: span,
-                region: RegionId::Block(block.id),
-            };
-            next_id += 1;
-            let close = Inst {
-                id: InstId(next_id),
-                opcode: Opcode::RegionClose,
-                ty: Ty::Unit,
-                args: vec![],
-                data: InstData::None,
-                origin: span,
-                region: RegionId::Block(block.id),
-            };
-            next_id += 1;
-
-            // Insert RegionClose just before the terminator. Every
-            // well-formed block ends with a terminal opcode; spec §12.3
-            // requires close on every exit edge, which inside a single
-            // basic block reduces to "right before the terminator."
-            let term_pos = block
-                .insts
+            let term_pos = old_insts
                 .iter()
                 .position(|i| i.opcode.is_terminal())
-                .unwrap_or(block.insts.len());
-            block.insts.insert(term_pos, close);
-            // RegionOpen at the very start of the block.
-            block.insts.insert(0, open);
+                .unwrap_or(old_insts.len());
+            let mut new_insts =
+                Vec::with_capacity(old_insts.len() + usize::from(opens_here) + closes.len());
+            if opens_here {
+                new_insts.push(region_marker_inst(
+                    next_id,
+                    Opcode::RegionOpen,
+                    block.id,
+                    span,
+                ));
+                next_id += 1;
+            }
+            new_insts.extend(old_insts[..term_pos].iter().cloned());
+            for close_block in closes {
+                new_insts.push(region_marker_inst(
+                    next_id,
+                    Opcode::RegionClose,
+                    close_block,
+                    span,
+                ));
+                next_id += 1;
+            }
+            new_insts.extend(old_insts[term_pos..].iter().cloned());
+            block.insts = new_insts;
         }
+    }
+}
+
+fn region_marker_inst(id: u32, opcode: Opcode, block: BlockId, origin: Span) -> Inst {
+    Inst {
+        id: InstId(id),
+        opcode,
+        ty: Ty::Unit,
+        args: vec![],
+        data: InstData::None,
+        origin,
+        region: RegionId::Block(block),
     }
 }
 
@@ -690,6 +1003,7 @@ fn analyze_function(
 
     // Pre-collect Pizlo-SSA Upsilon→Phi arms for deep origin walks.
     let phi_arms = collect_phi_arms(func);
+    let block_tree = BlockTree::from_function(func);
 
     // Forward sweep collecting use-set contributions.
     for block in &func.blocks {
@@ -700,6 +1014,7 @@ fn analyze_function(
                 block.id,
                 &inst_lookup,
                 summaries,
+                is_scalar_ty(func.return_ty),
                 &mut must_outlive,
                 &mut summary,
                 diagnostics,
@@ -723,7 +1038,17 @@ fn analyze_function(
                 continue;
             }
             let markers = must_outlive.get(&inst.id).cloned().unwrap_or_default();
-            let region_id = lub_to_region_id(&markers, block.id);
+            let mut region_id = lub_to_region_id(&markers, block.id, &block_tree);
+            if inst.opcode == Opcode::Call {
+                // Hidden caller-region codegen is still too shallow for
+                // aggregate FreshInCaller call results that are immediately
+                // projected and repackaged. Keep call materialisation
+                // conservative; issue #289 is about concrete block LUB for
+                // RegionAlloc producers.
+                if matches!(region_id, RegionId::Block(_) | RegionId::Caller(_)) {
+                    region_id = RegionId::Root;
+                }
+            }
             region_map.insert(inst.id, region_id);
         }
     }
@@ -775,6 +1100,7 @@ fn handle_inst(
     _block_id: BlockId,
     inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>,
     summaries: &[InternalSummary],
+    return_is_scalar: bool,
     must_outlive: &mut BTreeMap<InstId, BTreeSet<MustOutliveMarker>>,
     summary: &mut InternalSummary,
     diagnostics: &mut Vec<Diagnostic>,
@@ -784,7 +1110,7 @@ fn handle_inst(
             // The returned value escapes to the virtual caller. Mark it so
             // the inst.region populate pass tags any RegionAlloc that flows
             // into the return as Caller(0).
-            if let Some(&arg_id) = inst.args.first() {
+            if !return_is_scalar && let Some(&arg_id) = inst.args.first() {
                 add_marker(must_outlive, arg_id, MustOutliveMarker::VirtualCaller);
             }
             // The actual return-region summary contribution is computed in a
@@ -837,11 +1163,12 @@ fn handle_inst(
         Opcode::Call => {
             if let InstData::CallExtern(sym) = &inst.data {
                 for_each_extern_store_edge(sym, &inst.args, |target_id, source_id| {
-                    add_marker(
-                        must_outlive,
-                        source_id,
-                        target_region_marker(target_id, inst_lookup, summaries),
-                    );
+                    let marker = if trace_param(target_id, inst_lookup).is_some() {
+                        MustOutliveMarker::Root
+                    } else {
+                        target_region_marker(target_id, inst_lookup, summaries)
+                    };
+                    add_marker(must_outlive, source_id, marker);
                     if let Some(target_param) = trace_param(target_id, inst_lookup) {
                         let source_origin = trace_origin(source_id, inst_lookup);
                         let source_constraint = origin_to_constraint(&source_origin);
@@ -966,6 +1293,16 @@ fn propagate_alias_markers(
     for block in &func.blocks {
         for inst in &block.insts {
             match inst.opcode {
+                Opcode::FieldGet => {
+                    if let Some(&source) = inst.args.first() {
+                        alias_edges.push((inst.id, source));
+                    }
+                }
+                Opcode::Load if matches!(inst.ty, Ty::Ptr | Ty::LinearPtr) => {
+                    if let Some(&source) = inst.args.first() {
+                        alias_edges.push((inst.id, source));
+                    }
+                }
                 Opcode::Store | Opcode::FieldSet if inst.args.len() >= 2 => {
                     // Stored values must follow later widening of their target
                     // container. The direct store handler already contributes
@@ -973,63 +1310,61 @@ fn propagate_alias_markers(
                     // use-derived markers such as `Return(target)`.
                     alias_edges.push((inst.args[0], inst.args[1]));
                 }
-                Opcode::Call => match &inst.data {
-                    InstData::CallExtern(sym) => {
+                Opcode::Call => {
+                    if let InstData::CallExtern(sym) = &inst.data {
                         for_each_extern_store_edge(sym, &inst.args, |target_id, source_id| {
                             alias_edges.push((target_id, source_id));
                         });
                     }
-                    InstData::CallTarget(callee_id) => {
-                        let Some(summary) = summaries.get(callee_id.0 as usize) else {
+                    let InstData::CallTarget(callee_id) = &inst.data else {
+                        continue;
+                    };
+                    let Some(summary) = summaries.get(callee_id.0 as usize) else {
+                        continue;
+                    };
+                    for (target_param, source_constraint) in &summary.store_effects {
+                        let target_idx = *target_param as usize;
+                        if target_idx >= inst.args.len() {
                             continue;
-                        };
-                        for (target_param, source_constraint) in &summary.store_effects {
-                            let target_idx = *target_param as usize;
-                            if target_idx >= inst.args.len() {
-                                continue;
+                        }
+                        let target_arg = inst.args[target_idx];
+                        match source_constraint {
+                            InternalReturnRegion::Published(RegionConstraint::AliasOf(p)) => {
+                                let p_idx = *p as usize;
+                                if p_idx < inst.args.len() {
+                                    alias_edges.push((target_arg, inst.args[p_idx]));
+                                }
                             }
-                            let target_arg = inst.args[target_idx];
-                            match source_constraint {
-                                InternalReturnRegion::Published(RegionConstraint::AliasOf(p)) => {
+                            InternalReturnRegion::Published(RegionConstraint::AliasOfAny(ps)) => {
+                                for p in ps {
                                     let p_idx = *p as usize;
                                     if p_idx < inst.args.len() {
                                         alias_edges.push((target_arg, inst.args[p_idx]));
-                                    }
-                                }
-                                InternalReturnRegion::Published(RegionConstraint::AliasOfAny(
-                                    ps,
-                                )) => {
-                                    for p in ps {
-                                        let p_idx = *p as usize;
-                                        if p_idx < inst.args.len() {
-                                            alias_edges.push((target_arg, inst.args[p_idx]));
-                                        }
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-
-                        match &summary.return_region {
-                            InternalReturnRegion::Published(RegionConstraint::AliasOf(j)) => {
-                                let j_idx = *j as usize;
-                                if j_idx < inst.args.len() {
-                                    alias_edges.push((inst.id, inst.args[j_idx]));
-                                }
-                            }
-                            InternalReturnRegion::Published(RegionConstraint::AliasOfAny(js)) => {
-                                for j in js {
-                                    let j_idx = *j as usize;
-                                    if j_idx < inst.args.len() {
-                                        alias_edges.push((inst.id, inst.args[j_idx]));
                                     }
                                 }
                             }
                             _ => {}
                         }
                     }
-                    _ => {}
-                },
+
+                    match &summary.return_region {
+                        InternalReturnRegion::Published(RegionConstraint::AliasOf(j)) => {
+                            let j_idx = *j as usize;
+                            if j_idx < inst.args.len() {
+                                alias_edges.push((inst.id, inst.args[j_idx]));
+                            }
+                        }
+                        InternalReturnRegion::Published(RegionConstraint::AliasOfAny(js)) => {
+                            for j in js {
+                                let j_idx = *j as usize;
+                                if j_idx < inst.args.len() {
+                                    alias_edges.push((inst.id, inst.args[j_idx]));
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
                 _ => {}
             }
         }
@@ -1088,7 +1423,11 @@ enum MustOutliveMarker {
 /// `defining_block` is the basic block where the allocation lives — used as
 /// the default region when the marker set yields no narrower constraint
 /// (empty set, or pure block markers reducible to the defining block).
-fn lub_to_region_id(markers: &BTreeSet<MustOutliveMarker>, defining_block: BlockId) -> RegionId {
+fn lub_to_region_id(
+    markers: &BTreeSet<MustOutliveMarker>,
+    defining_block: BlockId,
+    block_tree: &BlockTree,
+) -> RegionId {
     let mut has_caller = false;
     let mut has_root = false;
     let mut has_rodata = false;
@@ -1115,15 +1454,16 @@ fn lub_to_region_id(markers: &BTreeSet<MustOutliveMarker>, defining_block: Block
     if has_caller {
         return RegionId::Caller(HiddenRegionIdx(0));
     }
+    blocks.push(defining_block);
     blocks.sort_unstable();
     blocks.dedup();
-    if blocks.is_empty() || (blocks.len() == 1 && blocks[0] == defining_block) {
+    if blocks.len() == 1 && blocks[0] == defining_block {
         return RegionId::Block(defining_block);
     }
-    // Conservative Phase 9 rule: a concrete-block use outside the defining
-    // block needs full block-tree dominance/LUB to place safely. Until that
-    // exists, Root outlives all blocks without risking a premature close.
-    RegionId::Root
+    match block_tree.lca_all(&blocks) {
+        Some(block) => RegionId::Block(block),
+        None => RegionId::Caller(HiddenRegionIdx(0)),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1418,9 +1758,6 @@ fn origin_to_constraint(origin: &ValueOrigin) -> RegionConstraint {
 ///   flow per §4.4 + issue #200.
 ///
 /// Still outside this partial checker:
-///   * Full block-tree LUB requires a dominator tree (`lub_to_region_id`
-///     currently routes undecidable block-marker sets to `Root` — the
-///     pre-existing §4.4 compliance gap shipped with Phase 4).
 ///   * Cross-param without published spanning effect (`source = Param(p)`,
 ///     `target = Param(q)`, `p != q`): needs the caller's full summary,
 ///     which is built up forward through this same pass.
@@ -1710,6 +2047,37 @@ mod tests {
             id: BlockId(id),
             insts,
         }
+    }
+
+    fn jump_inst(id: u32, target: u32) -> Inst {
+        inst(
+            id,
+            Opcode::Jump,
+            Ty::Unit,
+            vec![],
+            InstData::JumpTarget(BlockId(target)),
+        )
+    }
+
+    fn branch_inst(id: u32, then_block: u32, else_block: u32) -> Inst {
+        inst(
+            id,
+            Opcode::Branch,
+            Ty::Unit,
+            vec![],
+            InstData::BranchTargets {
+                then_block: BlockId(then_block),
+                else_block: BlockId(else_block),
+            },
+        )
+    }
+
+    fn return_unit_inst(id: u32) -> Inst {
+        inst(id, Opcode::Return, Ty::Unit, vec![], InstData::None)
+    }
+
+    fn marker_set(markers: &[MustOutliveMarker]) -> BTreeSet<MustOutliveMarker> {
+        markers.iter().cloned().collect()
     }
 
     fn function(
@@ -2126,10 +2494,150 @@ mod tests {
     }
 
     #[test]
+    fn block_tree_lub_of_siblings_routes_to_parent_block() {
+        let f = function(
+            0,
+            "siblings",
+            vec![],
+            Ty::Unit,
+            vec![
+                block(0, vec![branch_inst(0, 1, 2)]),
+                block(1, vec![return_unit_inst(1)]),
+                block(2, vec![return_unit_inst(2)]),
+            ],
+        );
+        let tree = BlockTree::from_function(&f);
+        let markers = marker_set(&[
+            MustOutliveMarker::Block(BlockId(1)),
+            MustOutliveMarker::Block(BlockId(2)),
+        ]);
+
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(0), &tree),
+            RegionId::Block(BlockId(0))
+        );
+    }
+
+    #[test]
+    fn block_tree_lub_of_block_and_descendant_routes_to_ancestor_block() {
+        let f = function(
+            0,
+            "descendant",
+            vec![],
+            Ty::Unit,
+            vec![
+                block(0, vec![jump_inst(0, 1)]),
+                block(1, vec![jump_inst(1, 2)]),
+                block(2, vec![return_unit_inst(2)]),
+            ],
+        );
+        let tree = BlockTree::from_function(&f);
+        let markers = marker_set(&[
+            MustOutliveMarker::Block(BlockId(1)),
+            MustOutliveMarker::Block(BlockId(2)),
+        ]);
+
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(1), &tree),
+            RegionId::Block(BlockId(1))
+        );
+    }
+
+    #[test]
+    fn block_tree_lub_of_branch_and_merge_routes_to_common_parent() {
+        let f = function(
+            0,
+            "diamond",
+            vec![],
+            Ty::Unit,
+            vec![
+                block(0, vec![branch_inst(0, 1, 2)]),
+                block(1, vec![jump_inst(1, 3)]),
+                block(2, vec![jump_inst(2, 3)]),
+                block(3, vec![return_unit_inst(3)]),
+            ],
+        );
+        let tree = BlockTree::from_function(&f);
+        let markers = marker_set(&[
+            MustOutliveMarker::Block(BlockId(1)),
+            MustOutliveMarker::Block(BlockId(3)),
+        ]);
+
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(1), &tree),
+            RegionId::Block(BlockId(0))
+        );
+    }
+
+    #[test]
+    fn block_tree_lub_of_disconnected_roots_routes_to_virtual_caller() {
+        let f = function(
+            0,
+            "disconnected",
+            vec![],
+            Ty::Unit,
+            vec![
+                block(0, vec![return_unit_inst(0)]),
+                block(10, vec![return_unit_inst(10)]),
+                block(20, vec![return_unit_inst(20)]),
+            ],
+        );
+        let tree = BlockTree::from_function(&f);
+        let markers = marker_set(&[
+            MustOutliveMarker::Block(BlockId(10)),
+            MustOutliveMarker::Block(BlockId(20)),
+        ]);
+
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(10), &tree),
+            RegionId::Caller(HiddenRegionIdx(0))
+        );
+    }
+
+    #[test]
+    fn block_tree_lub_single_defining_block_marker_stays_in_defining_block() {
+        let f = function(
+            0,
+            "single",
+            vec![],
+            Ty::Unit,
+            vec![block(0, vec![return_unit_inst(0)])],
+        );
+        let tree = BlockTree::from_function(&f);
+        let markers = marker_set(&[MustOutliveMarker::Block(BlockId(0))]);
+
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(0), &tree),
+            RegionId::Block(BlockId(0))
+        );
+    }
+
+    #[test]
+    fn block_tree_lub_root_marker_forces_root() {
+        let f = function(
+            0,
+            "root",
+            vec![],
+            Ty::Unit,
+            vec![block(0, vec![return_unit_inst(0)])],
+        );
+        let tree = BlockTree::from_function(&f);
+        let markers = marker_set(&[
+            MustOutliveMarker::Root,
+            MustOutliveMarker::Block(BlockId(0)),
+        ]);
+
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(0), &tree),
+            RegionId::Root
+        );
+    }
+
+    #[test]
     fn local_alloc_used_only_locally() {
         // Allocation that does NOT escape (no return, no store-into-param):
-        // its LUB stays in the local block. Conservative Phase 3 leaves it
-        // at Block(0). We assert the inst.region was set (not Root/default).
+        // its LUB stays in the local block. We assert the inst.region was
+        // set (not Root/default).
         let insts = vec![
             inst(
                 0,
@@ -2176,8 +2684,8 @@ mod tests {
         ];
         let f = function(0, "local", vec![], Ty::I64, vec![block(0, insts)]);
         let mut m = module(vec![f]);
-        // Skip infer_regions — it would overwrite the hand-set region with
-        // `Root` while Block emission is deferred.
+        // Skip infer_regions so this test stays focused on marker insertion
+        // rather than on the inference pass shape.
         insert_region_markers(&mut m);
 
         let block_insts = &m.functions[0].blocks[0].insts;
@@ -2267,7 +2775,7 @@ mod tests {
     }
 
     #[test]
-    fn alloc_used_from_another_block_stays_root() {
+    fn alloc_used_from_descendant_block_routes_to_lca_block() {
         let b0_insts = vec![
             inst(
                 0,
@@ -2300,13 +2808,197 @@ mod tests {
         let inst0 = &m.functions[0].blocks[0].insts[0];
         assert_eq!(
             inst0.region,
-            RegionId::Root,
-            "uses outside the defining block must stay conservative"
+            RegionId::Block(BlockId(0)),
+            "a value defined in an ancestor and used in a descendant should stay in the ancestor block"
         );
     }
 
     #[test]
-    fn fresh_in_caller_call_result_used_locally_routes_to_block_region() {
+    fn ancestor_block_region_closes_at_subtree_exit() {
+        let b0_insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            jump_inst(1, 1),
+        ];
+        let b1_insts = vec![
+            inst(2, Opcode::Load, Ty::I64, vec![0], InstData::None),
+            inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+        ];
+        let f = function(
+            0,
+            "cross_block",
+            vec![],
+            Ty::I64,
+            vec![block(0, b0_insts), block(1, b1_insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+        insert_region_markers(&mut m);
+
+        let block0 = &m.functions[0].blocks[0].insts;
+        let block1 = &m.functions[0].blocks[1].insts;
+        assert_eq!(block0[0].opcode, Opcode::RegionOpen);
+        assert_eq!(block0[0].region, RegionId::Block(BlockId(0)));
+        assert!(
+            !block0.iter().any(|i| i.opcode == Opcode::RegionClose),
+            "ancestor region must not close before jumping into its subtree"
+        );
+        let close_pos = block1
+            .iter()
+            .position(|i| i.opcode == Opcode::RegionClose)
+            .expect("subtree exit should close ancestor region");
+        let return_pos = block1
+            .iter()
+            .position(|i| i.opcode == Opcode::Return)
+            .expect("test block has return");
+        assert_eq!(close_pos + 1, return_pos);
+        assert_eq!(block1[close_pos].region, RegionId::Block(BlockId(0)));
+    }
+
+    #[test]
+    fn branch_alloc_used_at_merge_opens_at_common_parent() {
+        let b0_insts = vec![branch_inst(0, 1, 2)];
+        let b1_insts = vec![
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            jump_inst(2, 3),
+        ];
+        let b2_insts = vec![jump_inst(3, 3)];
+        let b3_insts = vec![
+            inst(4, Opcode::Load, Ty::I64, vec![1], InstData::None),
+            inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
+        ];
+        let f = function(
+            0,
+            "diamond_merge_use",
+            vec![],
+            Ty::I64,
+            vec![
+                block(0, b0_insts),
+                block(1, b1_insts),
+                block(2, b2_insts),
+                block(3, b3_insts),
+            ],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+        assert_eq!(
+            m.functions[0].blocks[1].insts[0].region,
+            RegionId::Block(BlockId(0)),
+            "a branch allocation used after merge must use the merge dominator"
+        );
+
+        insert_region_markers(&mut m);
+        let block0 = &m.functions[0].blocks[0].insts;
+        let block1 = &m.functions[0].blocks[1].insts;
+        let block2 = &m.functions[0].blocks[2].insts;
+        let block3 = &m.functions[0].blocks[3].insts;
+        assert_eq!(block0[0].opcode, Opcode::RegionOpen);
+        assert_eq!(block0[0].region, RegionId::Block(BlockId(0)));
+        assert!(
+            !block1.iter().any(|i| i.opcode == Opcode::RegionOpen),
+            "the non-dominating branch must not own the region open"
+        );
+        assert!(
+            !block2.iter().any(|i| i.opcode == Opcode::RegionClose),
+            "the sibling branch must not close a region it did not open"
+        );
+        let close_pos = block3
+            .iter()
+            .position(|i| i.opcode == Opcode::RegionClose)
+            .expect("merge exit should close the common-parent region");
+        assert_eq!(block3[close_pos].region, RegionId::Block(BlockId(0)));
+    }
+
+    #[test]
+    fn vec_push_val_routes_source_to_vector_target_region() {
+        let insts = vec![
+            inst(
+                0,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![],
+                InstData::CallExtern("__vow_vec_new".to_string()),
+            ),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Unit,
+                vec![0, 1],
+                InstData::CallExtern("__vow_vec_push_val".to_string()),
+            ),
+            inst(3, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+        ];
+        let f = function(0, "vec_push", vec![], Ty::I64, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[0].blocks[0].insts[1].region,
+            RegionId::Root,
+            "a value copied into an externally-managed vector must outlive the vector target"
+        );
+    }
+
+    #[test]
+    fn vec_push_val_into_param_vector_routes_source_to_root_without_conflict() {
+        let insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Unit,
+                vec![0, 1],
+                InstData::CallExtern("__vow_vec_push_val".to_string()),
+            ),
+            inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let f = function(
+            0,
+            "vec_push_param",
+            vec![Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert_eq!(m.functions[0].blocks[0].insts[1].region, RegionId::Root);
+        assert!(
+            m.warnings
+                .iter()
+                .all(|d| d.code != ErrorCode::RegionConflict),
+            "extern vector stores into parameter vectors should widen to Root, not reject"
+        );
+    }
+
+    #[test]
+    fn fresh_in_caller_call_result_used_locally_remains_root_until_aggregate_codegen() {
         let callee = build_returning_alloc();
         let caller_insts = vec![
             inst(
@@ -2325,8 +3017,8 @@ mod tests {
         let call = &m.functions[1].blocks[0].insts[0];
         assert_eq!(
             call.region,
-            RegionId::Block(BlockId(0)),
-            "FreshInCaller call result should allocate in the caller's local block"
+            RegionId::Root,
+            "FreshInCaller call result materialization remains conservative until aggregate hidden-region codegen is complete"
         );
     }
 
@@ -2441,6 +3133,55 @@ mod tests {
     }
 
     #[test]
+    fn field_get_escape_widens_container_and_stored_source() {
+        let insts = vec![
+            inst(
+                0,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                2,
+                Opcode::FieldSet,
+                Ty::Unit,
+                vec![0, 1],
+                InstData::FieldIndex(0),
+            ),
+            inst(
+                3,
+                Opcode::FieldGet,
+                Ty::Ptr,
+                vec![0],
+                InstData::FieldIndex(0),
+            ),
+            inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+        ];
+        let f = function(0, "field_escape", vec![], Ty::Ptr, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[0].blocks[0].insts[0].region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "container read by an escaping FieldGet must be widened"
+        );
+        assert_eq!(
+            m.functions[0].blocks[0].insts[1].region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "stored source must follow the widened container"
+        );
+    }
+
+    #[test]
     fn store_into_param_routes_source_to_caller_region() {
         let insts = vec![
             inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
@@ -2473,7 +3214,7 @@ mod tests {
     }
 
     #[test]
-    fn upsilon_source_inherits_phi_target_block() {
+    fn upsilon_source_inherits_phi_target_block_lca() {
         let phi_id = 10u32;
         let b0_insts = vec![
             inst(
@@ -2516,8 +3257,8 @@ mod tests {
         let source = &m.functions[0].blocks[0].insts[0];
         assert_eq!(
             source.region,
-            RegionId::Root,
-            "source feeding a Phi in another block must inherit the Phi block marker"
+            RegionId::Block(BlockId(0)),
+            "source feeding a Phi in a descendant block should use the concrete LCA"
         );
     }
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -3402,14 +3402,13 @@ fn add(a: i64, b: i64) -> i64 vow {
 **Phase:** Region Inference (arena-per-scope, Phase 3)
 **Meaning:** A heap-typed value's required lifetime cannot be satisfied by the regions the surrounding code provides. This fires when an interprocedural store-effect constraint is unsatisfiable — for example, a value allocated in an inner block is stored into a container that outlives that block.
 
-> **Coverage note (as of Phase 5):** the alloc→param-via-callee shape is
+> **Coverage note (as of issue #289):** the alloc→param-via-callee shape is
 > detected and emits this code with `Blame: Callee` and a hint pointing
 > at the three resolution strategies (copy into outer arena, hoist the
 > allocation, or restructure the data flow). Cross-parameter cases that
-> require a published store-effect, Phi-of-mixed-origins, and the full
-> block-tree LUB stay deferred to Phase 9 (issue #204). The spec shape
-> below is stable; the residual cases above silently promote to a
-> conservative `Root` region today rather than emitting a diagnostic.
+> require a published store-effect and Phi-of-mixed-origins remain partial.
+> Concrete block-marker sets now use the block-tree LUB from spec §4.1
+> step 3; they no longer silently promote to `Root`.
 
 ```vow
 fn store_into(out: Vec<String>, prefix: String) [io] {


### PR DESCRIPTION
## Summary

Implements issue #289 by replacing the conservative block-marker `Root` fallback in region inference with a cached per-function block-tree LUB/LCA path.

- Adds Rust block-tree/LCA region inference and focused regression coverage for siblings, ancestors, disconnected roots, defining-block-only markers, and Root hard wins.
- Mirrors concrete block-region placement in the self-hosted compiler while preserving the current hidden caller-region codegen limitation for non-concrete caller cases.
- Regenerates embedded help/spec text and adds a Rust/self-hosted concrete block-region parity check to `scripts/full_test.sh`.
- Fixes the exposed `main: ()` C ABI edge in Rust codegen and the self-hosted CLIF shim so block-region closes cannot leak a stray process exit status.

## Validation

- `cargo test -p vow-ir` passed: 119 tests.
- `cargo test --all` passed; existing `vow-types::make_param` dead-code warning remains.
- `scripts/full_test.sh` ran: 336 passed, 7 failed, 1 skipped. Remaining failures are verify-counterexample absence checks for `search`, `sum_range`, `vec_fill`, `gc`, `math`, plus the existing `vec_pop_enum` Rust/self stdout divergence. `chess_uci` is green.
- `bench/memory/run.sh` passed. `alloc_loop_branch` RSS `15760 KiB` vs bound `20016 KiB`; `alloc_phi_mixed` RSS `7248 KiB` vs bound `11460 KiB`. Bounds were not lowered.