### PR TITLE
[codex] Implement Vec arena routing

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -199,6 +199,7 @@ fn is_modelable(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>, modelabl
                    || op == IOP_VOW_REQ() || op == IOP_VOW_ENS() || op == IOP_VOW_INV()
                    || op == IOP_BRANCH() || op == IOP_JUMP() || op == IOP_RETURN() || op == IOP_UNREACHABLE()
                    || op == IOP_PHI() || op == IOP_UPSILON()
+                   || op == IOP_REGION_OPEN() || op == IOP_REGION_CLOSE()
                    || op == IOP_DEBUG_CALL() {
                     true
                 } else if op == IOP_CALL() {
@@ -236,7 +237,6 @@ fn is_modelable(f: IrFunction, m: IrModule, const_fn_indices: Vec<i64>, modelabl
                 } else if op == IOP_REM_F32() || op == IOP_REM_F64()
                    || op == IOP_LOAD() || op == IOP_STORE()
                    || op == IOP_REGION_ALLOC()
-                   || op == IOP_REGION_OPEN() || op == IOP_REGION_CLOSE()
                    || op == IOP_LINEAR_CONSUME() || op == IOP_LINEAR_BORROW()
                    || op == IOP_FIELD_SET() {
                     false
@@ -1126,8 +1126,12 @@ fn emit_inst(out: String, inst: IrInst, vec_vars: Vec<i64>, string_vars: Vec<i64
         return;
     }
 
+    if op == IOP_REGION_OPEN() || op == IOP_REGION_CLOSE() {
+        out.push_str(String::from("  /* verifier no-op: region scope marker */\n"));
+        return;
+    }
+
     if op == IOP_LOAD() || op == IOP_STORE() || op == IOP_REGION_ALLOC()
-       || op == IOP_REGION_OPEN() || op == IOP_REGION_CLOSE()
        || op == IOP_LINEAR_CONSUME() || op == IOP_LINEAR_BORROW() || op == IOP_FIELD_SET() {
         emit_unsupported_for_verification(out, inst);
         return;

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -10,6 +10,63 @@ fn str2(a: String, b: String) -> String {
     r
 }
 
+fn clif_find_inst_region(f: IrFunction, id: i64) -> i64 {
+    let blocks: Vec<IrBlock> = f.blocks;
+    let mut bi: i64 = 0;
+    while bi < blocks.len() {
+        let insts: Vec<IrInst> = blocks[bi].insts;
+        let mut ii: i64 = 0;
+        while ii < insts.len() {
+            if insts[ii].id == id {
+                return insts[ii].rgn;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    region_root()
+}
+
+fn clif_receiver_region(f: IrFunction, inst: IrInst) -> i64 {
+    if inst.args.len() == 0 {
+        return region_root();
+    }
+    clif_find_inst_region(f, inst.args[0])
+}
+
+fn clif_routed_extern_symbol(f: IrFunction, inst: IrInst) -> String {
+    let sym: String = inst.ds;
+    if sym == String::from("__vow_vec_new") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_vec_new_in_arena");
+    }
+    if sym == String::from("__vow_vec_new_val") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_vec_new_val_in_arena");
+    }
+    if sym == String::from("__vow_vec_push_val") {
+        let rr: i64 = clif_receiver_region(f, inst);
+        let rk: i64 = region_kind(rr);
+        if rk == REGION_KIND_BLOCK() || rk == REGION_KIND_CALLER() {
+            return String::from("__vow_vec_push_val_in_arena");
+        }
+        return sym;
+    }
+    if sym == String::from("__vow_vec_push") {
+        let rr2: i64 = clif_receiver_region(f, inst);
+        let rk2: i64 = region_kind(rr2);
+        if rk2 == REGION_KIND_BLOCK() || rk2 == REGION_KIND_CALLER() {
+            return String::from("__vow_vec_push_in_arena");
+        }
+        return sym;
+    }
+    sym
+}
+
 fn collect_extern_syms(m: IrModule, mode: i64) -> Vec<String> {
     let result: Vec<String> = Vec::new();
     let has_debug: bool = mode == 1 || mode == 3;
@@ -27,7 +84,7 @@ fn collect_extern_syms(m: IrModule, mode: i64) -> Vec<String> {
                 let inst: IrInst = insts[ii];
                 let skip: bool = inst.op == IOP_DEBUG_CALL() && !has_debug;
                 if inst.dk == IDATA_CALL_EXTERN() && !skip {
-                    let sym: String = inst.ds;
+                    let sym: String = clif_routed_extern_symbol(f, inst);
                     if !vec_contains_str(result, sym) {
                         result.push(sym);
                     }
@@ -132,7 +189,17 @@ fn clif_emit_module(m: IrModule, output_path: String, mode: i64, trace: i64) -> 
                 0
             }
         };
-        __vow_clif_declare_function(ctx, fi, f.name, f.params, f.params.len(), f.return_ty, is_main);
+        __vow_clif_declare_function(
+            ctx,
+            fi,
+            f.name,
+            f.params,
+            f.params.len(),
+            f.return_ty,
+            is_main,
+            f.rsum_return_kind,
+            f.rsum_store_effects
+        );
         fi = fi + 1;
     }
 

--- a/compiler/env.vow
+++ b/compiler/env.vow
@@ -290,6 +290,8 @@ fn env_new(dctx: DiagCtx, file: String) -> CheckEnv {
     clif_decl_p.push(i64_tid);
     clif_decl_p.push(i64_tid);
     clif_decl_p.push(i64_tid);
+    clif_decl_p.push(i64_tid);
+    clif_decl_p.push(vec_i64_tid);
     env_define_fn(e, String::from("__vow_clif_declare_function"), clif_decl_p, unit_tid, eff_io);
 
     let clif_begin_p: Vec<i64> = Vec::new();

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -770,14 +770,6 @@ fn check_region_store_conflicts_module(
 fn check_store_effects_at_call(
     flat: Vec<i64>, call_inst: IrInst, id_to_inst: Vec<IrInst>, dctx: DiagCtx, source_file: String
 ) {
-    // Divergence note: the Rust path (`vow-ir/src/region.rs::handle_inst`,
-    // `Opcode::Call` arm) adds a `VirtualCaller` marker on the target arg
-    // for `RSUM_KIND_FRESH_IN_CALLER` store effects, routing the target
-    // toward `Caller(0)`. The self-hosted compiler has no `VirtualCaller`
-    // marker mechanism — targets of FreshInCaller store effects stay at
-    // their default `Root`. No diagnostic effect (region routing only),
-    // but worth promoting to true parity once hidden-caller-region
-    // plumbing for `IOP_REGION_ALLOC` lands in `vow-clif-shim`.
     let mut i: i64 = 0;
     while i < flat.len() {
         let target: i64 = flat[i];
@@ -833,12 +825,15 @@ fn check_store_conflict(
     if source.kind != RSUM_KIND_FRESH_IN_CALLER() {
         return;
     }
+    let source_inst: IrInst = lookup_inst_or_default(id_to_inst, source_arg_id);
+    if source_inst.op != IOP_REGION_ALLOC() {
+        return;
+    }
     let target_param: i64 = trace_param_shallow(id_to_inst, target_arg_id);
     if target_param < 0 {
         return;
     }
 
-    let source_inst: IrInst = lookup_inst_or_default(id_to_inst, source_arg_id);
     let span_start: i64 = if source_inst.id >= 0 && source_inst.olen > 0 { source_inst.ostart } else { call_inst.ostart };
     let span_len: i64 = if source_inst.id >= 0 && source_inst.olen > 0 { source_inst.olen } else { call_inst.olen };
     // Diagnostic shape divergence from the Rust pass: the Rust
@@ -922,16 +917,15 @@ fn analyze_function(
                 let source_id: i64 = inst.args[1];
                 let target_param: i64 = trace_param_shallow(id_to_inst, target_id);
                 if target_param >= 0 {
-                    let source: DeepRet = trace_origin_shallow(id_to_inst, source_id);
-                    add_store_effect(
+                    add_store_effect_source_constraints(
+                        id_to_inst,
+                        source_id,
+                        target_param,
+                        int_kinds,
                         int_se_targets[fidx],
                         int_se_src_kinds[fidx],
                         int_se_src_aux[fidx],
                         int_se_src_aliases[fidx],
-                        target_param,
-                        source.kind,
-                        source.aux,
-                        source.aliases,
                     );
                 }
             }
@@ -948,75 +942,72 @@ fn analyze_function(
                         let source_id2: i64 = inst.args[source_pos];
                         let target_param2: i64 = trace_param_shallow(id_to_inst, target_id2);
                         if target_param2 >= 0 {
-                            let source2: DeepRet = trace_origin_shallow(id_to_inst, source_id2);
-                            add_store_effect(
+                            add_store_effect_source_constraints(
+                                id_to_inst,
+                                source_id2,
+                                target_param2,
+                                int_kinds,
                                 int_se_targets[fidx],
                                 int_se_src_kinds[fidx],
                                 int_se_src_aux[fidx],
                                 int_se_src_aliases[fidx],
-                                target_param2,
-                                source2.kind,
-                                source2.aux,
-                                source2.aliases,
                             );
                         }
                     }
                     edge_idx = edge_idx + 1;
                 }
             }
+            if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_TARGET() {
+                publish_transitive_store_effects(
+                    inst,
+                    id_to_inst,
+                    int_kinds,
+                    int_se_targets,
+                    int_se_src_kinds,
+                    int_se_src_aux,
+                    int_se_src_aliases,
+                    int_se_targets[fidx],
+                    int_se_src_kinds[fidx],
+                    int_se_src_aux[fidx],
+                    int_se_src_aliases[fidx],
+                );
+            }
             ii = ii + 1;
         }
         bi = bi + 1;
     }
 
-    // 2. Tag heap-producing instructions whose per-destination marker LUB
-    // resolves to a concrete block. This mirrors the Rust pass's marker model
-    // without materializing a must_outlive set for every value: for each heap
-    // producer, gather concrete block markers from direct uses plus Phi/call
-    // return-alias users, then compute the cached block-tree LCA.
+    // 2. Tag heap-producing instructions with the Block / Caller / Root LUB
+    // of their use markers. This mirrors the Rust pass's marker model without
+    // materializing a must_outlive set for every value: for each heap producer,
+    // gather direct-use markers plus Phi/call return-alias users, then compute
+    // the cached block-tree LCA when only block markers remain.
     let mut rbi: i64 = 0;
     while rbi < n_bks {
         let rb: IrBlock = bks[rbi];
         let mut rii: i64 = 0;
         while rii < rb.insts.len() {
             let rinst: IrInst = rb.insts[rii];
-            if rinst.op == IOP_REGION_ALLOC() {
-                let concrete_lca: i64 = value_lub_concrete_block(
+            if is_heap_producing_for_region(rinst, int_kinds) {
+                let mut rgn: i64 = value_lub_region(
                     f, rinst.id, rb.id, id_to_inst, id_to_block,
                     block_parent, block_depth,
                     is_scalar_ity(f.return_ty),
                     int_kinds, int_auxs, int_aliases_list,
                     int_se_targets, int_se_src_kinds, int_se_src_aux,
                 );
-                if concrete_lca >= 0 {
-                    put_inst_region(
-                        region_keys[fidx],
-                        region_vals[fidx],
-                        rinst.id,
-                        region_pack(REGION_KIND_BLOCK(), concrete_lca)
-                    );
+                if rinst.op == IOP_CALL() && rinst.dk != IDATA_CALL_EXTERN() {
+                    let rk: i64 = region_kind(rgn);
+                    if rk == REGION_KIND_BLOCK() || rk == REGION_KIND_CALLER() {
+                        rgn = region_root();
+                    }
                 }
+                put_inst_region(region_keys[fidx], region_vals[fidx], rinst.id, rgn);
             }
             rii = rii + 1;
         }
         rbi = rbi + 1;
     }
-
-    // Non-concrete RegionAlloc instructions still deliberately stay Root.
-    //
-    // Current self-hosted status: the Cranelift shim can lower block regions,
-    // but `IOP_REGION_ALLOC` still has no hidden-caller-region plumbing.
-    // Emitting `region_caller0()` here would break self-hosted codegen for any
-    // allocation whose LUB is the virtual caller. We therefore leave those
-    // allocations at their Phase-2 default (Root). The summary itself is still
-    // set to FreshInCaller where appropriate so the metadata remains correct
-    // for downstream consumers; only the per-inst region tag is degraded for
-    // codegen compatibility.
-    //
-    // Rust codegen accepts Caller(0) via `cranelift_backend.rs` + Phase 4's
-    // hidden-arena projection, so the Rust pass emits `Caller(0)` on escaping
-    // allocs. This is the remaining intentional divergence between the two
-    // compilers until the self-hosted shim catches up.
 
     let new_kind: i64 = acc_kind;
     let new_aux: i64 = acc_aux;
@@ -1048,7 +1039,7 @@ fn is_heap_producing_for_region(inst: IrInst, int_kinds: Vec<i64>) -> bool {
     if inst.op == IOP_REGION_ALLOC() {
         return true;
     }
-    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() && extern_fresh_in_caller(inst.ds) {
+    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() && heap_producing_extern(inst.ds) {
         return true;
     }
     if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_TARGET()
@@ -1060,11 +1051,350 @@ fn is_heap_producing_for_region(inst: IrInst, int_kinds: Vec<i64>) -> bool {
     false
 }
 
+fn add_store_effect_source_constraints(
+    id_to_inst: Vec<IrInst>, source_id: i64, target_param: i64,
+    int_kinds: Vec<i64>,
+    targets: Vec<i64>, kinds: Vec<i64>, auxs: Vec<i64>, aliases_list: Vec<Vec<i64>>
+) {
+    let source: DeepRet = trace_origin_shallow(id_to_inst, source_id);
+    add_store_effect(
+        targets,
+        kinds,
+        auxs,
+        aliases_list,
+        target_param,
+        source.kind,
+        source.aux,
+        source.aliases,
+    );
+    publish_embedded_param_aliases(
+        id_to_inst,
+        source_id,
+        target_param,
+        targets,
+        kinds,
+        auxs,
+        aliases_list,
+    );
+
+    let source_inst: IrInst = lookup_inst_or_default(id_to_inst, source_id);
+    if source_inst.op != IOP_CALL() || source_inst.dk != IDATA_CALL_TARGET() {
+        return;
+    }
+    let callee_idx: i64 = source_inst.dv;
+    if callee_idx < 0 || callee_idx >= int_kinds.len() {
+        return;
+    }
+    if int_kinds[callee_idx] != RSUM_KIND_FRESH_IN_CALLER() {
+        return;
+    }
+    let mut ai: i64 = 0;
+    while ai < source_inst.args.len() {
+        let param_idx: i64 = trace_param_shallow(id_to_inst, source_inst.args[ai]);
+        if param_idx >= 0 {
+            add_store_effect(
+                targets,
+                kinds,
+                auxs,
+                aliases_list,
+                target_param,
+                RSUM_KIND_ALIAS_OF(),
+                param_idx,
+                source_inst.args,
+            );
+        }
+        ai = ai + 1;
+    }
+}
+
+fn publish_embedded_param_aliases(
+    id_to_inst: Vec<IrInst>, aggregate_id: i64, target_param: i64,
+    targets: Vec<i64>, kinds: Vec<i64>, auxs: Vec<i64>, aliases_list: Vec<Vec<i64>>
+) {
+    let mut i: i64 = 0;
+    while i < id_to_inst.len() {
+        let inst: IrInst = id_to_inst[i];
+        if (inst.op == IOP_STORE() || inst.op == IOP_FIELD_SET())
+            && inst.args.len() >= 2 && inst.args[0] == aggregate_id
+        {
+            let param_idx: i64 = trace_param_shallow(id_to_inst, inst.args[1]);
+            if param_idx >= 0 {
+                add_store_effect(
+                    targets,
+                    kinds,
+                    auxs,
+                    aliases_list,
+                    target_param,
+                    RSUM_KIND_ALIAS_OF(),
+                    param_idx,
+                    inst.args,
+                );
+            }
+        }
+        i = i + 1;
+    }
+}
+
+fn publish_transitive_store_effects(
+    call_inst: IrInst, id_to_inst: Vec<IrInst>, int_kinds: Vec<i64>,
+    all_targets: Vec<Vec<i64>>, all_kinds: Vec<Vec<i64>>,
+    all_auxs: Vec<Vec<i64>>, all_aliases: Vec<Vec<Vec<i64>>>,
+    targets: Vec<i64>, kinds: Vec<i64>, auxs: Vec<i64>, aliases_list: Vec<Vec<i64>>
+) {
+    let callee_idx: i64 = call_inst.dv;
+    if callee_idx < 0 || callee_idx >= all_targets.len() {
+        return;
+    }
+    let callee_targets: Vec<i64> = all_targets[callee_idx];
+    let callee_kinds: Vec<i64> = all_kinds[callee_idx];
+    let callee_auxs: Vec<i64> = all_auxs[callee_idx];
+    let callee_aliases: Vec<Vec<i64>> = all_aliases[callee_idx];
+    let mut i: i64 = 0;
+    while i < callee_targets.len() && i < callee_kinds.len() && i < callee_auxs.len() {
+        let target_pos: i64 = callee_targets[i];
+        if target_pos >= 0 && target_pos < call_inst.args.len() {
+            let current_target_param: i64 = trace_param_shallow(id_to_inst, call_inst.args[target_pos]);
+            if current_target_param >= 0 {
+                let kind: i64 = callee_kinds[i];
+                if kind == RSUM_KIND_ALIAS_OF() {
+                    let source_pos: i64 = callee_auxs[i];
+                    if source_pos >= 0 && source_pos < call_inst.args.len() {
+                        add_store_effect_source_constraints(
+                            id_to_inst,
+                            call_inst.args[source_pos],
+                            current_target_param,
+                            int_kinds,
+                            targets,
+                            kinds,
+                            auxs,
+                            aliases_list,
+                        );
+                    }
+                } else if kind == RSUM_KIND_ALIAS_OF_ANY() {
+                    let als: Vec<i64> = if i < callee_aliases.len() { callee_aliases[i] } else { call_inst.args };
+                    let mut ai: i64 = 0;
+                    while ai < als.len() {
+                        let source_pos2: i64 = als[ai];
+                        if source_pos2 >= 0 && source_pos2 < call_inst.args.len() {
+                            add_store_effect_source_constraints(
+                                id_to_inst,
+                                call_inst.args[source_pos2],
+                                current_target_param,
+                                int_kinds,
+                                targets,
+                                kinds,
+                                auxs,
+                                aliases_list,
+                            );
+                        }
+                        ai = ai + 1;
+                    }
+                } else {
+                    let empty_aliases: Vec<i64> = if i < callee_aliases.len() { callee_aliases[i] } else { call_inst.args };
+                    add_store_effect(
+                        targets,
+                        kinds,
+                        auxs,
+                        aliases_list,
+                        current_target_param,
+                        kind,
+                        callee_auxs[i],
+                        empty_aliases,
+                    );
+                }
+            }
+        }
+        i = i + 1;
+    }
+}
+
 fn lookup_inst_block(id_to_block: Vec<i64>, id: i64) -> i64 {
     if id >= 0 && id < id_to_block.len() {
         return id_to_block[id];
     }
     -1
+}
+
+fn value_lub_region(
+    f: IrFunction, id: i64, defining_block: i64,
+    id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>,
+    block_parent: Vec<i64>, block_depth: Vec<i64>,
+    return_is_scalar: bool,
+    int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
+    int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>
+) -> i64 {
+    let work: Vec<i64> = Vec::new();
+    let seen: Vec<i64> = Vec::new();
+    let markers: Vec<i64> = Vec::new();
+    linear_insert_i64(markers, region_pack(REGION_KIND_BLOCK(), defining_block));
+    work.push(id);
+    while work.len() > 0 {
+        let cur: i64 = work[work.len() - 1];
+        work.pop();
+        if region_vec_contains_i64(seen, cur) {
+            continue;
+        }
+        seen.push(cur);
+        direct_markers_collect_regions(
+            f,
+            cur,
+            id_to_inst,
+            id_to_block,
+            markers,
+            return_is_scalar,
+            int_kinds,
+            int_auxs,
+            int_aliases_list,
+            int_se_targets,
+            int_se_src_kinds,
+            int_se_src_aux,
+            work,
+            seen
+        );
+    }
+    region_lub_from_markers(markers, defining_block, block_parent, block_depth)
+}
+
+fn region_lub_from_markers(
+    markers: Vec<i64>, defining_block: i64, block_parent: Vec<i64>, block_depth: Vec<i64>
+) -> i64 {
+    let blocks: Vec<i64> = Vec::new();
+    let mut has_caller: bool = false;
+    let mut has_root: bool = false;
+    let mut i: i64 = 0;
+    while i < markers.len() {
+        let marker: i64 = markers[i];
+        let kind: i64 = region_kind(marker);
+        if kind == REGION_KIND_ROOT() {
+            has_root = true;
+        } else if kind == REGION_KIND_CALLER() {
+            has_caller = true;
+        } else if kind == REGION_KIND_BLOCK() {
+            linear_insert_i64(blocks, region_val(marker));
+        }
+        i = i + 1;
+    }
+    if has_root {
+        return region_root();
+    }
+    if has_caller {
+        return region_caller0();
+    }
+    linear_insert_i64(blocks, defining_block);
+    sort_i64_vec_inplace(blocks);
+    let lca: i64 = block_tree_lca_all(block_parent, block_depth, blocks);
+    if lca >= 0 {
+        return region_pack(REGION_KIND_BLOCK(), lca);
+    }
+    region_caller0()
+}
+
+fn direct_markers_collect_regions(
+    f: IrFunction, id: i64,
+    id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>,
+    markers: Vec<i64>,
+    return_is_scalar: bool,
+    int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
+    int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>,
+    work: Vec<i64>, seen: Vec<i64>
+) {
+    let bks: Vec<IrBlock> = f.blocks;
+    let mut bi: i64 = 0;
+    while bi < bks.len() {
+        let blk: IrBlock = bks[bi];
+        let mut ii: i64 = 0;
+        while ii < blk.insts.len() {
+            let inst: IrInst = blk.insts[ii];
+            let mut ai: i64 = 0;
+            while ai < inst.args.len() {
+                if inst.args[ai] == id {
+                    // Every argument use contributes the use-block marker.
+                    linear_insert_i64(markers, region_pack(REGION_KIND_BLOCK(), blk.id));
+                    if inst.op == IOP_RETURN() && !return_is_scalar {
+                        linear_insert_i64(markers, region_caller0());
+                    }
+                    if (inst.op == IOP_STORE() || inst.op == IOP_FIELD_SET()) && ai == 1 {
+                        let target_marker: i64 = target_marker_region(
+                            id_to_inst,
+                            id_to_block,
+                            inst.args[0],
+                            int_kinds
+                        );
+                        linear_insert_i64(markers, target_marker);
+                        push_region_work(work, seen, inst.args[0]);
+                    }
+                    if inst.op == IOP_UPSILON() && ai == 0 && inst.dk == IDATA_PHI_TARGET() {
+                        let phi_block: i64 = lookup_inst_block(id_to_block, inst.dv);
+                        if phi_block >= 0 {
+                            linear_insert_i64(markers, region_pack(REGION_KIND_BLOCK(), phi_block));
+                            push_region_work(work, seen, inst.dv);
+                        } else {
+                            linear_insert_i64(markers, region_root());
+                        }
+                    }
+                    if inst.op == IOP_FIELD_GET() && ai == 0 {
+                        push_region_work(work, seen, inst.id);
+                    }
+                    if inst.op == IOP_LOAD() && ai == 0 && !is_scalar_ity(inst.ty) {
+                        push_region_work(work, seen, inst.id);
+                    }
+                    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_TARGET() {
+                        let callee_idx: i64 = inst.dv;
+                        call_store_effects_collect_regions(
+                            inst,
+                            ai,
+                            id_to_inst,
+                            id_to_block,
+                            int_kinds,
+                            markers,
+                            int_se_targets,
+                            int_se_src_kinds,
+                            int_se_src_aux,
+                            work,
+                            seen
+                        );
+                        if callee_idx >= 0 && callee_idx < int_kinds.len()
+                            && int_kinds[callee_idx] == RSUM_KIND_FRESH_IN_CALLER()
+                        {
+                            // Fresh aggregate results may embed heap descriptors
+                            // passed as constructor arguments. Let later widening
+                            // of the call result flow back to this argument.
+                            push_region_work(work, seen, inst.id);
+                        }
+                        if callee_return_aliases_arg(
+                            callee_idx,
+                            ai,
+                            int_kinds,
+                            int_auxs,
+                            int_aliases_list
+                        ) {
+                            push_region_work(work, seen, inst.id);
+                        }
+                    }
+                    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
+                        let target_pos2: i64 = extern_store_target_for_source(inst.ds, ai);
+                        if target_pos2 >= 0 && target_pos2 < inst.args.len() {
+                            let target_marker2: i64 = if trace_param_shallow(id_to_inst, inst.args[target_pos2]) >= 0 {
+                                region_root()
+                            } else {
+                                target_marker_region(
+                                    id_to_inst,
+                                    id_to_block,
+                                    inst.args[target_pos2],
+                                    int_kinds
+                                )
+                            };
+                            linear_insert_i64(markers, target_marker2);
+                            push_region_work(work, seen, inst.args[target_pos2]);
+                        }
+                    }
+                }
+                ai = ai + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
 }
 
 fn value_lub_concrete_block(
@@ -1182,6 +1512,11 @@ fn direct_markers_collect_concrete_blocks(
                         ) {
                             return false;
                         }
+                        if callee_idx >= 0 && callee_idx < int_kinds.len()
+                            && int_kinds[callee_idx] == RSUM_KIND_FRESH_IN_CALLER()
+                        {
+                            push_region_work(work, seen, inst.id);
+                        }
                         if callee_return_aliases_arg(
                             callee_idx,
                             ai,
@@ -1246,6 +1581,61 @@ fn target_marker_concrete_block(
         return lookup_inst_block(id_to_block, target_id);
     }
     -1
+}
+
+fn target_marker_region(
+    id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>, target_id: i64,
+    int_kinds: Vec<i64>
+) -> i64 {
+    let inst: IrInst = lookup_inst_or_default(id_to_inst, target_id);
+    if inst.id < 0 {
+        return region_root();
+    }
+    if inst.op == IOP_GET_ARG() {
+        return region_caller0();
+    }
+    if is_heap_producing_for_region(inst, int_kinds) {
+        let blk: i64 = lookup_inst_block(id_to_block, target_id);
+        if blk >= 0 {
+            return region_pack(REGION_KIND_BLOCK(), blk);
+        }
+    }
+    region_root()
+}
+
+fn call_store_effects_collect_regions(
+    call_inst: IrInst, source_arg_pos: i64,
+    id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>, int_kinds: Vec<i64>,
+    markers: Vec<i64>,
+    int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>,
+    work: Vec<i64>, seen: Vec<i64>
+) {
+    let callee_idx: i64 = call_inst.dv;
+    if callee_idx < 0 || callee_idx >= int_se_targets.len() {
+        return;
+    }
+    let targets: Vec<i64> = int_se_targets[callee_idx];
+    let kinds: Vec<i64> = int_se_src_kinds[callee_idx];
+    let auxs: Vec<i64> = int_se_src_aux[callee_idx];
+    let mut i: i64 = 0;
+    while i < targets.len() && i < kinds.len() && i < auxs.len() {
+        if kinds[i] == RSUM_KIND_ALIAS_OF() && auxs[i] == source_arg_pos {
+            let target_param: i64 = targets[i];
+            if target_param >= 0 && target_param < call_inst.args.len() {
+                let target_marker: i64 = target_marker_region(
+                    id_to_inst,
+                    id_to_block,
+                    call_inst.args[target_param],
+                    int_kinds
+                );
+                linear_insert_i64(markers, target_marker);
+                push_region_work(work, seen, call_inst.args[target_param]);
+            }
+        } else if kinds[i] == RSUM_KIND_ALIAS_OF_ANY() {
+            linear_insert_i64(markers, region_root());
+        }
+        i = i + 1;
+    }
 }
 
 fn call_store_effects_collect_concrete_blocks(
@@ -2291,6 +2681,15 @@ fn extern_fresh_in_caller(sym: String) -> bool {
         || sym == String::from("__vow_vec_from_raw_parts_copy_val")
 }
 
+fn vec_creation_extern(sym: String) -> bool {
+    sym == String::from("__vow_vec_new")
+        || sym == String::from("__vow_vec_new_val")
+}
+
+fn heap_producing_extern(sym: String) -> bool {
+    extern_fresh_in_caller(sym) || vec_creation_extern(sym)
+}
+
 fn extern_store_edge_count(sym: String) -> i64 {
     if sym == String::from("__vow_vec_push_val") { return 1; }
     if sym == String::from("__vow_vec_push_val_in_arena") { return 1; }
@@ -2359,6 +2758,9 @@ fn trace_origin_shallow(id_to_inst: Vec<IrInst>, id: i64) -> DeepRet {
     if inst.op == IOP_REGION_ALLOC() {
         return DeepRet { kind: RSUM_KIND_FRESH_IN_CALLER(), aux: 0, aliases: Vec::new() };
     }
+    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() && heap_producing_extern(inst.ds) {
+        return DeepRet { kind: RSUM_KIND_FRESH_IN_CALLER(), aux: 0, aliases: Vec::new() };
+    }
     if is_const_op(inst.op) {
         return deep_ret_const_global();
     }
@@ -2366,9 +2768,31 @@ fn trace_origin_shallow(id_to_inst: Vec<IrInst>, id: i64) -> DeepRet {
 }
 
 fn trace_param_shallow(id_to_inst: Vec<IrInst>, id: i64) -> i64 {
+    let visiting: Vec<i64> = Vec::new();
+    trace_param_inner(id_to_inst, id, visiting)
+}
+
+fn trace_param_inner(id_to_inst: Vec<IrInst>, id: i64, visiting: Vec<i64>) -> i64 {
+    if region_vec_contains_i64(visiting, id) {
+        return -1;
+    }
     let inst: IrInst = lookup_inst_or_default(id_to_inst, id);
     if inst.id >= 0 && inst.op == IOP_GET_ARG() {
         return inst.dv;
+    }
+    if inst.id >= 0 && (inst.op == IOP_FIELD_GET() || inst.op == IOP_LOAD()) && inst.args.len() > 0 {
+        visiting.push(id);
+        let r: i64 = trace_param_inner(id_to_inst, inst.args[0], visiting);
+        visiting.pop();
+        return r;
+    }
+    if inst.id >= 0 && inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN()
+        && inst.ds == String::from("__vow_vec_get_val") && inst.args.len() > 0
+    {
+        visiting.push(id);
+        let r2: i64 = trace_param_inner(id_to_inst, inst.args[0], visiting);
+        visiting.pop();
+        return r2;
     }
     -1
 }
@@ -2410,7 +2834,7 @@ fn deep_origin_inner(
         return deep_ret_const_global();
     }
     if inst.op == IOP_CALL() {
-        if inst.dk == IDATA_CALL_EXTERN() && extern_fresh_in_caller(inst.ds) {
+        if inst.dk == IDATA_CALL_EXTERN() && heap_producing_extern(inst.ds) {
             return DeepRet { kind: RSUM_KIND_FRESH_IN_CALLER(), aux: 0, aliases: Vec::new() };
         }
         if inst.dk == IDATA_CALL_TARGET() {

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -90,7 +90,10 @@ In particular:
 
 The compiler assigns each heap-producing instruction a region via a
 compiler pass (§4). The assignment determines which arena backs the
-allocation.
+allocation. Heap-producing instructions include `RegionAlloc` and
+runtime allocation externs that create fresh heap descriptors, such as
+canonical `__vow_vec_new` / `__vow_vec_new_val` calls emitted for
+`Vec::new`.
 
 ### 2.2. No explicit free
 
@@ -1258,10 +1261,13 @@ function's `return_region == FreshInCaller`; subsequent indices
 enumerate the store-target hidden parameters in the stable order
 defined in §5.2. Lowering uses `HiddenRegionIdx` to select the
 correct `*VowArena` parameter in the emitted
-`__vow_arena_alloc(...)` call; functions with a single hidden
-region always use `Caller(0)`.
+`__vow_arena_alloc(...)` call or to select the explicit-arena
+runtime symbol for a routed container allocation; functions with a
+single hidden region always use `Caller(0)`.
 
-Every heap-producing `Inst` carries a `region: RegionId` field.
+Every heap-producing `Inst` carries a `region: RegionId` field. This
+includes canonical Vec creation extern calls (`__vow_vec_new`,
+`__vow_vec_new_val`) even though they remain `Opcode::Call` in IR.
 
 ### 12.2. No new opcodes for allocation placement
 
@@ -1283,6 +1289,16 @@ Note the naming neighborhood: `RegionAlloc` / `RegionFree` are
 opcodes. Phase 2 may rename `RegionAlloc` to, e.g., `HeapAlloc` if
 this neighborhood becomes confusing — the choice is a phase-2
 implementation detail and not load-bearing on the spec.
+
+Vec creation is intentionally not a new opcode. The lowerer may keep
+emitting canonical root-wrapper extern symbols (`__vow_vec_new`,
+`__vow_vec_new_val`). After `infer_regions`, codegen reads the call's
+`region` field: `Root` keeps the ABI-stable wrapper symbol, while
+`Block(_)` and `Caller(_)` prepend the selected `*VowArena` and call
+`__vow_vec_new_in_arena` / `__vow_vec_new_val_in_arena`. Vec growth
+calls follow the same rule using the receiver Vec's defining region:
+root-owned receivers keep `__vow_vec_push*`, and block/caller-owned
+receivers route to the matching `_in_arena` symbol.
 
 ### 12.3. Block region opcodes
 

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -305,7 +305,7 @@ fn arena_value_for_region(
     }
 }
 
-fn routed_vec_extern<'a>(sym: &'a str, inst_rgn: i64, receiver_rgn: i64) -> (&'a str, Option<i64>) {
+fn routed_vec_extern(sym: &str, inst_rgn: i64, receiver_rgn: i64) -> (&str, Option<i64>) {
     match sym {
         "__vow_vec_new" => {
             if (inst_rgn & 3) == REGION_KIND_ROOT {

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -203,11 +203,148 @@ const REGION_KIND_CALLER: i64 = 1;
 const REGION_KIND_ROOT: i64 = 2;
 const REGION_KIND_RODATA: i64 = 3;
 
+const RSUM_KIND_FRESH_IN_CALLER: i64 = 0;
+const RSUM_KIND_ALIAS_OF: i64 = 1;
+const RSUM_KIND_ALIAS_OF_ANY: i64 = 2;
+const RSUM_KIND_CONSTANT_GLOBAL: i64 = 3;
+
+fn region_pack(kind: i64, val: i64) -> i64 {
+    val * 4 + kind
+}
+
+fn region_root() -> i64 {
+    region_pack(REGION_KIND_ROOT, 0)
+}
+
 fn extern_uses_target_region(sym: &str) -> bool {
     matches!(
         sym,
         "__vow_string_from_raw_parts_copy" | "__vow_vec_from_raw_parts_copy_val"
     )
+}
+
+fn hidden_region_store_targets(flat: &[i64]) -> Vec<i64> {
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i + 1 < flat.len() {
+        let target = flat[i];
+        let kind = flat[i + 1];
+        i += 2;
+        out.push(target);
+        match kind {
+            RSUM_KIND_ALIAS_OF => i += 1,
+            RSUM_KIND_ALIAS_OF_ANY => {
+                if i >= flat.len() {
+                    break;
+                }
+                let n = flat[i].max(0) as usize;
+                i = i.saturating_add(1).saturating_add(n);
+            }
+            RSUM_KIND_FRESH_IN_CALLER | RSUM_KIND_CONSTANT_GLOBAL => {}
+            _ => {}
+        }
+    }
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn hidden_region_count(return_kind: i64, store_effects: &[i64], is_main: bool) -> usize {
+    if is_main {
+        return 0;
+    }
+    let mut count = 0usize;
+    if return_kind == RSUM_KIND_FRESH_IN_CALLER {
+        count += 1;
+    }
+    count + hidden_region_store_targets(store_effects).len()
+}
+
+fn block_arena_value(
+    builder: &mut FunctionBuilder<'_>,
+    block_arena_slots: &mut BTreeMap<i64, StackSlot>,
+    block_id: i64,
+) -> Value {
+    let slot = *block_arena_slots.entry(block_id).or_insert_with(|| {
+        builder.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            VOW_ARENA_HEADER_SIZE,
+            VOW_ARENA_HEADER_ALIGN_LOG2,
+        ))
+    });
+    builder.ins().stack_addr(types::I64, slot, 0)
+}
+
+fn arena_value_for_region(
+    builder: &mut FunctionBuilder<'_>,
+    rgn: i64,
+    hidden_region_values: &[Value],
+    block_arena_slots: &mut BTreeMap<i64, StackSlot>,
+    root_arena_gv: GlobalValue,
+) -> Option<Value> {
+    let kind = rgn & 3;
+    let payload = rgn >> 2;
+    match kind {
+        REGION_KIND_ROOT => Some(builder.ins().global_value(types::I64, root_arena_gv)),
+        REGION_KIND_BLOCK => Some(block_arena_value(builder, block_arena_slots, payload)),
+        REGION_KIND_CALLER => hidden_region_values
+            .get(payload as usize)
+            .copied()
+            .or_else(|| {
+                eprintln!("clif_shim: missing hidden arena parameter k={payload}");
+                None
+            }),
+        REGION_KIND_RODATA => {
+            eprintln!("clif_shim: cannot allocate into REGION_KIND_RODATA");
+            None
+        }
+        _ => {
+            eprintln!("clif_shim: unknown region kind {kind}");
+            None
+        }
+    }
+}
+
+fn routed_vec_extern<'a>(sym: &'a str, inst_rgn: i64, receiver_rgn: i64) -> (&'a str, Option<i64>) {
+    match sym {
+        "__vow_vec_new" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_vec_new_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_vec_new_val" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_vec_new_val_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_vec_push_val" => {
+            let kind = receiver_rgn & 3;
+            if kind == REGION_KIND_BLOCK || kind == REGION_KIND_CALLER {
+                ("__vow_vec_push_val_in_arena", Some(receiver_rgn))
+            } else {
+                (sym, None)
+            }
+        }
+        "__vow_vec_push" => {
+            let kind = receiver_rgn & 3;
+            if kind == REGION_KIND_BLOCK || kind == REGION_KIND_CALLER {
+                ("__vow_vec_push_in_arena", Some(receiver_rgn))
+            } else {
+                (sym, None)
+            }
+        }
+        _ => {
+            if extern_uses_target_region(sym) {
+                (sym, Some(inst_rgn))
+            } else {
+                (sym, None)
+            }
+        }
+    }
 }
 
 /// Size of `vow_runtime::VowArena` in bytes — asserted in
@@ -299,6 +436,8 @@ struct FuncDecl {
     param_tys: Vec<i64>,
     ret_ty: i64,
     is_main: bool,
+    return_kind: i64,
+    store_effects: Vec<i64>,
 }
 
 struct ModuleContext {
@@ -512,6 +651,8 @@ pub unsafe extern "C" fn __vow_clif_declare_function(
     n_params: i64,
     ret_ty: i64,
     is_main: i64,
+    return_kind: i64,
+    store_effects_ptr: i64,
 ) {
     let ctx = unsafe { &mut *(ctx_ptr as *mut ModuleContext) };
     let name = unsafe { read_vow_string(name_ptr) };
@@ -521,6 +662,11 @@ pub unsafe extern "C" fn __vow_clif_declare_function(
         &[]
     };
     let param_tys: Vec<i64> = param_slice.to_vec();
+    let store_effects = if store_effects_ptr != 0 {
+        unsafe { read_i64_slice(store_effects_ptr) }.to_vec()
+    } else {
+        Vec::new()
+    };
 
     let call_conv = ctx.isa.default_call_conv();
     let mut sig = Signature::new(call_conv);
@@ -528,6 +674,9 @@ pub unsafe extern "C" fn __vow_clif_declare_function(
         if let Some(cl_ty) = ity_to_cranelift(pty) {
             sig.params.push(AbiParam::new(cl_ty));
         }
+    }
+    for _ in 0..hidden_region_count(return_kind, &store_effects, is_main != 0) {
+        sig.params.push(AbiParam::new(types::I64));
     }
     if let Some(cl_ty) = signature_return_ty(ret_ty, is_main != 0) {
         sig.returns.push(AbiParam::new(cl_ty));
@@ -549,6 +698,8 @@ pub unsafe extern "C" fn __vow_clif_declare_function(
         param_tys,
         ret_ty,
         is_main: is_main != 0,
+        return_kind,
+        store_effects,
     });
 }
 
@@ -753,11 +904,15 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
 
     // Build inst_id → block_index map
     let mut inst_block: HashMap<i64, usize> = HashMap::new();
+    let mut inst_region_by_id: HashMap<i64, i64> = HashMap::new();
     for bi in 0..nb {
         let start = block_starts[bi] as usize;
         let len = block_lengths[bi] as usize;
         for &iid in &inst_ids[start..start + len] {
             inst_block.insert(iid, bi);
+        }
+        for idx in start..start + len {
+            inst_region_by_id.insert(inst_ids[idx], inst_rgns[idx]);
         }
     }
 
@@ -899,6 +1054,13 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         }
     }
     let is_main = ctx.func_decls[fi].is_main;
+    for _ in 0..hidden_region_count(
+        ctx.func_decls[fi].return_kind,
+        &ctx.func_decls[fi].store_effects,
+        is_main,
+    ) {
+        sig.params.push(AbiParam::new(types::I64));
+    }
     if let Some(cl_ty) = signature_return_ty(ret_ty, is_main) {
         sig.returns.push(AbiParam::new(cl_ty));
     }
@@ -1118,6 +1280,7 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
 
     // Set up entry block arg values
     let mut arg_values: HashMap<i64, Value> = HashMap::new(); // arg_index → Value
+    let mut hidden_region_values: Vec<Value> = Vec::new();
     if nb > 0 {
         builder.switch_to_block(cl_blocks[0]);
         let entry_params = builder.block_params(cl_blocks[0]).to_vec();
@@ -1129,6 +1292,13 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                 }
                 cl_idx += 1;
             }
+        }
+        if !ctx.func_decls[fi].is_main && cl_idx < entry_params.len() {
+            hidden_region_values.extend(entry_params[cl_idx..].iter().copied());
+        }
+        if ctx.func_decls[fi].is_main {
+            let root_arena = builder.ins().global_value(types::I64, root_arena_gv);
+            hidden_region_values.push(root_arena);
         }
     }
 
@@ -1775,6 +1945,7 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
 
                 // Function calls
                 IOP_CALL => {
+                    let mut extern_target_region: Option<i64> = None;
                     let func_ref = match dk {
                         IDATA_CALL_TARGET => {
                             let target_idx = dv;
@@ -1787,10 +1958,22 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                         }
                         IDATA_CALL_EXTERN => {
                             let sym = unsafe { read_vow_string(inst_ds_ptrs[ii]) };
-                            if let Some(&fr) = extern_func_refs.get(sym) {
+                            let receiver_rgn = if alen > 0 {
+                                let receiver_id = all_args[aoff];
+                                inst_region_by_id
+                                    .get(&receiver_id)
+                                    .copied()
+                                    .unwrap_or_else(region_root)
+                            } else {
+                                region_root()
+                            };
+                            let (routed_sym, target_region) =
+                                routed_vec_extern(sym, inst_rgns[ii], receiver_rgn);
+                            extern_target_region = target_region;
+                            if let Some(&fr) = extern_func_refs.get(routed_sym) {
                                 fr
                             } else {
-                                eprintln!("clif_shim: unknown extern symbol: {sym}");
+                                eprintln!("clif_shim: unknown extern symbol: {routed_sym}");
                                 return -1;
                             }
                         }
@@ -1806,31 +1989,17 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                         .map(|p| p.value_type)
                         .collect();
                     let mut call_args: Vec<Value> = Vec::new();
-                    if dk == IDATA_CALL_EXTERN {
-                        let sym = unsafe { read_vow_string(inst_ds_ptrs[ii]) };
-                        if extern_uses_target_region(sym) {
-                            let rgn = inst_rgns[ii];
-                            let kind = rgn & 3;
-                            let payload = rgn >> 2;
-                            let arena = match kind {
-                                REGION_KIND_ROOT | REGION_KIND_CALLER => {
-                                    builder.ins().global_value(types::I64, root_arena_gv)
-                                }
-                                REGION_KIND_BLOCK => {
-                                    let slot =
-                                        *block_arena_slots.entry(payload).or_insert_with(|| {
-                                            builder.create_sized_stack_slot(StackSlotData::new(
-                                                StackSlotKind::ExplicitSlot,
-                                                48,
-                                                3,
-                                            ))
-                                        });
-                                    builder.ins().stack_addr(types::I64, slot, 0)
-                                }
-                                _ => builder.ins().global_value(types::I64, root_arena_gv),
-                            };
-                            call_args.push(arena);
-                        }
+                    if let Some(rgn) = extern_target_region {
+                        let Some(arena) = arena_value_for_region(
+                            &mut builder,
+                            rgn,
+                            &hidden_region_values,
+                            &mut block_arena_slots,
+                            root_arena_gv,
+                        ) else {
+                            return -1;
+                        };
+                        call_args.push(arena);
                     }
                     let hidden_arg_offset = call_args.len();
                     for i in 0..alen {
@@ -1854,6 +2023,51 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                                 v
                             };
                         call_args.push(v);
+                    }
+                    if dk == IDATA_CALL_TARGET {
+                        let target_idx = dv;
+                        if let Some(decl) = ctx.func_decls.get(target_idx as usize) {
+                            let mut push_hidden = |builder: &mut FunctionBuilder<'_>,
+                                                   call_args: &mut Vec<Value>,
+                                                   rgn: i64|
+                             -> bool {
+                                if call_args.len() >= expected_types.len() {
+                                    return true;
+                                }
+                                let Some(arena) = arena_value_for_region(
+                                    builder,
+                                    rgn,
+                                    &hidden_region_values,
+                                    &mut block_arena_slots,
+                                    root_arena_gv,
+                                ) else {
+                                    return false;
+                                };
+                                call_args.push(arena);
+                                true
+                            };
+                            if decl.return_kind == RSUM_KIND_FRESH_IN_CALLER
+                                && !push_hidden(&mut builder, &mut call_args, inst_rgns[ii])
+                            {
+                                return -1;
+                            }
+                            let store_targets = hidden_region_store_targets(&decl.store_effects);
+                            for target_param in store_targets {
+                                let arg_rgn = if target_param >= 0 && (target_param as usize) < alen
+                                {
+                                    let arg_id = all_args[aoff + target_param as usize];
+                                    inst_region_by_id
+                                        .get(&arg_id)
+                                        .copied()
+                                        .unwrap_or_else(region_root)
+                                } else {
+                                    region_root()
+                                };
+                                if !push_hidden(&mut builder, &mut call_args, arg_rgn) {
+                                    return -1;
+                                }
+                            }
+                        }
                     }
                     let call_inst = builder.ins().call(func_ref, &call_args);
                     let results = builder.inst_results(call_inst);
@@ -1907,57 +2121,19 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                 // Region / linear
                 IOP_REGION_ALLOC => {
                     let rgn = inst_rgns[ii];
-                    let kind = rgn & 3;
-                    let payload = rgn >> 2;
                     let (size, align) = if dk == IDATA_ALLOC_SIZE {
                         (dv, dv2)
                     } else {
                         (0, 8)
                     };
-                    let arena = match kind {
-                        REGION_KIND_ROOT => builder.ins().global_value(types::I64, root_arena_gv),
-                        REGION_KIND_BLOCK => {
-                            let slot = *block_arena_slots.entry(payload).or_insert_with(|| {
-                                builder.create_sized_stack_slot(StackSlotData::new(
-                                    StackSlotKind::ExplicitSlot,
-                                    VOW_ARENA_HEADER_SIZE,
-                                    VOW_ARENA_HEADER_ALIGN_LOG2,
-                                ))
-                            });
-                            builder.ins().stack_addr(types::I64, slot, 0)
-                        }
-                        REGION_KIND_CALLER => {
-                            // Hidden-region plumbing (spec §5.2) is not yet
-                            // wired in the shim — `__vow_clif_declare_function`
-                            // does not accept a hidden-param count, so the
-                            // self-hosted compiler cannot emit any
-                            // `Caller`-routed allocation regardless of `k`.
-                            // Reject all `k` values rather than silently
-                            // routing into the root arena. Phase 5 (#200)
-                            // extends the declare API and lifts this reject.
-                            eprintln!(
-                                "clif_shim: IOP_REGION_ALLOC with REGION_KIND_CALLER \
-                                 (k={}) is not yet wired — self-hosted compiler must \
-                                 not emit Caller-routed allocations until hidden-param \
-                                 plumbing lands",
-                                payload,
-                            );
-                            return -1;
-                        }
-                        REGION_KIND_RODATA => {
-                            eprintln!(
-                                "clif_shim: IOP_REGION_ALLOC with REGION_KIND_RODATA \
-                                 is invalid — rodata-backed values are static, not \
-                                 allocated"
-                            );
-                            return -1;
-                        }
-                        _ => {
-                            eprintln!(
-                                "clif_shim: IOP_REGION_ALLOC with unknown region kind {kind}"
-                            );
-                            return -1;
-                        }
+                    let Some(arena) = arena_value_for_region(
+                        &mut builder,
+                        rgn,
+                        &hidden_region_values,
+                        &mut block_arena_slots,
+                        root_arena_gv,
+                    ) else {
+                        return -1;
                     };
                     let size_val = builder.ins().iconst(types::I64, size);
                     let align_val = builder.ins().iconst(types::I64, align);
@@ -2802,7 +2978,7 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64));
         }
         "__vow_clif_declare_function" => {
-            for _ in 0..7 {
+            for _ in 0..9 {
                 sig.params.push(AbiParam::new(types::I64));
             }
         }

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -355,6 +355,56 @@ fn region_to_arena_value(
     }
 }
 
+fn vec_receiver_region(inst: &Inst, inst_index: &HashMap<InstId, &Inst>) -> RegionId {
+    inst.args
+        .first()
+        .and_then(|arg_id| inst_index.get(arg_id))
+        .map(|src| src.region)
+        .unwrap_or(RegionId::Root)
+}
+
+fn routed_vec_extern<'a>(
+    sym: &'a str,
+    inst: &Inst,
+    inst_index: &HashMap<InstId, &Inst>,
+) -> (&'a str, Option<RegionId>) {
+    match sym {
+        "__vow_vec_new" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_vec_new_in_arena", Some(region)),
+        },
+        "__vow_vec_new_val" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_vec_new_val_in_arena", Some(region)),
+        },
+        "__vow_vec_push_val" => {
+            let region = vec_receiver_region(inst, inst_index);
+            match region {
+                RegionId::Block(_) | RegionId::Caller(_) => {
+                    ("__vow_vec_push_val_in_arena", Some(region))
+                }
+                _ => (sym, None),
+            }
+        }
+        "__vow_vec_push" => {
+            let region = vec_receiver_region(inst, inst_index);
+            match region {
+                RegionId::Block(_) | RegionId::Caller(_) => {
+                    ("__vow_vec_push_in_arena", Some(region))
+                }
+                _ => (sym, None),
+            }
+        }
+        _ => {
+            if extern_uses_target_region(sym) {
+                (sym, Some(inst.region))
+            } else {
+                (sym, None)
+            }
+        }
+    }
+}
+
 /// True when the function may emit a return-materialisation clone call —
 /// i.e. it has `return_region == FreshInCaller` and at least one `Return`
 /// inst whose source path reaches a `.rodata` literal or a heap-typed
@@ -1085,6 +1135,7 @@ fn lower_inst(
         // ------------------------------------------------------------------
         Opcode::Call => {
             let mut internal_call = false;
+            let mut external_target_region = None;
             let func_ref = match &inst.data {
                 InstData::CallTarget(f) => {
                     internal_call = true;
@@ -1097,9 +1148,11 @@ fn lower_inst(
                     fr
                 }
                 InstData::CallExtern(sym) => {
-                    let Some(&fr) = ctx.extern_func_refs.get(sym.as_str()) else {
+                    let (routed_sym, target_region) = routed_vec_extern(sym, inst, ctx.inst_index);
+                    external_target_region = target_region;
+                    let Some(&fr) = ctx.extern_func_refs.get(routed_sym) else {
                         return Err(CodegenError::UnsupportedOpcode(format!(
-                            "unknown extern symbol: {sym}"
+                            "unknown extern symbol: {routed_sym}"
                         )));
                     };
                     fr
@@ -1116,10 +1169,6 @@ fn lower_inst(
                 .iter()
                 .map(|p| p.value_type)
                 .collect();
-            let external_target_region = match &inst.data {
-                InstData::CallExtern(sym) if extern_uses_target_region(sym) => Some(inst.region),
-                _ => None,
-            };
             let mut call_args: Vec<Value> = Vec::new();
             if let Some(region) = external_target_region {
                 let arena = region_to_arena_value(
@@ -1749,6 +1798,8 @@ fn compile_ir_function(
         }
         hidden_region_values.extend(entry_params[cl_idx..].iter().copied());
         if ir_func.name == "main" {
+            let root_arena = builder.ins().global_value(types::I64, root_arena_gv);
+            hidden_region_values.push(root_arena);
             let runtime_start_ref =
                 obj_module.declare_func_in_func(runtime.runtime_start_id, builder.func);
             builder.ins().call(runtime_start_ref, &[]);
@@ -2257,6 +2308,8 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // n_params
             sig.params.push(AbiParam::new(types::I64)); // ret_ty
             sig.params.push(AbiParam::new(types::I64)); // is_main
+            sig.params.push(AbiParam::new(types::I64)); // return summary kind
+            sig.params.push(AbiParam::new(types::I64)); // store_effects Vec
         }
         // Incremental per-function FFI (replaces the batched
         // __vow_clif_compile_function). Signatures must match
@@ -2370,13 +2423,15 @@ impl Backend for CraneliftBackend {
         // Scan all functions for CallExtern symbols and declare them as imports
         let mut extern_syms = HashSet::new();
         for func in &module.functions {
+            let inst_index = build_inst_index(func);
             for block in &func.blocks {
                 for inst in &block.insts {
                     if let InstData::CallExtern(sym) = &inst.data {
                         if inst.opcode == Opcode::DebugCall && !mode.has_debug_checks() {
                             continue;
                         }
-                        extern_syms.insert(sym.clone());
+                        let (routed_sym, _) = routed_vec_extern(sym, inst, &inst_index);
+                        extern_syms.insert(routed_sym.to_string());
                     }
                 }
             }
@@ -3969,6 +4024,132 @@ mod tests {
         let result =
             CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
         assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[test]
+    fn block_region_vec_new_imports_arena_variant() {
+        let mut vec_new = inst(
+            2,
+            Opcode::Call,
+            Ty::Ptr,
+            vec![0, 1],
+            InstData::CallExtern("__vow_vec_new".to_string()),
+        );
+        vec_new.region = RegionId::Block(BlockId(0));
+        let module = make_module(
+            "test",
+            vec![simple_fn(
+                0,
+                "f",
+                vec![],
+                Ty::Ptr,
+                vec![
+                    inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                    inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                    vec_new,
+                    inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+                ],
+            )],
+        );
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_vec_new_in_arena"));
+        assert!(!symbols.contains("__vow_vec_new"));
+    }
+
+    #[test]
+    fn root_region_vec_new_keeps_wrapper_symbol() {
+        let module = make_module(
+            "test",
+            vec![simple_fn(
+                0,
+                "f",
+                vec![],
+                Ty::Ptr,
+                vec![
+                    inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                    inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                    inst(
+                        2,
+                        Opcode::Call,
+                        Ty::Ptr,
+                        vec![0, 1],
+                        InstData::CallExtern("__vow_vec_new".to_string()),
+                    ),
+                    inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+                ],
+            )],
+        );
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_vec_new"));
+        assert!(!symbols.contains("__vow_vec_new_in_arena"));
+    }
+
+    #[test]
+    fn block_region_vec_push_val_imports_arena_variant() {
+        let mut vec_new = inst(
+            2,
+            Opcode::Call,
+            Ty::Ptr,
+            vec![0, 1],
+            InstData::CallExtern("__vow_vec_new".to_string()),
+        );
+        vec_new.region = RegionId::Block(BlockId(0));
+        let module = make_module(
+            "test",
+            vec![simple_fn(
+                0,
+                "f",
+                vec![],
+                Ty::Unit,
+                vec![
+                    inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                    inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+                    vec_new,
+                    inst(3, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(42)),
+                    inst(
+                        4,
+                        Opcode::Call,
+                        Ty::Unit,
+                        vec![2, 3],
+                        InstData::CallExtern("__vow_vec_push_val".to_string()),
+                    ),
+                    inst(5, Opcode::Return, Ty::Unit, vec![], InstData::None),
+                ],
+            )],
+        );
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_vec_push_val_in_arena"));
+        assert!(!symbols.contains("__vow_vec_push_val"));
     }
 
     #[test]

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -14,8 +14,9 @@
 //!    monotone fixed-point seeded at the internal `Uninit` ⊥ element
 //!    (spec §4.3 step 1).
 //! 3. Per function, walk every block / inst, collecting `must_outlive(I)`
-//!    sets. Heap-producing instructions (today: `Opcode::RegionAlloc`) get
-//!    their `region` field set from the LUB.
+//!    sets. Heap-producing instructions (`Opcode::RegionAlloc` plus
+//!    recognised fresh runtime allocation extern calls) get their `region`
+//!    field set from the LUB.
 //! 4. Per function, derive a `RegionSummary` from the `Return` arg's
 //!    `must_outlive` set + per-call store-effect contributions.
 //! 5. After fixed point, every still-`Uninit` summary is resolved by
@@ -1429,12 +1430,15 @@ fn analyze_function(
             }
             let markers = must_outlive.get(&inst.id).cloned().unwrap_or_default();
             let mut region_id = lub_to_region_id(&markers, block.id, &block_tree);
-            if inst.opcode == Opcode::Call {
+            if inst.opcode == Opcode::Call
+                && !matches!(&inst.data, InstData::CallExtern(sym) if heap_producing_extern(sym))
+            {
                 // Hidden caller-region codegen is still too shallow for
-                // aggregate FreshInCaller call results that are immediately
-                // projected and repackaged. Keep call materialisation
-                // conservative; issue #289 is about concrete block LUB for
-                // RegionAlloc producers.
+                // unresolved/internal aggregate FreshInCaller call results
+                // that are immediately projected and repackaged. Keep those
+                // materialisations conservative, while allowing recognised
+                // runtime heap producers to route through their explicit
+                // arena-aware ABI.
                 if matches!(region_id, RegionId::Block(_) | RegionId::Caller(_)) {
                     region_id = RegionId::Root;
                 }
@@ -1451,6 +1455,14 @@ fn extern_fresh_in_caller(sym: &str) -> bool {
         sym,
         "__vow_string_from_raw_parts_copy" | "__vow_vec_from_raw_parts_copy_val"
     )
+}
+
+fn vec_creation_extern(sym: &str) -> bool {
+    matches!(sym, "__vow_vec_new" | "__vow_vec_new_val")
+}
+
+fn heap_producing_extern(sym: &str) -> bool {
+    extern_fresh_in_caller(sym) || vec_creation_extern(sym)
 }
 
 fn for_each_extern_store_edge(sym: &str, args: &[InstId], mut visit: impl FnMut(InstId, InstId)) {
@@ -1470,7 +1482,7 @@ fn is_heap_producing(inst: &Inst, summaries: &[InternalSummary]) -> bool {
     matches!(inst.opcode, Opcode::RegionAlloc)
         || matches!(
             (&inst.opcode, &inst.data),
-            (Opcode::Call, InstData::CallExtern(sym)) if extern_fresh_in_caller(sym)
+            (Opcode::Call, InstData::CallExtern(sym)) if heap_producing_extern(sym)
         )
         || matches!(
             (&inst.opcode, &inst.data),
@@ -1532,11 +1544,13 @@ fn handle_inst(
                 );
                 // If the target traces to a parameter, record a store_effect.
                 if let Some(target_param) = trace_param(target_id, inst_lookup) {
-                    let source_origin = trace_origin(source_id, inst_lookup);
-                    let source_constraint = origin_to_constraint(&source_origin);
-                    summary
-                        .store_effects
-                        .insert((target_param, InternalReturnRegion::Published(source_constraint)));
+                    add_store_effect_source_constraints(
+                        summary,
+                        target_param,
+                        source_id,
+                        inst_lookup,
+                        summaries,
+                    );
                 }
             }
         Opcode::Upsilon => {
@@ -1561,12 +1575,13 @@ fn handle_inst(
                     };
                     add_marker(must_outlive, source_id, marker);
                     if let Some(target_param) = trace_param(target_id, inst_lookup) {
-                        let source_origin = trace_origin(source_id, inst_lookup);
-                        let source_constraint = origin_to_constraint(&source_origin);
-                        summary.store_effects.insert((
+                        add_store_effect_source_constraints(
+                            summary,
                             target_param,
-                            InternalReturnRegion::Published(source_constraint),
-                        ));
+                            source_id,
+                            inst_lookup,
+                            summaries,
+                        );
                     }
                 });
             }
@@ -1592,6 +1607,16 @@ fn handle_inst(
                         continue;
                     }
                     let target_arg_id = inst.args[target_idx];
+                    if let Some(current_target_param) = trace_param(target_arg_id, inst_lookup) {
+                        publish_transitive_store_effect(
+                            summary,
+                            current_target_param,
+                            source_constraint,
+                            inst,
+                            inst_lookup,
+                            summaries,
+                        );
+                    }
                     match source_constraint {
                         InternalReturnRegion::Published(RegionConstraint::AliasOf(p)) => {
                             // The callee writes argument-at-position-p into argument-at-position-target.
@@ -1648,12 +1673,126 @@ fn handle_inst(
     }
 }
 
+fn publish_transitive_store_effect(
+    summary: &mut InternalSummary,
+    current_target_param: u32,
+    source_constraint: &InternalReturnRegion,
+    call_inst: &Inst,
+    inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>,
+    summaries: &[InternalSummary],
+) {
+    match source_constraint {
+        InternalReturnRegion::Published(RegionConstraint::AliasOf(p)) => {
+            let p_idx = *p as usize;
+            if p_idx < call_inst.args.len() {
+                add_store_effect_source_constraints(
+                    summary,
+                    current_target_param,
+                    call_inst.args[p_idx],
+                    inst_lookup,
+                    summaries,
+                );
+            }
+        }
+        InternalReturnRegion::Published(RegionConstraint::AliasOfAny(ps)) => {
+            for p in ps {
+                let p_idx = *p as usize;
+                if p_idx < call_inst.args.len() {
+                    add_store_effect_source_constraints(
+                        summary,
+                        current_target_param,
+                        call_inst.args[p_idx],
+                        inst_lookup,
+                        summaries,
+                    );
+                }
+            }
+        }
+        InternalReturnRegion::Published(RegionConstraint::FreshInCaller) => {
+            summary.store_effects.insert((
+                current_target_param,
+                InternalReturnRegion::Published(RegionConstraint::FreshInCaller),
+            ));
+        }
+        InternalReturnRegion::Published(RegionConstraint::ConstantGlobal) => {
+            summary.store_effects.insert((
+                current_target_param,
+                InternalReturnRegion::Published(RegionConstraint::ConstantGlobal),
+            ));
+        }
+        InternalReturnRegion::Uninit => {}
+    }
+}
+
 fn add_marker(
     must_outlive: &mut BTreeMap<InstId, BTreeSet<MustOutliveMarker>>,
     inst_id: InstId,
     marker: MustOutliveMarker,
 ) {
     must_outlive.entry(inst_id).or_default().insert(marker);
+}
+
+fn add_store_effect_source_constraints(
+    summary: &mut InternalSummary,
+    target_param: u32,
+    source_id: InstId,
+    inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>,
+    summaries: &[InternalSummary],
+) {
+    let source_origin = trace_origin(source_id, inst_lookup);
+    let source_constraint = origin_to_constraint(&source_origin);
+    summary.store_effects.insert((
+        target_param,
+        InternalReturnRegion::Published(source_constraint),
+    ));
+    publish_embedded_param_aliases(summary, target_param, source_id, inst_lookup);
+
+    let Some((_, source_inst)) = inst_lookup.get(&source_id) else {
+        return;
+    };
+    let Opcode::Call = source_inst.opcode else {
+        return;
+    };
+    let InstData::CallTarget(callee_id) = &source_inst.data else {
+        return;
+    };
+    let Some(callee) = summaries.get(callee_id.0 as usize) else {
+        return;
+    };
+    if callee.return_region != InternalReturnRegion::Published(RegionConstraint::FreshInCaller) {
+        return;
+    }
+
+    for &arg_id in &source_inst.args {
+        if let Some(param_idx) = trace_param(arg_id, inst_lookup) {
+            summary.store_effects.insert((
+                target_param,
+                InternalReturnRegion::Published(RegionConstraint::AliasOf(param_idx)),
+            ));
+        }
+    }
+}
+
+fn publish_embedded_param_aliases(
+    summary: &mut InternalSummary,
+    target_param: u32,
+    aggregate_id: InstId,
+    inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>,
+) {
+    for (_, inst) in inst_lookup.values() {
+        if !matches!(inst.opcode, Opcode::Store | Opcode::FieldSet) || inst.args.len() < 2 {
+            continue;
+        }
+        if inst.args[0] != aggregate_id {
+            continue;
+        }
+        if let Some(param_idx) = trace_param(inst.args[1], inst_lookup) {
+            summary.store_effects.insert((
+                target_param,
+                InternalReturnRegion::Published(RegionConstraint::AliasOf(param_idx)),
+            ));
+        }
+    }
 }
 
 fn collect_regular_use_markers(
@@ -1751,6 +1890,17 @@ fn propagate_alias_markers(
                                 if j_idx < inst.args.len() {
                                     alias_edges.push((inst.id, inst.args[j_idx]));
                                 }
+                            }
+                        }
+                        InternalReturnRegion::Published(RegionConstraint::FreshInCaller) => {
+                            // A fresh aggregate can still contain borrowed
+                            // heap descriptors passed as constructor args
+                            // (`IrInst { args: ... }` is the bootstrap
+                            // stress case). Any later widening of the call
+                            // result must therefore widen the heap-producing
+                            // arguments that may have been embedded in it.
+                            for &arg_id in &inst.args {
+                                alias_edges.push((inst.id, arg_id));
                             }
                         }
                         _ => {}
@@ -1961,7 +2111,7 @@ fn origin_to_internal_inner(
         | Opcode::ConstUnit => InternalReturnRegion::Published(RegionConstraint::ConstantGlobal),
         Opcode::Call => {
             if let InstData::CallExtern(sym) = &inst.data
-                && extern_fresh_in_caller(sym)
+                && heap_producing_extern(sym)
             {
                 return InternalReturnRegion::Published(RegionConstraint::FreshInCaller);
             }
@@ -2066,6 +2216,9 @@ fn trace_origin(id: InstId, inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>) ->
             }
         }
         Opcode::RegionAlloc => ValueOrigin::RegionAlloc,
+        Opcode::Call if matches!(&inst.data, InstData::CallExtern(sym) if heap_producing_extern(sym)) => {
+            ValueOrigin::RegionAlloc
+        }
         Opcode::ConstStr
         | Opcode::ConstI32
         | Opcode::ConstI64
@@ -2094,11 +2247,38 @@ fn target_region_marker(
 }
 
 fn trace_param(id: InstId, inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>) -> Option<u32> {
+    let mut visiting = VecDeque::new();
+    trace_param_inner(id, inst_lookup, &mut visiting)
+}
+
+fn trace_param_inner(
+    id: InstId,
+    inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>,
+    visiting: &mut VecDeque<InstId>,
+) -> Option<u32> {
+    if visiting.contains(&id) {
+        return None;
+    }
     let (_, inst) = inst_lookup.get(&id)?;
-    if let (Opcode::GetArg, InstData::ArgIndex(i)) = (inst.opcode, &inst.data) {
-        Some(*i)
-    } else {
-        None
+    match (&inst.opcode, &inst.data) {
+        (Opcode::GetArg, InstData::ArgIndex(i)) => Some(*i),
+        (Opcode::FieldGet, _) | (Opcode::Load, _) => {
+            let source = *inst.args.first()?;
+            visiting.push_back(id);
+            let result = trace_param_inner(source, inst_lookup, visiting);
+            visiting.pop_back();
+            result
+        }
+        (Opcode::Call, InstData::CallExtern(sym))
+            if matches!(sym.as_str(), "__vow_vec_get_val" | "__vow_vec_get") =>
+        {
+            let source = *inst.args.first()?;
+            visiting.push_back(id);
+            let result = trace_param_inner(source, inst_lookup, visiting);
+            visiting.pop_back();
+            result
+        }
+        _ => None,
     }
 }
 
@@ -2166,6 +2346,12 @@ fn check_store_conflict(
     let target_origin = trace_origin(target_arg_id, inst_lookup);
 
     if !matches!(source_origin, ValueOrigin::RegionAlloc) {
+        return;
+    }
+    let Some((_, source_inst)) = inst_lookup.get(&source_arg_id) else {
+        return;
+    };
+    if source_inst.opcode != Opcode::RegionAlloc {
         return;
     }
     let ValueOrigin::Param(_) = target_origin else {
@@ -3732,7 +3918,7 @@ mod tests {
     }
 
     #[test]
-    fn vec_push_val_routes_source_to_vector_target_region() {
+    fn vec_push_val_routes_source_to_local_vector_region() {
         let insts = vec![
             inst(
                 0,
@@ -3764,8 +3950,109 @@ mod tests {
 
         assert_eq!(
             m.functions[0].blocks[0].insts[1].region,
-            RegionId::Root,
-            "a value copied into an externally-managed vector must outlive the vector target"
+            RegionId::Block(BlockId(0)),
+            "a value copied into a local vector should inherit the vector target's region"
+        );
+    }
+
+    #[test]
+    fn vec_new_local_result_routes_to_block_region() {
+        let insts = vec![
+            inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+            inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![0, 1],
+                InstData::CallExtern("__vow_vec_new".to_string()),
+            ),
+            inst(
+                3,
+                Opcode::Call,
+                Ty::I64,
+                vec![2],
+                InstData::CallExtern("__vow_vec_len".to_string()),
+            ),
+            inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+        ];
+        let f = function(0, "vec_local", vec![], Ty::I64, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[0].blocks[0].insts[2].region,
+            RegionId::Block(BlockId(0))
+        );
+    }
+
+    #[test]
+    fn returned_vec_new_routes_to_caller_region() {
+        let insts = vec![
+            inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+            inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![0, 1],
+                InstData::CallExtern("__vow_vec_new".to_string()),
+            ),
+            inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+        ];
+        let f = function(0, "vec_return", vec![], Ty::Ptr, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[0].summary.return_region,
+            RegionConstraint::FreshInCaller
+        );
+        assert_eq!(
+            m.functions[0].blocks[0].insts[2].region,
+            RegionId::Caller(HiddenRegionIdx(0))
+        );
+    }
+
+    #[test]
+    fn vec_push_into_returned_vec_lifts_source_to_outer_region() {
+        let insts = vec![
+            inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+            inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(8)),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![0, 1],
+                InstData::CallExtern("__vow_vec_new".to_string()),
+            ),
+            inst(
+                3,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![0, 1],
+                InstData::CallExtern("__vow_vec_new".to_string()),
+            ),
+            inst(
+                4,
+                Opcode::Call,
+                Ty::Unit,
+                vec![2, 3],
+                InstData::CallExtern("__vow_vec_push_val".to_string()),
+            ),
+            inst(5, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+        ];
+        let f = function(0, "vec_push_escape", vec![], Ty::Ptr, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[0].blocks[0].insts[2].region,
+            RegionId::Caller(HiddenRegionIdx(0))
+        );
+        assert_eq!(
+            m.functions[0].blocks[0].insts[3].region,
+            RegionId::Caller(HiddenRegionIdx(0))
         );
     }
 
@@ -3830,6 +4117,323 @@ mod tests {
             call.region,
             RegionId::Root,
             "FreshInCaller call result materialization remains conservative until aggregate hidden-region codegen is complete"
+        );
+    }
+
+    #[test]
+    fn fresh_aggregate_call_widens_argument_stored_in_result() {
+        let callee_insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                2,
+                Opcode::FieldSet,
+                Ty::Unit,
+                vec![1, 0],
+                InstData::FieldIndex(0),
+            ),
+            inst(3, Opcode::Return, Ty::Unit, vec![1], InstData::None),
+        ];
+        let callee = function(
+            0,
+            "wrap_arg",
+            vec![Ty::Ptr],
+            Ty::Ptr,
+            vec![block(0, callee_insts)],
+        );
+        let caller_insts = vec![
+            inst(
+                10,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![],
+                InstData::CallExtern("__vow_vec_new".to_string()),
+            ),
+            inst(
+                11,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![10],
+                InstData::CallTarget(FuncId(0)),
+            ),
+            inst(12, Opcode::Return, Ty::Unit, vec![11], InstData::None),
+        ];
+        let caller = function(1, "caller", vec![], Ty::Ptr, vec![block(0, caller_insts)]);
+        let mut m = module(vec![callee, caller]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[1].blocks[0].insts[0].region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "argument embedded in a returned fresh aggregate must follow the aggregate escape"
+        );
+    }
+
+    #[test]
+    fn fresh_aggregate_store_effect_preserves_embedded_argument_alias() {
+        let wrap_insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(
+                1,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                2,
+                Opcode::FieldSet,
+                Ty::Unit,
+                vec![1, 0],
+                InstData::FieldIndex(0),
+            ),
+            inst(3, Opcode::Return, Ty::Unit, vec![1], InstData::None),
+        ];
+        let wrap = function(
+            0,
+            "wrap_arg",
+            vec![Ty::Ptr],
+            Ty::Ptr,
+            vec![block(0, wrap_insts)],
+        );
+        let store_insts = vec![
+            inst(10, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(11, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+            inst(
+                12,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![11],
+                InstData::CallTarget(FuncId(0)),
+            ),
+            inst(
+                13,
+                Opcode::Call,
+                Ty::Unit,
+                vec![10, 12],
+                InstData::CallExtern("__vow_vec_push_val".to_string()),
+            ),
+            inst(14, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let store = function(
+            1,
+            "store_wrapped_arg",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, store_insts)],
+        );
+        let mut m = module(vec![wrap, store]);
+        infer_regions(&mut m);
+
+        assert!(
+            m.functions[1].summary.store_effects.iter().any(|effect| {
+                effect.target == 0 && effect.source == RegionConstraint::AliasOf(1)
+            }),
+            "storing a fresh aggregate into a target must also publish aliases embedded in that aggregate"
+        );
+    }
+
+    #[test]
+    fn nested_parameter_container_store_publishes_store_effect() {
+        let insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+            inst(
+                2,
+                Opcode::FieldGet,
+                Ty::Ptr,
+                vec![0],
+                InstData::FieldIndex(0),
+            ),
+            inst(
+                3,
+                Opcode::Call,
+                Ty::Unit,
+                vec![2, 1],
+                InstData::CallExtern("__vow_vec_push_val".to_string()),
+            ),
+            inst(4, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let f = function(
+            0,
+            "store_nested",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert!(
+            m.functions[0].summary.store_effects.iter().any(|effect| {
+                effect.target == 0 && effect.source == RegionConstraint::AliasOf(1)
+            }),
+            "stores through parameter-owned fields must publish a store effect for the owning parameter"
+        );
+    }
+
+    #[test]
+    fn vec_new_through_callee_store_effect_lifts_without_conflict() {
+        let callee_insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Unit,
+                vec![0, 1],
+                InstData::CallExtern("__vow_vec_push_val".to_string()),
+            ),
+            inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let callee = function(
+            0,
+            "push_arg",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, callee_insts)],
+        );
+        let caller_insts = vec![
+            inst(10, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(
+                11,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![],
+                InstData::CallExtern("__vow_vec_new".to_string()),
+            ),
+            inst(
+                12,
+                Opcode::Call,
+                Ty::Unit,
+                vec![10, 11],
+                InstData::CallTarget(FuncId(0)),
+            ),
+            inst(13, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let caller = function(
+            1,
+            "caller",
+            vec![Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, caller_insts)],
+        );
+        let mut m = module(vec![callee, caller]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[1].blocks[0].insts[1].region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "Vec creation passed through a store-effecting callee should lift to the target parameter region"
+        );
+        assert!(
+            m.warnings
+                .iter()
+                .all(|d| d.code != ErrorCode::RegionConflict),
+            "routable Vec creation should not trip the block-local RegionAlloc conflict"
+        );
+    }
+
+    #[test]
+    fn internal_call_republishes_callee_store_effect_for_parameter_target() {
+        let callee_insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Unit,
+                vec![0, 1],
+                InstData::CallExtern("__vow_vec_push_val".to_string()),
+            ),
+            inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let callee = function(
+            0,
+            "push_arg",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, callee_insts)],
+        );
+        let wrapper_insts = vec![
+            inst(10, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(11, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+            inst(
+                12,
+                Opcode::Call,
+                Ty::Unit,
+                vec![10, 11],
+                InstData::CallTarget(FuncId(0)),
+            ),
+            inst(13, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let wrapper = function(
+            1,
+            "wrapper",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, wrapper_insts)],
+        );
+        let mut m = module(vec![callee, wrapper]);
+        infer_regions(&mut m);
+
+        assert!(
+            m.functions[1].summary.store_effects.iter().any(|effect| {
+                effect.target == 0 && effect.source == RegionConstraint::AliasOf(1)
+            }),
+            "internal wrappers must republish callee store effects for their own parameter targets"
+        );
+    }
+
+    #[test]
+    fn fresh_aggregate_stored_into_param_publishes_field_aliases() {
+        let insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+            inst(
+                2,
+                Opcode::RegionAlloc,
+                Ty::Ptr,
+                vec![],
+                InstData::AllocSize { size: 16, align: 8 },
+            ),
+            inst(
+                3,
+                Opcode::FieldSet,
+                Ty::Unit,
+                vec![2, 1],
+                InstData::FieldIndex(0),
+            ),
+            inst(
+                4,
+                Opcode::Call,
+                Ty::Unit,
+                vec![0, 2],
+                InstData::CallExtern("__vow_vec_push_val".to_string()),
+            ),
+            inst(5, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let f = function(
+            0,
+            "store_aggregate_with_param_field",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert!(
+            m.functions[0].summary.store_effects.iter().any(|effect| {
+                effect.target == 0 && effect.source == RegionConstraint::AliasOf(1)
+            }),
+            "fresh aggregates stored into parameter containers must publish parameter aliases in their fields"
         );
     }
 

--- a/vow-types/src/env.rs
+++ b/vow-types/src/env.rs
@@ -557,6 +557,8 @@ impl TypeEnv {
                     Ty::I64,
                     Ty::I64,
                     Ty::I64,
+                    Ty::I64,
+                    Ty::Applied(Box::new(Ty::Struct("Vec".to_string())), vec![Ty::I64]),
                 ],
                 return_ty: Ty::Unit,
                 effects: [Effect::IO].into_iter().collect(),

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -403,7 +403,9 @@ pub fn is_modelable(
                 | Opcode::Return
                 | Opcode::Unreachable
                 | Opcode::Phi
-                | Opcode::Upsilon => true,
+                | Opcode::Upsilon
+                | Opcode::RegionOpen
+                | Opcode::RegionClose => true,
 
                 Opcode::Call => match &inst.data {
                     InstData::CallExtern(name) => is_known_builtin(name),
@@ -430,8 +432,6 @@ pub fn is_modelable(
                 | Opcode::Load
                 | Opcode::Store
                 | Opcode::RegionAlloc
-                | Opcode::RegionOpen
-                | Opcode::RegionClose
                 | Opcode::LinearConsume
                 | Opcode::LinearBorrow
                 | Opcode::FieldSet => false,
@@ -494,8 +494,6 @@ fn first_unsupported_opcode(
                 | Opcode::Load
                 | Opcode::Store
                 | Opcode::RegionAlloc
-                | Opcode::RegionOpen
-                | Opcode::RegionClose
                 | Opcode::LinearConsume
                 | Opcode::LinearBorrow
                 | Opcode::FieldSet => return Some(format!("{:?}", inst.opcode)),
@@ -1228,13 +1226,15 @@ fn emit_inst(
             }
         }
 
+        Opcode::RegionOpen | Opcode::RegionClose => {
+            out.push_str("  /* verifier no-op: region scope marker */\n");
+        }
+
         // Other calls, memory, region/linear/field ops — not yet supported for verification
         Opcode::Call
         | Opcode::Load
         | Opcode::Store
         | Opcode::RegionAlloc
-        | Opcode::RegionOpen
-        | Opcode::RegionClose
         | Opcode::LinearConsume
         | Opcode::LinearBorrow
         | Opcode::FieldSet => {

--- a/vow/src/cache.rs
+++ b/vow/src/cache.rs
@@ -8,7 +8,7 @@ use crate::frontend::DependencyManifest;
 // Bump this whenever generated object files are no longer ABI-compatible with
 // existing cached artifacts. Phase 7 adds FFI wrapper stdlib intrinsics and
 // runtime helper imports, so pre-cutover objects must not be reused.
-const COMPILE_CACHE_ABI_VERSION: &str = "arena-loop-refresh-v2";
+const COMPILE_CACHE_ABI_VERSION: &str = "vec-arena-routing-v1";
 
 pub struct CompileCache {
     dir: PathBuf,


### PR DESCRIPTION
## Summary
- Treat Vec creation externs as heap-producing region producers and preserve Block/Caller/Root inference for recognized heap allocations.
- Route arena-eligible Vec creation and growth calls to explicit `_in_arena` runtime symbols in Rust codegen and the self-hosted Cranelift shim.
- Mirror hidden-region ABI metadata through the self-hosted compiler and update arena-memory docs.
- Model `RegionOpen`/`RegionClose` as verifier no-ops so arena-scoped Vec code remains verifiable.

Closes #292.

## Validation
- `cargo fmt --all`
- `cargo build --release -p vow`
- `scripts/bootstrap.sh --skip-cargo`
- `cargo test --all`
- `./tests/run_tests.sh`
- manual `scripts/concat_vow.sh` fixed-point check
- `bench/memory/run.sh`