### PR TITLE
[codex] Refresh arena regions on loop backedges

### DIFF
--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1746,6 +1746,277 @@ fn block_depth_at(depth: Vec<i64>, id: i64) -> i64 {
     -1
 }
 
+struct BackEdges {
+    preds: Vec<i64>,
+    headers: Vec<i64>,
+}
+
+fn back_edges_new() -> BackEdges {
+    BackEdges {
+        preds: Vec::new(),
+        headers: Vec::new(),
+    }
+}
+
+fn back_edges_contains(edges: BackEdges, pred: i64, header: i64) -> bool {
+    let mut i: i64 = 0;
+    while i < edges.preds.len() {
+        if edges.preds[i] == pred && edges.headers[i] == header {
+            return true;
+        }
+        i = i + 1;
+    }
+    false
+}
+
+fn back_edges_push_unique(edges: BackEdges, pred: i64, header: i64) {
+    if !back_edges_contains(edges, pred, header) {
+        edges.preds.push(pred);
+        edges.headers.push(header);
+    }
+}
+
+fn sort_back_edges(edges: BackEdges) {
+    let n: i64 = edges.preds.len();
+    let mut i: i64 = 1;
+    while i < n {
+        let mut j: i64 = i;
+        while j > 0 {
+            let lp: i64 = edges.preds[j - 1];
+            let lh: i64 = edges.headers[j - 1];
+            let rp: i64 = edges.preds[j];
+            let rh: i64 = edges.headers[j];
+            if lp < rp || (lp == rp && lh <= rh) {
+                j = 0;
+            } else {
+                edges.preds[j - 1] = rp;
+                edges.headers[j - 1] = rh;
+                edges.preds[j] = lp;
+                edges.headers[j] = lh;
+                j = j - 1;
+            }
+        }
+        i = i + 1;
+    }
+}
+
+fn detect_loop_back_edges(f: IrFunction) -> BackEdges {
+    let edges: BackEdges = back_edges_new();
+    let starts: Vec<i64> = Vec::new();
+    if f.blocks.len() > 0 {
+        starts.push(f.blocks[0].id);
+    }
+    let rest: Vec<i64> = Vec::new();
+    let mut bi: i64 = 0;
+    while bi < f.blocks.len() {
+        let id: i64 = f.blocks[bi].id;
+        if !region_vec_contains_i64(starts, id) {
+            rest.push(id);
+        }
+        bi = bi + 1;
+    }
+    sort_i64_vec_inplace(rest);
+    let mut ri: i64 = 0;
+    while ri < rest.len() {
+        starts.push(rest[ri]);
+        ri = ri + 1;
+    }
+
+    let visited: Vec<i64> = Vec::new();
+    let on_stack: Vec<i64> = Vec::new();
+    let mut si: i64 = 0;
+    while si < starts.len() {
+        let start: i64 = starts[si];
+        if region_vec_contains_i64(visited, start) {
+            si = si + 1;
+            continue;
+        }
+        let ids: Vec<i64> = Vec::new();
+        let kinds: Vec<i64> = Vec::new();
+        ids.push(start);
+        kinds.push(0);
+        while ids.len() > 0 {
+            let top: i64 = ids.len() - 1;
+            let id2: i64 = ids[top];
+            let kind: i64 = kinds[top];
+            ids.pop();
+            kinds.pop();
+
+            if kind == 1 {
+                linear_remove_i64(on_stack, id2);
+                continue;
+            }
+            if region_vec_contains_i64(visited, id2) {
+                continue;
+            }
+            if !block_id_exists(f, id2) {
+                continue;
+            }
+
+            visited.push(id2);
+            linear_insert_i64(on_stack, id2);
+            ids.push(id2);
+            kinds.push(1);
+
+            let succs: Vec<i64> = block_successors_by_id(f, id2);
+            sort_i64_vec_inplace(succs);
+            let mut succ_i: i64 = succs.len();
+            while succ_i > 0 {
+                succ_i = succ_i - 1;
+                let succ: i64 = succs[succ_i];
+                if !block_id_exists(f, succ) {
+                    continue;
+                }
+                if region_vec_contains_i64(on_stack, succ) {
+                    back_edges_push_unique(edges, id2, succ);
+                    continue;
+                }
+                if !region_vec_contains_i64(visited, succ) {
+                    ids.push(succ);
+                    kinds.push(0);
+                }
+            }
+        }
+        si = si + 1;
+    }
+    sort_back_edges(edges);
+    edges
+}
+
+fn forward_graph_without_back_edges(f: IrFunction, edges: BackEdges) -> Vec<Vec<i64>> {
+    let graph: Vec<Vec<i64>> = Vec::new();
+    let max_id: i64 = max_block_id(f);
+    let mut i: i64 = 0;
+    while i <= max_id {
+        graph.push(Vec::new());
+        i = i + 1;
+    }
+    let mut bi: i64 = 0;
+    while bi < f.blocks.len() {
+        let blk: IrBlock = f.blocks[bi];
+        if blk.id >= 0 && blk.id < graph.len() {
+            let succs: Vec<i64> = linear_successors(blk);
+            sort_i64_vec_inplace(succs);
+            let mut si: i64 = 0;
+            while si < succs.len() {
+                let succ: i64 = succs[si];
+                if succ >= 0 && succ < graph.len() && !back_edges_contains(edges, blk.id, succ) {
+                    linear_insert_i64(graph[blk.id], succ);
+                }
+                si = si + 1;
+            }
+        }
+        bi = bi + 1;
+    }
+    graph
+}
+
+fn reverse_graph(graph: Vec<Vec<i64>>) -> Vec<Vec<i64>> {
+    let rev: Vec<Vec<i64>> = Vec::new();
+    let mut i: i64 = 0;
+    while i < graph.len() {
+        rev.push(Vec::new());
+        i = i + 1;
+    }
+    let mut pred: i64 = 0;
+    while pred < graph.len() {
+        let succs: Vec<i64> = graph[pred];
+        let mut si: i64 = 0;
+        while si < succs.len() {
+            let succ: i64 = succs[si];
+            if succ >= 0 && succ < rev.len() {
+                linear_insert_i64(rev[succ], pred);
+            }
+            si = si + 1;
+        }
+        pred = pred + 1;
+    }
+    rev
+}
+
+fn reachable_from_blocks(starts: Vec<i64>, graph: Vec<Vec<i64>>) -> Vec<i64> {
+    let reachable: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec::new();
+    let mut si: i64 = 0;
+    while si < starts.len() {
+        stack.push(starts[si]);
+        si = si + 1;
+    }
+    sort_i64_vec_inplace(stack);
+    while stack.len() > 0 {
+        let block: i64 = stack[stack.len() - 1];
+        stack.pop();
+        if region_vec_contains_i64(reachable, block) {
+            continue;
+        }
+        reachable.push(block);
+        if block >= 0 && block < graph.len() {
+            let succs: Vec<i64> = graph[block];
+            let mut gi: i64 = succs.len();
+            while gi > 0 {
+                gi = gi - 1;
+                let succ: i64 = succs[gi];
+                if !region_vec_contains_i64(reachable, succ) {
+                    stack.push(succ);
+                }
+            }
+        }
+    }
+    sort_i64_vec_inplace(reachable);
+    reachable
+}
+
+fn refresh_regions_for_block(
+    pred: i64, block_regions: Vec<i64>, edges: BackEdges,
+    forward: Vec<Vec<i64>>, reverse: Vec<Vec<i64>>
+) -> Vec<i64> {
+    let refresh: Vec<i64> = Vec::new();
+    let mut ei: i64 = 0;
+    while ei < edges.preds.len() {
+        if edges.preds[ei] == pred {
+            let header: i64 = edges.headers[ei];
+            let header_succs: Vec<i64> = Vec::new();
+            if header >= 0 && header < forward.len() {
+                let src: Vec<i64> = forward[header];
+                let mut si: i64 = 0;
+                while si < src.len() {
+                    header_succs.push(src[si]);
+                    si = si + 1;
+                }
+            }
+            let reachable_from_header: Vec<i64> = reachable_from_blocks(header_succs, forward);
+            let pred_start: Vec<i64> = Vec::new();
+            pred_start.push(pred);
+            let reaches_pred: Vec<i64> = reachable_from_blocks(pred_start, reverse);
+            let mut ri: i64 = 0;
+            while ri < block_regions.len() {
+                let region_block: i64 = block_regions[ri];
+                if region_vec_contains_i64(reachable_from_header, region_block)
+                    && region_vec_contains_i64(reaches_pred, region_block)
+                {
+                    linear_insert_i64(refresh, region_block);
+                }
+                ri = ri + 1;
+            }
+        }
+        ei = ei + 1;
+    }
+    sort_i64_vec_inplace(refresh);
+    refresh
+}
+
+fn remove_regions(regions: Vec<i64>, remove: Vec<i64>) -> Vec<i64> {
+    let kept: Vec<i64> = Vec::new();
+    let mut i: i64 = 0;
+    while i < regions.len() {
+        if !region_vec_contains_i64(remove, regions[i]) {
+            kept.push(regions[i]);
+        }
+        i = i + 1;
+    }
+    kept
+}
+
 fn build_id_to_inst(f: IrFunction) -> Vec<IrInst> {
     let bks: Vec<IrBlock> = f.blocks;
     let mut max_id: i64 = -1;
@@ -2519,15 +2790,22 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
 
         let block_parent: Vec<i64> = build_block_parent(f);
         let block_depth: Vec<i64> = build_block_depth(block_parent);
+        let back_edges: BackEdges = detect_loop_back_edges(f);
+        let forward_no_backedges: Vec<Vec<i64>> = forward_graph_without_back_edges(f, back_edges);
+        let reverse_no_backedges: Vec<Vec<i64>> = reverse_graph(forward_no_backedges);
 
         // Pass 2: insert RegionOpen at each region root and RegionClose
         // before terminators that leave that region's block-tree subtree.
         let mut bi4: i64 = 0;
         while bi4 < f.blocks.len() {
             let blk3: IrBlock = f.blocks[bi4];
-            let close_regions: Vec<i64> = close_regions_for_block(blk3, block_regions, block_parent, block_depth);
+            let refresh_regions: Vec<i64> = refresh_regions_for_block(
+                blk3.id, block_regions, back_edges, forward_no_backedges, reverse_no_backedges
+            );
+            let close_regions0: Vec<i64> = close_regions_for_block(blk3, block_regions, block_parent, block_depth);
+            let close_regions: Vec<i64> = remove_regions(close_regions0, refresh_regions);
             let opens_here: bool = region_vec_contains_i64(block_regions, blk3.id);
-            if opens_here || close_regions.len() > 0 {
+            if opens_here || close_regions.len() > 0 || refresh_regions.len() > 0 {
                 let mut open_inst: IrInst = ir_inst_new(
                     next_id, IOP_REGION_OPEN(), ITY_UNIT(),
                     Vec::new(), 0, 0, 0, String::from(""),
@@ -2556,24 +2834,48 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                 while copy_i < blk3.insts.len() {
                     if copy_i == term_pos {
                         let mut ci: i64 = 0;
-                        while ci < close_regions.len() {
-                            let mut close_inst: IrInst = ir_inst_new(
-                                next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
-                                Vec::new(), 0, 0, 0, String::from(""),
+	                    while ci < close_regions.len() {
+	                        let mut close_inst: IrInst = ir_inst_new(
+	                            next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
+	                            Vec::new(), 0, 0, 0, String::from(""),
                             );
                             close_inst = ir_inst_set_region(
                                 close_inst,
                                 region_pack(REGION_KIND_BLOCK(), close_regions[ci])
                             );
                             next_id = next_id + 1;
-                            new_insts.push(close_inst);
-                            ci = ci + 1;
-                        }
-                    }
-                    new_insts.push(blk3.insts[copy_i]);
-                    copy_i = copy_i + 1;
-                }
-                if term_pos == blk3.insts.len() {
+	                        new_insts.push(close_inst);
+	                        ci = ci + 1;
+	                    }
+	                    let mut ri: i64 = 0;
+	                    while ri < refresh_regions.len() {
+	                        let mut refresh_close: IrInst = ir_inst_new(
+	                            next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
+	                            Vec::new(), 0, 0, 0, String::from(""),
+	                        );
+	                        refresh_close = ir_inst_set_region(
+	                            refresh_close,
+	                            region_pack(REGION_KIND_BLOCK(), refresh_regions[ri])
+	                        );
+	                        next_id = next_id + 1;
+	                        new_insts.push(refresh_close);
+	                        let mut refresh_open: IrInst = ir_inst_new(
+	                            next_id, IOP_REGION_OPEN(), ITY_UNIT(),
+	                            Vec::new(), 0, 0, 0, String::from(""),
+	                        );
+	                        refresh_open = ir_inst_set_region(
+	                            refresh_open,
+	                            region_pack(REGION_KIND_BLOCK(), refresh_regions[ri])
+	                        );
+	                        next_id = next_id + 1;
+	                        new_insts.push(refresh_open);
+	                        ri = ri + 1;
+	                    }
+	                }
+	                new_insts.push(blk3.insts[copy_i]);
+	                copy_i = copy_i + 1;
+	            }
+	            if term_pos == blk3.insts.len() {
                     let mut ci2: i64 = 0;
                     while ci2 < close_regions.len() {
                         let mut close_inst2: IrInst = ir_inst_new(
@@ -2585,13 +2887,37 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                             region_pack(REGION_KIND_BLOCK(), close_regions[ci2])
                         );
                         next_id = next_id + 1;
-                        new_insts.push(close_inst2);
-                        ci2 = ci2 + 1;
-                    }
-                }
-                blk3.insts = new_insts;
-                f.blocks[bi4] = blk3;
-            }
+	                    new_insts.push(close_inst2);
+	                    ci2 = ci2 + 1;
+	                }
+	                let mut ri2: i64 = 0;
+	                while ri2 < refresh_regions.len() {
+	                    let mut refresh_close2: IrInst = ir_inst_new(
+	                        next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
+	                        Vec::new(), 0, 0, 0, String::from(""),
+	                    );
+	                    refresh_close2 = ir_inst_set_region(
+	                        refresh_close2,
+	                        region_pack(REGION_KIND_BLOCK(), refresh_regions[ri2])
+	                    );
+	                    next_id = next_id + 1;
+	                    new_insts.push(refresh_close2);
+	                    let mut refresh_open2: IrInst = ir_inst_new(
+	                        next_id, IOP_REGION_OPEN(), ITY_UNIT(),
+	                        Vec::new(), 0, 0, 0, String::from(""),
+	                    );
+	                    refresh_open2 = ir_inst_set_region(
+	                        refresh_open2,
+	                        region_pack(REGION_KIND_BLOCK(), refresh_regions[ri2])
+	                    );
+	                    next_id = next_id + 1;
+	                    new_insts.push(refresh_open2);
+	                    ri2 = ri2 + 1;
+	                }
+	            }
+	            blk3.insts = new_insts;
+	            f.blocks[bi4] = blk3;
+	        }
             bi4 = bi4 + 1;
         }
 

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2904,6 +2904,7 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
             }
 
             let mut new_insts: Vec<IrInst> = Vec::new();
+            let mut block_changed: bool = opens_here;
             if opens_here {
                 let mut open_inst: IrInst = region_marker_inst(next_id, IOP_REGION_OPEN(), blk3.id);
                 next_id = next_id + 1;
@@ -2937,6 +2938,7 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                             next_id = split.next_id;
                             then_target = split.block.id;
                             extra_blocks.push(split.block);
+                            block_changed = true;
                         }
                         if else_close.len() > 0 || else_refresh.len() > 0 {
                             let split2: EdgeSplitBlock = build_edge_split_block(
@@ -2946,6 +2948,7 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                             next_id = split2.next_id;
                             else_target = split2.block.id;
                             extra_blocks.push(split2.block);
+                            block_changed = true;
                         }
                         new_insts.push(branch_inst_with_targets(term, then_target, else_target));
                     } else if term.op == IOP_JUMP() && term.dk == IDATA_JUMP_TARGET() {
@@ -2955,6 +2958,9 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                         let jump_close: Vec<i64> = close_regions_for_edge(
                             blk3.id, term.dv, true, block_regions, block_parent, block_depth, jump_refresh
                         );
+                        if jump_close.len() > 0 || jump_refresh.len() > 0 {
+                            block_changed = true;
+                        }
                         next_id = append_region_markers(new_insts, next_id, jump_close, jump_refresh);
                         new_insts.push(term);
                     } else {
@@ -2963,6 +2969,9 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                             blk3.id, 0, false, block_regions, block_parent, block_depth, no_refresh
                         );
                         let no_succ_refresh: Vec<i64> = Vec::new();
+                        if no_succ_close.len() > 0 {
+                            block_changed = true;
+                        }
                         next_id = append_region_markers(new_insts, next_id, no_succ_close, no_succ_refresh);
                         new_insts.push(term);
                     }
@@ -2977,9 +2986,12 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                     blk3.id, 0, false, block_regions, block_parent, block_depth, no_refresh2
                 );
                 let no_succ_refresh2: Vec<i64> = Vec::new();
+                if no_succ_close2.len() > 0 {
+                    block_changed = true;
+                }
                 next_id = append_region_markers(new_insts, next_id, no_succ_close2, no_succ_refresh2);
             }
-            if opens_here || new_insts.len() != blk3.insts.len() {
+            if block_changed {
                 blk3.insts = new_insts;
                 f.blocks[bi4] = blk3;
             }

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1683,24 +1683,17 @@ fn block_tree_is_ancestor(parent: Vec<i64>, ancestor: i64, block: i64) -> bool {
     false
 }
 
-fn close_regions_for_block(
-    blk: IrBlock, block_regions: Vec<i64>, block_parent: Vec<i64>, block_depth: Vec<i64>
+fn close_regions_for_edge(
+    pred: i64, succ: i64, has_succ: bool, block_regions: Vec<i64>,
+    block_parent: Vec<i64>, block_depth: Vec<i64>, refresh_regions: Vec<i64>
 ) -> Vec<i64> {
     let close_regions: Vec<i64> = Vec::new();
-    let succs: Vec<i64> = linear_successors(blk);
     let mut i: i64 = 0;
     while i < block_regions.len() {
         let region_block: i64 = block_regions[i];
-        if block_tree_is_ancestor(block_parent, region_block, blk.id) {
-            let mut exits_region: bool = succs.len() == 0;
-            let mut si: i64 = 0;
-            while si < succs.len() && !exits_region {
-                if !block_tree_is_ancestor(block_parent, region_block, succs[si]) {
-                    exits_region = true;
-                }
-                si = si + 1;
-            }
-            if exits_region {
+        if block_tree_is_ancestor(block_parent, region_block, pred) {
+            let exits_region: bool = !has_succ || !block_tree_is_ancestor(block_parent, region_block, succ);
+            if exits_region && !region_vec_contains_i64(refresh_regions, region_block) {
                 linear_insert_i64(close_regions, region_block);
             }
         }
@@ -1966,14 +1959,14 @@ fn reachable_from_blocks(starts: Vec<i64>, graph: Vec<Vec<i64>>) -> Vec<i64> {
     reachable
 }
 
-fn refresh_regions_for_block(
-    pred: i64, block_regions: Vec<i64>, edges: BackEdges,
+fn refresh_regions_for_edge(
+    pred: i64, succ: i64, block_regions: Vec<i64>, edges: BackEdges,
     forward: Vec<Vec<i64>>, reverse: Vec<Vec<i64>>
 ) -> Vec<i64> {
     let refresh: Vec<i64> = Vec::new();
     let mut ei: i64 = 0;
     while ei < edges.preds.len() {
-        if edges.preds[ei] == pred {
+        if edges.preds[ei] == pred && edges.headers[ei] == succ {
             let header: i64 = edges.headers[ei];
             let header_succs: Vec<i64> = Vec::new();
             header_succs.push(header);
@@ -2016,6 +2009,90 @@ fn remove_regions(regions: Vec<i64>, remove: Vec<i64>) -> Vec<i64> {
         i = i + 1;
     }
     kept
+}
+
+fn region_marker_inst(id: i64, op: i64, region_block: i64) -> IrInst {
+    let mut marker: IrInst = ir_inst_new(
+        id, op, ITY_UNIT(), Vec::new(), 0, 0, 0, String::from("")
+    );
+    marker = ir_inst_set_region(marker, region_pack(REGION_KIND_BLOCK(), region_block));
+    marker
+}
+
+fn append_region_markers(
+    insts: Vec<IrInst>, next_id: i64, close_regions: Vec<i64>, refresh_regions: Vec<i64>
+) -> i64 {
+    let mut id: i64 = next_id;
+    let mut ci: i64 = 0;
+    while ci < close_regions.len() {
+        insts.push(region_marker_inst(id, IOP_REGION_CLOSE(), close_regions[ci]));
+        id = id + 1;
+        ci = ci + 1;
+    }
+    let mut ri: i64 = 0;
+    while ri < refresh_regions.len() {
+        insts.push(region_marker_inst(id, IOP_REGION_CLOSE(), refresh_regions[ri]));
+        id = id + 1;
+        insts.push(region_marker_inst(id, IOP_REGION_OPEN(), refresh_regions[ri]));
+        id = id + 1;
+        ri = ri + 1;
+    }
+    id
+}
+
+struct EdgeSplitBlock {
+    block: IrBlock,
+    next_id: i64,
+}
+
+fn build_edge_split_block(
+    block_id: i64, next_id: i64, close_regions: Vec<i64>, refresh_regions: Vec<i64>,
+    edge_upsilons: Vec<IrInst>, target: i64
+) -> EdgeSplitBlock {
+    let blk: IrBlock = ir_block_new(block_id);
+    let mut id: i64 = append_region_markers(blk.insts, next_id, close_regions, refresh_regions);
+    let mut ui: i64 = 0;
+    while ui < edge_upsilons.len() {
+        let src: IrInst = edge_upsilons[ui];
+        let copied: IrInst = IrInst {
+            id: id,
+            op: src.op,
+            ty: src.ty,
+            args: src.args,
+            dk: src.dk,
+            dv: src.dv,
+            dv2: src.dv2,
+            ds: src.ds,
+            ostart: src.ostart,
+            olen: src.olen,
+            rgn: src.rgn,
+        };
+        id = id + 1;
+        blk.insts.push(copied);
+        ui = ui + 1;
+    }
+    let jump_inst: IrInst = ir_inst_new(
+        id, IOP_JUMP(), ITY_UNIT(), Vec::new(), IDATA_JUMP_TARGET(), target, 0, String::from("")
+    );
+    id = id + 1;
+    blk.insts.push(jump_inst);
+    EdgeSplitBlock { block: blk, next_id: id }
+}
+
+fn branch_inst_with_targets(inst: IrInst, then_block: i64, else_block: i64) -> IrInst {
+    IrInst {
+        id: inst.id,
+        op: inst.op,
+        ty: inst.ty,
+        args: inst.args,
+        dk: inst.dk,
+        dv: then_block,
+        dv2: else_block,
+        ds: inst.ds,
+        ostart: inst.ostart,
+        olen: inst.olen,
+        rgn: inst.rgn,
+    }
 }
 
 fn build_id_to_inst(f: IrFunction) -> Vec<IrInst> {
@@ -2795,131 +2872,124 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
         let forward_no_backedges: Vec<Vec<i64>> = forward_graph_without_back_edges(f, back_edges);
         let reverse_no_backedges: Vec<Vec<i64>> = reverse_graph(forward_no_backedges);
 
-        // Pass 2: insert RegionOpen at each region root and RegionClose
-        // before terminators that leave that region's block-tree subtree.
+        let mut next_block_id: i64 = max_block_id(f) + 1;
+        let extra_blocks: Vec<IrBlock> = Vec::new();
+
+        // Pass 2: insert RegionOpen at each region root, and materialize
+        // close/refresh markers on the exact control-flow edge that needs
+        // them. Branches with mixed exit/backedge successors split only the
+        // marked edges so exit paths do not reopen a region they are leaving.
         let mut bi4: i64 = 0;
         while bi4 < f.blocks.len() {
             let blk3: IrBlock = f.blocks[bi4];
-            let refresh_regions: Vec<i64> = refresh_regions_for_block(
-                blk3.id, block_regions, back_edges, forward_no_backedges, reverse_no_backedges
-            );
-            let close_regions0: Vec<i64> = close_regions_for_block(blk3, block_regions, block_parent, block_depth);
-            let close_regions: Vec<i64> = remove_regions(close_regions0, refresh_regions);
             let opens_here: bool = region_vec_contains_i64(block_regions, blk3.id);
-            if opens_here || close_regions.len() > 0 || refresh_regions.len() > 0 {
-                let mut open_inst: IrInst = ir_inst_new(
-                    next_id, IOP_REGION_OPEN(), ITY_UNIT(),
-                    Vec::new(), 0, 0, 0, String::from(""),
-                );
-                if opens_here {
-                    open_inst = ir_inst_set_region(open_inst, region_pack(REGION_KIND_BLOCK(), blk3.id));
-                    next_id = next_id + 1;
-                }
 
-                let mut term_pos: i64 = blk3.insts.len();
-                let mut k: i64 = 0;
-                while k < blk3.insts.len() {
-                    if iop_is_terminal(blk3.insts[k].op) {
-                        term_pos = k;
-                        k = blk3.insts.len();
+            let mut term_pos: i64 = blk3.insts.len();
+            let mut k: i64 = 0;
+            while k < blk3.insts.len() {
+                if iop_is_terminal(blk3.insts[k].op) {
+                    term_pos = k;
+                    k = blk3.insts.len();
+                } else {
+                    k = k + 1;
+                }
+            }
+            let edge_upsilons: Vec<IrInst> = Vec::new();
+            let mut ui0: i64 = term_pos + 1;
+            while ui0 < blk3.insts.len() {
+                if blk3.insts[ui0].op == IOP_UPSILON() {
+                    edge_upsilons.push(blk3.insts[ui0]);
+                }
+                ui0 = ui0 + 1;
+            }
+
+            let mut new_insts: Vec<IrInst> = Vec::new();
+            if opens_here {
+                let mut open_inst: IrInst = region_marker_inst(next_id, IOP_REGION_OPEN(), blk3.id);
+                next_id = next_id + 1;
+                new_insts.push(open_inst);
+            }
+
+            let mut copy_i: i64 = 0;
+            while copy_i < blk3.insts.len() {
+                if copy_i == term_pos {
+                    let term: IrInst = blk3.insts[copy_i];
+                    if term.op == IOP_BRANCH() && term.dk == IDATA_BRANCH_TARGETS() {
+                        let then_refresh: Vec<i64> = refresh_regions_for_edge(
+                            blk3.id, term.dv, block_regions, back_edges, forward_no_backedges, reverse_no_backedges
+                        );
+                        let then_close: Vec<i64> = close_regions_for_edge(
+                            blk3.id, term.dv, true, block_regions, block_parent, block_depth, then_refresh
+                        );
+                        let else_refresh: Vec<i64> = refresh_regions_for_edge(
+                            blk3.id, term.dv2, block_regions, back_edges, forward_no_backedges, reverse_no_backedges
+                        );
+                        let else_close: Vec<i64> = close_regions_for_edge(
+                            blk3.id, term.dv2, true, block_regions, block_parent, block_depth, else_refresh
+                        );
+                        let mut then_target: i64 = term.dv;
+                        let mut else_target: i64 = term.dv2;
+                        if then_close.len() > 0 || then_refresh.len() > 0 {
+                            let split: EdgeSplitBlock = build_edge_split_block(
+                                next_block_id, next_id, then_close, then_refresh, edge_upsilons, term.dv
+                            );
+                            next_block_id = next_block_id + 1;
+                            next_id = split.next_id;
+                            then_target = split.block.id;
+                            extra_blocks.push(split.block);
+                        }
+                        if else_close.len() > 0 || else_refresh.len() > 0 {
+                            let split2: EdgeSplitBlock = build_edge_split_block(
+                                next_block_id, next_id, else_close, else_refresh, edge_upsilons, term.dv2
+                            );
+                            next_block_id = next_block_id + 1;
+                            next_id = split2.next_id;
+                            else_target = split2.block.id;
+                            extra_blocks.push(split2.block);
+                        }
+                        new_insts.push(branch_inst_with_targets(term, then_target, else_target));
+                    } else if term.op == IOP_JUMP() && term.dk == IDATA_JUMP_TARGET() {
+                        let jump_refresh: Vec<i64> = refresh_regions_for_edge(
+                            blk3.id, term.dv, block_regions, back_edges, forward_no_backedges, reverse_no_backedges
+                        );
+                        let jump_close: Vec<i64> = close_regions_for_edge(
+                            blk3.id, term.dv, true, block_regions, block_parent, block_depth, jump_refresh
+                        );
+                        next_id = append_region_markers(new_insts, next_id, jump_close, jump_refresh);
+                        new_insts.push(term);
                     } else {
-                        k = k + 1;
+                        let no_refresh: Vec<i64> = Vec::new();
+                        let no_succ_close: Vec<i64> = close_regions_for_edge(
+                            blk3.id, 0, false, block_regions, block_parent, block_depth, no_refresh
+                        );
+                        let no_succ_refresh: Vec<i64> = Vec::new();
+                        next_id = append_region_markers(new_insts, next_id, no_succ_close, no_succ_refresh);
+                        new_insts.push(term);
                     }
+                } else {
+                    new_insts.push(blk3.insts[copy_i]);
                 }
-
-                let mut new_insts: Vec<IrInst> = Vec::new();
-                if opens_here {
-                    new_insts.push(open_inst);
-                }
-                let mut copy_i: i64 = 0;
-                while copy_i < blk3.insts.len() {
-                    if copy_i == term_pos {
-                        let mut ci: i64 = 0;
-	                    while ci < close_regions.len() {
-	                        let mut close_inst: IrInst = ir_inst_new(
-	                            next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
-	                            Vec::new(), 0, 0, 0, String::from(""),
-                            );
-                            close_inst = ir_inst_set_region(
-                                close_inst,
-                                region_pack(REGION_KIND_BLOCK(), close_regions[ci])
-                            );
-                            next_id = next_id + 1;
-	                        new_insts.push(close_inst);
-	                        ci = ci + 1;
-	                    }
-	                    let mut ri: i64 = 0;
-	                    while ri < refresh_regions.len() {
-	                        let mut refresh_close: IrInst = ir_inst_new(
-	                            next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
-	                            Vec::new(), 0, 0, 0, String::from(""),
-	                        );
-	                        refresh_close = ir_inst_set_region(
-	                            refresh_close,
-	                            region_pack(REGION_KIND_BLOCK(), refresh_regions[ri])
-	                        );
-	                        next_id = next_id + 1;
-	                        new_insts.push(refresh_close);
-	                        let mut refresh_open: IrInst = ir_inst_new(
-	                            next_id, IOP_REGION_OPEN(), ITY_UNIT(),
-	                            Vec::new(), 0, 0, 0, String::from(""),
-	                        );
-	                        refresh_open = ir_inst_set_region(
-	                            refresh_open,
-	                            region_pack(REGION_KIND_BLOCK(), refresh_regions[ri])
-	                        );
-	                        next_id = next_id + 1;
-	                        new_insts.push(refresh_open);
-	                        ri = ri + 1;
-	                    }
-	                }
-	                new_insts.push(blk3.insts[copy_i]);
-	                copy_i = copy_i + 1;
-	            }
-	            if term_pos == blk3.insts.len() {
-                    let mut ci2: i64 = 0;
-                    while ci2 < close_regions.len() {
-                        let mut close_inst2: IrInst = ir_inst_new(
-                            next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
-                            Vec::new(), 0, 0, 0, String::from(""),
-                        );
-                        close_inst2 = ir_inst_set_region(
-                            close_inst2,
-                            region_pack(REGION_KIND_BLOCK(), close_regions[ci2])
-                        );
-                        next_id = next_id + 1;
-	                    new_insts.push(close_inst2);
-	                    ci2 = ci2 + 1;
-	                }
-	                let mut ri2: i64 = 0;
-	                while ri2 < refresh_regions.len() {
-	                    let mut refresh_close2: IrInst = ir_inst_new(
-	                        next_id, IOP_REGION_CLOSE(), ITY_UNIT(),
-	                        Vec::new(), 0, 0, 0, String::from(""),
-	                    );
-	                    refresh_close2 = ir_inst_set_region(
-	                        refresh_close2,
-	                        region_pack(REGION_KIND_BLOCK(), refresh_regions[ri2])
-	                    );
-	                    next_id = next_id + 1;
-	                    new_insts.push(refresh_close2);
-	                    let mut refresh_open2: IrInst = ir_inst_new(
-	                        next_id, IOP_REGION_OPEN(), ITY_UNIT(),
-	                        Vec::new(), 0, 0, 0, String::from(""),
-	                    );
-	                    refresh_open2 = ir_inst_set_region(
-	                        refresh_open2,
-	                        region_pack(REGION_KIND_BLOCK(), refresh_regions[ri2])
-	                    );
-	                    next_id = next_id + 1;
-	                    new_insts.push(refresh_open2);
-	                    ri2 = ri2 + 1;
-	                }
-	            }
-	            blk3.insts = new_insts;
-	            f.blocks[bi4] = blk3;
-	        }
+                copy_i = copy_i + 1;
+            }
+            if term_pos == blk3.insts.len() {
+                let no_refresh2: Vec<i64> = Vec::new();
+                let no_succ_close2: Vec<i64> = close_regions_for_edge(
+                    blk3.id, 0, false, block_regions, block_parent, block_depth, no_refresh2
+                );
+                let no_succ_refresh2: Vec<i64> = Vec::new();
+                next_id = append_region_markers(new_insts, next_id, no_succ_close2, no_succ_refresh2);
+            }
+            if opens_here || new_insts.len() != blk3.insts.len() {
+                blk3.insts = new_insts;
+                f.blocks[bi4] = blk3;
+            }
             bi4 = bi4 + 1;
+        }
+
+        let mut ebi: i64 = 0;
+        while ebi < extra_blocks.len() {
+            f.blocks.push(extra_blocks[ebi]);
+            ebi = ebi + 1;
         }
 
         m.functions[fi] = f;

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2033,8 +2033,6 @@ fn append_region_markers(
     while ri < refresh_regions.len() {
         insts.push(region_marker_inst(id, IOP_REGION_CLOSE(), refresh_regions[ri]));
         id = id + 1;
-        insts.push(region_marker_inst(id, IOP_REGION_OPEN(), refresh_regions[ri]));
-        id = id + 1;
         ri = ri + 1;
     }
     id

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1976,6 +1976,7 @@ fn refresh_regions_for_block(
         if edges.preds[ei] == pred {
             let header: i64 = edges.headers[ei];
             let header_succs: Vec<i64> = Vec::new();
+            header_succs.push(header);
             if header >= 0 && header < forward.len() {
                 let src: Vec<i64> = forward[header];
                 let mut si: i64 = 0;

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2040,6 +2040,91 @@ fn append_region_markers(
     id
 }
 
+fn build_phi_home_blocks(f: IrFunction) -> Vec<i64> {
+    let mut max_id: i64 = -1;
+    let mut bi: i64 = 0;
+    while bi < f.blocks.len() {
+        let blk: IrBlock = f.blocks[bi];
+        let mut ii: i64 = 0;
+        while ii < blk.insts.len() {
+            if blk.insts[ii].id > max_id {
+                max_id = blk.insts[ii].id;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
+    let homes: Vec<i64> = Vec::new();
+    let mut hi: i64 = 0;
+    while hi <= max_id {
+        homes.push(-1);
+        hi = hi + 1;
+    }
+
+    bi = 0;
+    while bi < f.blocks.len() {
+        let blk2: IrBlock = f.blocks[bi];
+        let mut ii2: i64 = 0;
+        while ii2 < blk2.insts.len() {
+            let inst: IrInst = blk2.insts[ii2];
+            if inst.op == IOP_PHI() && inst.id >= 0 && inst.id < homes.len() {
+                homes[inst.id] = blk2.id;
+            }
+            ii2 = ii2 + 1;
+        }
+        bi = bi + 1;
+    }
+    homes
+}
+
+fn upsilon_targets_block(inst: IrInst, target: i64, phi_home: Vec<i64>) -> bool {
+    if inst.op != IOP_UPSILON() || inst.dk != IDATA_PHI_TARGET() {
+        return false;
+    }
+    let phi_id: i64 = inst.dv;
+    if phi_id < 0 || phi_id >= phi_home.len() {
+        return false;
+    }
+    phi_home[phi_id] == target
+}
+
+fn collect_edge_upsilons_for_target(
+    insts: Vec<IrInst>, target: i64, phi_home: Vec<i64>
+) -> Vec<IrInst> {
+    let result: Vec<IrInst> = Vec::new();
+    let mut i: i64 = 0;
+    while i < insts.len() {
+        let inst: IrInst = insts[i];
+        if upsilon_targets_block(inst, target, phi_home) {
+            result.push(inst);
+        }
+        i = i + 1;
+    }
+    result
+}
+
+fn append_moved_upsilon_ids(moved_ids: Vec<i64>, upsilons: Vec<IrInst>) {
+    let mut i: i64 = 0;
+    while i < upsilons.len() {
+        linear_insert_i64(moved_ids, upsilons[i].id);
+        i = i + 1;
+    }
+}
+
+fn filter_out_moved_upsilons(insts: Vec<IrInst>, moved_ids: Vec<i64>) -> Vec<IrInst> {
+    let kept: Vec<IrInst> = Vec::new();
+    let mut i: i64 = 0;
+    while i < insts.len() {
+        let inst: IrInst = insts[i];
+        if !region_vec_contains_i64(moved_ids, inst.id) {
+            kept.push(inst);
+        }
+        i = i + 1;
+    }
+    kept
+}
+
 struct EdgeSplitBlock {
     block: IrBlock,
     next_id: i64,
@@ -2871,6 +2956,7 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
         let back_edges: BackEdges = detect_loop_back_edges(f);
         let forward_no_backedges: Vec<Vec<i64>> = forward_graph_without_back_edges(f, back_edges);
         let reverse_no_backedges: Vec<Vec<i64>> = reverse_graph(forward_no_backedges);
+        let phi_home: Vec<i64> = build_phi_home_blocks(f);
 
         let mut next_block_id: i64 = max_block_id(f) + 1;
         let extra_blocks: Vec<IrBlock> = Vec::new();
@@ -2894,17 +2980,9 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                     k = k + 1;
                 }
             }
-            let edge_upsilons: Vec<IrInst> = Vec::new();
-            let mut ui0: i64 = term_pos + 1;
-            while ui0 < blk3.insts.len() {
-                if blk3.insts[ui0].op == IOP_UPSILON() {
-                    edge_upsilons.push(blk3.insts[ui0]);
-                }
-                ui0 = ui0 + 1;
-            }
-
             let mut new_insts: Vec<IrInst> = Vec::new();
             let mut block_changed: bool = opens_here;
+            let moved_upsilon_ids: Vec<i64> = Vec::new();
             if opens_here {
                 let mut open_inst: IrInst = region_marker_inst(next_id, IOP_REGION_OPEN(), blk3.id);
                 next_id = next_id + 1;
@@ -2928,27 +3006,38 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                         let else_close: Vec<i64> = close_regions_for_edge(
                             blk3.id, term.dv2, true, block_regions, block_parent, block_depth, else_refresh
                         );
+                        let then_upsilons: Vec<IrInst> = collect_edge_upsilons_for_target(
+                            blk3.insts, term.dv, phi_home
+                        );
+                        let else_upsilons: Vec<IrInst> = collect_edge_upsilons_for_target(
+                            blk3.insts, term.dv2, phi_home
+                        );
                         let mut then_target: i64 = term.dv;
                         let mut else_target: i64 = term.dv2;
                         if then_close.len() > 0 || then_refresh.len() > 0 {
                             let split: EdgeSplitBlock = build_edge_split_block(
-                                next_block_id, next_id, then_close, then_refresh, edge_upsilons, term.dv
+                                next_block_id, next_id, then_close, then_refresh, then_upsilons, term.dv
                             );
                             next_block_id = next_block_id + 1;
                             next_id = split.next_id;
                             then_target = split.block.id;
                             extra_blocks.push(split.block);
+                            append_moved_upsilon_ids(moved_upsilon_ids, then_upsilons);
                             block_changed = true;
                         }
                         if else_close.len() > 0 || else_refresh.len() > 0 {
                             let split2: EdgeSplitBlock = build_edge_split_block(
-                                next_block_id, next_id, else_close, else_refresh, edge_upsilons, term.dv2
+                                next_block_id, next_id, else_close, else_refresh, else_upsilons, term.dv2
                             );
                             next_block_id = next_block_id + 1;
                             next_id = split2.next_id;
                             else_target = split2.block.id;
                             extra_blocks.push(split2.block);
+                            append_moved_upsilon_ids(moved_upsilon_ids, else_upsilons);
                             block_changed = true;
+                        }
+                        if moved_upsilon_ids.len() > 0 {
+                            new_insts = filter_out_moved_upsilons(new_insts, moved_upsilon_ids);
                         }
                         new_insts.push(branch_inst_with_targets(term, then_target, else_target));
                     } else if term.op == IOP_JUMP() && term.dk == IDATA_JUMP_TARGET() {
@@ -2976,7 +3065,10 @@ fn insert_region_markers_module(m: IrModule) -> IrModule {
                         new_insts.push(term);
                     }
                 } else {
-                    new_insts.push(blk3.insts[copy_i]);
+                    let copied_inst: IrInst = blk3.insts[copy_i];
+                    if !region_vec_contains_i64(moved_upsilon_ids, copied_inst.id) {
+                        new_insts.push(copied_inst);
+                    }
                 }
                 copy_i = copy_i + 1;
             }

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -159,6 +159,7 @@ The following C-callable primitives MUST be provided by `vow-runtime`:
 ```c
 void     __vow_arena_open(struct VowArena* a);
 void     __vow_arena_close(struct VowArena* a);
+void     __vow_arena_init_closed(struct VowArena* a);
 void*    __vow_arena_alloc(struct VowArena* a, uintptr_t bytes, uintptr_t align);
 int64_t  __vow_arena_try_extend(struct VowArena* a, void* ptr,
                                 uintptr_t old_size, uintptr_t new_size);
@@ -175,11 +176,19 @@ same convention. In the C header the type is written `int64_t`
 (from `<stdint.h>`); in the Rust definition and in Vow FFI bindings
 the corresponding `i64` ABI-compatible type is used.
 
+**`__vow_arena_init_closed(a)`**: initializes `*a` to the closed
+all-zero state. The compiler emits this once when a block-arena stack
+slot is first materialized, before the first open or close can observe
+the header.
+
 **`__vow_arena_open(a)`**: initializes `*a` to an arena with one
 freshly-allocated chunk of 4 KB plus the 8-byte next-chunk link
-(4104 bytes total, per §3.2). If the underlying `malloc` fails, the
-runtime traps with a structured OOM error (consistent with the
-root-region OOM policy in §16); the trap is not recoverable from
+(4104 bytes total, per §3.2). If `a` already names an open arena,
+`__vow_arena_open(a)` is a no-op; this makes the loop back-edge
+`close`+`open` refresh sequence robust when the next loop-body entry
+also executes the block's entry `open`. If the underlying `malloc`
+fails, the runtime traps with a structured OOM error (consistent with
+the root-region OOM policy in §16); the trap is not recoverable from
 within Vow.
 
 **`__vow_arena_close(a)`**: walks the chunk chain, calls `free` on
@@ -1260,6 +1269,15 @@ Two new IR opcodes mark region boundaries:
   header on the next iteration's `RegionOpen`, which is
   undefined in the runtime model. The loop body's region thus
   has the same open/close cadence as one iteration of its body.
+
+  At the IR level, every loop back-edge `P -> H` refreshes each
+  non-empty block region `Block(B)` on that loop-body path:
+  `RegionClose(B)` is emitted immediately followed by
+  `RegionOpen(B)` before `P`'s terminator. `B` is selected only
+  when it is reachable from `H` through non-back-edge forward
+  edges and can reach `P`; multiple refreshed regions on the same
+  predecessor are ordered by `BlockId`. Empty loop-body regions
+  remain elided by §3.5.
 
 Empty-region blocks do not emit these opcodes.
 

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -184,9 +184,8 @@ the header.
 **`__vow_arena_open(a)`**: initializes `*a` to an arena with one
 freshly-allocated chunk of 4 KB plus the 8-byte next-chunk link
 (4104 bytes total, per §3.2). If `a` already names an open arena,
-`__vow_arena_open(a)` is a no-op; this makes the loop back-edge
-`close`+`open` refresh sequence robust when the next loop-body entry
-also executes the block's entry `open`. If the underlying `malloc`
+`__vow_arena_open(a)` is a no-op; this protects structured entries
+that reach an already-open region root. If the underlying `malloc`
 fails, the runtime traps with a structured OOM error (consistent with
 the root-region OOM policy in §16); the trap is not recoverable from
 within Vow.
@@ -1271,13 +1270,15 @@ Two new IR opcodes mark region boundaries:
   has the same open/close cadence as one iteration of its body.
 
   At the IR level, every loop back-edge `P -> H` refreshes each
-  non-empty block region `Block(B)` on that loop-body path:
-  `RegionClose(B)` is emitted immediately followed by
-  `RegionOpen(B)` before `P`'s terminator. `B` is selected only
-  when it is reachable from `H` through non-back-edge forward
-  edges and can reach `P`; multiple refreshed regions on the same
-  predecessor are ordered by `BlockId`. Empty loop-body regions
-  remain elided by §3.5.
+  non-empty block region `Block(B)` on that loop-body path by
+  emitting `RegionClose(B)` before `P`'s terminator. The matching
+  `RegionOpen(B)` is the normal entry marker at `B`; it fires only
+  if the next trip actually re-enters the region, so a header exit
+  immediately after a back-edge cannot leave a freshly reopened body
+  arena live. `B` is selected only when it is reachable from `H`
+  through non-back-edge forward edges and can reach `P`; multiple
+  refreshed regions on the same predecessor are ordered by `BlockId`.
+  Empty loop-body regions remain elided by §3.5.
 
 Empty-region blocks do not emit these opcodes.
 

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -1173,8 +1173,7 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     }
 
     let mut block_arena_ids: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
-    for ii in 0..n_insts {
-        let rgn = inst_rgns[ii];
+    for &rgn in inst_rgns.iter().take(n_insts) {
         if (rgn & 3) == REGION_KIND_BLOCK {
             block_arena_ids.insert(rgn >> 2);
         }

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -782,6 +782,14 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         .obj_module
         .declare_function("__vow_arena_close", Linkage::Import, &arena_open_close_sig)
         .expect("declare __vow_arena_close");
+    let arena_init_id = ctx
+        .obj_module
+        .declare_function(
+            "__vow_arena_init_closed",
+            Linkage::Import,
+            &arena_open_close_sig,
+        )
+        .expect("declare __vow_arena_init_closed");
 
     let root_arena_id = ctx
         .obj_module
@@ -944,6 +952,9 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     let arena_close_ref = ctx
         .obj_module
         .declare_func_in_func(arena_close_id, builder.func);
+    let arena_init_ref = ctx
+        .obj_module
+        .declare_func_in_func(arena_init_id, builder.func);
     let root_arena_gv = ctx
         .obj_module
         .declare_data_in_func(root_arena_id, builder.func);
@@ -1161,6 +1172,14 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         }
     }
 
+    let mut block_arena_ids: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
+    for ii in 0..n_insts {
+        let rgn = inst_rgns[ii];
+        if (rgn & 3) == REGION_KIND_BLOCK {
+            block_arena_ids.insert(rgn >> 2);
+        }
+    }
+
     // Zero-initialize all stack slots to match C's typical behavior (GCC
     // zero-initializes locals). The self-hosted IR has uninitialized cross-block
     // refs that happen to work in C codegen due to this.
@@ -1168,6 +1187,17 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         let zero = builder.ins().iconst(types::I64, 0);
         for &slot in slot_map.values() {
             builder.ins().stack_store(zero, slot, 0);
+        }
+        for payload in block_arena_ids {
+            let slot = *block_arena_slots.entry(payload).or_insert_with(|| {
+                builder.create_sized_stack_slot(StackSlotData::new(
+                    StackSlotKind::ExplicitSlot,
+                    VOW_ARENA_HEADER_SIZE,
+                    VOW_ARENA_HEADER_ALIGN_LOG2,
+                ))
+            });
+            let arena_addr = builder.ins().stack_addr(types::I64, slot, 0);
+            builder.ins().call(arena_init_ref, &[arena_addr]);
         }
         // Emit stack_guard_init at main entry (all modes)
         if ctx.func_decls[fi].is_main {
@@ -1960,13 +1990,23 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                         return -1;
                     }
                     let payload = rgn >> 2;
-                    let slot = *block_arena_slots.entry(payload).or_insert_with(|| {
-                        builder.create_sized_stack_slot(StackSlotData::new(
+                    let (slot, created) = if let Some(&slot) = block_arena_slots.get(&payload) {
+                        (slot, false)
+                    } else {
+                        let slot = builder.create_sized_stack_slot(StackSlotData::new(
                             StackSlotKind::ExplicitSlot,
                             VOW_ARENA_HEADER_SIZE,
                             VOW_ARENA_HEADER_ALIGN_LOG2,
-                        ))
-                    });
+                        ));
+                        block_arena_slots.insert(payload, slot);
+                        (slot, true)
+                    };
+                    if created {
+                        let zero = builder.ins().iconst(types::I64, 0);
+                        for offset in (0..VOW_ARENA_HEADER_SIZE as i32).step_by(8) {
+                            builder.ins().stack_store(zero, slot, offset);
+                        }
+                    }
                     let arena_addr = builder.ins().stack_addr(types::I64, slot, 0);
                     let func_ref = if op == IOP_REGION_OPEN {
                         arena_open_ref

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -11,7 +11,7 @@ use cranelift_module::{
     DataDescription, DataId, FuncId as CraneliftFuncId, Linkage, Module as CraneliftModule,
 };
 use cranelift_object::{ObjectBuilder, ObjectModule};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use vow_ir::{
     BlockId, FuncId as IrFuncId, Function as IrFunction, Inst, InstData, InstId,
@@ -289,13 +289,36 @@ fn block_arena_slot(
     slots: &mut BTreeMap<BlockId, StackSlot>,
     block_id: BlockId,
 ) -> StackSlot {
-    *slots.entry(block_id).or_insert_with(|| {
-        builder.create_sized_stack_slot(StackSlotData::new(
-            StackSlotKind::ExplicitSlot,
-            VOW_ARENA_HEADER_SIZE,
-            VOW_ARENA_HEADER_ALIGN_LOG2,
-        ))
-    })
+    block_arena_slot_with_created(builder, slots, block_id).0
+}
+
+fn block_arena_slot_with_created(
+    builder: &mut FunctionBuilder,
+    slots: &mut BTreeMap<BlockId, StackSlot>,
+    block_id: BlockId,
+) -> (StackSlot, bool) {
+    if let Some(&slot) = slots.get(&block_id) {
+        return (slot, false);
+    }
+    let slot = builder.create_sized_stack_slot(StackSlotData::new(
+        StackSlotKind::ExplicitSlot,
+        VOW_ARENA_HEADER_SIZE,
+        VOW_ARENA_HEADER_ALIGN_LOG2,
+    ));
+    slots.insert(block_id, slot);
+    (slot, true)
+}
+
+fn collect_block_arena_ids(func: &IrFunction) -> BTreeSet<BlockId> {
+    let mut ids = BTreeSet::new();
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if let RegionId::Block(block_id) = inst.region {
+                ids.insert(block_id);
+            }
+        }
+    }
+    ids
 }
 
 /// Materialise the Cranelift `Value` (`*VowArena`) representing `region` in
@@ -1264,12 +1287,12 @@ fn lower_inst(
             };
             let slot = block_arena_slot(builder, ctx.block_arena_slots, block_id);
             let arena_addr = builder.ins().stack_addr(types::I64, slot, 0);
-            let func_ref = if inst.opcode == Opcode::RegionOpen {
-                ctx.arena_open_ref
+
+            if inst.opcode == Opcode::RegionOpen {
+                builder.ins().call(ctx.arena_open_ref, &[arena_addr]);
             } else {
-                ctx.arena_close_ref
-            };
-            builder.ins().call(func_ref, &[arena_addr]);
+                builder.ins().call(ctx.arena_close_ref, &[arena_addr]);
+            }
             let unit = builder.ins().iconst(types::I32, 0);
             ctx.value_map.insert(inst.id, unit);
         }
@@ -1512,6 +1535,7 @@ struct RuntimeIds {
     vow_violation_id: Option<CraneliftFuncId>,
     overflow_id: Option<CraneliftFuncId>,
     arena_alloc_id: CraneliftFuncId,
+    arena_init_id: CraneliftFuncId,
     arena_open_id: CraneliftFuncId,
     arena_close_id: CraneliftFuncId,
     string_clone_id: Option<CraneliftFuncId>,
@@ -1579,6 +1603,7 @@ fn compile_ir_function(
         vow_violation_id.map(|id| obj_module.declare_func_in_func(id, builder.func));
     let overflow_ref = overflow_id.map(|id| obj_module.declare_func_in_func(id, builder.func));
     let arena_alloc_ref = obj_module.declare_func_in_func(runtime.arena_alloc_id, builder.func);
+    let arena_init_ref = obj_module.declare_func_in_func(runtime.arena_init_id, builder.func);
     let arena_open_ref = obj_module.declare_func_in_func(runtime.arena_open_id, builder.func);
     let arena_close_ref = obj_module.declare_func_in_func(runtime.arena_close_id, builder.func);
     let string_clone_ref = runtime
@@ -1760,6 +1785,11 @@ fn compile_ir_function(
 
     let mut value_map: HashMap<InstId, Value> = HashMap::new();
     let mut block_arena_slots: BTreeMap<BlockId, StackSlot> = BTreeMap::new();
+    for block_id in collect_block_arena_ids(ir_func) {
+        let slot = block_arena_slot(&mut builder, &mut block_arena_slots, block_id);
+        let arena_addr = builder.ins().stack_addr(types::I64, slot, 0);
+        builder.ins().call(arena_init_ref, &[arena_addr]);
+    }
 
     // Emit each block
     let mut first_block = true;
@@ -2361,6 +2391,13 @@ impl Backend for CraneliftBackend {
         let arena_close_id = obj_module
             .declare_function("__vow_arena_close", Linkage::Import, &arena_open_close_sig)
             .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
+        let arena_init_id = obj_module
+            .declare_function(
+                "__vow_arena_init_closed",
+                Linkage::Import,
+                &arena_open_close_sig,
+            )
+            .map_err(|e| CodegenError::FunctionDeclare(e.to_string()))?;
 
         // `__vow_string_clone_into_arena` is only imported when some function
         // in the module actually emits a return-materialisation call. This
@@ -2533,6 +2570,7 @@ impl Backend for CraneliftBackend {
                     vow_violation_id,
                     overflow_id,
                     arena_alloc_id,
+                    arena_init_id,
                     arena_open_id,
                     arena_close_id,
                     string_clone_id,

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -496,10 +496,10 @@ fn reachable_from(
     reachable
 }
 
-fn backedge_refresh_regions_by_block(
+fn backedge_refresh_regions_by_edge(
     func: &Function,
     block_regions: &BTreeSet<BlockId>,
-) -> BTreeMap<BlockId, Vec<BlockId>> {
+) -> BTreeMap<(BlockId, BlockId), Vec<BlockId>> {
     let mut back_edges = detect_loop_back_edges(func);
     back_edges.sort_unstable();
     back_edges.dedup();
@@ -509,14 +509,17 @@ fn backedge_refresh_regions_by_block(
 
     let forward = forward_graph_without_back_edges(func, &back_edges);
     let reverse = reverse_graph(&forward);
-    let mut by_pred: BTreeMap<BlockId, BTreeSet<BlockId>> = BTreeMap::new();
+    let mut by_pred: BTreeMap<(BlockId, BlockId), BTreeSet<BlockId>> = BTreeMap::new();
     for (pred, header) in back_edges {
         let reachable_from_header = reachable_from([header], &forward);
         let reaches_pred = reachable_from([pred], &reverse);
         for &region_block in block_regions {
             if reachable_from_header.contains(&region_block) && reaches_pred.contains(&region_block)
             {
-                by_pred.entry(pred).or_default().insert(region_block);
+                by_pred
+                    .entry((pred, header))
+                    .or_default()
+                    .insert(region_block);
             }
         }
     }
@@ -525,6 +528,18 @@ fn backedge_refresh_regions_by_block(
         .into_iter()
         .map(|(pred, regions)| (pred, regions.into_iter().collect()))
         .collect()
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct EdgeRegionMarkers {
+    closes: Vec<BlockId>,
+    refreshes: Vec<BlockId>,
+}
+
+impl EdgeRegionMarkers {
+    fn is_empty(&self) -> bool {
+        self.closes.is_empty() && self.refreshes.is_empty()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -841,6 +856,107 @@ fn emit_live_linear_errors(
     }
 }
 
+fn edge_region_markers(
+    pred: BlockId,
+    succ: Option<BlockId>,
+    block_regions: &BTreeSet<BlockId>,
+    block_tree: &BlockTree,
+    refresh_regions_by_edge: &BTreeMap<(BlockId, BlockId), Vec<BlockId>>,
+) -> EdgeRegionMarkers {
+    let refreshes = succ
+        .and_then(|target| refresh_regions_by_edge.get(&(pred, target)).cloned())
+        .unwrap_or_default();
+    let mut closes = Vec::new();
+    for &region_block in block_regions {
+        if !block_tree.is_ancestor(region_block, pred) {
+            continue;
+        }
+        let exits_region = succ
+            .map(|target| !block_tree.is_ancestor(region_block, target))
+            .unwrap_or(true);
+        if exits_region && !refreshes.contains(&region_block) {
+            closes.push(region_block);
+        }
+    }
+    closes.sort_by(|a, b| {
+        block_tree
+            .depth_of(*b)
+            .cmp(&block_tree.depth_of(*a))
+            .then_with(|| b.cmp(a))
+    });
+    EdgeRegionMarkers { closes, refreshes }
+}
+
+fn marker_insts(next_id: &mut u32, markers: &EdgeRegionMarkers, span: Span) -> Vec<Inst> {
+    let mut insts = Vec::with_capacity(markers.closes.len() + markers.refreshes.len() * 2);
+    for &close_block in &markers.closes {
+        insts.push(region_marker_inst(
+            *next_id,
+            Opcode::RegionClose,
+            close_block,
+            span,
+        ));
+        *next_id += 1;
+    }
+    for &refresh_block in &markers.refreshes {
+        insts.push(region_marker_inst(
+            *next_id,
+            Opcode::RegionClose,
+            refresh_block,
+            span,
+        ));
+        *next_id += 1;
+        insts.push(region_marker_inst(
+            *next_id,
+            Opcode::RegionOpen,
+            refresh_block,
+            span,
+        ));
+        *next_id += 1;
+    }
+    insts
+}
+
+fn split_edge_with_markers(
+    target: BlockId,
+    markers: &EdgeRegionMarkers,
+    edge_upsilons: &[Inst],
+    span: Span,
+    next_id: &mut u32,
+    next_block_id: &mut u32,
+    split_blocks: &mut Vec<crate::types::BasicBlock>,
+) -> BlockId {
+    if markers.is_empty() {
+        return target;
+    }
+    let split_id = BlockId(*next_block_id);
+    *next_block_id = next_block_id
+        .checked_add(1)
+        .expect("BlockId overflow while splitting region-marker edge");
+    let mut insts = marker_insts(next_id, markers, span);
+    for upsilon in edge_upsilons {
+        let mut cloned = upsilon.clone();
+        cloned.id = InstId(*next_id);
+        *next_id += 1;
+        insts.push(cloned);
+    }
+    insts.push(Inst {
+        id: InstId(*next_id),
+        opcode: Opcode::Jump,
+        ty: Ty::Unit,
+        args: vec![],
+        data: InstData::JumpTarget(target),
+        origin: span,
+        region: RegionId::Root,
+    });
+    *next_id += 1;
+    split_blocks.push(crate::types::BasicBlock {
+        id: split_id,
+        insts,
+    });
+    split_id
+}
+
 /// Insert `RegionOpen` / `RegionClose` markers around basic blocks whose
 /// region is non-empty (spec §3.5). Must run AFTER `infer_regions` so that
 /// every `RegionAlloc` inst carries its inferred `region: RegionId`.
@@ -888,65 +1004,117 @@ pub fn insert_region_markers(module: &mut Module) {
         }
 
         let block_tree = BlockTree::from_function(func);
-        let refresh_regions_by_block = backedge_refresh_regions_by_block(func, &block_regions);
-        let mut close_regions_by_block: BTreeMap<BlockId, Vec<BlockId>> = BTreeMap::new();
-        for block in &func.blocks {
-            let succs = block_successors(block);
-            let mut close_regions = Vec::new();
-            let refresh_regions = refresh_regions_by_block
-                .get(&block.id)
-                .cloned()
-                .unwrap_or_default();
-            for &region_block in &block_regions {
-                if !block_tree.is_ancestor(region_block, block.id) {
-                    continue;
-                }
-                let exits_region = succs.is_empty()
-                    || succs
-                        .iter()
-                        .any(|&succ| !block_tree.is_ancestor(region_block, succ));
-                if exits_region && !refresh_regions.contains(&region_block) {
-                    close_regions.push(region_block);
-                }
-            }
-            close_regions.sort_by(|a, b| {
-                block_tree
-                    .depth_of(*b)
-                    .cmp(&block_tree.depth_of(*a))
-                    .then_with(|| b.cmp(a))
-            });
-            if !close_regions.is_empty() {
-                close_regions_by_block.insert(block.id, close_regions);
-            }
-        }
+        let refresh_regions_by_edge = backedge_refresh_regions_by_edge(func, &block_regions);
 
         let mut next_id = next_inst_id(func);
+        let mut next_block_id = next_block_id(func);
+        let mut split_blocks = Vec::new();
         for block in &mut func.blocks {
             let old_insts = std::mem::take(&mut block.insts);
             let span = old_insts
                 .first()
                 .map(|i| i.origin)
                 .unwrap_or(Span { start: 0, len: 0 });
-            let closes = close_regions_by_block
-                .get(&block.id)
-                .cloned()
-                .unwrap_or_default();
-            let refreshes = refresh_regions_by_block
-                .get(&block.id)
-                .cloned()
-                .unwrap_or_default();
             let opens_here = block_regions.contains(&block.id);
-            if !opens_here && closes.is_empty() && refreshes.is_empty() {
-                block.insts = old_insts;
-                continue;
-            }
 
             let term_pos = old_insts
                 .iter()
                 .position(|i| i.opcode.is_terminal())
                 .unwrap_or(old_insts.len());
+            let term_span = old_insts.get(term_pos).map(|i| i.origin).unwrap_or(span);
+            let edge_upsilons: Vec<Inst> = old_insts[term_pos.saturating_add(1)..]
+                .iter()
+                .filter(|inst| inst.opcode == Opcode::Upsilon)
+                .cloned()
+                .collect();
+            let mut before_term_markers = EdgeRegionMarkers::default();
+            let mut rewritten_term: Option<Inst> = None;
+            if let Some(term) = old_insts.get(term_pos) {
+                match &term.data {
+                    InstData::JumpTarget(target) if term.opcode == Opcode::Jump => {
+                        before_term_markers = edge_region_markers(
+                            block.id,
+                            Some(*target),
+                            &block_regions,
+                            &block_tree,
+                            &refresh_regions_by_edge,
+                        );
+                    }
+                    InstData::BranchTargets {
+                        then_block,
+                        else_block,
+                    } if term.opcode == Opcode::Branch => {
+                        let then_markers = edge_region_markers(
+                            block.id,
+                            Some(*then_block),
+                            &block_regions,
+                            &block_tree,
+                            &refresh_regions_by_edge,
+                        );
+                        let else_markers = edge_region_markers(
+                            block.id,
+                            Some(*else_block),
+                            &block_regions,
+                            &block_tree,
+                            &refresh_regions_by_edge,
+                        );
+                        let new_then = split_edge_with_markers(
+                            *then_block,
+                            &then_markers,
+                            &edge_upsilons,
+                            term_span,
+                            &mut next_id,
+                            &mut next_block_id,
+                            &mut split_blocks,
+                        );
+                        let new_else = split_edge_with_markers(
+                            *else_block,
+                            &else_markers,
+                            &edge_upsilons,
+                            term_span,
+                            &mut next_id,
+                            &mut next_block_id,
+                            &mut split_blocks,
+                        );
+                        if new_then != *then_block || new_else != *else_block {
+                            let mut new_term = term.clone();
+                            new_term.data = InstData::BranchTargets {
+                                then_block: new_then,
+                                else_block: new_else,
+                            };
+                            rewritten_term = Some(new_term);
+                        }
+                    }
+                    _ => {
+                        before_term_markers = edge_region_markers(
+                            block.id,
+                            None,
+                            &block_regions,
+                            &block_tree,
+                            &refresh_regions_by_edge,
+                        );
+                    }
+                }
+            } else {
+                before_term_markers = edge_region_markers(
+                    block.id,
+                    None,
+                    &block_regions,
+                    &block_tree,
+                    &refresh_regions_by_edge,
+                );
+            }
+
+            if !opens_here && before_term_markers.is_empty() && rewritten_term.is_none() {
+                block.insts = old_insts;
+                continue;
+            }
+
             let mut new_insts = Vec::with_capacity(
-                old_insts.len() + usize::from(opens_here) + closes.len() + refreshes.len() * 2,
+                old_insts.len()
+                    + usize::from(opens_here)
+                    + before_term_markers.closes.len()
+                    + before_term_markers.refreshes.len() * 2,
             );
             if opens_here {
                 new_insts.push(region_marker_inst(
@@ -958,34 +1126,16 @@ pub fn insert_region_markers(module: &mut Module) {
                 next_id += 1;
             }
             new_insts.extend(old_insts[..term_pos].iter().cloned());
-            for close_block in closes {
-                new_insts.push(region_marker_inst(
-                    next_id,
-                    Opcode::RegionClose,
-                    close_block,
-                    span,
-                ));
-                next_id += 1;
+            new_insts.extend(marker_insts(&mut next_id, &before_term_markers, term_span));
+            if let Some(term) = rewritten_term {
+                new_insts.push(term);
+                new_insts.extend(old_insts[term_pos + 1..].iter().cloned());
+            } else {
+                new_insts.extend(old_insts[term_pos..].iter().cloned());
             }
-            for refresh_block in refreshes {
-                new_insts.push(region_marker_inst(
-                    next_id,
-                    Opcode::RegionClose,
-                    refresh_block,
-                    span,
-                ));
-                next_id += 1;
-                new_insts.push(region_marker_inst(
-                    next_id,
-                    Opcode::RegionOpen,
-                    refresh_block,
-                    span,
-                ));
-                next_id += 1;
-            }
-            new_insts.extend(old_insts[term_pos..].iter().cloned());
             block.insts = new_insts;
         }
+        func.blocks.extend(split_blocks);
     }
 }
 
@@ -1017,6 +1167,18 @@ fn next_inst_id(func: &Function) -> u32 {
     max_id
         .checked_add(1)
         .expect("InstId overflow in insert_region_markers — function too large")
+}
+
+fn next_block_id(func: &Function) -> u32 {
+    let mut max_id = 0u32;
+    for block in &func.blocks {
+        if block.id.0 > max_id {
+            max_id = block.id.0;
+        }
+    }
+    max_id
+        .checked_add(1)
+        .expect("BlockId overflow in insert_region_markers — function too large")
 }
 
 fn internal_compiler_error(message: &str) -> Diagnostic {
@@ -2954,7 +3116,10 @@ mod tests {
     #[test]
     fn backedge_single_loop_refreshes_body_region() {
         let b0_insts = vec![jump_inst(0, 1)];
-        let b1_insts = vec![branch_inst(1, 2, 3)];
+        let b1_insts = vec![
+            inst(5, Opcode::Phi, Ty::Ptr, vec![], InstData::None),
+            branch_inst(1, 2, 3),
+        ];
         let mut alloc = inst(
             2,
             Opcode::RegionAlloc,
@@ -3146,6 +3311,125 @@ mod tests {
             backedge_block[jump_pos - 1].region,
             RegionId::Block(BlockId(2))
         );
+    }
+
+    #[test]
+    fn backedge_mixed_branch_splits_exit_and_refresh_edges() {
+        let b0_insts = vec![jump_inst(0, 1)];
+        let b1_insts = vec![branch_inst(1, 2, 3)];
+        let mut alloc = inst(
+            2,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        alloc.region = RegionId::Block(BlockId(2));
+        let b2_insts = vec![
+            alloc,
+            branch_inst(3, 1, 3),
+            inst(
+                4,
+                Opcode::Upsilon,
+                Ty::Unit,
+                vec![2],
+                InstData::PhiTarget(InstId(5)),
+            ),
+        ];
+        let b3_insts = vec![return_unit_inst(6)];
+        let f = function(
+            0,
+            "mixed_backedge_exit",
+            vec![],
+            Ty::Unit,
+            vec![
+                block(0, b0_insts),
+                block(1, b1_insts),
+                block(2, b2_insts),
+                block(3, b3_insts),
+            ],
+        );
+        let mut m = module(vec![f]);
+
+        insert_region_markers(&mut m);
+
+        let pred = m.functions[0]
+            .blocks
+            .iter()
+            .find(|block| block.id == BlockId(2))
+            .expect("predecessor block should remain present");
+        let branch = pred
+            .insts
+            .iter()
+            .find(|inst| inst.opcode == Opcode::Branch)
+            .expect("predecessor should keep a conditional branch");
+        let InstData::BranchTargets {
+            then_block,
+            else_block,
+        } = branch.data
+        else {
+            panic!("branch should carry targets");
+        };
+        assert_ne!(
+            then_block,
+            BlockId(1),
+            "backedge must route via split block"
+        );
+        assert_ne!(
+            else_block,
+            BlockId(3),
+            "exit edge must route via split block"
+        );
+        assert!(
+            !pred.insts
+                .iter()
+                .any(|i| i.opcode == Opcode::RegionClose && i.region == RegionId::Block(BlockId(2))),
+            "mixed branch predecessor must not emit one block-wide close before both edges"
+        );
+
+        let then_split = m.functions[0]
+            .blocks
+            .iter()
+            .find(|block| block.id == then_block)
+            .expect("backedge split block should exist");
+        assert_eq!(then_split.insts[0].opcode, Opcode::RegionClose);
+        assert_eq!(then_split.insts[0].region, RegionId::Block(BlockId(2)));
+        assert_eq!(then_split.insts[1].opcode, Opcode::RegionOpen);
+        assert_eq!(then_split.insts[1].region, RegionId::Block(BlockId(2)));
+        assert!(
+            then_split
+                .insts
+                .iter()
+                .any(|i| i.opcode == Opcode::Upsilon && i.id != InstId(4)),
+            "split edge should preserve phi feeds with fresh instruction ids"
+        );
+        let then_jump = then_split
+            .insts
+            .last()
+            .expect("split block should not be empty");
+        assert_eq!(then_jump.opcode, Opcode::Jump);
+        assert_eq!(then_jump.data, InstData::JumpTarget(BlockId(1)));
+
+        let else_split = m.functions[0]
+            .blocks
+            .iter()
+            .find(|block| block.id == else_block)
+            .expect("exit split block should exist");
+        assert_eq!(else_split.insts[0].opcode, Opcode::RegionClose);
+        assert_eq!(else_split.insts[0].region, RegionId::Block(BlockId(2)));
+        assert!(
+            !else_split
+                .insts
+                .iter()
+                .any(|i| i.opcode == Opcode::RegionOpen),
+            "exit split block must not reopen the region it is leaving"
+        );
+        let else_jump = else_split
+            .insts
+            .last()
+            .expect("split block should not be empty");
+        assert_eq!(else_jump.opcode, Opcode::Jump);
+        assert_eq!(else_jump.data, InstData::JumpTarget(BlockId(3)));
     }
 
     #[test]

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -511,13 +511,7 @@ fn backedge_refresh_regions_by_block(
     let reverse = reverse_graph(&forward);
     let mut by_pred: BTreeMap<BlockId, BTreeSet<BlockId>> = BTreeMap::new();
     for (pred, header) in back_edges {
-        let header_succs = forward
-            .get(&header)
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let reachable_from_header = reachable_from(header_succs, &forward);
+        let reachable_from_header = reachable_from([header], &forward);
         let reaches_pred = reachable_from([pred], &reverse);
         for &region_block in block_regions {
             if reachable_from_header.contains(&region_block) && reaches_pred.contains(&region_block)
@@ -2908,6 +2902,52 @@ mod tests {
             close_pos + 1,
             term_pos,
             "RegionClose must immediately precede the block's terminator"
+        );
+    }
+
+    #[test]
+    fn backedge_self_loop_refreshes_header_region() {
+        let mut alloc = inst(
+            0,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        alloc.region = RegionId::Block(BlockId(0));
+        let f = function(
+            0,
+            "self_loop",
+            vec![],
+            Ty::Unit,
+            vec![block(0, vec![alloc, jump_inst(1, 0)])],
+        );
+        let mut m = module(vec![f]);
+
+        insert_region_markers(&mut m);
+
+        let block_insts = &m.functions[0].blocks[0].insts;
+        let jump_pos = block_insts
+            .iter()
+            .position(|i| i.opcode == Opcode::Jump)
+            .expect("self-loop should end in a back-edge jump");
+        assert_eq!(
+            block_insts[jump_pos - 2].opcode,
+            Opcode::RegionClose,
+            "self-loop backedge should close the header-owned region before jumping"
+        );
+        assert_eq!(
+            block_insts[jump_pos - 2].region,
+            RegionId::Block(BlockId(0))
+        );
+        assert_eq!(
+            block_insts[jump_pos - 1].opcode,
+            Opcode::RegionOpen,
+            "self-loop backedge should reopen the header-owned region immediately"
+        );
+        assert_eq!(
+            block_insts[jump_pos - 1].region,
+            RegionId::Block(BlockId(0))
         );
     }
 

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -369,6 +369,170 @@ fn block_successors(block: &crate::types::BasicBlock) -> Vec<BlockId> {
     }
 }
 
+fn detect_loop_back_edges(func: &Function) -> Vec<(BlockId, BlockId)> {
+    let blocks: BTreeMap<BlockId, &crate::types::BasicBlock> =
+        func.blocks.iter().map(|block| (block.id, block)).collect();
+    let mut visited = BTreeSet::new();
+    let mut on_stack = BTreeSet::new();
+    let mut back_edges = BTreeSet::new();
+    let mut starts = Vec::new();
+    if let Some(entry) = func.blocks.first() {
+        starts.push(entry.id);
+    }
+    for &block in blocks.keys() {
+        if !starts.contains(&block) {
+            starts.push(block);
+        }
+    }
+
+    for start in starts {
+        if visited.contains(&start) {
+            continue;
+        }
+        let mut stack = vec![BlockDfsFrame::Enter(start, 0)];
+        while let Some(frame) = stack.pop() {
+            match frame {
+                BlockDfsFrame::Enter(id, _) => {
+                    if visited.contains(&id) {
+                        continue;
+                    }
+                    let Some(block) = blocks.get(&id) else {
+                        continue;
+                    };
+                    visited.insert(id);
+                    on_stack.insert(id);
+                    stack.push(BlockDfsFrame::Exit(id));
+
+                    let mut succs = block_successors(block);
+                    succs.sort_unstable();
+                    succs.dedup();
+                    for succ in succs.into_iter().rev() {
+                        if !blocks.contains_key(&succ) {
+                            continue;
+                        }
+                        if on_stack.contains(&succ) {
+                            back_edges.insert((id, succ));
+                            continue;
+                        }
+                        if !visited.contains(&succ) {
+                            stack.push(BlockDfsFrame::Enter(succ, 0));
+                        }
+                    }
+                }
+                BlockDfsFrame::Exit(id) => {
+                    on_stack.remove(&id);
+                }
+            }
+        }
+    }
+
+    back_edges.into_iter().collect()
+}
+
+fn forward_graph_without_back_edges(
+    func: &Function,
+    back_edges: &[(BlockId, BlockId)],
+) -> BTreeMap<BlockId, BTreeSet<BlockId>> {
+    let back_edge_set: BTreeSet<(BlockId, BlockId)> = back_edges.iter().copied().collect();
+    let mut graph: BTreeMap<BlockId, BTreeSet<BlockId>> = func
+        .blocks
+        .iter()
+        .map(|block| (block.id, BTreeSet::new()))
+        .collect();
+    let block_ids: BTreeSet<BlockId> = graph.keys().copied().collect();
+
+    for block in &func.blocks {
+        let mut succs = block_successors(block);
+        succs.sort_unstable();
+        succs.dedup();
+        for succ in succs {
+            if block_ids.contains(&succ) && !back_edge_set.contains(&(block.id, succ)) {
+                graph.entry(block.id).or_default().insert(succ);
+            }
+        }
+    }
+
+    graph
+}
+
+fn reverse_graph(
+    graph: &BTreeMap<BlockId, BTreeSet<BlockId>>,
+) -> BTreeMap<BlockId, BTreeSet<BlockId>> {
+    let mut reverse: BTreeMap<BlockId, BTreeSet<BlockId>> = graph
+        .keys()
+        .copied()
+        .map(|block| (block, BTreeSet::new()))
+        .collect();
+    for (&pred, succs) in graph {
+        reverse.entry(pred).or_default();
+        for &succ in succs {
+            reverse.entry(succ).or_default().insert(pred);
+        }
+    }
+    reverse
+}
+
+fn reachable_from(
+    starts: impl IntoIterator<Item = BlockId>,
+    graph: &BTreeMap<BlockId, BTreeSet<BlockId>>,
+) -> BTreeSet<BlockId> {
+    let mut reachable = BTreeSet::new();
+    let mut stack: Vec<BlockId> = starts.into_iter().collect();
+    stack.sort_unstable();
+    stack.dedup();
+    while let Some(block) = stack.pop() {
+        if !reachable.insert(block) {
+            continue;
+        }
+        let Some(succs) = graph.get(&block) else {
+            continue;
+        };
+        for &succ in succs.iter().rev() {
+            if !reachable.contains(&succ) {
+                stack.push(succ);
+            }
+        }
+    }
+    reachable
+}
+
+fn backedge_refresh_regions_by_block(
+    func: &Function,
+    block_regions: &BTreeSet<BlockId>,
+) -> BTreeMap<BlockId, Vec<BlockId>> {
+    let mut back_edges = detect_loop_back_edges(func);
+    back_edges.sort_unstable();
+    back_edges.dedup();
+    if back_edges.is_empty() {
+        return BTreeMap::new();
+    }
+
+    let forward = forward_graph_without_back_edges(func, &back_edges);
+    let reverse = reverse_graph(&forward);
+    let mut by_pred: BTreeMap<BlockId, BTreeSet<BlockId>> = BTreeMap::new();
+    for (pred, header) in back_edges {
+        let header_succs = forward
+            .get(&header)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let reachable_from_header = reachable_from(header_succs, &forward);
+        let reaches_pred = reachable_from([pred], &reverse);
+        for &region_block in block_regions {
+            if reachable_from_header.contains(&region_block) && reaches_pred.contains(&region_block)
+            {
+                by_pred.entry(pred).or_default().insert(region_block);
+            }
+        }
+    }
+
+    by_pred
+        .into_iter()
+        .map(|(pred, regions)| (pred, regions.into_iter().collect()))
+        .collect()
+}
+
 #[derive(Debug, Clone)]
 struct BlockTree {
     parent: BTreeMap<BlockId, Option<BlockId>>,
@@ -730,10 +894,15 @@ pub fn insert_region_markers(module: &mut Module) {
         }
 
         let block_tree = BlockTree::from_function(func);
+        let refresh_regions_by_block = backedge_refresh_regions_by_block(func, &block_regions);
         let mut close_regions_by_block: BTreeMap<BlockId, Vec<BlockId>> = BTreeMap::new();
         for block in &func.blocks {
             let succs = block_successors(block);
             let mut close_regions = Vec::new();
+            let refresh_regions = refresh_regions_by_block
+                .get(&block.id)
+                .cloned()
+                .unwrap_or_default();
             for &region_block in &block_regions {
                 if !block_tree.is_ancestor(region_block, block.id) {
                     continue;
@@ -742,7 +911,7 @@ pub fn insert_region_markers(module: &mut Module) {
                     || succs
                         .iter()
                         .any(|&succ| !block_tree.is_ancestor(region_block, succ));
-                if exits_region {
+                if exits_region && !refresh_regions.contains(&region_block) {
                     close_regions.push(region_block);
                 }
             }
@@ -768,8 +937,12 @@ pub fn insert_region_markers(module: &mut Module) {
                 .get(&block.id)
                 .cloned()
                 .unwrap_or_default();
+            let refreshes = refresh_regions_by_block
+                .get(&block.id)
+                .cloned()
+                .unwrap_or_default();
             let opens_here = block_regions.contains(&block.id);
-            if !opens_here && closes.is_empty() {
+            if !opens_here && closes.is_empty() && refreshes.is_empty() {
                 block.insts = old_insts;
                 continue;
             }
@@ -778,8 +951,9 @@ pub fn insert_region_markers(module: &mut Module) {
                 .iter()
                 .position(|i| i.opcode.is_terminal())
                 .unwrap_or(old_insts.len());
-            let mut new_insts =
-                Vec::with_capacity(old_insts.len() + usize::from(opens_here) + closes.len());
+            let mut new_insts = Vec::with_capacity(
+                old_insts.len() + usize::from(opens_here) + closes.len() + refreshes.len() * 2,
+            );
             if opens_here {
                 new_insts.push(region_marker_inst(
                     next_id,
@@ -795,6 +969,22 @@ pub fn insert_region_markers(module: &mut Module) {
                     next_id,
                     Opcode::RegionClose,
                     close_block,
+                    span,
+                ));
+                next_id += 1;
+            }
+            for refresh_block in refreshes {
+                new_insts.push(region_marker_inst(
+                    next_id,
+                    Opcode::RegionClose,
+                    refresh_block,
+                    span,
+                ));
+                next_id += 1;
+                new_insts.push(region_marker_inst(
+                    next_id,
+                    Opcode::RegionOpen,
+                    refresh_block,
                     span,
                 ));
                 next_id += 1;
@@ -2719,6 +2909,256 @@ mod tests {
             term_pos,
             "RegionClose must immediately precede the block's terminator"
         );
+    }
+
+    #[test]
+    fn backedge_single_loop_refreshes_body_region() {
+        let b0_insts = vec![jump_inst(0, 1)];
+        let b1_insts = vec![branch_inst(1, 2, 3)];
+        let mut alloc = inst(
+            2,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        alloc.region = RegionId::Block(BlockId(2));
+        let b2_insts = vec![alloc, jump_inst(3, 1)];
+        let b3_insts = vec![return_unit_inst(4)];
+        let f = function(
+            0,
+            "single_loop",
+            vec![],
+            Ty::Unit,
+            vec![
+                block(0, b0_insts),
+                block(1, b1_insts),
+                block(2, b2_insts),
+                block(3, b3_insts),
+            ],
+        );
+        let mut m = module(vec![f]);
+
+        insert_region_markers(&mut m);
+
+        let body = &m.functions[0].blocks[2].insts;
+        let jump_pos = body
+            .iter()
+            .position(|i| i.opcode == Opcode::Jump)
+            .expect("body should end in a back-edge jump");
+        assert_eq!(
+            body[jump_pos - 2].opcode,
+            Opcode::RegionClose,
+            "back-edge predecessor should close the body region before jumping to the header"
+        );
+        assert_eq!(body[jump_pos - 2].region, RegionId::Block(BlockId(2)));
+        assert_eq!(
+            body[jump_pos - 1].opcode,
+            Opcode::RegionOpen,
+            "back-edge predecessor should reopen the body region immediately after closing it"
+        );
+        assert_eq!(body[jump_pos - 1].region, RegionId::Block(BlockId(2)));
+    }
+
+    #[test]
+    fn backedge_nested_loops_refresh_inner_and_outer_regions() {
+        let b0_insts = vec![jump_inst(0, 1)];
+        let b1_insts = vec![branch_inst(1, 2, 7)];
+        let mut outer_alloc = inst(
+            2,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        outer_alloc.region = RegionId::Block(BlockId(2));
+        let b2_insts = vec![outer_alloc, jump_inst(3, 3)];
+        let b3_insts = vec![branch_inst(4, 4, 6)];
+        let mut inner_alloc = inst(
+            5,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        inner_alloc.region = RegionId::Block(BlockId(4));
+        let b4_insts = vec![inner_alloc, jump_inst(6, 3)];
+        let b6_insts = vec![jump_inst(7, 1)];
+        let b7_insts = vec![return_unit_inst(8)];
+        let f = function(
+            0,
+            "nested_loops",
+            vec![],
+            Ty::Unit,
+            vec![
+                block(0, b0_insts),
+                block(1, b1_insts),
+                block(2, b2_insts),
+                block(3, b3_insts),
+                block(4, b4_insts),
+                block(6, b6_insts),
+                block(7, b7_insts),
+            ],
+        );
+        let mut m = module(vec![f]);
+
+        insert_region_markers(&mut m);
+
+        let inner_body = &m.functions[0].blocks[4].insts;
+        let inner_jump = inner_body
+            .iter()
+            .position(|i| i.opcode == Opcode::Jump)
+            .expect("inner body should jump back to inner header");
+        assert_eq!(inner_body[inner_jump - 2].opcode, Opcode::RegionClose);
+        assert_eq!(
+            inner_body[inner_jump - 2].region,
+            RegionId::Block(BlockId(4))
+        );
+        assert_eq!(inner_body[inner_jump - 1].opcode, Opcode::RegionOpen);
+        assert_eq!(
+            inner_body[inner_jump - 1].region,
+            RegionId::Block(BlockId(4))
+        );
+
+        let outer_backedge = &m.functions[0].blocks[5].insts;
+        let outer_jump = outer_backedge
+            .iter()
+            .position(|i| i.opcode == Opcode::Jump)
+            .expect("outer body should jump back to outer header");
+        assert_eq!(outer_backedge[outer_jump - 2].opcode, Opcode::RegionClose);
+        assert_eq!(
+            outer_backedge[outer_jump - 2].region,
+            RegionId::Block(BlockId(2))
+        );
+        assert_eq!(outer_backedge[outer_jump - 1].opcode, Opcode::RegionOpen);
+        assert_eq!(
+            outer_backedge[outer_jump - 1].region,
+            RegionId::Block(BlockId(2))
+        );
+        assert!(
+            !outer_backedge
+                .iter()
+                .any(|i| i.region == RegionId::Block(BlockId(4))),
+            "outer back-edge must not refresh the inner loop body's region"
+        );
+    }
+
+    #[test]
+    fn backedge_break_predecessor_does_not_refresh_body_region() {
+        let b0_insts = vec![jump_inst(0, 1)];
+        let b1_insts = vec![branch_inst(1, 2, 4)];
+        let mut alloc = inst(
+            2,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        alloc.region = RegionId::Block(BlockId(2));
+        let b2_insts = vec![alloc, branch_inst(3, 3, 5)];
+        let b3_insts = vec![jump_inst(4, 4)];
+        let b4_insts = vec![return_unit_inst(5)];
+        let b5_insts = vec![jump_inst(6, 1)];
+        let f = function(
+            0,
+            "break_loop",
+            vec![],
+            Ty::Unit,
+            vec![
+                block(0, b0_insts),
+                block(1, b1_insts),
+                block(2, b2_insts),
+                block(3, b3_insts),
+                block(4, b4_insts),
+                block(5, b5_insts),
+            ],
+        );
+        let mut m = module(vec![f]);
+
+        insert_region_markers(&mut m);
+
+        let break_block = &m.functions[0].blocks[3].insts;
+        assert!(
+            !break_block
+                .iter()
+                .any(|i| i.opcode == Opcode::RegionOpen && i.region == RegionId::Block(BlockId(2))),
+            "break edge exits the loop and must not reopen the body region"
+        );
+        assert!(
+            break_block
+                .iter()
+                .any(|i| i.opcode == Opcode::RegionClose && i.region == RegionId::Block(BlockId(2))),
+            "break edge still keeps the ordinary exit close"
+        );
+
+        let backedge_block = &m.functions[0].blocks[5].insts;
+        let jump_pos = backedge_block
+            .iter()
+            .position(|i| i.opcode == Opcode::Jump)
+            .expect("natural loop path should jump back to header");
+        assert_eq!(backedge_block[jump_pos - 2].opcode, Opcode::RegionClose);
+        assert_eq!(
+            backedge_block[jump_pos - 2].region,
+            RegionId::Block(BlockId(2))
+        );
+        assert_eq!(backedge_block[jump_pos - 1].opcode, Opcode::RegionOpen);
+        assert_eq!(
+            backedge_block[jump_pos - 1].region,
+            RegionId::Block(BlockId(2))
+        );
+    }
+
+    #[test]
+    fn backedge_continue_predecessors_each_refresh_body_region() {
+        let b0_insts = vec![jump_inst(0, 1)];
+        let b1_insts = vec![branch_inst(1, 2, 6)];
+        let mut alloc = inst(
+            2,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        alloc.region = RegionId::Block(BlockId(2));
+        let b2_insts = vec![alloc, branch_inst(3, 3, 4)];
+        let b3_insts = vec![jump_inst(4, 1)];
+        let b4_insts = vec![jump_inst(5, 1)];
+        let b6_insts = vec![return_unit_inst(6)];
+        let f = function(
+            0,
+            "continue_loop",
+            vec![],
+            Ty::Unit,
+            vec![
+                block(0, b0_insts),
+                block(1, b1_insts),
+                block(2, b2_insts),
+                block(3, b3_insts),
+                block(4, b4_insts),
+                block(6, b6_insts),
+            ],
+        );
+        let mut m = module(vec![f]);
+
+        insert_region_markers(&mut m);
+
+        for block_idx in [3usize, 4usize] {
+            let backedge_block = &m.functions[0].blocks[block_idx].insts;
+            let jump_pos = backedge_block
+                .iter()
+                .position(|i| i.opcode == Opcode::Jump)
+                .expect("continue path should jump back to header");
+            assert_eq!(backedge_block[jump_pos - 2].opcode, Opcode::RegionClose);
+            assert_eq!(
+                backedge_block[jump_pos - 2].region,
+                RegionId::Block(BlockId(2))
+            );
+            assert_eq!(backedge_block[jump_pos - 1].opcode, Opcode::RegionOpen);
+            assert_eq!(
+                backedge_block[jump_pos - 1].region,
+                RegionId::Block(BlockId(2))
+            );
+        }
     }
 
     #[test]

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -917,6 +917,40 @@ fn marker_insts(next_id: &mut u32, markers: &EdgeRegionMarkers, span: Span) -> V
     insts
 }
 
+fn phi_home_blocks(func: &Function) -> BTreeMap<InstId, BlockId> {
+    let mut homes = BTreeMap::new();
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if inst.opcode == Opcode::Phi {
+                homes.insert(inst.id, block.id);
+            }
+        }
+    }
+    homes
+}
+
+fn upsilon_target_block(inst: &Inst, phi_homes: &BTreeMap<InstId, BlockId>) -> Option<BlockId> {
+    if inst.opcode == Opcode::Upsilon
+        && let InstData::PhiTarget(phi_id) = inst.data
+    {
+        phi_homes.get(&phi_id).copied()
+    } else {
+        None
+    }
+}
+
+fn edge_upsilons_for_target(
+    insts: &[Inst],
+    target: BlockId,
+    phi_homes: &BTreeMap<InstId, BlockId>,
+) -> Vec<Inst> {
+    insts
+        .iter()
+        .filter(|inst| upsilon_target_block(inst, phi_homes) == Some(target))
+        .cloned()
+        .collect()
+}
+
 fn split_edge_with_markers(
     target: BlockId,
     markers: &EdgeRegionMarkers,
@@ -1005,6 +1039,7 @@ pub fn insert_region_markers(module: &mut Module) {
 
         let block_tree = BlockTree::from_function(func);
         let refresh_regions_by_edge = backedge_refresh_regions_by_edge(func, &block_regions);
+        let phi_homes = phi_home_blocks(func);
 
         let mut next_id = next_inst_id(func);
         let mut next_block_id = next_block_id(func);
@@ -1022,13 +1057,9 @@ pub fn insert_region_markers(module: &mut Module) {
                 .position(|i| i.opcode.is_terminal())
                 .unwrap_or(old_insts.len());
             let term_span = old_insts.get(term_pos).map(|i| i.origin).unwrap_or(span);
-            let edge_upsilons: Vec<Inst> = old_insts[term_pos.saturating_add(1)..]
-                .iter()
-                .filter(|inst| inst.opcode == Opcode::Upsilon)
-                .cloned()
-                .collect();
             let mut before_term_markers = EdgeRegionMarkers::default();
             let mut rewritten_term: Option<Inst> = None;
+            let mut moved_upsilons = BTreeSet::new();
             if let Some(term) = old_insts.get(term_pos) {
                 match &term.data {
                     InstData::JumpTarget(target) if term.opcode == Opcode::Jump => {
@@ -1051,6 +1082,8 @@ pub fn insert_region_markers(module: &mut Module) {
                             &block_tree,
                             &refresh_regions_by_edge,
                         );
+                        let then_upsilons =
+                            edge_upsilons_for_target(&old_insts, *then_block, &phi_homes);
                         let else_markers = edge_region_markers(
                             block.id,
                             Some(*else_block),
@@ -1058,10 +1091,12 @@ pub fn insert_region_markers(module: &mut Module) {
                             &block_tree,
                             &refresh_regions_by_edge,
                         );
+                        let else_upsilons =
+                            edge_upsilons_for_target(&old_insts, *else_block, &phi_homes);
                         let new_then = split_edge_with_markers(
                             *then_block,
                             &then_markers,
-                            &edge_upsilons,
+                            &then_upsilons,
                             term_span,
                             &mut next_id,
                             &mut next_block_id,
@@ -1070,13 +1105,19 @@ pub fn insert_region_markers(module: &mut Module) {
                         let new_else = split_edge_with_markers(
                             *else_block,
                             &else_markers,
-                            &edge_upsilons,
+                            &else_upsilons,
                             term_span,
                             &mut next_id,
                             &mut next_block_id,
                             &mut split_blocks,
                         );
                         if new_then != *then_block || new_else != *else_block {
+                            if new_then != *then_block {
+                                moved_upsilons.extend(then_upsilons.iter().map(|inst| inst.id));
+                            }
+                            if new_else != *else_block {
+                                moved_upsilons.extend(else_upsilons.iter().map(|inst| inst.id));
+                            }
                             let mut new_term = term.clone();
                             new_term.data = InstData::BranchTargets {
                                 then_block: new_then,
@@ -1125,11 +1166,21 @@ pub fn insert_region_markers(module: &mut Module) {
                 ));
                 next_id += 1;
             }
-            new_insts.extend(old_insts[..term_pos].iter().cloned());
+            new_insts.extend(
+                old_insts[..term_pos]
+                    .iter()
+                    .filter(|inst| !moved_upsilons.contains(&inst.id))
+                    .cloned(),
+            );
             new_insts.extend(marker_insts(&mut next_id, &before_term_markers, term_span));
             if let Some(term) = rewritten_term {
                 new_insts.push(term);
-                new_insts.extend(old_insts[term_pos + 1..].iter().cloned());
+                new_insts.extend(
+                    old_insts[term_pos + 1..]
+                        .iter()
+                        .filter(|inst| !moved_upsilons.contains(&inst.id))
+                        .cloned(),
+                );
             } else {
                 new_insts.extend(old_insts[term_pos..].iter().cloned());
             }
@@ -3327,7 +3378,6 @@ mod tests {
         alloc.region = RegionId::Block(BlockId(2));
         let b2_insts = vec![
             alloc,
-            branch_inst(3, 1, 3),
             inst(
                 4,
                 Opcode::Upsilon,
@@ -3335,8 +3385,12 @@ mod tests {
                 vec![2],
                 InstData::PhiTarget(InstId(5)),
             ),
+            branch_inst(3, 1, 3),
         ];
-        let b3_insts = vec![return_unit_inst(6)];
+        let b3_insts = vec![
+            inst(5, Opcode::Phi, Ty::Ptr, vec![], InstData::None),
+            return_unit_inst(6),
+        ];
         let f = function(
             0,
             "mixed_backedge_exit",
@@ -3386,6 +3440,13 @@ mod tests {
                 .any(|i| i.opcode == Opcode::RegionClose && i.region == RegionId::Block(BlockId(2))),
             "mixed branch predecessor must not emit one block-wide close before both edges"
         );
+        assert!(
+            !pred
+                .insts
+                .iter()
+                .any(|i| i.opcode == Opcode::Upsilon && i.data == InstData::PhiTarget(InstId(5))),
+            "exit phi feed should move from the predecessor onto the split exit edge"
+        );
 
         let then_split = m.functions[0]
             .blocks
@@ -3397,11 +3458,11 @@ mod tests {
         assert_eq!(then_split.insts[1].opcode, Opcode::RegionOpen);
         assert_eq!(then_split.insts[1].region, RegionId::Block(BlockId(2)));
         assert!(
-            then_split
+            !then_split
                 .insts
                 .iter()
-                .any(|i| i.opcode == Opcode::Upsilon && i.id != InstId(4)),
-            "split edge should preserve phi feeds with fresh instruction ids"
+                .any(|i| i.opcode == Opcode::Upsilon && i.data == InstData::PhiTarget(InstId(5))),
+            "backedge split must not steal exit phi feeds"
         );
         let then_jump = then_split
             .insts
@@ -3423,6 +3484,13 @@ mod tests {
                 .iter()
                 .any(|i| i.opcode == Opcode::RegionOpen),
             "exit split block must not reopen the region it is leaving"
+        );
+        assert!(
+            else_split.insts.iter().any(|i| i.opcode == Opcode::Upsilon
+                && i.id != InstId(4)
+                && i.args == vec![InstId(2)]
+                && i.data == InstData::PhiTarget(InstId(5))),
+            "exit split should preserve pre-branch phi feeds with fresh instruction ids"
         );
         let else_jump = else_split
             .insts

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -888,7 +888,7 @@ fn edge_region_markers(
 }
 
 fn marker_insts(next_id: &mut u32, markers: &EdgeRegionMarkers, span: Span) -> Vec<Inst> {
-    let mut insts = Vec::with_capacity(markers.closes.len() + markers.refreshes.len() * 2);
+    let mut insts = Vec::with_capacity(markers.closes.len() + markers.refreshes.len());
     for &close_block in &markers.closes {
         insts.push(region_marker_inst(
             *next_id,
@@ -902,13 +902,6 @@ fn marker_insts(next_id: &mut u32, markers: &EdgeRegionMarkers, span: Span) -> V
         insts.push(region_marker_inst(
             *next_id,
             Opcode::RegionClose,
-            refresh_block,
-            span,
-        ));
-        *next_id += 1;
-        insts.push(region_marker_inst(
-            *next_id,
-            Opcode::RegionOpen,
             refresh_block,
             span,
         ));
@@ -1155,7 +1148,7 @@ pub fn insert_region_markers(module: &mut Module) {
                 old_insts.len()
                     + usize::from(opens_here)
                     + before_term_markers.closes.len()
-                    + before_term_markers.refreshes.len() * 2,
+                    + before_term_markers.refreshes.len(),
             );
             if opens_here {
                 new_insts.push(region_marker_inst(
@@ -3140,23 +3133,23 @@ mod tests {
         insert_region_markers(&mut m);
 
         let block_insts = &m.functions[0].blocks[0].insts;
+        let opens: Vec<_> = block_insts
+            .iter()
+            .filter(|i| i.opcode == Opcode::RegionOpen && i.region == RegionId::Block(BlockId(0)))
+            .collect();
+        assert_eq!(
+            opens.len(),
+            1,
+            "self-loop header should reopen only when control reaches the block entry"
+        );
         let jump_pos = block_insts
             .iter()
             .position(|i| i.opcode == Opcode::Jump)
             .expect("self-loop should end in a back-edge jump");
         assert_eq!(
-            block_insts[jump_pos - 2].opcode,
+            block_insts[jump_pos - 1].opcode,
             Opcode::RegionClose,
             "self-loop backedge should close the header-owned region before jumping"
-        );
-        assert_eq!(
-            block_insts[jump_pos - 2].region,
-            RegionId::Block(BlockId(0))
-        );
-        assert_eq!(
-            block_insts[jump_pos - 1].opcode,
-            Opcode::RegionOpen,
-            "self-loop backedge should reopen the header-owned region immediately"
         );
         assert_eq!(
             block_insts[jump_pos - 1].region,
@@ -3203,17 +3196,17 @@ mod tests {
             .position(|i| i.opcode == Opcode::Jump)
             .expect("body should end in a back-edge jump");
         assert_eq!(
-            body[jump_pos - 2].opcode,
+            body[jump_pos - 1].opcode,
             Opcode::RegionClose,
             "back-edge predecessor should close the body region before jumping to the header"
         );
-        assert_eq!(body[jump_pos - 2].region, RegionId::Block(BlockId(2)));
-        assert_eq!(
-            body[jump_pos - 1].opcode,
-            Opcode::RegionOpen,
-            "back-edge predecessor should reopen the body region immediately after closing it"
-        );
         assert_eq!(body[jump_pos - 1].region, RegionId::Block(BlockId(2)));
+        assert!(
+            !body[jump_pos..]
+                .iter()
+                .any(|i| i.opcode == Opcode::RegionOpen && i.region == RegionId::Block(BlockId(2))),
+            "back-edge refresh must not reopen the body region before the header can exit"
+        );
     }
 
     #[test]
@@ -3265,12 +3258,7 @@ mod tests {
             .iter()
             .position(|i| i.opcode == Opcode::Jump)
             .expect("inner body should jump back to inner header");
-        assert_eq!(inner_body[inner_jump - 2].opcode, Opcode::RegionClose);
-        assert_eq!(
-            inner_body[inner_jump - 2].region,
-            RegionId::Block(BlockId(4))
-        );
-        assert_eq!(inner_body[inner_jump - 1].opcode, Opcode::RegionOpen);
+        assert_eq!(inner_body[inner_jump - 1].opcode, Opcode::RegionClose);
         assert_eq!(
             inner_body[inner_jump - 1].region,
             RegionId::Block(BlockId(4))
@@ -3281,12 +3269,7 @@ mod tests {
             .iter()
             .position(|i| i.opcode == Opcode::Jump)
             .expect("outer body should jump back to outer header");
-        assert_eq!(outer_backedge[outer_jump - 2].opcode, Opcode::RegionClose);
-        assert_eq!(
-            outer_backedge[outer_jump - 2].region,
-            RegionId::Block(BlockId(2))
-        );
-        assert_eq!(outer_backedge[outer_jump - 1].opcode, Opcode::RegionOpen);
+        assert_eq!(outer_backedge[outer_jump - 1].opcode, Opcode::RegionClose);
         assert_eq!(
             outer_backedge[outer_jump - 1].region,
             RegionId::Block(BlockId(2))
@@ -3294,7 +3277,7 @@ mod tests {
         assert!(
             !outer_backedge
                 .iter()
-                .any(|i| i.region == RegionId::Block(BlockId(4))),
+                .any(|i| i.opcode == Opcode::RegionClose && i.region == RegionId::Block(BlockId(4))),
             "outer back-edge must not refresh the inner loop body's region"
         );
     }
@@ -3352,12 +3335,7 @@ mod tests {
             .iter()
             .position(|i| i.opcode == Opcode::Jump)
             .expect("natural loop path should jump back to header");
-        assert_eq!(backedge_block[jump_pos - 2].opcode, Opcode::RegionClose);
-        assert_eq!(
-            backedge_block[jump_pos - 2].region,
-            RegionId::Block(BlockId(2))
-        );
-        assert_eq!(backedge_block[jump_pos - 1].opcode, Opcode::RegionOpen);
+        assert_eq!(backedge_block[jump_pos - 1].opcode, Opcode::RegionClose);
         assert_eq!(
             backedge_block[jump_pos - 1].region,
             RegionId::Block(BlockId(2))
@@ -3455,8 +3433,13 @@ mod tests {
             .expect("backedge split block should exist");
         assert_eq!(then_split.insts[0].opcode, Opcode::RegionClose);
         assert_eq!(then_split.insts[0].region, RegionId::Block(BlockId(2)));
-        assert_eq!(then_split.insts[1].opcode, Opcode::RegionOpen);
-        assert_eq!(then_split.insts[1].region, RegionId::Block(BlockId(2)));
+        assert!(
+            !then_split
+                .insts
+                .iter()
+                .any(|i| i.opcode == Opcode::RegionOpen && i.region == RegionId::Block(BlockId(2))),
+            "backedge split must not reopen before the header can exit"
+        );
         assert!(
             !then_split
                 .insts
@@ -3540,12 +3523,7 @@ mod tests {
                 .iter()
                 .position(|i| i.opcode == Opcode::Jump)
                 .expect("continue path should jump back to header");
-            assert_eq!(backedge_block[jump_pos - 2].opcode, Opcode::RegionClose);
-            assert_eq!(
-                backedge_block[jump_pos - 2].region,
-                RegionId::Block(BlockId(2))
-            );
-            assert_eq!(backedge_block[jump_pos - 1].opcode, Opcode::RegionOpen);
+            assert_eq!(backedge_block[jump_pos - 1].opcode, Opcode::RegionClose);
             assert_eq!(
                 backedge_block[jump_pos - 1].region,
                 RegionId::Block(BlockId(2))

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -659,7 +659,23 @@ unsafe fn chunk_usable_start(base: *mut u8, align: usize) -> usize {
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_arena_init_closed(a: *mut VowArena) {
+    let arena = unsafe { &mut *a };
+    arena.first_chunk = core::ptr::null_mut();
+    arena.current_chunk = core::ptr::null_mut();
+    arena.cursor = 0;
+    arena.chunk_end = 0;
+    arena.last_alloc_start = core::ptr::null_mut();
+    arena.last_alloc_size = 0;
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_arena_open(a: *mut VowArena) {
+    let arena = unsafe { &mut *a };
+    if !arena.first_chunk.is_null() {
+        return;
+    }
+
     let total = normal_chunk_total();
     let base = unsafe { alloc_chunk(total) };
     if base.is_null() {
@@ -2948,11 +2964,29 @@ mod tests {
     #[test]
     fn arena_open_close_roundtrip() {
         let mut a = empty_arena_header();
+        unsafe { __vow_arena_init_closed(&mut a) };
         unsafe { __vow_arena_open(&mut a) };
         assert!(!a.first_chunk.is_null());
         assert_eq!(a.first_chunk, a.current_chunk);
         assert!(a.cursor >= a.first_chunk as usize + CHUNK_LINK_BYTES);
         assert_eq!(a.chunk_end, a.first_chunk as usize + normal_chunk_total());
+        unsafe { __vow_arena_close(&mut a) };
+        assert!(a.first_chunk.is_null());
+    }
+
+    #[test]
+    fn arena_open_on_open_arena_is_noop() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_init_closed(&mut a) };
+        unsafe { __vow_arena_open(&mut a) };
+        let first = a.first_chunk;
+        let p = unsafe { __vow_arena_alloc(&mut a, 64, 8) };
+        unsafe { __vow_arena_open(&mut a) };
+        assert!(!a.first_chunk.is_null());
+        assert_eq!(a.first_chunk, first);
+        assert_eq!(a.first_chunk, a.current_chunk);
+        assert_eq!(a.last_alloc_start, p);
+        assert_eq!(a.last_alloc_size, 64);
         unsafe { __vow_arena_close(&mut a) };
         assert!(a.first_chunk.is_null());
     }

--- a/vow-runtime/verify/arena.c
+++ b/vow-runtime/verify/arena.c
@@ -72,7 +72,22 @@ static uintptr_t chunk_usable_start(void* base, uintptr_t align) {
     return align_up((uintptr_t)base + CHUNK_LINK_BYTES, align);
 }
 
+void __vow_arena_close(struct VowArena* a);
+
+void __vow_arena_init_closed(struct VowArena* a) {
+    a->first_chunk = NULL;
+    a->current_chunk = NULL;
+    a->cursor = 0;
+    a->chunk_end = 0;
+    a->last_alloc_start = NULL;
+    a->last_alloc_size = 0;
+}
+
 void __vow_arena_open(struct VowArena* a) {
+    if (a->first_chunk != NULL) {
+        return;
+    }
+
     uintptr_t total = normal_total();
     void* base = alloc_chunk(total);
     __ESBMC_assume(base != NULL);  /* OOM is out of scope for §10.4; covered by OutOfMemory trap */
@@ -136,9 +151,19 @@ int64_t __vow_arena_try_extend(struct VowArena* a, void* ptr,
 
 int main(void) {
     struct VowArena a;
+    __vow_arena_init_closed(&a);
     __vow_arena_open(&a);
     /* Invariant at open: cursor <= chunk_end. */
     assert(a.cursor <= a.chunk_end);
+    void* opened_first_chunk = a.first_chunk;
+    void* opened_current_chunk = a.current_chunk;
+    uintptr_t opened_cursor = a.cursor;
+    uintptr_t opened_chunk_end = a.chunk_end;
+    __vow_arena_open(&a);
+    assert(a.first_chunk == opened_first_chunk);
+    assert(a.current_chunk == opened_current_chunk);
+    assert(a.cursor == opened_cursor);
+    assert(a.chunk_end == opened_chunk_end);
 
     /* Perform up to two symbolic allocations bounded in size. With large
      * symbolic alignments each alloc may take the oversized path (own

--- a/vow/src/cache.rs
+++ b/vow/src/cache.rs
@@ -8,7 +8,7 @@ use crate::frontend::DependencyManifest;
 // Bump this whenever generated object files are no longer ABI-compatible with
 // existing cached artifacts. Phase 7 adds FFI wrapper stdlib intrinsics and
 // runtime helper imports, so pre-cutover objects must not be reused.
-const COMPILE_CACHE_ABI_VERSION: &str = "arena-phase7-ffi-wrapper-v1";
+const COMPILE_CACHE_ABI_VERSION: &str = "arena-loop-refresh-v2";
 
 pub struct CompileCache {
     dir: PathBuf,


### PR DESCRIPTION
## Summary

- Detect DFS loop backedges in the Rust and self-hosted region marker passes.
- Refresh non-empty loop-body block arenas with deterministic close/open pairs before backedge jumps.
- Initialize block arena stack slots before marker execution and make arena open idempotent so refreshes compose with block-entry opens.
- Update the arena memory design doc, runtime ESBMC model, and compile-cache ABI seed.

Closes #290.

## Validation

- `cargo test -p vow-ir`
- `cargo test -p vow-ir backedge_`
- `cargo test -p vow-runtime`
- `cargo check -p vow-codegen -p vow-clif-shim -p vow-runtime -p vow`
- `scripts/bootstrap.sh --skip-cargo`
- `bench/memory/run.sh`
- `scripts/full_test.sh` completed with `338 passed`, `5 failed`, `1 skipped`; `arena/esbmc` passed. Remaining failures are existing verify-counterexample reporting cases: `search`, `sum_range`, `vec_fill`, `gc`, and `math`.
