### PR TITLE
[codex] Add explicit arena Vec runtime APIs

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -92,9 +92,15 @@ fn vec_insert_i64(v: Vec<i64>, val: i64) -> bool {
 
 fn is_known_builtin(name: String) -> bool {
     name == String::from("__vow_vec_new")
+    || name == String::from("__vow_vec_new_val")
+    || name == String::from("__vow_vec_new_in_arena")
+    || name == String::from("__vow_vec_new_val_in_arena")
     || name == String::from("__vow_vec_from_raw_parts_copy_val")
     || name == String::from("__vow_vec_pin_to_root_val")
     || name == String::from("__vow_vec_push_val")
+    || name == String::from("__vow_vec_push_in_arena")
+    || name == String::from("__vow_vec_push_val_in_arena")
+    || name == String::from("__vow_vec_reserve_in_arena")
     || name == String::from("__vow_vec_get_val")
     || name == String::from("__vow_vec_len")
     || name == String::from("__vow_vec_pop")
@@ -433,6 +439,27 @@ fn c_nondet_suffix(ty: i64) -> String {
     String::from("int")
 }
 
+fn is_vec_model_constructor(name: String) -> bool {
+    name == String::from("__vow_vec_new")
+    || name == String::from("__vow_vec_new_val")
+    || name == String::from("__vow_vec_new_in_arena")
+    || name == String::from("__vow_vec_new_val_in_arena")
+    || name == String::from("__vow_vec_from_raw_parts_copy_val")
+    || name == String::from("__vow_vec_pin_to_root_val")
+}
+
+fn vec_model_receiver_arg(name: String) -> i64 {
+    if name == String::from("__vow_vec_push_val") { return 0; }
+    if name == String::from("__vow_vec_get_val") { return 0; }
+    if name == String::from("__vow_vec_len") { return 0; }
+    if name == String::from("__vow_vec_pop") { return 0; }
+    if name == String::from("__vow_vec_set_val") { return 0; }
+    if name == String::from("__vow_vec_push_in_arena") { return 1; }
+    if name == String::from("__vow_vec_push_val_in_arena") { return 1; }
+    if name == String::from("__vow_vec_reserve_in_arena") { return 1; }
+    -1
+}
+
 fn detect_const_fns(m: IrModule) -> Vec<i64> {
     let result: Vec<i64> = Vec::new();
     let fns: Vec<IrFunction> = m.functions;
@@ -531,7 +558,9 @@ fn collect_modelled_vars(f: IrFunction, constructor: String, prefix: String) -> 
                     || (prefix == String::from("__vow_string_")
                         && (ds == String::from("__vow_string_from_raw_parts_copy")
                             || ds == String::from("__vow_string_pin_to_root")));
-                if ds == constructor || alt_creator {
+                let is_creator: bool = ds == constructor || alt_creator
+                    || (prefix == String::from("__vow_vec_") && is_vec_model_constructor(ds));
+                if is_creator {
                     vec_insert_i64(vars, inst.id);
                 }
             }
@@ -554,10 +583,19 @@ fn collect_modelled_vars(f: IrFunction, constructor: String, prefix: String) -> 
                     || (prefix == String::from("__vow_string_")
                         && (ds == String::from("__vow_string_from_raw_parts_copy")
                             || ds == String::from("__vow_string_pin_to_root")));
-                if str_starts_with(ds, prefix) && !(ds == constructor) && !alt_creator {
+                let is_creator: bool = ds == constructor || alt_creator
+                    || (prefix == String::from("__vow_vec_") && is_vec_model_constructor(ds));
+                if str_starts_with(ds, prefix) && !is_creator {
                     let iargs: Vec<i64> = inst.args;
-                    if iargs.len() > 0 {
-                        vec_insert_i64(vars, iargs[0]);
+                    let receiver_arg: i64 = {
+                        if prefix == String::from("__vow_vec_") {
+                            vec_model_receiver_arg(ds)
+                        } else {
+                            0
+                        }
+                    };
+                    if receiver_arg >= 0 && iargs.len() > receiver_arg {
+                        vec_insert_i64(vars, iargs[receiver_arg]);
                     }
                 }
             }
@@ -1103,7 +1141,10 @@ fn emit_vec_op(out: String, inst: IrInst, vec_max: i64) {
     let ds: String = inst.ds;
     let iargs: Vec<i64> = inst.args;
 
-    if ds == String::from("__vow_vec_new") {
+    if ds == String::from("__vow_vec_new")
+       || ds == String::from("__vow_vec_new_val")
+       || ds == String::from("__vow_vec_new_in_arena")
+       || ds == String::from("__vow_vec_new_val_in_arena") {
         let ids: String = i64_to_str(id);
         out.push_str(str3(String::from("  v"), ids, String::from(".len = 0;\n")));
         return;
@@ -1124,9 +1165,12 @@ fn emit_vec_op(out: String, inst: IrInst, vec_max: i64) {
             String::from(" = v"), i64_to_str(src), String::from(";\n")));
         return;
     }
-    if ds == String::from("__vow_vec_push_val") {
-        let vec: i64 = iargs[0];
-        let val: i64 = iargs[1];
+    if ds == String::from("__vow_vec_push_val")
+       || ds == String::from("__vow_vec_push_val_in_arena") {
+        let vec_arg: i64 = { if ds == String::from("__vow_vec_push_val_in_arena") { 1 } else { 0 } };
+        let val_arg: i64 = { if ds == String::from("__vow_vec_push_val_in_arena") { 2 } else { 1 } };
+        let vec: i64 = iargs[vec_arg];
+        let val: i64 = iargs[val_arg];
         let vs: String = i64_to_str(vec);
         let vas: String = i64_to_str(val);
         out.push_str(str5(String::from("  __ESBMC_assert(v"), vs,
@@ -1134,6 +1178,19 @@ fn emit_vec_op(out: String, inst: IrInst, vec_max: i64) {
         out.push_str(str6(String::from("  v"), vs, String::from(".data[v"), vs,
             String::from(".len] = v"), str2(vas, String::from(";\n"))));
         out.push_str(str3(String::from("  v"), vs, String::from(".len++;\n")));
+        return;
+    }
+    if ds == String::from("__vow_vec_push_in_arena") {
+        let vec: i64 = iargs[1];
+        let vs: String = i64_to_str(vec);
+        out.push_str(str5(String::from("  __ESBMC_assert(v"), vs,
+            String::from(".len < "), i64_to_str(vec_max), String::from(", \"vec capacity\");\n")));
+        out.push_str(str5(String::from("  v"), vs, String::from(".data[v"), vs,
+            String::from(".len] = __VERIFIER_nondet_long();\n")));
+        out.push_str(str3(String::from("  v"), vs, String::from(".len++;\n")));
+        return;
+    }
+    if ds == String::from("__vow_vec_reserve_in_arena") {
         return;
     }
     if ds == String::from("__vow_vec_get_val") {

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2293,6 +2293,7 @@ fn extern_fresh_in_caller(sym: String) -> bool {
 
 fn extern_store_edge_count(sym: String) -> i64 {
     if sym == String::from("__vow_vec_push_val") { return 1; }
+    if sym == String::from("__vow_vec_push_val_in_arena") { return 1; }
     if sym == String::from("__vow_vec_set_val") { return 1; }
     if sym == String::from("__vow_map_insert") { return 2; }
     if sym == String::from("__vow_btreemap_insert") { return 2; }
@@ -2303,11 +2304,13 @@ fn extern_store_target_pos(sym: String, edge_idx: i64) -> i64 {
     if edge_idx < 0 || edge_idx >= extern_store_edge_count(sym) {
         return -1;
     }
+    if sym == String::from("__vow_vec_push_val_in_arena") && edge_idx == 0 { return 1; }
     0
 }
 
 fn extern_store_source_pos(sym: String, edge_idx: i64) -> i64 {
     if sym == String::from("__vow_vec_push_val") && edge_idx == 0 { return 1; }
+    if sym == String::from("__vow_vec_push_val_in_arena") && edge_idx == 0 { return 2; }
     if sym == String::from("__vow_vec_set_val") && edge_idx == 0 { return 2; }
     if (sym == String::from("__vow_map_insert") || sym == String::from("__vow_btreemap_insert"))
         && edge_idx == 0

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -220,6 +220,48 @@ If `__vow_arena_alloc`'s fallback `malloc` for a new chunk fails,
 the runtime traps with the same structured OOM error as
 `__vow_arena_open` (§16).
 
+#### Vec runtime allocation API
+
+The existing root-region Vec symbols remain ABI-stable:
+
+```c
+void* __vow_vec_new(uintptr_t elem_size, uintptr_t align);
+void* __vow_vec_new_val(void);
+void  __vow_vec_push(void* vec, const void* value_ptr,
+                     uintptr_t elem_size, uintptr_t elem_align);
+void  __vow_vec_push_val(void* vec, int64_t value);
+```
+
+These are root wrappers: they open `__vow_root_arena` if needed, then
+delegate to the corresponding explicit-arena primitive with
+`&__vow_root_arena`.
+
+The explicit-arena forms are:
+
+```c
+void* __vow_vec_new_in_arena(struct VowArena* arena,
+                             uintptr_t elem_size, uintptr_t align);
+void* __vow_vec_new_val_in_arena(struct VowArena* arena);
+void  __vow_vec_push_in_arena(struct VowArena* arena, void* vec,
+                              const void* value_ptr,
+                              uintptr_t elem_size, uintptr_t elem_align);
+void  __vow_vec_push_val_in_arena(struct VowArena* arena, void* vec,
+                                  int64_t value);
+void  __vow_vec_reserve_in_arena(struct VowArena* arena, void* vec,
+                                 uintptr_t additional,
+                                 uintptr_t elem_size,
+                                 uintptr_t elem_align);
+```
+
+Every explicit-arena Vec entry traps with
+`RuntimeInvariantViolation` and `reason = "null arena"` before
+dereferencing a null arena pointer. Growth for both root and
+explicit-arena Vecs uses the shared arena grow path: first
+`__vow_arena_try_extend`, then `__vow_arena_alloc` + copy + zero-fill
+on fallback. `__vow_vec_from_raw_parts_copy_val(arena, ptr, len)`
+already has the explicit-arena shape and copies the raw slots into the
+supplied arena.
+
 ### 3.4. Determinism
 
 The arena **allocation strategy**, the **chunk-size policy**, and

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2422,7 +2422,17 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }
+        "__vow_vec_new_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
         "__vow_vec_new_val" => {
+            sig.returns.push(AbiParam::new(types::I64));
+        }
+        "__vow_vec_new_val_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }
         "__vow_vec_from_raw_parts_copy_val" => {
@@ -2440,6 +2450,25 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.returns.push(AbiParam::new(types::I64));
         }
         "__vow_vec_push_val" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+        }
+        "__vow_vec_push_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+        }
+        "__vow_vec_push_val_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+        }
+        "__vow_vec_reserve_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
         }

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -1869,6 +1869,19 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // elem_align
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec
         }
+        "__vow_vec_new_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // elem_size
+            sig.params.push(AbiParam::new(types::I64)); // elem_align
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec
+        }
+        "__vow_vec_new_val" => {
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<i64>
+        }
+        "__vow_vec_new_val_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<i64>
+        }
         "__vow_vec_from_raw_parts_copy_val" => {
             sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64)); // raw i64 ptr
@@ -1886,6 +1899,25 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_vec_push_val" => {
             sig.params.push(AbiParam::new(types::I64)); // vec ptr
             sig.params.push(AbiParam::new(types::I64)); // value (i64)
+        }
+        "__vow_vec_push_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // vec ptr
+            sig.params.push(AbiParam::new(types::I64)); // value ptr
+            sig.params.push(AbiParam::new(types::I64)); // elem_size
+            sig.params.push(AbiParam::new(types::I64)); // elem_align
+        }
+        "__vow_vec_push_val_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // vec ptr
+            sig.params.push(AbiParam::new(types::I64)); // value (i64)
+        }
+        "__vow_vec_reserve_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // vec ptr
+            sig.params.push(AbiParam::new(types::I64)); // additional
+            sig.params.push(AbiParam::new(types::I64)); // elem_size
+            sig.params.push(AbiParam::new(types::I64)); // elem_align
         }
         "__vow_vec_get_val" => {
             sig.params.push(AbiParam::new(types::I64)); // vec ptr

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1456,6 +1456,7 @@ fn extern_fresh_in_caller(sym: &str) -> bool {
 fn for_each_extern_store_edge(sym: &str, args: &[InstId], mut visit: impl FnMut(InstId, InstId)) {
     match sym {
         "__vow_vec_push_val" if args.len() >= 2 => visit(args[0], args[1]),
+        "__vow_vec_push_val_in_arena" if args.len() >= 3 => visit(args[1], args[2]),
         "__vow_vec_set_val" if args.len() >= 3 => visit(args[0], args[2]),
         "__vow_map_insert" | "__vow_btreemap_insert" if args.len() >= 3 => {
             visit(args[0], args[1]);
@@ -4276,6 +4277,57 @@ mod tests {
             source.region,
             RegionId::Caller(HiddenRegionIdx(0)),
             "source stored by an extern container mutator must inherit target escapes"
+        );
+    }
+
+    #[test]
+    fn explicit_arena_vec_push_val_into_escaping_target_widens_source_to_caller_region() {
+        let insts = vec![
+            inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                2,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                3,
+                Opcode::Call,
+                Ty::Unit,
+                vec![0, 1, 2],
+                InstData::CallExtern("__vow_vec_push_val_in_arena".to_string()),
+            ),
+            inst(4, Opcode::Return, Ty::Unit, vec![1], InstData::None),
+        ];
+        let f = function(
+            0,
+            "extern_arena_vec_push_escape",
+            vec![],
+            Ty::Ptr,
+            vec![block(0, insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        let target = &m.functions[0].blocks[0].insts[1];
+        let source = &m.functions[0].blocks[0].insts[2];
+        assert_eq!(
+            target.region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "returned explicit-arena extern-mutated target should be caller-region allocated"
+        );
+        assert_eq!(
+            source.region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "source stored by explicit-arena Vec::push_val must inherit target escapes"
         );
     }
 

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -221,6 +221,22 @@ fn region_literal_mutation_trap(operation: &'static str) -> ! {
     std::process::exit(1);
 }
 
+fn runtime_invariant_trap(operation: &'static str, reason: &'static str) -> ! {
+    use std::io::Write;
+    let stderr = std::io::stderr();
+    let mut lock = stderr.lock();
+    let _ = lock.write_all(b"{\"error\":\"RuntimeInvariantViolation\",\"operation\":\"");
+    let _ = lock.write_all(operation.as_bytes());
+    let _ = lock.write_all(b"\",\"reason\":\"");
+    let _ = lock.write_all(reason.as_bytes());
+    let _ = lock.write_all(b"\"}\n");
+    std::process::exit(1);
+}
+
+fn null_arena_trap(operation: &'static str) -> ! {
+    runtime_invariant_trap(operation, "null arena");
+}
+
 // ---------------------------------------------------------------------------
 // Trace instrumentation
 // ---------------------------------------------------------------------------
@@ -820,19 +836,31 @@ unsafe fn root_arena_alloc_zeroed(bytes: usize, align: usize) -> *mut u8 {
     ptr
 }
 
-/// Grow a backing buffer that lives in `__vow_root_arena`. Implements the
-/// spec §7.2 zero-copy fast path: try `__vow_arena_try_extend` first; if
-/// the backing is the most recent allocation in the chunk and the new
-/// size still fits, growth is O(1) with no copy and no orphaned backing.
-/// Otherwise fall back to a fresh allocation + memcpy of the prefix.
-///
-/// Phase 4 / S6 status: this fast path is wired for **root-arena-backed**
-/// containers — the only kind today, since `__vow_vec_new` /
-/// `__vow_string_new` / `__vow_map_new` all allocate from
-/// `__vow_root_arena`. Threading a per-container arena pointer through
-/// the descriptor (so block-arena-backed `Vec`/`String`/`HashMap` also
-/// benefit from try_extend) is a much larger API change deferred to
-/// Phase 9 (performance), per `docs/design/arena_memory.md` §15.
+/// Grow a backing buffer that lives in `arena`. Implements the spec §7.2
+/// zero-copy fast path: try `__vow_arena_try_extend` first; if the backing
+/// is the most recent allocation in the chunk and the new size still fits,
+/// growth is O(1) with no copy and no orphaned backing. Otherwise fall back
+/// to a fresh allocation + memcpy of the prefix.
+unsafe fn arena_grow_backing(
+    arena: *mut VowArena,
+    ptr: *mut u8,
+    old_size: usize,
+    new_size: usize,
+    align: usize,
+) -> *mut u8 {
+    if old_size > 0 && unsafe { __vow_arena_try_extend(arena, ptr, old_size, new_size) != 0 } {
+        unsafe { std::ptr::write_bytes(ptr.add(old_size), 0, new_size - old_size) };
+        return ptr;
+    }
+
+    let new_ptr = unsafe { __vow_arena_alloc(arena, new_size, align) };
+    if old_size > 0 {
+        unsafe { std::ptr::copy_nonoverlapping(ptr, new_ptr, old_size) };
+    }
+    unsafe { std::ptr::write_bytes(new_ptr.add(old_size), 0, new_size - old_size) };
+    new_ptr
+}
+
 unsafe fn root_arena_grow_backing(
     ptr: *mut u8,
     old_size: usize,
@@ -841,21 +869,7 @@ unsafe fn root_arena_grow_backing(
 ) -> *mut u8 {
     let _guard = ROOT_ARENA_LOCK.lock().unwrap();
     unsafe { ensure_root_arena_locked() };
-    if old_size > 0
-        && unsafe {
-            __vow_arena_try_extend(&raw mut __vow_root_arena, ptr, old_size, new_size) != 0
-        }
-    {
-        unsafe { std::ptr::write_bytes(ptr.add(old_size), 0, new_size - old_size) };
-        return ptr;
-    }
-
-    let new_ptr = unsafe { __vow_arena_alloc(&raw mut __vow_root_arena, new_size, align) };
-    if old_size > 0 {
-        unsafe { std::ptr::copy_nonoverlapping(ptr, new_ptr, old_size) };
-    }
-    unsafe { std::ptr::write_bytes(new_ptr.add(old_size), 0, new_size - old_size) };
-    new_ptr
+    unsafe { arena_grow_backing(&raw mut __vow_root_arena, ptr, old_size, new_size, align) }
 }
 
 #[unsafe(no_mangle)]
@@ -934,9 +948,16 @@ fn read_stdin_line_into_scratch<R: std::io::BufRead>(
 const VEC_INITIAL_CAP: usize = 8;
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __vow_vec_new(elem_size: usize, align: usize) -> *mut u8 {
+pub unsafe extern "C" fn __vow_vec_new_in_arena(
+    arena: *mut VowArena,
+    elem_size: usize,
+    align: usize,
+) -> *mut u8 {
     let _ = elem_size;
-    let header_ptr = unsafe { root_arena_alloc_zeroed(24, 8) } as *mut VowVec;
+    if arena.is_null() {
+        null_arena_trap("Vec::new");
+    }
+    let header_ptr = unsafe { __vow_arena_alloc(arena, 24, 8) } as *mut VowVec;
     // Lazy allocation: don't allocate buffer until first push.
     // Use a dangling aligned pointer so from_raw_parts with len=0 is safe.
     unsafe {
@@ -949,19 +970,22 @@ pub extern "C" fn __vow_vec_new(elem_size: usize, align: usize) -> *mut u8 {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __vow_vec_new_val() -> *mut u8 {
-    __vow_vec_new(8, 8)
+pub extern "C" fn __vow_vec_new(elem_size: usize, align: usize) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_vec_new_in_arena(&raw mut __vow_root_arena, elem_size, align) }
 }
 
-unsafe fn __vow_vec_new_val_in_arena(arena: *mut VowArena) -> *mut u8 {
-    let header_ptr = unsafe { __vow_arena_alloc(arena, 24, 8) } as *mut VowVec;
-    unsafe {
-        (*header_ptr).ptr = 8 as *mut u8;
-        (*header_ptr).len = 0;
-        (*header_ptr).cap = 0;
-    }
-    sanitize_on_vec_new(header_ptr as usize);
-    header_ptr as *mut u8
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_vec_new_val_in_arena(arena: *mut VowArena) -> *mut u8 {
+    unsafe { __vow_vec_new_in_arena(arena, 8, 8) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __vow_vec_new_val() -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_vec_new_val_in_arena(&raw mut __vow_root_arena) }
 }
 
 #[unsafe(no_mangle)]
@@ -970,6 +994,9 @@ pub unsafe extern "C" fn __vow_vec_from_raw_parts_copy_val(
     ptr: *const i64,
     len: usize,
 ) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("Vec::from_raw_parts_copy");
+    }
     let vec = unsafe { __vow_vec_new_val_in_arena(arena) };
     if len == 0 || ptr.is_null() {
         return vec;
@@ -999,7 +1026,13 @@ pub unsafe extern "C" fn __vow_vec_pin_to_root_val(source: *const u8) -> *mut u8
     }
 }
 
-unsafe fn __vow_vec_reserve(vec: *mut u8, additional: usize, elem_size: usize, elem_align: usize) {
+unsafe fn vec_reserve_in_arena_no_null_check(
+    arena: *mut VowArena,
+    vec: *mut u8,
+    additional: usize,
+    elem_size: usize,
+    elem_align: usize,
+) {
     let v = unsafe { &mut *(vec as *mut VowVec) };
     if v.cap == VOW_CAP_RODATA {
         region_literal_mutation_trap("Vec::reserve");
@@ -1014,9 +1047,55 @@ unsafe fn __vow_vec_reserve(vec: *mut u8, additional: usize, elem_size: usize, e
     }
     let old_size = v.cap * elem_size;
     let new_size = new_cap * elem_size;
-    let new_ptr = unsafe { root_arena_grow_backing(v.ptr, old_size, new_size, elem_align) };
+    let new_ptr = unsafe { arena_grow_backing(arena, v.ptr, old_size, new_size, elem_align) };
     v.ptr = new_ptr;
     v.cap = new_cap;
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_vec_reserve_in_arena(
+    arena: *mut VowArena,
+    vec: *mut u8,
+    additional: usize,
+    elem_size: usize,
+    elem_align: usize,
+) {
+    if arena.is_null() {
+        null_arena_trap("Vec::reserve");
+    }
+    unsafe { vec_reserve_in_arena_no_null_check(arena, vec, additional, elem_size, elem_align) };
+}
+
+unsafe fn __vow_vec_reserve(vec: *mut u8, additional: usize, elem_size: usize, elem_align: usize) {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe {
+        vec_reserve_in_arena_no_null_check(
+            &raw mut __vow_root_arena,
+            vec,
+            additional,
+            elem_size,
+            elem_align,
+        )
+    };
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_vec_push_in_arena(
+    arena: *mut VowArena,
+    vec: *mut u8,
+    elem: *const u8,
+    elem_size: usize,
+    elem_align: usize,
+) {
+    if arena.is_null() {
+        null_arena_trap("Vec::push");
+    }
+    // Sanitizer first — consults the shadow table by pointer value and
+    // diagnoses UseAfterFree without dereferencing. The cap check must
+    // dereference, so it has to run after the sanitizer.
+    sanitize_on_push(vec as usize);
+    unsafe { vec_push_no_sanitize_in_arena(arena, vec, elem, elem_size, elem_align, "Vec::push") };
 }
 
 #[unsafe(no_mangle)]
@@ -1026,11 +1105,28 @@ pub unsafe extern "C" fn __vow_vec_push(
     elem_size: usize,
     elem_align: usize,
 ) {
-    // Sanitizer first — consults the shadow table by pointer value and
-    // diagnoses UseAfterFree without dereferencing. The cap check must
-    // dereference, so it has to run after the sanitizer.
-    sanitize_on_push(vec as usize);
-    unsafe { vec_push_no_sanitize(vec, elem, elem_size, elem_align, "Vec::push") };
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_vec_push_in_arena(&raw mut __vow_root_arena, vec, elem, elem_size, elem_align) };
+}
+
+unsafe fn vec_push_no_sanitize_in_arena(
+    arena: *mut VowArena,
+    vec: *mut u8,
+    elem: *const u8,
+    elem_size: usize,
+    elem_align: usize,
+    op: &'static str,
+) {
+    let v = unsafe { &*(vec as *const VowVec) };
+    if v.cap == VOW_CAP_RODATA {
+        region_literal_mutation_trap(op);
+    }
+    unsafe { vec_reserve_in_arena_no_null_check(arena, vec, 1, elem_size, elem_align) };
+    let v = unsafe { &mut *(vec as *mut VowVec) };
+    let dest = unsafe { v.ptr.add(v.len * elem_size) };
+    unsafe { std::ptr::copy_nonoverlapping(elem, dest, elem_size) };
+    v.len += 1;
 }
 
 // Inner push that assumes the caller has already run sanitize_on_push for
@@ -1043,15 +1139,18 @@ unsafe fn vec_push_no_sanitize(
     elem_align: usize,
     op: &'static str,
 ) {
-    let v = unsafe { &*(vec as *const VowVec) };
-    if v.cap == VOW_CAP_RODATA {
-        region_literal_mutation_trap(op);
-    }
-    unsafe { __vow_vec_reserve(vec, 1, elem_size, elem_align) };
-    let v = unsafe { &mut *(vec as *mut VowVec) };
-    let dest = unsafe { v.ptr.add(v.len * elem_size) };
-    unsafe { std::ptr::copy_nonoverlapping(elem, dest, elem_size) };
-    v.len += 1;
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe {
+        vec_push_no_sanitize_in_arena(
+            &raw mut __vow_root_arena,
+            vec,
+            elem,
+            elem_size,
+            elem_align,
+            op,
+        )
+    };
 }
 
 #[unsafe(no_mangle)]
@@ -1062,7 +1161,14 @@ pub unsafe extern "C" fn __vow_vec_len(vec: *const u8) -> usize {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_vec_push_val(vec: *mut u8, value: i64) {
+pub unsafe extern "C" fn __vow_vec_push_val_in_arena(
+    arena: *mut VowArena,
+    vec: *mut u8,
+    value: i64,
+) {
+    if arena.is_null() {
+        null_arena_trap("Vec::push_val");
+    }
     // Sanitize + cap-check here with the precise operation name. Delegating
     // the whole path to __vow_vec_push would (a) double-sanitize and (b)
     // report the trap as "Vec::push" instead of "Vec::push_val". Delegate
@@ -1070,7 +1176,14 @@ pub unsafe extern "C" fn __vow_vec_push_val(vec: *mut u8, value: i64) {
     // a single generation per appended element.
     sanitize_on_push(vec as usize);
     let bytes = value.to_ne_bytes();
-    unsafe { vec_push_no_sanitize(vec, bytes.as_ptr(), 8, 8, "Vec::push_val") };
+    unsafe { vec_push_no_sanitize_in_arena(arena, vec, bytes.as_ptr(), 8, 8, "Vec::push_val") };
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_vec_push_val(vec: *mut u8, value: i64) {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_vec_push_val_in_arena(&raw mut __vow_root_arena, vec, value) };
 }
 
 #[unsafe(no_mangle)]
@@ -3103,6 +3216,111 @@ mod tests {
     }
 
     #[test]
+    fn explicit_arena_vec_pushes_values() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+
+        let v = unsafe { __vow_vec_new_in_arena(&mut a, 8, 8) };
+        let header = unsafe { &*(v as *const VowVec) };
+        assert_eq!(header.len, 0);
+        assert_eq!(header.cap, 0);
+
+        let first = 17_i64;
+        let second = 23_i64;
+        unsafe { __vow_vec_push_in_arena(&mut a, v, &first as *const _ as *const u8, 8, 8) };
+        unsafe { __vow_vec_push_in_arena(&mut a, v, &second as *const _ as *const u8, 8, 8) };
+
+        assert_eq!(unsafe { __vow_vec_len(v) }, 2);
+        assert_eq!(unsafe { __vow_vec_get_val(v, 0) }, 17);
+        assert_eq!(unsafe { __vow_vec_get_val(v, 1) }, 23);
+
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
+    fn explicit_arena_vec_new_val_reserve_and_push_val() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+
+        let v = unsafe { __vow_vec_new_val_in_arena(&mut a) };
+        unsafe { __vow_vec_reserve_in_arena(&mut a, v, 12, 8, 8) };
+        let header = unsafe { &*(v as *const VowVec) };
+        assert_eq!(header.len, 0, "reserve must not change len");
+        assert!(header.cap >= 12);
+
+        unsafe { __vow_vec_push_val_in_arena(&mut a, v, 99) };
+        assert_eq!(unsafe { __vow_vec_len(v) }, 1);
+        assert_eq!(unsafe { __vow_vec_get_val(v, 0) }, 99);
+
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
+    fn explicit_arena_vec_growth_preserves_values_after_copy_fallback() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+
+        let v = unsafe { __vow_vec_new_val_in_arena(&mut a) };
+        for i in 0..8 {
+            unsafe { __vow_vec_push_val_in_arena(&mut a, v, i) };
+        }
+        let before = unsafe { &*(v as *const VowVec) }.ptr;
+        let _intervening = unsafe { __vow_arena_alloc(&mut a, 16, 8) };
+        unsafe { __vow_vec_push_val_in_arena(&mut a, v, 8) };
+
+        let after = unsafe { &*(v as *const VowVec) }.ptr;
+        assert_ne!(
+            after, before,
+            "intervening allocation should force allocate-copy growth"
+        );
+        for i in 0..9 {
+            assert_eq!(unsafe { __vow_vec_get_val(v, i as usize) }, i);
+        }
+
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
+    fn explicit_arena_vecs_remain_independent_across_two_open_arenas() {
+        let mut a = empty_arena_header();
+        let mut b = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+        unsafe { __vow_arena_open(&mut b) };
+
+        let va = unsafe { __vow_vec_new_val_in_arena(&mut a) };
+        let vb = unsafe { __vow_vec_new_val_in_arena(&mut b) };
+        unsafe { __vow_vec_push_val_in_arena(&mut a, va, 1) };
+        unsafe { __vow_vec_push_val_in_arena(&mut b, vb, 10) };
+        unsafe { __vow_vec_push_val_in_arena(&mut b, vb, 20) };
+
+        assert_eq!(unsafe { __vow_vec_get_val(va, 0) }, 1);
+        assert_eq!(unsafe { __vow_vec_get_val(vb, 0) }, 10);
+        assert_eq!(unsafe { __vow_vec_get_val(vb, 1) }, 20);
+
+        unsafe { __vow_arena_close(&mut a) };
+        unsafe { __vow_vec_push_val_in_arena(&mut b, vb, 30) };
+        assert_eq!(unsafe { __vow_vec_len(vb) }, 3);
+        assert_eq!(unsafe { __vow_vec_get_val(vb, 2) }, 30);
+        unsafe { __vow_arena_close(&mut b) };
+    }
+
+    #[test]
+    fn explicit_arena_vec_allocation_works_after_close_and_reopen() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+        let first = unsafe { __vow_vec_new_val_in_arena(&mut a) };
+        unsafe { __vow_vec_push_val_in_arena(&mut a, first, 1) };
+        unsafe { __vow_arena_close(&mut a) };
+
+        unsafe { __vow_arena_open(&mut a) };
+        let second = unsafe { __vow_vec_new_val_in_arena(&mut a) };
+        unsafe { __vow_vec_push_val_in_arena(&mut a, second, 2) };
+        assert_eq!(unsafe { __vow_vec_len(second) }, 1);
+        assert_eq!(unsafe { __vow_vec_get_val(second, 0) }, 2);
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
     fn string_clone_into_arena_copies_bytes() {
         // Phase 4 / S5 return materialization: clones a String descriptor's
         // backing into the supplied arena, returning a fresh, mutable
@@ -3349,10 +3567,10 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // VOW_CAP_RODATA trap tests. These use the subprocess pattern:
+    // Runtime trap tests. These use the subprocess pattern:
     // rodata_trap_worker reruns itself with an env var and invokes the
-    // appropriate mutation on a rodata-backed descriptor; it exits(1) via
-    // the trap. Parent tests spawn the worker and assert exit status + stderr.
+    // appropriate trap path; it exits(1) via the trap. Parent tests spawn
+    // the worker and assert exit status + stderr.
     // -----------------------------------------------------------------------
 
     fn make_rodata_vec_val() -> VowVec {
@@ -3386,6 +3604,30 @@ mod tests {
             unsafe { __vow_arena_open(&mut arena) };
             let _ = unsafe { __vow_arena_alloc(&mut arena, usize::MAX, 8) };
             eprintln!("rodata_trap_worker: arena overflow did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "Vec::new_in_arena_null" {
+            let _ = unsafe { __vow_vec_new_in_arena(std::ptr::null_mut(), 8, 8) };
+            eprintln!("rodata_trap_worker: null arena constructor did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "Vec::push_in_arena_null" {
+            let mut v = VowVec {
+                ptr: 8 as *mut u8,
+                len: 0,
+                cap: 0,
+            };
+            let elem = 0_i64;
+            unsafe {
+                __vow_vec_push_in_arena(
+                    std::ptr::null_mut(),
+                    &mut v as *mut _ as *mut u8,
+                    &elem as *const _ as *const u8,
+                    8,
+                    8,
+                )
+            };
+            eprintln!("rodata_trap_worker: null arena push did NOT trap");
             std::process::exit(42);
         }
         let mut v = make_rodata_vec_val();
@@ -3462,6 +3704,26 @@ mod tests {
         }
     }
 
+    fn assert_runtime_invariant_null_arena(op: &str, expected_op_in_json: &str) {
+        let (out, stderr) = spawn_trap_worker(op);
+        assert!(
+            !out.status.success(),
+            "worker for {op} should have exited non-zero; stderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(r#""error":"RuntimeInvariantViolation""#),
+            "stderr missing RuntimeInvariantViolation for {op}:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(&format!(r#""operation":"{expected_op_in_json}""#)),
+            "stderr missing operation={expected_op_in_json}:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(r#""reason":"null arena""#),
+            "stderr missing null arena reason:\n{stderr}"
+        );
+    }
+
     #[test]
     fn arena_alloc_rejects_overflow() {
         // Verifies the isize::MAX size-limit guard: passing bytes=usize::MAX
@@ -3476,6 +3738,16 @@ mod tests {
             stderr.contains(r#""error":"OutOfMemory""#),
             "stderr missing OutOfMemory trap:\n{stderr}"
         );
+    }
+
+    #[test]
+    fn explicit_arena_vec_new_null_arena_traps() {
+        assert_runtime_invariant_null_arena("Vec::new_in_arena_null", "Vec::new");
+    }
+
+    #[test]
+    fn explicit_arena_vec_push_null_arena_traps() {
+        assert_runtime_invariant_null_arena("Vec::push_in_arena_null", "Vec::push");
     }
 
     #[test]

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -93,6 +93,29 @@ fn ir_ty_to_c(ty: Ty) -> &'static str {
 // Typed variable analysis (Vec, String, HashMap)
 // ---------------------------------------------------------------------------
 
+fn is_vec_model_creator(name: &str) -> bool {
+    matches!(
+        name,
+        "__vow_vec_new"
+            | "__vow_vec_new_val"
+            | "__vow_vec_new_in_arena"
+            | "__vow_vec_new_val_in_arena"
+            | "__vow_vec_from_raw_parts_copy_val"
+            | "__vow_vec_pin_to_root_val"
+    )
+}
+
+fn vec_model_receiver_arg(name: &str) -> Option<usize> {
+    match name {
+        "__vow_vec_push_val" | "__vow_vec_get_val" | "__vow_vec_len" | "__vow_vec_pop"
+        | "__vow_vec_set_val" => Some(0),
+        "__vow_vec_push_in_arena"
+        | "__vow_vec_push_val_in_arena"
+        | "__vow_vec_reserve_in_arena" => Some(1),
+        _ => None,
+    }
+}
+
 fn collect_typed_vars(func: &Function, creator: &str, prefix: &str) -> HashSet<u32> {
     let mut vars = HashSet::new();
 
@@ -107,10 +130,22 @@ fn collect_typed_vars(func: &Function, creator: &str, prefix: &str) -> HashSet<u
                     || (prefix == "__vow_string_"
                         && (name == "__vow_string_from_raw_parts_copy"
                             || name == "__vow_string_pin_to_root"));
-                if name == creator || is_alt_creator {
+                let is_creator = name == creator
+                    || is_alt_creator
+                    || (prefix == "__vow_vec_" && is_vec_model_creator(name));
+                if is_creator {
                     vars.insert(inst.id.0);
-                } else if name.starts_with(prefix) && !inst.args.is_empty() {
-                    vars.insert(inst.args[0].0);
+                } else if name.starts_with(prefix) {
+                    let receiver_arg = if prefix == "__vow_vec_" {
+                        vec_model_receiver_arg(name)
+                    } else {
+                        Some(0)
+                    };
+                    if let Some(arg_idx) = receiver_arg
+                        && let Some(arg) = inst.args.get(arg_idx)
+                    {
+                        vars.insert(arg.0);
+                    }
                 }
             }
         }
@@ -191,7 +226,13 @@ fn is_known_builtin(name: &str) -> bool {
     matches!(
         name,
         "__vow_vec_new"
+            | "__vow_vec_new_val"
+            | "__vow_vec_new_in_arena"
+            | "__vow_vec_new_val_in_arena"
             | "__vow_vec_push_val"
+            | "__vow_vec_push_in_arena"
+            | "__vow_vec_push_val_in_arena"
+            | "__vow_vec_reserve_in_arena"
             | "__vow_vec_get_val"
             | "__vow_vec_from_raw_parts_copy_val"
             | "__vow_vec_pin_to_root_val"
@@ -811,7 +852,10 @@ fn emit_inst(
         Opcode::Call if matches!(&inst.data, InstData::CallExtern(n) if n.starts_with("__vow_vec_")) => {
             if let InstData::CallExtern(ref name) = inst.data {
                 match name.as_str() {
-                    "__vow_vec_new" => {
+                    "__vow_vec_new"
+                    | "__vow_vec_new_val"
+                    | "__vow_vec_new_in_arena"
+                    | "__vow_vec_new_val_in_arena" => {
                         out.push_str(&format!("  v{id}.len = 0;\n"));
                     }
                     "__vow_vec_from_raw_parts_copy_val" => {
@@ -825,15 +869,29 @@ fn emit_inst(
                         let source = inst.args[0].0;
                         out.push_str(&format!("  v{id} = v{source};\n"));
                     }
-                    "__vow_vec_push_val" => {
-                        let vec = inst.args[0].0;
-                        let val = inst.args[1].0;
+                    "__vow_vec_push_val" | "__vow_vec_push_val_in_arena" => {
+                        let (vec_arg, val_arg) = if name == "__vow_vec_push_val_in_arena" {
+                            (1, 2)
+                        } else {
+                            (0, 1)
+                        };
+                        let vec = inst.args[vec_arg].0;
+                        let val = inst.args[val_arg].0;
                         let vec_max = limits.vec_max;
                         out.push_str(&format!(
                             "  __ESBMC_assert(v{vec}.len < {vec_max}, \"vec capacity\");\n\
                              \x20 v{vec}.data[v{vec}.len] = v{val};\n  v{vec}.len++;\n",
                         ));
                     }
+                    "__vow_vec_push_in_arena" => {
+                        let vec = inst.args[1].0;
+                        let vec_max = limits.vec_max;
+                        out.push_str(&format!(
+                            "  __ESBMC_assert(v{vec}.len < {vec_max}, \"vec capacity\");\n\
+                             \x20 v{vec}.data[v{vec}.len] = __VERIFIER_nondet_long();\n  v{vec}.len++;\n",
+                        ));
+                    }
+                    "__vow_vec_reserve_in_arena" => {}
                     "__vow_vec_get_val" => {
                         let vec = inst.args[0].0;
                         let idx = inst.args[1].0;
@@ -2751,6 +2809,123 @@ mod tests {
         );
         assert!(c.contains("v2.data[v2.len] = v3;"), "push store: {c}");
         assert!(c.contains("v2.len++;"), "push increment: {c}");
+    }
+
+    #[test]
+    fn emit_explicit_arena_vec_push_val() {
+        use vow_ir::InstId;
+        let func = make_func(
+            "push_one_in_arena",
+            vec![],
+            Ty::Ptr,
+            vec![
+                inst(
+                    0,
+                    Opcode::ConstI64,
+                    Ty::I64,
+                    vec![],
+                    InstData::ConstI64(1000),
+                ),
+                inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                Inst {
+                    id: InstId(3),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(0), InstId(1), InstId(2)],
+                    data: InstData::CallExtern("__vow_vec_new_in_arena".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(4, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(42)),
+                Inst {
+                    id: InstId(5),
+                    opcode: Opcode::Call,
+                    ty: Ty::Unit,
+                    args: vec![InstId(0), InstId(3), InstId(4)],
+                    data: InstData::CallExtern("__vow_vec_push_val_in_arena".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(6, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+            ],
+        );
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        assert!(c.contains("__vow_vec_t v3;"), "arena vec decl: {c}");
+        assert!(
+            !c.contains("__vow_vec_t v0;"),
+            "arena pointer must not be tracked as vec: {c}"
+        );
+        assert!(c.contains("v3.len = 0;"), "arena vec init: {c}");
+        assert!(
+            c.contains("v3.data[v3.len] = v4;"),
+            "arena push value store: {c}"
+        );
+        assert!(c.contains("v3.len++;"), "arena push increment: {c}");
+        assert!(
+            !c.contains("not modelled"),
+            "arena vec calls should be modelled: {c}"
+        );
+    }
+
+    #[test]
+    fn emit_explicit_arena_vec_reserve_and_generic_push() {
+        use vow_ir::InstId;
+        let func = make_func(
+            "reserve_and_push_in_arena",
+            vec![],
+            Ty::Ptr,
+            vec![
+                inst(
+                    0,
+                    Opcode::ConstI64,
+                    Ty::I64,
+                    vec![],
+                    InstData::ConstI64(1000),
+                ),
+                inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                Inst {
+                    id: InstId(3),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(0)],
+                    data: InstData::CallExtern("__vow_vec_new_val_in_arena".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(4, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(1)),
+                Inst {
+                    id: InstId(5),
+                    opcode: Opcode::Call,
+                    ty: Ty::Unit,
+                    args: vec![InstId(0), InstId(3), InstId(4), InstId(1), InstId(2)],
+                    data: InstData::CallExtern("__vow_vec_reserve_in_arena".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(6),
+                    opcode: Opcode::Call,
+                    ty: Ty::Unit,
+                    args: vec![InstId(0), InstId(3), InstId(4), InstId(1), InstId(2)],
+                    data: InstData::CallExtern("__vow_vec_push_in_arena".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(7, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+            ],
+        );
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        assert!(
+            c.contains("v3.data[v3.len] = __VERIFIER_nondet_long();"),
+            "generic arena push should over-approximate element value: {c}"
+        );
+        assert!(c.contains("v3.len++;"), "generic arena push increment: {c}");
+        assert!(
+            !c.contains("not modelled"),
+            "reserve/generic arena push should be modelled: {c}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add explicit-arena Vec runtime exports for constructor, reserve, push, and push_val paths while keeping existing root-arena Vec symbols ABI-compatible.
- Share Vec backing growth through an arena-aware `arena_grow_backing` path that tries `__vow_arena_try_extend` before allocate-copy-zero fallback.
- Add null explicit-arena runtime invariant traps, runtime behavior coverage, extern signature table entries, and arena design documentation.

Closes #291.

## Validation

- `cargo fmt --all`
- `cargo test -p vow-runtime`
- `cargo build -p vow-runtime -p vow-clif-shim`
- `cargo test --all`
- `cargo clippy --all -- -D warnings`
