### PR TITLE
[codex] Implement String arena routing

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -489,8 +489,12 @@ fn vec_model_receiver_arg(name: String) -> i64 {
 fn string_model_receiver_arg(name: String) -> i64 {
     if name == String::from("__vow_string_push_str_in_arena") { return 1; }
     if name == String::from("__vow_string_push_byte_in_arena") { return 1; }
+    if name == String::from("__vow_string_substr_in_arena") { return 1; }
+    if name == String::from("__vow_string_substring_in_arena") { return 1; }
     if name == String::from("__vow_string_push_str") { return 0; }
     if name == String::from("__vow_string_push_byte") { return 0; }
+    if name == String::from("__vow_string_substr") { return 0; }
+    if name == String::from("__vow_string_substring") { return 0; }
     if name == String::from("__vow_string_len") { return 0; }
     if name == String::from("__vow_string_clear") { return 0; }
     if name == String::from("__vow_string_byte_at") { return 0; }
@@ -614,12 +618,7 @@ fn collect_modelled_vars(f: IrFunction, constructor: String, prefix: String) -> 
             let inst: IrInst = insts[ii];
             if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
                 let ds: String = inst.ds;
-                let alt_creator: bool = (prefix == String::from("__vow_vec_")
-                    && is_vec_model_constructor(ds))
-                    || (prefix == String::from("__vow_string_")
-                        && is_string_model_constructor(ds));
-                let is_creator: bool = ds == constructor || alt_creator;
-                if str_starts_with(ds, prefix) && !is_creator {
+                if str_starts_with(ds, prefix) {
                     let iargs: Vec<i64> = inst.args;
                     let receiver_arg: i64 = {
                         if prefix == String::from("__vow_vec_") {

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -105,16 +105,27 @@ fn is_known_builtin(name: String) -> bool {
     || name == String::from("__vow_vec_len")
     || name == String::from("__vow_vec_pop")
     || name == String::from("__vow_vec_set_val")
+    || name == String::from("__vow_string_new")
+    || name == String::from("__vow_string_new_in_arena")
     || name == String::from("__vow_string_from_cstr")
+    || name == String::from("__vow_string_from_cstr_in_arena")
     || name == String::from("__vow_string_from_raw_parts_copy")
     || name == String::from("__vow_string_pin_to_root")
     || name == String::from("__vow_string_len")
     || name == String::from("__vow_string_push_str")
+    || name == String::from("__vow_string_push_str_in_arena")
     || name == String::from("__vow_string_push_byte")
+    || name == String::from("__vow_string_push_byte_in_arena")
     || name == String::from("__vow_string_clear")
     || name == String::from("__vow_string_byte_at")
     || name == String::from("__vow_string_eq")
     || name == String::from("__vow_string_contains")
+    || name == String::from("__vow_string_substr")
+    || name == String::from("__vow_string_substr_in_arena")
+    || name == String::from("__vow_string_substring")
+    || name == String::from("__vow_string_substring_in_arena")
+    || name == String::from("__vow_string_from_i64")
+    || name == String::from("__vow_string_from_i64_in_arena")
     || name == String::from("__vow_string_print")
     || name == String::from("__vow_map_new")
     || name == String::from("__vow_map_len")
@@ -448,6 +459,21 @@ fn is_vec_model_constructor(name: String) -> bool {
     || name == String::from("__vow_vec_pin_to_root_val")
 }
 
+fn is_string_model_constructor(name: String) -> bool {
+    name == String::from("__vow_string_new")
+    || name == String::from("__vow_string_new_in_arena")
+    || name == String::from("__vow_string_from_cstr")
+    || name == String::from("__vow_string_from_cstr_in_arena")
+    || name == String::from("__vow_string_from_raw_parts_copy")
+    || name == String::from("__vow_string_pin_to_root")
+    || name == String::from("__vow_string_substr")
+    || name == String::from("__vow_string_substr_in_arena")
+    || name == String::from("__vow_string_substring")
+    || name == String::from("__vow_string_substring_in_arena")
+    || name == String::from("__vow_string_from_i64")
+    || name == String::from("__vow_string_from_i64_in_arena")
+}
+
 fn vec_model_receiver_arg(name: String) -> i64 {
     if name == String::from("__vow_vec_push_val") { return 0; }
     if name == String::from("__vow_vec_get_val") { return 0; }
@@ -457,6 +483,20 @@ fn vec_model_receiver_arg(name: String) -> i64 {
     if name == String::from("__vow_vec_push_in_arena") { return 1; }
     if name == String::from("__vow_vec_push_val_in_arena") { return 1; }
     if name == String::from("__vow_vec_reserve_in_arena") { return 1; }
+    -1
+}
+
+fn string_model_receiver_arg(name: String) -> i64 {
+    if name == String::from("__vow_string_push_str_in_arena") { return 1; }
+    if name == String::from("__vow_string_push_byte_in_arena") { return 1; }
+    if name == String::from("__vow_string_push_str") { return 0; }
+    if name == String::from("__vow_string_push_byte") { return 0; }
+    if name == String::from("__vow_string_len") { return 0; }
+    if name == String::from("__vow_string_clear") { return 0; }
+    if name == String::from("__vow_string_byte_at") { return 0; }
+    if name == String::from("__vow_string_eq") { return 0; }
+    if name == String::from("__vow_string_contains") { return 0; }
+    if name == String::from("__vow_string_print") { return 0; }
     -1
 }
 
@@ -553,13 +593,10 @@ fn collect_modelled_vars(f: IrFunction, constructor: String, prefix: String) -> 
             if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
                 let ds: String = inst.ds;
                 let alt_creator: bool = (prefix == String::from("__vow_vec_")
-                    && (ds == String::from("__vow_vec_from_raw_parts_copy_val")
-                        || ds == String::from("__vow_vec_pin_to_root_val")))
+                    && is_vec_model_constructor(ds))
                     || (prefix == String::from("__vow_string_")
-                        && (ds == String::from("__vow_string_from_raw_parts_copy")
-                            || ds == String::from("__vow_string_pin_to_root")));
-                let is_creator: bool = ds == constructor || alt_creator
-                    || (prefix == String::from("__vow_vec_") && is_vec_model_constructor(ds));
+                        && is_string_model_constructor(ds));
+                let is_creator: bool = ds == constructor || alt_creator;
                 if is_creator {
                     vec_insert_i64(vars, inst.id);
                 }
@@ -578,18 +615,17 @@ fn collect_modelled_vars(f: IrFunction, constructor: String, prefix: String) -> 
             if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
                 let ds: String = inst.ds;
                 let alt_creator: bool = (prefix == String::from("__vow_vec_")
-                    && (ds == String::from("__vow_vec_from_raw_parts_copy_val")
-                        || ds == String::from("__vow_vec_pin_to_root_val")))
+                    && is_vec_model_constructor(ds))
                     || (prefix == String::from("__vow_string_")
-                        && (ds == String::from("__vow_string_from_raw_parts_copy")
-                            || ds == String::from("__vow_string_pin_to_root")));
-                let is_creator: bool = ds == constructor || alt_creator
-                    || (prefix == String::from("__vow_vec_") && is_vec_model_constructor(ds));
+                        && is_string_model_constructor(ds));
+                let is_creator: bool = ds == constructor || alt_creator;
                 if str_starts_with(ds, prefix) && !is_creator {
                     let iargs: Vec<i64> = inst.args;
                     let receiver_arg: i64 = {
                         if prefix == String::from("__vow_vec_") {
                             vec_model_receiver_arg(ds)
+                        } else if prefix == String::from("__vow_string_") {
+                            string_model_receiver_arg(ds)
                         } else {
                             0
                         }
@@ -1305,7 +1341,18 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, e
     let ds: String = inst.ds;
     let iargs: Vec<i64> = inst.args;
 
-    if ds == String::from("__vow_string_from_cstr") {
+    if ds == String::from("__vow_string_new") || ds == String::from("__vow_string_new_in_arena") {
+        let len_arg: i64 = if ds == String::from("__vow_string_new_in_arena") { iargs[2] } else { iargs[1] };
+        let ids: String = i64_to_str(id);
+        let ls: String = i64_to_str(len_arg);
+        out.push_str(str5(String::from("  __ESBMC_assume(v"), ls,
+            String::from(" >= 0 && v"), ls,
+            str3(String::from(" < "), i64_to_str(string_max), String::from(");\n"))));
+        out.push_str(str5(String::from("  v"), ids, String::from(".len = v"), ls, String::from(";\n")));
+        return;
+    }
+    if ds == String::from("__vow_string_from_cstr")
+        || ds == String::from("__vow_string_from_cstr_in_arena") {
         let ids: String = i64_to_str(id);
         out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
         out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
@@ -1329,15 +1376,23 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, e
             String::from(" = v"), i64_to_str(src), String::from(";\n")));
         return;
     }
+    if ds == String::from("__vow_string_from_i64") || ds == String::from("__vow_string_from_i64_in_arena") {
+        let ids: String = i64_to_str(id);
+        out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
+        out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
+            String::from(".len >= 0 && v"), ids,
+            str3(String::from(".len < "), i64_to_str(string_max), String::from(");\n"))));
+        return;
+    }
     if ds == String::from("__vow_string_len") {
         let s: i64 = iargs[0];
         out.push_str(str5(String::from("  v"), i64_to_str(id),
             String::from(" = v"), i64_to_str(s), String::from(".len;\n")));
         return;
     }
-    if ds == String::from("__vow_string_push_str") {
-        let dest: i64 = iargs[0];
-        let src: i64 = iargs[1];
+    if ds == String::from("__vow_string_push_str") || ds == String::from("__vow_string_push_str_in_arena") {
+        let dest: i64 = if ds == String::from("__vow_string_push_str_in_arena") { iargs[1] } else { iargs[0] };
+        let src: i64 = if ds == String::from("__vow_string_push_str_in_arena") { iargs[2] } else { iargs[1] };
         let dests: String = i64_to_str(dest);
         let srcs: String = i64_to_str(src);
         out.push_str(str7(String::from("  __ESBMC_assert(v"), dests,
@@ -1349,9 +1404,9 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, e
         emit_string_eq_invalidate(out, dest, eq_lo, eq_hi);
         return;
     }
-    if ds == String::from("__vow_string_push_byte") {
-        let s: i64 = iargs[0];
-        let byte: i64 = iargs[1];
+    if ds == String::from("__vow_string_push_byte") || ds == String::from("__vow_string_push_byte_in_arena") {
+        let s: i64 = if ds == String::from("__vow_string_push_byte_in_arena") { iargs[1] } else { iargs[0] };
+        let byte: i64 = if ds == String::from("__vow_string_push_byte_in_arena") { iargs[2] } else { iargs[1] };
         let ss: String = i64_to_str(s);
         out.push_str(str5(String::from("  __ESBMC_assert(v"), ss,
             String::from(".len < "), i64_to_str(string_max), String::from(", \"string capacity\");\n")));
@@ -1426,6 +1481,53 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, e
         out.push_str(String::from("      }\n"));
         out.push_str(str3(String::from("      if (__match) { v"), ids, String::from(" = 1; break; }\n")));
         out.push_str(String::from("    }\n"));
+        out.push_str(String::from("  }\n"));
+        return;
+    }
+    if ds == String::from("__vow_string_substr") || ds == String::from("__vow_string_substr_in_arena") {
+        let s: i64 = if ds == String::from("__vow_string_substr_in_arena") { iargs[1] } else { iargs[0] };
+        let start: i64 = if ds == String::from("__vow_string_substr_in_arena") { iargs[2] } else { iargs[1] };
+        let len: i64 = if ds == String::from("__vow_string_substr_in_arena") { iargs[3] } else { iargs[2] };
+        let ss: String = i64_to_str(s);
+        let starts: String = i64_to_str(start);
+        let lens: String = i64_to_str(len);
+        let ids: String = i64_to_str(id);
+        out.push_str(str7(String::from("  __ESBMC_assert(v"), starts,
+            String::from(" >= 0 && v"), starts,
+            String::from(" <= v"), ss, String::from(".len, \"substr start\");\n")));
+        out.push_str(str7(String::from("  __ESBMC_assert(v"), lens,
+            String::from(" >= 0 && v"), starts,
+            String::from(" + v"), lens, String::from(" <= v")));
+        out.push_str(str2(ss, String::from(".len, \"substr len\");\n")));
+        out.push_str(str5(String::from("  v"), ids, String::from(".len = v"), lens, String::from(";\n")));
+        out.push_str(str5(String::from("  for (int64_t __i = 0; __i < v"), ids,
+            String::from(".len && __i < "), i64_to_str(string_max), String::from("; __i++) {\n")));
+        out.push_str(str5(String::from("    v"), ids, String::from(".data[__i] = v"), ss, String::from(".data[v")));
+        out.push_str(str2(starts, String::from(" + __i];\n")));
+        out.push_str(String::from("  }\n"));
+        return;
+    }
+    if ds == String::from("__vow_string_substring") || ds == String::from("__vow_string_substring_in_arena") {
+        let s2: i64 = if ds == String::from("__vow_string_substring_in_arena") { iargs[1] } else { iargs[0] };
+        let start2: i64 = if ds == String::from("__vow_string_substring_in_arena") { iargs[2] } else { iargs[1] };
+        let end2: i64 = if ds == String::from("__vow_string_substring_in_arena") { iargs[3] } else { iargs[2] };
+        let ss2: String = i64_to_str(s2);
+        let starts2: String = i64_to_str(start2);
+        let ends2: String = i64_to_str(end2);
+        let ids2: String = i64_to_str(id);
+        out.push_str(str7(String::from("  __ESBMC_assert(v"), starts2,
+            String::from(" >= 0 && v"), starts2,
+            String::from(" <= v"), ss2, String::from(".len, \"substring start\");\n")));
+        out.push_str(str7(String::from("  __ESBMC_assert(v"), ends2,
+            String::from(" >= v"), starts2,
+            String::from(" && v"), ends2, String::from(" <= v")));
+        out.push_str(str2(ss2, String::from(".len, \"substring end\");\n")));
+        out.push_str(str5(String::from("  v"), ids2, String::from(".len = v"), ends2, String::from(" - v")));
+        out.push_str(str2(starts2, String::from(";\n")));
+        out.push_str(str5(String::from("  for (int64_t __i = 0; __i < v"), ids2,
+            String::from(".len && __i < "), i64_to_str(string_max), String::from("; __i++) {\n")));
+        out.push_str(str5(String::from("    v"), ids2, String::from(".data[__i] = v"), ss2, String::from(".data[v")));
+        out.push_str(str2(starts2, String::from(" + __i];\n")));
         out.push_str(String::from("  }\n"));
         return;
     }

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -674,7 +674,7 @@ fn collect_vec_vars(f: IrFunction) -> Vec<i64> {
 }
 
 fn collect_string_vars(f: IrFunction) -> Vec<i64> {
-    collect_modelled_vars(f, String::from("__vow_string_from_cstr"), String::from("__vow_string_"))
+    collect_modelled_vars(f, String::from("__vow_string_new"), String::from("__vow_string_"))
 }
 
 fn collect_hashmap_vars(f: IrFunction) -> Vec<i64> {

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -90,7 +90,21 @@ fn vec_insert_i64(v: Vec<i64>, val: i64) -> bool {
     true
 }
 
+fn is_string_fresh_helper(name: String) -> bool {
+    name == String::from("__vow_string_trim")
+    || name == String::from("__vow_string_trim_in_arena")
+    || name == String::from("__vow_string_to_upper")
+    || name == String::from("__vow_string_to_upper_in_arena")
+    || name == String::from("__vow_string_to_lower")
+    || name == String::from("__vow_string_to_lower_in_arena")
+    || name == String::from("__vow_string_replace")
+    || name == String::from("__vow_string_replace_in_arena")
+    || name == String::from("__vow_string_join")
+    || name == String::from("__vow_string_join_in_arena")
+}
+
 fn is_known_builtin(name: String) -> bool {
+    if is_string_fresh_helper(name) { return true; }
     name == String::from("__vow_vec_new")
     || name == String::from("__vow_vec_new_val")
     || name == String::from("__vow_vec_new_in_arena")
@@ -105,6 +119,8 @@ fn is_known_builtin(name: String) -> bool {
     || name == String::from("__vow_vec_len")
     || name == String::from("__vow_vec_pop")
     || name == String::from("__vow_vec_set_val")
+    || name == String::from("__vow_string_split")
+    || name == String::from("__vow_string_split_in_arena")
     || name == String::from("__vow_string_new")
     || name == String::from("__vow_string_new_in_arena")
     || name == String::from("__vow_string_from_cstr")
@@ -457,9 +473,12 @@ fn is_vec_model_constructor(name: String) -> bool {
     || name == String::from("__vow_vec_new_val_in_arena")
     || name == String::from("__vow_vec_from_raw_parts_copy_val")
     || name == String::from("__vow_vec_pin_to_root_val")
+    || name == String::from("__vow_string_split")
+    || name == String::from("__vow_string_split_in_arena")
 }
 
 fn is_string_model_constructor(name: String) -> bool {
+    if is_string_fresh_helper(name) { return true; }
     name == String::from("__vow_string_new")
     || name == String::from("__vow_string_new_in_arena")
     || name == String::from("__vow_string_from_cstr")
@@ -1050,7 +1069,7 @@ fn emit_inst(out: String, inst: IrInst, vec_vars: Vec<i64>, string_vars: Vec<i64
                 return;
             }
             if str_starts_with(ds, String::from("__vow_string_")) {
-                emit_string_op(out, inst, string_max, eq_lo, eq_hi);
+                emit_string_op(out, inst, vec_max, string_max, eq_lo, eq_hi);
                 return;
             }
             if str_starts_with(ds, String::from("__vow_map_")) {
@@ -1335,7 +1354,23 @@ fn emit_string_eq_invalidate(out: String, operand: i64, eq_lo: Vec<i64>, eq_hi: 
     }
 }
 
-fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, eq_hi: Vec<i64>) {
+fn emit_nondet_string_len(out: String, id: i64, string_max: i64) {
+    let ids: String = i64_to_str(id);
+    out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
+    out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
+        String::from(".len >= 0 && v"), ids,
+        str3(String::from(".len < "), i64_to_str(string_max), String::from(");\n"))));
+}
+
+fn emit_nondet_vec_len(out: String, id: i64, vec_max: i64) {
+    let ids: String = i64_to_str(id);
+    out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
+    out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
+        String::from(".len >= 0 && v"), ids,
+        str3(String::from(".len < "), i64_to_str(vec_max), String::from(");\n"))));
+}
+
+fn emit_string_op(out: String, inst: IrInst, vec_max: i64, string_max: i64, eq_lo: Vec<i64>, eq_hi: Vec<i64>) {
     let id: i64 = inst.id;
     let ds: String = inst.ds;
     let iargs: Vec<i64> = inst.args;
@@ -1381,6 +1416,14 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, e
         out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
             String::from(".len >= 0 && v"), ids,
             str3(String::from(".len < "), i64_to_str(string_max), String::from(");\n"))));
+        return;
+    }
+    if ds == String::from("__vow_string_split") || ds == String::from("__vow_string_split_in_arena") {
+        emit_nondet_vec_len(out, id, vec_max);
+        return;
+    }
+    if is_string_fresh_helper(ds) {
+        emit_nondet_string_len(out, id, string_max);
         return;
     }
     if ds == String::from("__vow_string_len") {

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -1491,18 +1491,24 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, e
         let starts: String = i64_to_str(start);
         let lens: String = i64_to_str(len);
         let ids: String = i64_to_str(id);
-        out.push_str(str7(String::from("  __ESBMC_assert(v"), starts,
-            String::from(" >= 0 && v"), starts,
-            String::from(" <= v"), ss, String::from(".len, \"substr start\");\n")));
-        out.push_str(str7(String::from("  __ESBMC_assert(v"), lens,
-            String::from(" >= 0 && v"), starts,
-            String::from(" + v"), lens, String::from(" <= v")));
-        out.push_str(str2(ss, String::from(".len, \"substr len\");\n")));
-        out.push_str(str5(String::from("  v"), ids, String::from(".len = v"), lens, String::from(";\n")));
+        let start_tmp: String = str2(String::from("__substr_start_"), ids);
+        let len_tmp: String = str2(String::from("__substr_len_"), ids);
+        let max_tmp: String = str2(String::from("__substr_max_len_"), ids);
+        out.push_str(str5(String::from("  int64_t "), start_tmp, String::from(" = v"), starts, String::from(";\n")));
+        out.push_str(str5(String::from("  if ("), start_tmp, String::from(" < 0) { "), start_tmp, String::from(" = 0; }\n")));
+        out.push_str(str7(String::from("  if ("), start_tmp, String::from(" > v"), ss, String::from(".len) { "), start_tmp, String::from(" = v")));
+        out.push_str(str2(ss, String::from(".len; }\n")));
+        out.push_str(str5(String::from("  int64_t "), len_tmp, String::from(" = v"), lens, String::from(";\n")));
+        out.push_str(str5(String::from("  if ("), len_tmp, String::from(" < 0) { "), len_tmp, String::from(" = 0; }\n")));
+        out.push_str(str5(String::from("  int64_t "), max_tmp, String::from(" = v"), ss, String::from(".len - ")));
+        out.push_str(str2(start_tmp, String::from(";\n")));
+        out.push_str(str5(String::from("  if ("), len_tmp, String::from(" > "), max_tmp, String::from(") { ")));
+        out.push_str(str5(len_tmp, String::from(" = "), max_tmp, String::from("; }\n"), String::from("")));
+        out.push_str(str5(String::from("  v"), ids, String::from(".len = "), len_tmp, String::from(";\n")));
         out.push_str(str5(String::from("  for (int64_t __i = 0; __i < v"), ids,
             String::from(".len && __i < "), i64_to_str(string_max), String::from("; __i++) {\n")));
-        out.push_str(str5(String::from("    v"), ids, String::from(".data[__i] = v"), ss, String::from(".data[v")));
-        out.push_str(str2(starts, String::from(" + __i];\n")));
+        out.push_str(str5(String::from("    v"), ids, String::from(".data[__i] = v"), ss, String::from(".data[")));
+        out.push_str(str2(start_tmp, String::from(" + __i];\n")));
         out.push_str(String::from("  }\n"));
         return;
     }
@@ -1514,19 +1520,23 @@ fn emit_string_op(out: String, inst: IrInst, string_max: i64, eq_lo: Vec<i64>, e
         let starts2: String = i64_to_str(start2);
         let ends2: String = i64_to_str(end2);
         let ids2: String = i64_to_str(id);
-        out.push_str(str7(String::from("  __ESBMC_assert(v"), starts2,
-            String::from(" >= 0 && v"), starts2,
-            String::from(" <= v"), ss2, String::from(".len, \"substring start\");\n")));
-        out.push_str(str7(String::from("  __ESBMC_assert(v"), ends2,
-            String::from(" >= v"), starts2,
-            String::from(" && v"), ends2, String::from(" <= v")));
-        out.push_str(str2(ss2, String::from(".len, \"substring end\");\n")));
-        out.push_str(str5(String::from("  v"), ids2, String::from(".len = v"), ends2, String::from(" - v")));
-        out.push_str(str2(starts2, String::from(";\n")));
+        let start_tmp2: String = str2(String::from("__substring_start_"), ids2);
+        let end_tmp2: String = str2(String::from("__substring_end_"), ids2);
+        out.push_str(str5(String::from("  int64_t "), start_tmp2, String::from(" = v"), starts2, String::from(";\n")));
+        out.push_str(str5(String::from("  if ("), start_tmp2, String::from(" < 0) { "), start_tmp2, String::from(" = 0; }\n")));
+        out.push_str(str7(String::from("  if ("), start_tmp2, String::from(" > v"), ss2, String::from(".len) { "), start_tmp2, String::from(" = v")));
+        out.push_str(str2(ss2, String::from(".len; }\n")));
+        out.push_str(str5(String::from("  int64_t "), end_tmp2, String::from(" = v"), ends2, String::from(";\n")));
+        out.push_str(str5(String::from("  if ("), end_tmp2, String::from(" < "), start_tmp2, String::from(") { ")));
+        out.push_str(str5(end_tmp2, String::from(" = "), start_tmp2, String::from("; }\n"), String::from("")));
+        out.push_str(str7(String::from("  if ("), end_tmp2, String::from(" > v"), ss2, String::from(".len) { "), end_tmp2, String::from(" = v")));
+        out.push_str(str2(ss2, String::from(".len; }\n")));
+        out.push_str(str5(String::from("  v"), ids2, String::from(".len = "), end_tmp2, String::from(" - ")));
+        out.push_str(str2(start_tmp2, String::from(";\n")));
         out.push_str(str5(String::from("  for (int64_t __i = 0; __i < v"), ids2,
             String::from(".len && __i < "), i64_to_str(string_max), String::from("; __i++) {\n")));
-        out.push_str(str5(String::from("    v"), ids2, String::from(".data[__i] = v"), ss2, String::from(".data[v")));
-        out.push_str(str2(starts2, String::from(" + __i];\n")));
+        out.push_str(str5(String::from("    v"), ids2, String::from(".data[__i] = v"), ss2, String::from(".data[")));
+        out.push_str(str2(start_tmp2, String::from(" + __i];\n")));
         out.push_str(String::from("  }\n"));
         return;
     }

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -10,7 +10,7 @@ fn str2(a: String, b: String) -> String {
     r
 }
 
-fn clif_find_inst_region(f: IrFunction, id: i64) -> i64 {
+fn clif_find_inst(f: IrFunction, id: i64) -> IrInst {
     let blocks: Vec<IrBlock> = f.blocks;
     let mut bi: i64 = 0;
     while bi < blocks.len() {
@@ -18,11 +18,53 @@ fn clif_find_inst_region(f: IrFunction, id: i64) -> i64 {
         let mut ii: i64 = 0;
         while ii < insts.len() {
             if insts[ii].id == id {
-                return insts[ii].rgn;
+                return insts[ii];
             }
             ii = ii + 1;
         }
         bi = bi + 1;
+    }
+    ir_inst_new(-1, IOP_CONST_UNIT(), ITY_UNIT(), Vec::new(), IDATA_NONE(), 0, 0, String::from(""))
+}
+
+fn clif_store_effect_advance(flat: Vec<i64>, start: i64) -> i64 {
+    if start + 1 >= flat.len() {
+        return flat.len();
+    }
+    let kind: i64 = flat[start + 1];
+    let mut i: i64 = start + 2;
+    if kind == RSUM_KIND_ALIAS_OF() {
+        i = i + 1;
+    } else if kind == RSUM_KIND_ALIAS_OF_ANY() {
+        if i < flat.len() {
+            let n: i64 = flat[i];
+            i = i + 1 + n;
+        }
+    }
+    if i > flat.len() {
+        return flat.len();
+    }
+    i
+}
+
+fn clif_hidden_store_target_region(f: IrFunction, target_param: i64) -> i64 {
+    let flat: Vec<i64> = f.rsum_store_effects;
+    let mut hidden_idx: i64 = 0;
+    if f.rsum_return_kind == RSUM_KIND_FRESH_IN_CALLER() {
+        hidden_idx = hidden_idx + 1;
+    }
+    let mut prev_target: i64 = -1;
+    let mut i: i64 = 0;
+    while i + 1 < flat.len() {
+        let target: i64 = flat[i];
+        if target != prev_target {
+            if target == target_param {
+                return region_pack(REGION_KIND_CALLER(), hidden_idx);
+            }
+            hidden_idx = hidden_idx + 1;
+            prev_target = target;
+        }
+        i = clif_store_effect_advance(flat, i);
     }
     region_root()
 }
@@ -31,7 +73,17 @@ fn clif_receiver_region(f: IrFunction, inst: IrInst) -> i64 {
     if inst.args.len() == 0 {
         return region_root();
     }
-    clif_find_inst_region(f, inst.args[0])
+    let receiver: IrInst = clif_find_inst(f, inst.args[0]);
+    if receiver.id < 0 {
+        return region_root();
+    }
+    if receiver.op == IOP_GET_ARG() && receiver.dk == IDATA_ARG_INDEX() {
+        let hidden: i64 = clif_hidden_store_target_region(f, receiver.dv);
+        if region_kind(hidden) == REGION_KIND_CALLER() {
+            return hidden;
+        }
+    }
+    receiver.rgn
 }
 
 fn clif_routed_extern_symbol(f: IrFunction, inst: IrInst) -> String {

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -139,6 +139,18 @@ fn clif_value_receiver_region(f: IrFunction, receiver: IrInst, seen: Vec<i64>) -
             return hidden;
         }
     }
+    if (receiver.op == IOP_FIELD_GET() || receiver.op == IOP_LOAD()) && receiver.args.len() > 0 {
+        let src0: IrInst = clif_find_inst(f, receiver.args[0]);
+        return clif_value_receiver_region(f, src0, next_seen);
+    }
+    if receiver.op == IOP_CALL()
+        && receiver.dk == IDATA_CALL_EXTERN()
+        && (receiver.ds == String::from("__vow_vec_get_val") || receiver.ds == String::from("__vow_vec_get"))
+        && receiver.args.len() > 0
+    {
+        let src1: IrInst = clif_find_inst(f, receiver.args[0]);
+        return clif_value_receiver_region(f, src1, next_seen);
+    }
     if receiver.op == IOP_PHI() {
         let blocks: Vec<IrBlock> = f.blocks;
         let mut have: bool = false;

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -75,6 +75,8 @@ fn clif_hidden_store_targets(flat: Vec<i64>) -> Vec<i64> {
     let mut i: i64 = 0;
     while i + 1 < flat.len() {
         let target: i64 = flat[i];
+        // Rust collects all targets then sorts/dedups; this dedups before sorting.
+        // Both paths produce the same sorted unique slot order.
         if !clif_i64_vec_contains(targets, target) {
             targets.push(target);
         }
@@ -122,6 +124,7 @@ fn clif_value_receiver_region(f: IrFunction, receiver: IrInst, depth: i64) -> i6
             return hidden;
         }
     }
+    // Rust uses an exact visited set; this depth cap is conservative for lowerer IR.
     if receiver.op == IOP_PHI() && depth < 32 {
         let blocks: Vec<IrBlock> = f.blocks;
         let mut have: bool = false;

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -70,6 +70,16 @@ fn clif_i64_vec_contains(v: Vec<i64>, x: i64) -> bool {
     false
 }
 
+fn clif_clone_i64_vec(src: Vec<i64>) -> Vec<i64> {
+    let out: Vec<i64> = Vec::new();
+    let mut i: i64 = 0;
+    while i < src.len() {
+        out.push(src[i]);
+        i = i + 1;
+    }
+    out
+}
+
 fn clif_hidden_store_targets(flat: Vec<i64>) -> Vec<i64> {
     let targets: Vec<i64> = Vec::new();
     let mut i: i64 = 0;
@@ -114,18 +124,22 @@ fn clif_hidden_store_target_region(f: IrFunction, target_param: i64) -> i64 {
     region_root()
 }
 
-fn clif_value_receiver_region(f: IrFunction, receiver: IrInst, depth: i64) -> i64 {
+fn clif_value_receiver_region(f: IrFunction, receiver: IrInst, seen: Vec<i64>) -> i64 {
     if receiver.id < 0 {
         return region_root();
     }
+    if clif_i64_vec_contains(seen, receiver.id) {
+        return receiver.rgn;
+    }
+    let next_seen: Vec<i64> = clif_clone_i64_vec(seen);
+    next_seen.push(receiver.id);
     if receiver.op == IOP_GET_ARG() && receiver.dk == IDATA_ARG_INDEX() {
         let hidden: i64 = clif_hidden_store_target_region(f, receiver.dv);
         if region_kind(hidden) == REGION_KIND_CALLER() {
             return hidden;
         }
     }
-    // Rust uses an exact visited set; this depth cap is conservative for lowerer IR.
-    if receiver.op == IOP_PHI() && depth < 32 {
+    if receiver.op == IOP_PHI() {
         let blocks: Vec<IrBlock> = f.blocks;
         let mut have: bool = false;
         let mut merged: i64 = region_root();
@@ -140,7 +154,7 @@ fn clif_value_receiver_region(f: IrFunction, receiver: IrInst, depth: i64) -> i6
                     && up.dv == receiver.id
                     && up.args.len() > 0 {
                     let src: IrInst = clif_find_inst(f, up.args[0]);
-                    let rgn: i64 = clif_value_receiver_region(f, src, depth + 1);
+                    let rgn: i64 = clif_value_receiver_region(f, src, clif_clone_i64_vec(next_seen));
                     if !have {
                         have = true;
                         merged = rgn;
@@ -164,7 +178,7 @@ fn clif_receiver_region(f: IrFunction, inst: IrInst) -> i64 {
         return region_root();
     }
     let receiver: IrInst = clif_find_inst(f, inst.args[0]);
-    clif_value_receiver_region(f, receiver, 0)
+    clif_value_receiver_region(f, receiver, Vec::new())
 }
 
 fn clif_routed_extern_symbol(f: IrFunction, inst: IrInst) -> String {

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -59,33 +59,60 @@ fn clif_store_effect_advance(flat: Vec<i64>, start: i64) -> i64 {
     i
 }
 
+fn clif_i64_vec_contains(v: Vec<i64>, x: i64) -> bool {
+    let mut i: i64 = 0;
+    while i < v.len() {
+        if v[i] == x {
+            return true;
+        }
+        i = i + 1;
+    }
+    false
+}
+
+fn clif_hidden_store_targets(flat: Vec<i64>) -> Vec<i64> {
+    let targets: Vec<i64> = Vec::new();
+    let mut i: i64 = 0;
+    while i + 1 < flat.len() {
+        let target: i64 = flat[i];
+        if !clif_i64_vec_contains(targets, target) {
+            targets.push(target);
+        }
+        i = clif_store_effect_advance(flat, i);
+    }
+    let mut a: i64 = 1;
+    while a < targets.len() {
+        let mut b: i64 = a;
+        while b > 0 && targets[b] < targets[b - 1] {
+            let tmp: i64 = targets[b - 1];
+            targets[b - 1] = targets[b];
+            targets[b] = tmp;
+            b = b - 1;
+        }
+        a = a + 1;
+    }
+    targets
+}
+
 fn clif_hidden_store_target_region(f: IrFunction, target_param: i64) -> i64 {
     let flat: Vec<i64> = f.rsum_store_effects;
     let mut hidden_idx: i64 = 0;
     if f.rsum_return_kind == RSUM_KIND_FRESH_IN_CALLER() {
         hidden_idx = hidden_idx + 1;
     }
-    let mut prev_target: i64 = -1;
+    let targets: Vec<i64> = clif_hidden_store_targets(flat);
     let mut i: i64 = 0;
-    while i + 1 < flat.len() {
-        let target: i64 = flat[i];
-        if target != prev_target {
-            if target == target_param {
-                return region_pack(REGION_KIND_CALLER(), hidden_idx);
-            }
-            hidden_idx = hidden_idx + 1;
-            prev_target = target;
+    while i < targets.len() {
+        if targets[i] == target_param {
+            return region_pack(REGION_KIND_CALLER(), hidden_idx);
         }
-        i = clif_store_effect_advance(flat, i);
+        hidden_idx = hidden_idx + 1;
+        i = i + 1;
     }
     region_root()
 }
 
-fn clif_receiver_region(f: IrFunction, inst: IrInst) -> i64 {
-    if inst.args.len() == 0 {
-        return region_root();
-    }
-    let receiver: IrInst = clif_find_inst(f, inst.args[0]);
+fn clif_value_receiver_region(f: IrFunction, receiver: IrInst, depth: i64) -> i64 {
     if receiver.id < 0 {
         return region_root();
     }
@@ -95,7 +122,46 @@ fn clif_receiver_region(f: IrFunction, inst: IrInst) -> i64 {
             return hidden;
         }
     }
+    if receiver.op == IOP_PHI() && depth < 32 {
+        let blocks: Vec<IrBlock> = f.blocks;
+        let mut have: bool = false;
+        let mut merged: i64 = region_root();
+        let mut bi: i64 = 0;
+        while bi < blocks.len() {
+            let insts: Vec<IrInst> = blocks[bi].insts;
+            let mut ii: i64 = 0;
+            while ii < insts.len() {
+                let up: IrInst = insts[ii];
+                if up.op == IOP_UPSILON()
+                    && up.dk == IDATA_PHI_TARGET()
+                    && up.dv == receiver.id
+                    && up.args.len() > 0 {
+                    let src: IrInst = clif_find_inst(f, up.args[0]);
+                    let rgn: i64 = clif_value_receiver_region(f, src, depth + 1);
+                    if !have {
+                        have = true;
+                        merged = rgn;
+                    } else if merged != rgn {
+                        return receiver.rgn;
+                    }
+                }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        if have {
+            return merged;
+        }
+    }
     receiver.rgn
+}
+
+fn clif_receiver_region(f: IrFunction, inst: IrInst) -> i64 {
+    if inst.args.len() == 0 {
+        return region_root();
+    }
+    let receiver: IrInst = clif_find_inst(f, inst.args[0]);
+    clif_value_receiver_region(f, receiver, 0)
 }
 
 fn clif_routed_extern_symbol(f: IrFunction, inst: IrInst) -> String {

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -241,6 +241,42 @@ fn clif_routed_extern_symbol(f: IrFunction, inst: IrInst) -> String {
         }
         return String::from("__vow_string_from_i64_in_arena");
     }
+    if sym == String::from("__vow_string_split") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_split_in_arena");
+    }
+    if sym == String::from("__vow_string_trim") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_trim_in_arena");
+    }
+    if sym == String::from("__vow_string_to_upper") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_to_upper_in_arena");
+    }
+    if sym == String::from("__vow_string_to_lower") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_to_lower_in_arena");
+    }
+    if sym == String::from("__vow_string_replace") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_replace_in_arena");
+    }
+    if sym == String::from("__vow_string_join") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_join_in_arena");
+    }
     if sym == String::from("__vow_string_push_str") {
         let sr: i64 = clif_receiver_region(f, inst);
         let sk: i64 = region_kind(sr);

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -37,8 +37,20 @@ fn clif_store_effect_advance(flat: Vec<i64>, start: i64) -> i64 {
         i = i + 1;
     } else if kind == RSUM_KIND_ALIAS_OF_ANY() {
         if i < flat.len() {
-            let n: i64 = flat[i];
-            i = i + 1 + n;
+            let raw_n: i64 = flat[i];
+            let n: i64 = {
+                if raw_n < 0 {
+                    0
+                } else {
+                    raw_n
+                }
+            };
+            i = i + 1;
+            let remaining: i64 = flat.len() - i;
+            if n > remaining {
+                return flat.len();
+            }
+            i = i + n;
         }
     }
     if i > flat.len() {

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -64,6 +64,52 @@ fn clif_routed_extern_symbol(f: IrFunction, inst: IrInst) -> String {
         }
         return sym;
     }
+    if sym == String::from("__vow_string_new") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_new_in_arena");
+    }
+    if sym == String::from("__vow_string_from_cstr") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_from_cstr_in_arena");
+    }
+    if sym == String::from("__vow_string_substr") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_substr_in_arena");
+    }
+    if sym == String::from("__vow_string_substring") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_substring_in_arena");
+    }
+    if sym == String::from("__vow_string_from_i64") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_string_from_i64_in_arena");
+    }
+    if sym == String::from("__vow_string_push_str") {
+        let sr: i64 = clif_receiver_region(f, inst);
+        let sk: i64 = region_kind(sr);
+        if sk == REGION_KIND_BLOCK() || sk == REGION_KIND_CALLER() {
+            return String::from("__vow_string_push_str_in_arena");
+        }
+        return sym;
+    }
+    if sym == String::from("__vow_string_push_byte") {
+        let br: i64 = clif_receiver_region(f, inst);
+        let bk: i64 = region_kind(br);
+        if bk == REGION_KIND_BLOCK() || bk == REGION_KIND_CALLER() {
+            return String::from("__vow_string_push_byte_in_arena");
+        }
+        return sym;
+    }
     sym
 }
 

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -171,6 +171,8 @@ fn clif_value_receiver_region(f: IrFunction, receiver: IrInst, seen: Vec<i64>) -
                         have = true;
                         merged = rgn;
                     } else if merged != rgn {
+                        // Divergent Phi arms cannot be unified safely. Fall back to the
+                        // receiver's own region, which is conservatively Root before routing.
                         return receiver.rgn;
                     }
                 }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -1992,14 +1992,14 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         }
 
         if enum_name == String::from("String") && variant_name == String::from("new") {
-            let size_args: Vec<i64> = Vec::new();
-            let size_val: i64 = lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), size_args, IDATA_CONST_I64(), 1, 0, String::from(""));
-            let align_args: Vec<i64> = Vec::new();
-            let align_val: i64 = lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), align_args, IDATA_CONST_I64(), 1, 0, String::from(""));
+            let ptr_args: Vec<i64> = Vec::new();
+            let ptr_val: i64 = lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), ptr_args, IDATA_CONST_I64(), 0, 0, String::from(""));
+            let len_args: Vec<i64> = Vec::new();
+            let len_val: i64 = lctx_emit(ctx, IOP_CONST_I64(), ITY_I64(), len_args, IDATA_CONST_I64(), 0, 0, String::from(""));
             let call_args: Vec<i64> = Vec::new();
-            call_args.push(size_val);
-            call_args.push(align_val);
-            let str_result: i64 = lctx_emit(ctx, IOP_CALL(), ITY_PTR(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_vec_new"));
+            call_args.push(ptr_val);
+            call_args.push(len_val);
+            let str_result: i64 = lctx_emit(ctx, IOP_CALL(), ITY_PTR(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_new"));
             lctx_tag(ctx, str_result, String::from("String"));
             return str_result;
         }

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -956,6 +956,22 @@ fn analyze_function(
                     }
                     edge_idx = edge_idx + 1;
                 }
+                let growth_target_pos: i64 = extern_growth_target_pos(inst.ds);
+                if growth_target_pos >= 0 && growth_target_pos < inst.args.len() {
+                    let growth_target_param: i64 = trace_param_shallow(id_to_inst, inst.args[growth_target_pos]);
+                    if growth_target_param >= 0 {
+                        add_store_effect(
+                            int_se_targets[fidx],
+                            int_se_src_kinds[fidx],
+                            int_se_src_aux[fidx],
+                            int_se_src_aliases[fidx],
+                            growth_target_param,
+                            RSUM_KIND_CONSTANT_GLOBAL(),
+                            0,
+                            Vec::new(),
+                        );
+                    }
+                }
             }
             if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_TARGET() {
                 publish_transitive_store_effects(
@@ -2734,6 +2750,17 @@ fn extern_store_source_pos(sym: String, edge_idx: i64) -> i64 {
     {
         return 2;
     }
+    -1
+}
+
+fn extern_growth_target_pos(sym: String) -> i64 {
+    if sym == String::from("__vow_vec_push") { return 0; }
+    if sym == String::from("__vow_vec_push_in_arena") { return 1; }
+    if sym == String::from("__vow_vec_reserve_in_arena") { return 1; }
+    if sym == String::from("__vow_string_push_str") { return 0; }
+    if sym == String::from("__vow_string_push_str_in_arena") { return 1; }
+    if sym == String::from("__vow_string_push_byte") { return 0; }
+    if sym == String::from("__vow_string_push_byte_in_arena") { return 1; }
     -1
 }
 

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -829,7 +829,7 @@ fn check_store_conflict(
     if source_inst.op != IOP_REGION_ALLOC() {
         return;
     }
-    let target_param: i64 = trace_param_shallow(id_to_inst, target_arg_id);
+    let target_param: i64 = trace_param(id_to_inst, target_arg_id);
     if target_param < 0 {
         return;
     }
@@ -915,7 +915,7 @@ fn analyze_function(
             if (inst.op == IOP_STORE() || inst.op == IOP_FIELD_SET()) && inst.args.len() >= 2 {
                 let target_id: i64 = inst.args[0];
                 let source_id: i64 = inst.args[1];
-                let target_param: i64 = trace_param_shallow(id_to_inst, target_id);
+                let target_param: i64 = trace_param(id_to_inst, target_id);
                 if target_param >= 0 {
                     add_store_effect_source_constraints(
                         id_to_inst,
@@ -940,7 +940,7 @@ fn analyze_function(
                     {
                         let target_id2: i64 = inst.args[target_pos];
                         let source_id2: i64 = inst.args[source_pos];
-                        let target_param2: i64 = trace_param_shallow(id_to_inst, target_id2);
+                        let target_param2: i64 = trace_param(id_to_inst, target_id2);
                         if target_param2 >= 0 {
                             add_store_effect_source_constraints(
                                 id_to_inst,
@@ -958,7 +958,7 @@ fn analyze_function(
                 }
                 let growth_target_pos: i64 = extern_growth_target_pos(inst.ds);
                 if growth_target_pos >= 0 && growth_target_pos < inst.args.len() {
-                    let growth_target_param: i64 = trace_param_shallow(id_to_inst, inst.args[growth_target_pos]);
+                    let growth_target_param: i64 = trace_param(id_to_inst, inst.args[growth_target_pos]);
                     if growth_target_param >= 0 {
                         add_store_effect(
                             int_se_targets[fidx],
@@ -1106,7 +1106,7 @@ fn add_store_effect_source_constraints(
     }
     let mut ai: i64 = 0;
     while ai < source_inst.args.len() {
-        let param_idx: i64 = trace_param_shallow(id_to_inst, source_inst.args[ai]);
+        let param_idx: i64 = trace_param(id_to_inst, source_inst.args[ai]);
         if param_idx >= 0 {
             add_store_effect(
                 targets,
@@ -1133,7 +1133,7 @@ fn publish_embedded_param_aliases(
         if (inst.op == IOP_STORE() || inst.op == IOP_FIELD_SET())
             && inst.args.len() >= 2 && inst.args[0] == aggregate_id
         {
-            let param_idx: i64 = trace_param_shallow(id_to_inst, inst.args[1]);
+            let param_idx: i64 = trace_param(id_to_inst, inst.args[1]);
             if param_idx >= 0 {
                 add_store_effect(
                     targets,
@@ -1169,7 +1169,7 @@ fn publish_transitive_store_effects(
     while i < callee_targets.len() && i < callee_kinds.len() && i < callee_auxs.len() {
         let target_pos: i64 = callee_targets[i];
         if target_pos >= 0 && target_pos < call_inst.args.len() {
-            let current_target_param: i64 = trace_param_shallow(id_to_inst, call_inst.args[target_pos]);
+            let current_target_param: i64 = trace_param(id_to_inst, call_inst.args[target_pos]);
             if current_target_param >= 0 {
                 let kind: i64 = callee_kinds[i];
                 if kind == RSUM_KIND_ALIAS_OF() {
@@ -1390,7 +1390,7 @@ fn direct_markers_collect_regions(
                     if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
                         let target_pos2: i64 = extern_store_target_for_source(inst.ds, ai);
                         if target_pos2 >= 0 && target_pos2 < inst.args.len() {
-                            let target_marker2: i64 = if trace_param_shallow(id_to_inst, inst.args[target_pos2]) >= 0 {
+                            let target_marker2: i64 = if trace_param(id_to_inst, inst.args[target_pos2]) >= 0 {
                                 region_root()
                             } else {
                                 target_marker_region(
@@ -2807,7 +2807,8 @@ fn trace_origin_shallow(id_to_inst: Vec<IrInst>, id: i64) -> DeepRet {
     deep_ret_const_global()
 }
 
-fn trace_param_shallow(id_to_inst: Vec<IrInst>, id: i64) -> i64 {
+fn trace_param(id_to_inst: Vec<IrInst>, id: i64) -> i64 {
+    // Mirrors Rust trace_param: walk through field/load and Vec get wrappers back to GetArg.
     let visiting: Vec<i64> = Vec::new();
     trace_param_inner(id_to_inst, id, visiting)
 }
@@ -2827,7 +2828,8 @@ fn trace_param_inner(id_to_inst: Vec<IrInst>, id: i64, visiting: Vec<i64>) -> i6
         return r;
     }
     if inst.id >= 0 && inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN()
-        && inst.ds == String::from("__vow_vec_get_val") && inst.args.len() > 0
+        && (inst.ds == String::from("__vow_vec_get_val") || inst.ds == String::from("__vow_vec_get"))
+        && inst.args.len() > 0
     {
         visiting.push(id);
         let r2: i64 = trace_param_inner(id_to_inst, inst.args[0], visiting);

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2686,8 +2686,21 @@ fn vec_creation_extern(sym: String) -> bool {
         || sym == String::from("__vow_vec_new_val")
 }
 
+fn string_creation_extern(sym: String) -> bool {
+    sym == String::from("__vow_string_new")
+        || sym == String::from("__vow_string_new_in_arena")
+        || sym == String::from("__vow_string_from_cstr")
+        || sym == String::from("__vow_string_from_cstr_in_arena")
+        || sym == String::from("__vow_string_substr")
+        || sym == String::from("__vow_string_substr_in_arena")
+        || sym == String::from("__vow_string_substring")
+        || sym == String::from("__vow_string_substring_in_arena")
+        || sym == String::from("__vow_string_from_i64")
+        || sym == String::from("__vow_string_from_i64_in_arena")
+}
+
 fn heap_producing_extern(sym: String) -> bool {
-    extern_fresh_in_caller(sym) || vec_creation_extern(sym)
+    extern_fresh_in_caller(sym) || vec_creation_extern(sym) || string_creation_extern(sym)
 }
 
 fn extern_store_edge_count(sym: String) -> i64 {

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2713,6 +2713,18 @@ fn string_creation_extern(sym: String) -> bool {
         || sym == String::from("__vow_string_substring_in_arena")
         || sym == String::from("__vow_string_from_i64")
         || sym == String::from("__vow_string_from_i64_in_arena")
+        || sym == String::from("__vow_string_split")
+        || sym == String::from("__vow_string_split_in_arena")
+        || sym == String::from("__vow_string_trim")
+        || sym == String::from("__vow_string_trim_in_arena")
+        || sym == String::from("__vow_string_to_upper")
+        || sym == String::from("__vow_string_to_upper_in_arena")
+        || sym == String::from("__vow_string_to_lower")
+        || sym == String::from("__vow_string_to_lower_in_arena")
+        || sym == String::from("__vow_string_replace")
+        || sym == String::from("__vow_string_replace_in_arena")
+        || sym == String::from("__vow_string_join")
+        || sym == String::from("__vow_string_join_in_arena")
 }
 
 fn heap_producing_extern(sym: String) -> bool {

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -277,6 +277,12 @@ void  __vow_string_push_byte(void* string, int64_t byte);
 void* __vow_string_substr(const void* string, int64_t start, int64_t len);
 void* __vow_string_substring(const void* string, int64_t start, int64_t end);
 void* __vow_string_from_i64(int64_t value);
+void* __vow_string_split(const void* haystack, const void* separator);
+void* __vow_string_trim(const void* string);
+void* __vow_string_to_upper(const void* string);
+void* __vow_string_to_lower(const void* string);
+void* __vow_string_replace(const void* string, const void* from, const void* to);
+void* __vow_string_join(const void* vec, const void* separator);
 ```
 
 These are root wrappers: they open `__vow_root_arena` if needed, then
@@ -302,6 +308,21 @@ void* __vow_string_substring_in_arena(struct VowArena* arena,
                                       int64_t start, int64_t end);
 void* __vow_string_from_i64_in_arena(struct VowArena* arena,
                                      int64_t value);
+void* __vow_string_split_in_arena(struct VowArena* arena,
+                                  const void* haystack,
+                                  const void* separator);
+void* __vow_string_trim_in_arena(struct VowArena* arena,
+                                 const void* string);
+void* __vow_string_to_upper_in_arena(struct VowArena* arena,
+                                     const void* string);
+void* __vow_string_to_lower_in_arena(struct VowArena* arena,
+                                     const void* string);
+void* __vow_string_replace_in_arena(struct VowArena* arena,
+                                    const void* string,
+                                    const void* from, const void* to);
+void* __vow_string_join_in_arena(struct VowArena* arena,
+                                 const void* vec,
+                                 const void* separator);
 ```
 
 Every explicit-arena String entry traps with

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -809,6 +809,13 @@ arena header; per §3.1, block-region headers live in the caller's
 stack frame, so the caller must pass the address of the header
 the callee will allocate into.
 
+Receiver-growth effects use the same target projection even when
+no heap source is stored. For example, `String::push_byte`,
+`String::push_str`, and raw `Vec::push` on a parameter receiver
+publish a `StoreEffect` with `source = ConstantGlobal`; the source
+constraint is inert, but the target membership makes the receiver's
+arena available to growth code inside the callee.
+
 The hidden-region parameter set for a function is therefore:
 
 ```

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -265,6 +265,54 @@ on fallback. `__vow_vec_from_raw_parts_copy_val(arena, ptr, len)`
 already has the explicit-arena shape and copies the raw slots into the
 supplied arena.
 
+#### String runtime allocation API
+
+The existing root-region String symbols remain ABI-stable:
+
+```c
+void* __vow_string_new(const char* ptr, uintptr_t len);
+void* __vow_string_from_cstr(const char* ptr);
+void  __vow_string_push_str(void* dest, const void* src);
+void  __vow_string_push_byte(void* string, int64_t byte);
+void* __vow_string_substr(const void* string, int64_t start, int64_t len);
+void* __vow_string_substring(const void* string, int64_t start, int64_t end);
+void* __vow_string_from_i64(int64_t value);
+```
+
+These are root wrappers: they open `__vow_root_arena` if needed, then
+delegate to the corresponding explicit-arena primitive with
+`&__vow_root_arena`.
+
+The explicit-arena forms are:
+
+```c
+void* __vow_string_new_in_arena(struct VowArena* arena,
+                                const char* ptr, uintptr_t len);
+void* __vow_string_from_cstr_in_arena(struct VowArena* arena,
+                                      const char* ptr);
+void  __vow_string_push_str_in_arena(struct VowArena* arena,
+                                     void* dest, const void* src);
+void  __vow_string_push_byte_in_arena(struct VowArena* arena,
+                                      void* string, int64_t byte);
+void* __vow_string_substr_in_arena(struct VowArena* arena,
+                                   const void* string,
+                                   int64_t start, int64_t len);
+void* __vow_string_substring_in_arena(struct VowArena* arena,
+                                      const void* string,
+                                      int64_t start, int64_t end);
+void* __vow_string_from_i64_in_arena(struct VowArena* arena,
+                                     int64_t value);
+```
+
+Every explicit-arena String entry traps with
+`RuntimeInvariantViolation` and `reason = "null arena"` before
+dereferencing a null arena pointer. String literals and C string
+payloads remain in `.rodata`; the arena owns the allocated String
+descriptor/header and any later growth allocation. Growth for both root
+and explicit-arena Strings uses the same arena grow path as Vec: try to
+extend in place, then allocate in the selected arena and copy on
+fallback.
+
 ### 3.4. Determinism
 
 The arena **allocation strategy**, the **chunk-size policy**, and
@@ -1290,15 +1338,16 @@ opcodes. Phase 2 may rename `RegionAlloc` to, e.g., `HeapAlloc` if
 this neighborhood becomes confusing — the choice is a phase-2
 implementation detail and not load-bearing on the spec.
 
-Vec creation is intentionally not a new opcode. The lowerer may keep
-emitting canonical root-wrapper extern symbols (`__vow_vec_new`,
-`__vow_vec_new_val`). After `infer_regions`, codegen reads the call's
-`region` field: `Root` keeps the ABI-stable wrapper symbol, while
-`Block(_)` and `Caller(_)` prepend the selected `*VowArena` and call
-`__vow_vec_new_in_arena` / `__vow_vec_new_val_in_arena`. Vec growth
-calls follow the same rule using the receiver Vec's defining region:
-root-owned receivers keep `__vow_vec_push*`, and block/caller-owned
-receivers route to the matching `_in_arena` symbol.
+Vec and String creation are intentionally not new opcodes. The lowerer
+may keep emitting canonical root-wrapper extern symbols
+(`__vow_vec_new`, `__vow_vec_new_val`, `__vow_string_new`,
+`__vow_string_from_cstr`, and related String copy constructors). After
+`infer_regions`, codegen reads the call's `region` field: `Root` keeps
+the ABI-stable wrapper symbol, while `Block(_)` and `Caller(_)` prepend
+the selected `*VowArena` and call the matching `_in_arena` symbol. Vec
+and String growth calls follow the same rule using the receiver's
+defining region: root-owned receivers keep the wrapper symbol, and
+block/caller-owned receivers route to the matching `_in_arena` symbol.
 
 ### 12.3. Block region opcodes
 

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -228,21 +228,8 @@ fn hidden_region_store_targets(flat: &[i64]) -> Vec<i64> {
     let mut i = 0usize;
     while i + 1 < flat.len() {
         let target = flat[i];
-        let kind = flat[i + 1];
-        i += 2;
         out.push(target);
-        match kind {
-            RSUM_KIND_ALIAS_OF => i += 1,
-            RSUM_KIND_ALIAS_OF_ANY => {
-                if i >= flat.len() {
-                    break;
-                }
-                let n = flat[i].max(0) as usize;
-                i = i.saturating_add(1).saturating_add(n);
-            }
-            RSUM_KIND_FRESH_IN_CALLER | RSUM_KIND_CONSTANT_GLOBAL => {}
-            _ => {}
-        }
+        i = store_effect_advance(flat, i);
     }
     out.sort_unstable();
     out.dedup();
@@ -276,18 +263,11 @@ fn hidden_region_for_store_target(
     if return_kind == RSUM_KIND_FRESH_IN_CALLER {
         hidden_idx += 1;
     }
-    let mut prev_target: Option<i64> = None;
-    let mut i = 0usize;
-    while i + 1 < store_effects.len() {
-        let target = store_effects[i];
-        if prev_target != Some(target) {
-            if target == target_param {
-                return Some(region_pack(REGION_KIND_CALLER, hidden_idx));
-            }
-            hidden_idx += 1;
-            prev_target = Some(target);
+    for target in hidden_region_store_targets(store_effects) {
+        if target == target_param {
+            return Some(region_pack(REGION_KIND_CALLER, hidden_idx));
         }
-        i = store_effect_advance(store_effects, i);
+        hidden_idx += 1;
     }
     None
 }
@@ -307,14 +287,76 @@ fn inst_region_for_value(
     inst_id: i64,
     inst_region_by_id: &HashMap<i64, i64>,
     inst_data_by_id: &HashMap<i64, (i64, i64)>,
+    inst_op_by_id: &HashMap<i64, i64>,
+    upsilon_sources_by_phi: &HashMap<i64, Vec<i64>>,
     return_kind: i64,
     store_effects: &[i64],
 ) -> i64 {
+    inst_region_for_value_inner(
+        inst_id,
+        inst_region_by_id,
+        inst_data_by_id,
+        inst_op_by_id,
+        upsilon_sources_by_phi,
+        return_kind,
+        store_effects,
+        &mut std::collections::HashSet::new(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inst_region_for_value_inner(
+    inst_id: i64,
+    inst_region_by_id: &HashMap<i64, i64>,
+    inst_data_by_id: &HashMap<i64, (i64, i64)>,
+    inst_op_by_id: &HashMap<i64, i64>,
+    upsilon_sources_by_phi: &HashMap<i64, Vec<i64>>,
+    return_kind: i64,
+    store_effects: &[i64],
+    seen: &mut std::collections::HashSet<i64>,
+) -> i64 {
+    if !seen.insert(inst_id) {
+        return inst_region_by_id
+            .get(&inst_id)
+            .copied()
+            .unwrap_or_else(region_root);
+    }
     if let Some(&(dk, dv)) = inst_data_by_id.get(&inst_id)
         && dk == IDATA_ARG_INDEX
         && let Some(rgn) = hidden_region_for_store_target(return_kind, store_effects, dv)
     {
         return rgn;
+    }
+    if inst_op_by_id.get(&inst_id).copied() == Some(IOP_PHI)
+        && let Some(sources) = upsilon_sources_by_phi.get(&inst_id)
+    {
+        let mut merged: Option<i64> = None;
+        for &source_id in sources {
+            let mut source_seen = seen.clone();
+            let rgn = inst_region_for_value_inner(
+                source_id,
+                inst_region_by_id,
+                inst_data_by_id,
+                inst_op_by_id,
+                upsilon_sources_by_phi,
+                return_kind,
+                store_effects,
+                &mut source_seen,
+            );
+            match merged {
+                Some(existing) if existing != rgn => {
+                    return inst_region_by_id
+                        .get(&inst_id)
+                        .copied()
+                        .unwrap_or_else(region_root);
+                }
+                Some(_) => {}
+                None => merged = Some(rgn),
+            }
+        }
+        if let Some(rgn) = merged {
+            return rgn;
+        }
     }
     inst_region_by_id
         .get(&inst_id)
@@ -1019,6 +1061,8 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     let mut inst_block: HashMap<i64, usize> = HashMap::new();
     let mut inst_region_by_id: HashMap<i64, i64> = HashMap::new();
     let mut inst_data_by_id: HashMap<i64, (i64, i64)> = HashMap::new();
+    let mut inst_op_by_id: HashMap<i64, i64> = HashMap::new();
+    let mut upsilon_sources_by_phi: HashMap<i64, Vec<i64>> = HashMap::new();
     for bi in 0..nb {
         let start = block_starts[bi] as usize;
         let len = block_lengths[bi] as usize;
@@ -1028,6 +1072,15 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         for idx in start..start + len {
             inst_region_by_id.insert(inst_ids[idx], inst_rgns[idx]);
             inst_data_by_id.insert(inst_ids[idx], (inst_dks[idx], inst_dvs[idx]));
+            inst_op_by_id.insert(inst_ids[idx], inst_ops[idx]);
+            let aoff = arg_offsets[idx] as usize;
+            let alen = arg_lengths[idx] as usize;
+            if inst_ops[idx] == IOP_UPSILON && inst_dks[idx] == IDATA_PHI_TARGET && alen > 0 {
+                upsilon_sources_by_phi
+                    .entry(inst_dvs[idx])
+                    .or_default()
+                    .push(all_args[aoff]);
+            }
         }
     }
 
@@ -2080,6 +2133,8 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                                     receiver_id,
                                     &inst_region_by_id,
                                     &inst_data_by_id,
+                                    &inst_op_by_id,
+                                    &upsilon_sources_by_phi,
                                     decl.return_kind,
                                     &decl.store_effects,
                                 )
@@ -2180,6 +2235,8 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                                         arg_id,
                                         &inst_region_by_id,
                                         &inst_data_by_id,
+                                        &inst_op_by_id,
+                                        &upsilon_sources_by_phi,
                                         current_decl.return_kind,
                                         &current_decl.store_effects,
                                     )
@@ -3199,6 +3256,19 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hidden_region_for_store_target_uses_sorted_target_slots() {
+        let flat = [1, RSUM_KIND_CONSTANT_GLOBAL, 0, RSUM_KIND_CONSTANT_GLOBAL];
+        assert_eq!(
+            hidden_region_for_store_target(RSUM_KIND_CONSTANT_GLOBAL, &flat, 0),
+            Some(region_pack(REGION_KIND_CALLER, 0))
+        );
+        assert_eq!(
+            hidden_region_for_store_target(RSUM_KIND_CONSTANT_GLOBAL, &flat, 1),
+            Some(region_pack(REGION_KIND_CALLER, 1))
+        );
+    }
 
     #[test]
     fn finds_lib_in_installed_lib_vow_dir() {

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -476,6 +476,48 @@ fn routed_vec_extern(sym: &str, inst_rgn: i64, receiver_rgn: i64) -> (&str, Opti
                 ("__vow_string_from_i64_in_arena", Some(inst_rgn))
             }
         }
+        "__vow_string_split" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_split_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_trim" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_trim_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_to_upper" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_to_upper_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_to_lower" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_to_lower_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_replace" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_replace_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_join" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_join_in_arena", Some(inst_rgn))
+            }
+        }
         "__vow_string_push_str" => {
             let kind = receiver_rgn & 3;
             if kind == REGION_KIND_BLOCK || kind == REGION_KIND_CALLER {
@@ -3019,6 +3061,12 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }
+        "__vow_string_split_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
         "__vow_string_starts_with" | "__vow_string_ends_with" => {
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
@@ -3028,13 +3076,33 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }
+        "__vow_string_trim_in_arena"
+        | "__vow_string_to_upper_in_arena"
+        | "__vow_string_to_lower_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
         "__vow_string_replace" => {
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }
+        "__vow_string_replace_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
         "__vow_string_join" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
+        "__vow_string_join_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -337,6 +337,57 @@ fn routed_vec_extern(sym: &str, inst_rgn: i64, receiver_rgn: i64) -> (&str, Opti
                 (sym, None)
             }
         }
+        "__vow_string_new" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_new_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_from_cstr" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_from_cstr_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_substr" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_substr_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_substring" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_substring_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_from_i64" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_string_from_i64_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_string_push_str" => {
+            let kind = receiver_rgn & 3;
+            if kind == REGION_KIND_BLOCK || kind == REGION_KIND_CALLER {
+                ("__vow_string_push_str_in_arena", Some(receiver_rgn))
+            } else {
+                (sym, None)
+            }
+        }
+        "__vow_string_push_byte" => {
+            let kind = receiver_rgn & 3;
+            if kind == REGION_KIND_BLOCK || kind == REGION_KIND_CALLER {
+                ("__vow_string_push_byte_in_arena", Some(receiver_rgn))
+            } else {
+                (sym, None)
+            }
+        }
         _ => {
             if extern_uses_target_region(sym) {
                 (sym, Some(inst_rgn))
@@ -2673,7 +2724,18 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }
+        "__vow_string_new_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
         "__vow_string_from_cstr" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
+        "__vow_string_from_cstr_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }
@@ -2708,6 +2770,11 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
         }
+        "__vow_string_push_str_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+        }
         "__vow_string_byte_at" => {
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
@@ -2717,7 +2784,17 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
         }
+        "__vow_string_push_byte_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+        }
         "__vow_string_from_i64" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
+        "__vow_string_from_i64_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }
@@ -2784,7 +2861,21 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64));
             sig.returns.push(AbiParam::new(types::I64));
         }
+        "__vow_string_substr_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
         "__vow_string_substring" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.returns.push(AbiParam::new(types::I64));
+        }
+        "__vow_string_substring_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -249,6 +249,49 @@ fn hidden_region_store_targets(flat: &[i64]) -> Vec<i64> {
     out
 }
 
+fn store_effect_advance(flat: &[i64], start: usize) -> usize {
+    if start + 1 >= flat.len() {
+        return flat.len();
+    }
+    let kind = flat[start + 1];
+    let mut i = start + 2;
+    match kind {
+        RSUM_KIND_ALIAS_OF => i += 1,
+        RSUM_KIND_ALIAS_OF_ANY if i < flat.len() => {
+            let n = flat[i].max(0) as usize;
+            i = i.saturating_add(1).saturating_add(n);
+        }
+        RSUM_KIND_FRESH_IN_CALLER | RSUM_KIND_CONSTANT_GLOBAL => {}
+        _ => {}
+    }
+    i.min(flat.len())
+}
+
+fn hidden_region_for_store_target(
+    return_kind: i64,
+    store_effects: &[i64],
+    target_param: i64,
+) -> Option<i64> {
+    let mut hidden_idx = 0i64;
+    if return_kind == RSUM_KIND_FRESH_IN_CALLER {
+        hidden_idx += 1;
+    }
+    let mut prev_target: Option<i64> = None;
+    let mut i = 0usize;
+    while i + 1 < store_effects.len() {
+        let target = store_effects[i];
+        if prev_target != Some(target) {
+            if target == target_param {
+                return Some(region_pack(REGION_KIND_CALLER, hidden_idx));
+            }
+            hidden_idx += 1;
+            prev_target = Some(target);
+        }
+        i = store_effect_advance(store_effects, i);
+    }
+    None
+}
+
 fn hidden_region_count(return_kind: i64, store_effects: &[i64], is_main: bool) -> usize {
     if is_main {
         return 0;
@@ -258,6 +301,25 @@ fn hidden_region_count(return_kind: i64, store_effects: &[i64], is_main: bool) -
         count += 1;
     }
     count + hidden_region_store_targets(store_effects).len()
+}
+
+fn inst_region_for_value(
+    inst_id: i64,
+    inst_region_by_id: &HashMap<i64, i64>,
+    inst_data_by_id: &HashMap<i64, (i64, i64)>,
+    return_kind: i64,
+    store_effects: &[i64],
+) -> i64 {
+    if let Some(&(dk, dv)) = inst_data_by_id.get(&inst_id)
+        && dk == IDATA_ARG_INDEX
+        && let Some(rgn) = hidden_region_for_store_target(return_kind, store_effects, dv)
+    {
+        return rgn;
+    }
+    inst_region_by_id
+        .get(&inst_id)
+        .copied()
+        .unwrap_or_else(region_root)
 }
 
 fn block_arena_value(
@@ -956,6 +1018,7 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     // Build inst_id → block_index map
     let mut inst_block: HashMap<i64, usize> = HashMap::new();
     let mut inst_region_by_id: HashMap<i64, i64> = HashMap::new();
+    let mut inst_data_by_id: HashMap<i64, (i64, i64)> = HashMap::new();
     for bi in 0..nb {
         let start = block_starts[bi] as usize;
         let len = block_lengths[bi] as usize;
@@ -964,6 +1027,7 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
         }
         for idx in start..start + len {
             inst_region_by_id.insert(inst_ids[idx], inst_rgns[idx]);
+            inst_data_by_id.insert(inst_ids[idx], (inst_dks[idx], inst_dvs[idx]));
         }
     }
 
@@ -2011,10 +2075,14 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                             let sym = unsafe { read_vow_string(inst_ds_ptrs[ii]) };
                             let receiver_rgn = if alen > 0 {
                                 let receiver_id = all_args[aoff];
-                                inst_region_by_id
-                                    .get(&receiver_id)
-                                    .copied()
-                                    .unwrap_or_else(region_root)
+                                let decl = &ctx.func_decls[fi];
+                                inst_region_for_value(
+                                    receiver_id,
+                                    &inst_region_by_id,
+                                    &inst_data_by_id,
+                                    decl.return_kind,
+                                    &decl.store_effects,
+                                )
                             } else {
                                 region_root()
                             };
@@ -2107,10 +2175,14 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                                 let arg_rgn = if target_param >= 0 && (target_param as usize) < alen
                                 {
                                     let arg_id = all_args[aoff + target_param as usize];
-                                    inst_region_by_id
-                                        .get(&arg_id)
-                                        .copied()
-                                        .unwrap_or_else(region_root)
+                                    let current_decl = &ctx.func_decls[fi];
+                                    inst_region_for_value(
+                                        arg_id,
+                                        &inst_region_by_id,
+                                        &inst_data_by_id,
+                                        current_decl.return_kind,
+                                        &current_decl.store_effects,
+                                    )
                                 } else {
                                     region_root()
                                 };

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -283,11 +283,14 @@ fn hidden_region_count(return_kind: i64, store_effects: &[i64], is_main: bool) -
     count + hidden_region_store_targets(store_effects).len()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn inst_region_for_value(
     inst_id: i64,
     inst_region_by_id: &HashMap<i64, i64>,
     inst_data_by_id: &HashMap<i64, (i64, i64)>,
     inst_op_by_id: &HashMap<i64, i64>,
+    inst_ds_by_id: &HashMap<i64, String>,
+    inst_first_arg_by_id: &HashMap<i64, i64>,
     upsilon_sources_by_phi: &HashMap<i64, Vec<i64>>,
     return_kind: i64,
     store_effects: &[i64],
@@ -297,6 +300,8 @@ fn inst_region_for_value(
         inst_region_by_id,
         inst_data_by_id,
         inst_op_by_id,
+        inst_ds_by_id,
+        inst_first_arg_by_id,
         upsilon_sources_by_phi,
         return_kind,
         store_effects,
@@ -310,6 +315,8 @@ fn inst_region_for_value_inner(
     inst_region_by_id: &HashMap<i64, i64>,
     inst_data_by_id: &HashMap<i64, (i64, i64)>,
     inst_op_by_id: &HashMap<i64, i64>,
+    inst_ds_by_id: &HashMap<i64, String>,
+    inst_first_arg_by_id: &HashMap<i64, i64>,
     upsilon_sources_by_phi: &HashMap<i64, Vec<i64>>,
     return_kind: i64,
     store_effects: &[i64],
@@ -327,6 +334,44 @@ fn inst_region_for_value_inner(
     {
         return rgn;
     }
+    if matches!(
+        inst_op_by_id.get(&inst_id).copied(),
+        Some(IOP_FIELD_GET | IOP_LOAD)
+    ) && let Some(&source_id) = inst_first_arg_by_id.get(&inst_id)
+    {
+        return inst_region_for_value_inner(
+            source_id,
+            inst_region_by_id,
+            inst_data_by_id,
+            inst_op_by_id,
+            inst_ds_by_id,
+            inst_first_arg_by_id,
+            upsilon_sources_by_phi,
+            return_kind,
+            store_effects,
+            seen,
+        );
+    }
+    if inst_op_by_id.get(&inst_id).copied() == Some(IOP_CALL)
+        && let Some(&(dk, _)) = inst_data_by_id.get(&inst_id)
+        && dk == IDATA_CALL_EXTERN
+        && let Some(sym) = inst_ds_by_id.get(&inst_id)
+        && matches!(sym.as_str(), "__vow_vec_get_val" | "__vow_vec_get")
+        && let Some(&source_id) = inst_first_arg_by_id.get(&inst_id)
+    {
+        return inst_region_for_value_inner(
+            source_id,
+            inst_region_by_id,
+            inst_data_by_id,
+            inst_op_by_id,
+            inst_ds_by_id,
+            inst_first_arg_by_id,
+            upsilon_sources_by_phi,
+            return_kind,
+            store_effects,
+            seen,
+        );
+    }
     if inst_op_by_id.get(&inst_id).copied() == Some(IOP_PHI)
         && let Some(sources) = upsilon_sources_by_phi.get(&inst_id)
     {
@@ -338,6 +383,8 @@ fn inst_region_for_value_inner(
                 inst_region_by_id,
                 inst_data_by_id,
                 inst_op_by_id,
+                inst_ds_by_id,
+                inst_first_arg_by_id,
                 upsilon_sources_by_phi,
                 return_kind,
                 store_effects,
@@ -1104,6 +1151,8 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     let mut inst_region_by_id: HashMap<i64, i64> = HashMap::new();
     let mut inst_data_by_id: HashMap<i64, (i64, i64)> = HashMap::new();
     let mut inst_op_by_id: HashMap<i64, i64> = HashMap::new();
+    let mut inst_ds_by_id: HashMap<i64, String> = HashMap::new();
+    let mut inst_first_arg_by_id: HashMap<i64, i64> = HashMap::new();
     let mut upsilon_sources_by_phi: HashMap<i64, Vec<i64>> = HashMap::new();
     for bi in 0..nb {
         let start = block_starts[bi] as usize;
@@ -1117,6 +1166,15 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
             inst_op_by_id.insert(inst_ids[idx], inst_ops[idx]);
             let aoff = arg_offsets[idx] as usize;
             let alen = arg_lengths[idx] as usize;
+            if alen > 0 {
+                inst_first_arg_by_id.insert(inst_ids[idx], all_args[aoff]);
+            }
+            if inst_dks[idx] == IDATA_CALL_EXTERN {
+                inst_ds_by_id.insert(
+                    inst_ids[idx],
+                    unsafe { read_vow_string(inst_ds_ptrs[idx]) }.to_string(),
+                );
+            }
             if inst_ops[idx] == IOP_UPSILON && inst_dks[idx] == IDATA_PHI_TARGET && alen > 0 {
                 upsilon_sources_by_phi
                     .entry(inst_dvs[idx])
@@ -2176,6 +2234,8 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                                     &inst_region_by_id,
                                     &inst_data_by_id,
                                     &inst_op_by_id,
+                                    &inst_ds_by_id,
+                                    &inst_first_arg_by_id,
                                     &upsilon_sources_by_phi,
                                     decl.return_kind,
                                     &decl.store_effects,
@@ -2278,6 +2338,8 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                                         &inst_region_by_id,
                                         &inst_data_by_id,
                                         &inst_op_by_id,
+                                        &inst_ds_by_id,
+                                        &inst_first_arg_by_id,
                                         &upsilon_sources_by_phi,
                                         current_decl.return_kind,
                                         &current_decl.store_effects,

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -3398,6 +3398,14 @@ mod tests {
             hidden_region_for_store_target(RSUM_KIND_CONSTANT_GLOBAL, &flat, 1),
             Some(region_pack(REGION_KIND_CALLER, 1))
         );
+        assert_eq!(
+            hidden_region_for_store_target(RSUM_KIND_FRESH_IN_CALLER, &flat, 0),
+            Some(region_pack(REGION_KIND_CALLER, 1))
+        );
+        assert_eq!(
+            hidden_region_for_store_target(RSUM_KIND_FRESH_IN_CALLER, &flat, 1),
+            Some(region_pack(REGION_KIND_CALLER, 2))
+        );
     }
 
     #[test]

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -194,6 +194,8 @@ fn build_signature(ir_func: &IrFunction, call_conv: cranelift_codegen::isa::Call
 }
 
 fn hidden_region_store_targets(ir_func: &IrFunction) -> Vec<u32> {
+    // Keep this slot order in sync with compiler/clif.vow's clif_hidden_store_targets.
+    // The self-hosted path dedups before sorting; both paths must return sorted unique targets.
     let mut targets: Vec<u32> = ir_func
         .summary
         .store_effects

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -14,7 +14,7 @@ use cranelift_object::{ObjectBuilder, ObjectModule};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use vow_ir::{
-    BlockId, FuncId as IrFuncId, Function as IrFunction, Inst, InstData, InstId,
+    BlockId, FuncId as IrFuncId, Function as IrFunction, HiddenRegionIdx, Inst, InstData, InstId,
     Module as IrModule, Opcode, RegionConstraint, RegionId, RegionSummary, Ty as IrTy,
 };
 
@@ -216,6 +216,30 @@ fn hidden_region_param_count(ir_func: &IrFunction) -> usize {
     count + hidden_region_store_targets(ir_func).len()
 }
 
+fn hidden_region_idx_for_store_target(
+    summary: &RegionSummary,
+    target_param: u32,
+) -> Option<HiddenRegionIdx> {
+    let mut idx = 0u32;
+    if summary.return_region == RegionConstraint::FreshInCaller {
+        idx += 1;
+    }
+    let mut targets: Vec<u32> = summary
+        .store_effects
+        .iter()
+        .map(|effect| effect.target)
+        .collect();
+    targets.sort_unstable();
+    targets.dedup();
+    for target in targets {
+        if target == target_param {
+            return Some(HiddenRegionIdx(idx));
+        }
+        idx += 1;
+    }
+    None
+}
+
 fn coerce_return_value(builder: &mut FunctionBuilder<'_>, val: Value, return_ty: IrTy) -> Value {
     let val_ty = builder.func.dfg.value_type(val);
     match (val_ty, ir_ty_to_cranelift(return_ty)) {
@@ -355,11 +379,34 @@ fn region_to_arena_value(
     }
 }
 
-fn first_arg_region(inst: &Inst, inst_index: &HashMap<InstId, &Inst>) -> RegionId {
+fn source_value_region(source: &Inst, current_summary: &RegionSummary) -> RegionId {
+    if let (Opcode::GetArg, InstData::ArgIndex(param_idx)) = (&source.opcode, &source.data)
+        && let Some(hidden_idx) = hidden_region_idx_for_store_target(current_summary, *param_idx)
+    {
+        return RegionId::Caller(hidden_idx);
+    }
+    source.region
+}
+
+fn arg_region(
+    arg_id: InstId,
+    inst_index: &HashMap<InstId, &Inst>,
+    current_summary: &RegionSummary,
+) -> RegionId {
+    inst_index
+        .get(&arg_id)
+        .map(|src| source_value_region(src, current_summary))
+        .unwrap_or(RegionId::Root)
+}
+
+fn first_arg_region(
+    inst: &Inst,
+    inst_index: &HashMap<InstId, &Inst>,
+    current_summary: &RegionSummary,
+) -> RegionId {
     inst.args
         .first()
-        .and_then(|arg_id| inst_index.get(arg_id))
-        .map(|src| src.region)
+        .map(|arg_id| arg_region(*arg_id, inst_index, current_summary))
         .unwrap_or(RegionId::Root)
 }
 
@@ -367,6 +414,7 @@ fn routed_vec_extern<'a>(
     sym: &'a str,
     inst: &Inst,
     inst_index: &HashMap<InstId, &Inst>,
+    current_summary: &RegionSummary,
 ) -> (&'a str, Option<RegionId>) {
     match sym {
         "__vow_vec_new" => match inst.region {
@@ -378,7 +426,7 @@ fn routed_vec_extern<'a>(
             region => ("__vow_vec_new_val_in_arena", Some(region)),
         },
         "__vow_vec_push_val" => {
-            let region = first_arg_region(inst, inst_index);
+            let region = first_arg_region(inst, inst_index, current_summary);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_vec_push_val_in_arena", Some(region))
@@ -387,7 +435,7 @@ fn routed_vec_extern<'a>(
             }
         }
         "__vow_vec_push" => {
-            let region = first_arg_region(inst, inst_index);
+            let region = first_arg_region(inst, inst_index, current_summary);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_vec_push_in_arena", Some(region))
@@ -416,7 +464,7 @@ fn routed_vec_extern<'a>(
             region => ("__vow_string_from_i64_in_arena", Some(region)),
         },
         "__vow_string_push_str" => {
-            let region = first_arg_region(inst, inst_index);
+            let region = first_arg_region(inst, inst_index, current_summary);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_string_push_str_in_arena", Some(region))
@@ -425,7 +473,7 @@ fn routed_vec_extern<'a>(
             }
         }
         "__vow_string_push_byte" => {
-            let region = first_arg_region(inst, inst_index);
+            let region = first_arg_region(inst, inst_index, current_summary);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_string_push_byte_in_arena", Some(region))
@@ -1186,7 +1234,8 @@ fn lower_inst(
                     fr
                 }
                 InstData::CallExtern(sym) => {
-                    let (routed_sym, target_region) = routed_vec_extern(sym, inst, ctx.inst_index);
+                    let (routed_sym, target_region) =
+                        routed_vec_extern(sym, inst, ctx.inst_index, &ctx.ir_func.summary);
                     external_target_region = target_region;
                     let Some(&fr) = ctx.extern_func_refs.get(routed_sym) else {
                         return Err(CodegenError::UnsupportedOpcode(format!(
@@ -1313,8 +1362,7 @@ fn lower_inst(
                     let arg_region = inst
                         .args
                         .get(target_idx as usize)
-                        .and_then(|arg_id| ctx.inst_index.get(arg_id))
-                        .map(|src_inst| src_inst.region)
+                        .map(|arg_id| arg_region(*arg_id, ctx.inst_index, &ctx.ir_func.summary))
                         .unwrap_or(RegionId::Root);
                     push_hidden(builder, &mut call_args, arg_region)?;
                 }
@@ -2508,7 +2556,8 @@ impl Backend for CraneliftBackend {
                         if inst.opcode == Opcode::DebugCall && !mode.has_debug_checks() {
                             continue;
                         }
-                        let (routed_sym, _) = routed_vec_extern(sym, inst, &inst_index);
+                        let (routed_sym, _) =
+                            routed_vec_extern(sym, inst, &inst_index, &func.summary);
                         extern_syms.insert(routed_sym.to_string());
                     }
                 }
@@ -4315,6 +4364,64 @@ mod tests {
             .collect();
         assert!(symbols.contains("__vow_string_push_str_in_arena"));
         assert!(!symbols.contains("__vow_string_push_str"));
+    }
+
+    #[test]
+    fn parameter_region_string_push_byte_imports_arena_variant() {
+        let grow_param = Function {
+            id: FuncId(0),
+            name: "grow_param".to_string(),
+            params: vec![Ty::Ptr],
+            param_names: vec!["s".to_string()],
+            return_ty: Ty::Unit,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+                    inst(
+                        1,
+                        Opcode::ConstI64,
+                        Ty::I64,
+                        vec![],
+                        InstData::ConstI64(120),
+                    ),
+                    inst(
+                        2,
+                        Opcode::Call,
+                        Ty::Unit,
+                        vec![0, 1],
+                        InstData::CallExtern("__vow_string_push_byte".to_string()),
+                    ),
+                    inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary {
+                param_regions: vec![],
+                return_region: RegionConstraint::ConstantGlobal,
+                store_effects: vec![StoreEffect {
+                    target: 0,
+                    source: RegionConstraint::ConstantGlobal,
+                }],
+            },
+            source_file: String::new(),
+        };
+        let module = make_module("test", vec![grow_param]);
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_string_push_byte_in_arena"));
+        assert!(!symbols.contains("__vow_string_push_byte"));
     }
 
     #[test]

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -396,6 +396,17 @@ fn source_value_region(
     {
         return RegionId::Caller(hidden_idx);
     }
+    if matches!(source.opcode, Opcode::FieldGet | Opcode::Load)
+        && let Some(source_id) = source.args.first()
+    {
+        return arg_region_inner(*source_id, inst_index, current_summary, phi_data, seen);
+    }
+    if let (Opcode::Call, InstData::CallExtern(sym)) = (&source.opcode, &source.data)
+        && matches!(sym.as_str(), "__vow_vec_get_val" | "__vow_vec_get")
+        && let Some(source_id) = source.args.first()
+    {
+        return arg_region_inner(*source_id, inst_index, current_summary, phi_data, seen);
+    }
     if source.opcode == Opcode::Phi {
         let mut merged: Option<RegionId> = None;
         for upsilons in phi_data.block_upsilons.values() {
@@ -4569,6 +4580,100 @@ mod tests {
             source_file: String::new(),
         };
         let module = make_module("test", vec![grow_param]);
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_string_push_byte_in_arena"));
+        assert!(!symbols.contains("__vow_string_push_byte"));
+    }
+
+    #[test]
+    fn projected_parameter_region_string_push_byte_imports_arena_variant() {
+        let grow_projection = Function {
+            id: FuncId(0),
+            name: "grow_projection".to_string(),
+            params: vec![Ty::Ptr, Ty::Ptr],
+            param_names: vec!["strings".to_string(), "holder".to_string()],
+            return_ty: Ty::Unit,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+                    inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(
+                        2,
+                        Opcode::Call,
+                        Ty::Ptr,
+                        vec![0, 1],
+                        InstData::CallExtern("__vow_vec_get_val".to_string()),
+                    ),
+                    inst(3, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+                    inst(
+                        4,
+                        Opcode::FieldGet,
+                        Ty::Ptr,
+                        vec![3],
+                        InstData::FieldIndex(0),
+                    ),
+                    inst(
+                        5,
+                        Opcode::ConstI64,
+                        Ty::I64,
+                        vec![],
+                        InstData::ConstI64(120),
+                    ),
+                    inst(
+                        6,
+                        Opcode::Call,
+                        Ty::Unit,
+                        vec![2, 5],
+                        InstData::CallExtern("__vow_string_push_byte".to_string()),
+                    ),
+                    inst(
+                        7,
+                        Opcode::ConstI64,
+                        Ty::I64,
+                        vec![],
+                        InstData::ConstI64(121),
+                    ),
+                    inst(
+                        8,
+                        Opcode::Call,
+                        Ty::Unit,
+                        vec![4, 7],
+                        InstData::CallExtern("__vow_string_push_byte".to_string()),
+                    ),
+                    inst(9, Opcode::Return, Ty::Unit, vec![], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary {
+                param_regions: vec![],
+                return_region: RegionConstraint::ConstantGlobal,
+                store_effects: vec![
+                    StoreEffect {
+                        target: 0,
+                        source: RegionConstraint::ConstantGlobal,
+                    },
+                    StoreEffect {
+                        target: 1,
+                        source: RegionConstraint::ConstantGlobal,
+                    },
+                ],
+            },
+            source_file: String::new(),
+        };
+        let module = make_module("test", vec![grow_projection]);
         let result =
             CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
         assert!(result.is_ok(), "{:?}", result.err());

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -355,7 +355,7 @@ fn region_to_arena_value(
     }
 }
 
-fn vec_receiver_region(inst: &Inst, inst_index: &HashMap<InstId, &Inst>) -> RegionId {
+fn first_arg_region(inst: &Inst, inst_index: &HashMap<InstId, &Inst>) -> RegionId {
     inst.args
         .first()
         .and_then(|arg_id| inst_index.get(arg_id))
@@ -378,7 +378,7 @@ fn routed_vec_extern<'a>(
             region => ("__vow_vec_new_val_in_arena", Some(region)),
         },
         "__vow_vec_push_val" => {
-            let region = vec_receiver_region(inst, inst_index);
+            let region = first_arg_region(inst, inst_index);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_vec_push_val_in_arena", Some(region))
@@ -387,10 +387,48 @@ fn routed_vec_extern<'a>(
             }
         }
         "__vow_vec_push" => {
-            let region = vec_receiver_region(inst, inst_index);
+            let region = first_arg_region(inst, inst_index);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_vec_push_in_arena", Some(region))
+                }
+                _ => (sym, None),
+            }
+        }
+        "__vow_string_new" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_new_in_arena", Some(region)),
+        },
+        "__vow_string_from_cstr" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_from_cstr_in_arena", Some(region)),
+        },
+        "__vow_string_substr" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_substr_in_arena", Some(region)),
+        },
+        "__vow_string_substring" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_substring_in_arena", Some(region)),
+        },
+        "__vow_string_from_i64" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_from_i64_in_arena", Some(region)),
+        },
+        "__vow_string_push_str" => {
+            let region = first_arg_region(inst, inst_index);
+            match region {
+                RegionId::Block(_) | RegionId::Caller(_) => {
+                    ("__vow_string_push_str_in_arena", Some(region))
+                }
+                _ => (sym, None),
+            }
+        }
+        "__vow_string_push_byte" => {
+            let region = first_arg_region(inst, inst_index);
+            match region {
+                RegionId::Block(_) | RegionId::Caller(_) => {
+                    ("__vow_string_push_byte_in_arena", Some(region))
                 }
                 _ => (sym, None),
             }
@@ -1996,7 +2034,18 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // len
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
         }
+        "__vow_string_new_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // ptr
+            sig.params.push(AbiParam::new(types::I64)); // len
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
         "__vow_string_from_cstr" => {
+            sig.params.push(AbiParam::new(types::I64)); // C-string ptr
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
+        "__vow_string_from_cstr_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64)); // C-string ptr
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
         }
@@ -2031,6 +2080,11 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // dest ptr
             sig.params.push(AbiParam::new(types::I64)); // src ptr
         }
+        "__vow_string_push_str_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // dest ptr
+            sig.params.push(AbiParam::new(types::I64)); // src ptr
+        }
         "__vow_string_byte_at" => {
             sig.params.push(AbiParam::new(types::I64)); // string ptr
             sig.params.push(AbiParam::new(types::I64)); // index
@@ -2040,7 +2094,17 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // string ptr
             sig.params.push(AbiParam::new(types::I64)); // byte value
         }
+        "__vow_string_push_byte_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // string ptr
+            sig.params.push(AbiParam::new(types::I64)); // byte value
+        }
         "__vow_string_from_i64" => {
+            sig.params.push(AbiParam::new(types::I64)); // value
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
+        "__vow_string_from_i64_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64)); // value
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
         }
@@ -2108,7 +2172,21 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // len
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
         }
+        "__vow_string_substr_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // string ptr
+            sig.params.push(AbiParam::new(types::I64)); // start
+            sig.params.push(AbiParam::new(types::I64)); // len
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
         "__vow_string_substring" => {
+            sig.params.push(AbiParam::new(types::I64)); // string ptr
+            sig.params.push(AbiParam::new(types::I64)); // start
+            sig.params.push(AbiParam::new(types::I64)); // end (exclusive)
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
+        "__vow_string_substring_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64)); // string ptr
             sig.params.push(AbiParam::new(types::I64)); // start
             sig.params.push(AbiParam::new(types::I64)); // end (exclusive)
@@ -4102,6 +4180,141 @@ mod tests {
             .collect();
         assert!(symbols.contains("__vow_vec_new"));
         assert!(!symbols.contains("__vow_vec_new_in_arena"));
+    }
+
+    #[test]
+    fn block_region_string_from_cstr_imports_arena_variant() {
+        let mut string_new = inst(
+            1,
+            Opcode::Call,
+            Ty::Ptr,
+            vec![0],
+            InstData::CallExtern("__vow_string_from_cstr".to_string()),
+        );
+        string_new.region = RegionId::Block(BlockId(0));
+        let module = make_module(
+            "test",
+            vec![simple_fn(
+                0,
+                "f",
+                vec![],
+                Ty::I64,
+                vec![
+                    inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                    string_new,
+                    inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+                ],
+            )],
+        );
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_string_from_cstr_in_arena"));
+        assert!(!symbols.contains("__vow_string_from_cstr"));
+    }
+
+    #[test]
+    fn root_region_string_from_cstr_keeps_wrapper_symbol() {
+        let module = make_module(
+            "test",
+            vec![simple_fn(
+                0,
+                "f",
+                vec![],
+                Ty::I64,
+                vec![
+                    inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                    inst(
+                        1,
+                        Opcode::Call,
+                        Ty::Ptr,
+                        vec![0],
+                        InstData::CallExtern("__vow_string_from_cstr".to_string()),
+                    ),
+                    inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+                ],
+            )],
+        );
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_string_from_cstr"));
+        assert!(!symbols.contains("__vow_string_from_cstr_in_arena"));
+    }
+
+    #[test]
+    fn block_region_string_push_str_imports_arena_variant() {
+        let mut dest = inst(
+            1,
+            Opcode::Call,
+            Ty::Ptr,
+            vec![0],
+            InstData::CallExtern("__vow_string_from_cstr".to_string()),
+        );
+        dest.region = RegionId::Block(BlockId(0));
+        let mut src = inst(
+            3,
+            Opcode::Call,
+            Ty::Ptr,
+            vec![2],
+            InstData::CallExtern("__vow_string_from_cstr".to_string()),
+        );
+        src.region = RegionId::Block(BlockId(0));
+        let module = make_module(
+            "test",
+            vec![simple_fn(
+                0,
+                "f",
+                vec![],
+                Ty::I64,
+                vec![
+                    inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                    dest,
+                    inst(2, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(1)),
+                    src,
+                    inst(
+                        4,
+                        Opcode::Call,
+                        Ty::Unit,
+                        vec![1, 3],
+                        InstData::CallExtern("__vow_string_push_str".to_string()),
+                    ),
+                    inst(5, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(6, Opcode::Return, Ty::Unit, vec![5], InstData::None),
+                ],
+            )],
+        );
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_string_push_str_in_arena"));
+        assert!(!symbols.contains("__vow_string_push_str"));
     }
 
     #[test]

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -379,34 +379,77 @@ fn region_to_arena_value(
     }
 }
 
-fn source_value_region(source: &Inst, current_summary: &RegionSummary) -> RegionId {
+fn source_value_region(
+    source: &Inst,
+    inst_index: &HashMap<InstId, &Inst>,
+    current_summary: &RegionSummary,
+    phi_data: &PhiUpsilonData,
+    seen: &mut BTreeSet<InstId>,
+) -> RegionId {
+    if !seen.insert(source.id) {
+        return source.region;
+    }
     if let (Opcode::GetArg, InstData::ArgIndex(param_idx)) = (&source.opcode, &source.data)
         && let Some(hidden_idx) = hidden_region_idx_for_store_target(current_summary, *param_idx)
     {
         return RegionId::Caller(hidden_idx);
     }
+    if source.opcode == Opcode::Phi {
+        let mut merged: Option<RegionId> = None;
+        for upsilons in phi_data.block_upsilons.values() {
+            for &(phi_id, val_id) in upsilons {
+                if phi_id != source.id {
+                    continue;
+                }
+                let mut arm_seen = seen.clone();
+                let arm_region =
+                    arg_region_inner(val_id, inst_index, current_summary, phi_data, &mut arm_seen);
+                match merged {
+                    Some(existing) if existing != arm_region => return source.region,
+                    Some(_) => {}
+                    None => merged = Some(arm_region),
+                }
+            }
+        }
+        if let Some(region) = merged {
+            return region;
+        }
+    }
     source.region
+}
+
+fn arg_region_inner(
+    arg_id: InstId,
+    inst_index: &HashMap<InstId, &Inst>,
+    current_summary: &RegionSummary,
+    phi_data: &PhiUpsilonData,
+    seen: &mut BTreeSet<InstId>,
+) -> RegionId {
+    inst_index
+        .get(&arg_id)
+        .map(|src| source_value_region(src, inst_index, current_summary, phi_data, seen))
+        .unwrap_or(RegionId::Root)
 }
 
 fn arg_region(
     arg_id: InstId,
     inst_index: &HashMap<InstId, &Inst>,
     current_summary: &RegionSummary,
+    phi_data: &PhiUpsilonData,
 ) -> RegionId {
-    inst_index
-        .get(&arg_id)
-        .map(|src| source_value_region(src, current_summary))
-        .unwrap_or(RegionId::Root)
+    let mut seen = BTreeSet::new();
+    arg_region_inner(arg_id, inst_index, current_summary, phi_data, &mut seen)
 }
 
 fn first_arg_region(
     inst: &Inst,
     inst_index: &HashMap<InstId, &Inst>,
     current_summary: &RegionSummary,
+    phi_data: &PhiUpsilonData,
 ) -> RegionId {
     inst.args
         .first()
-        .map(|arg_id| arg_region(*arg_id, inst_index, current_summary))
+        .map(|arg_id| arg_region(*arg_id, inst_index, current_summary, phi_data))
         .unwrap_or(RegionId::Root)
 }
 
@@ -415,6 +458,7 @@ fn routed_vec_extern<'a>(
     inst: &Inst,
     inst_index: &HashMap<InstId, &Inst>,
     current_summary: &RegionSummary,
+    phi_data: &PhiUpsilonData,
 ) -> (&'a str, Option<RegionId>) {
     match sym {
         "__vow_vec_new" => match inst.region {
@@ -426,7 +470,7 @@ fn routed_vec_extern<'a>(
             region => ("__vow_vec_new_val_in_arena", Some(region)),
         },
         "__vow_vec_push_val" => {
-            let region = first_arg_region(inst, inst_index, current_summary);
+            let region = first_arg_region(inst, inst_index, current_summary, phi_data);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_vec_push_val_in_arena", Some(region))
@@ -435,7 +479,7 @@ fn routed_vec_extern<'a>(
             }
         }
         "__vow_vec_push" => {
-            let region = first_arg_region(inst, inst_index, current_summary);
+            let region = first_arg_region(inst, inst_index, current_summary, phi_data);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_vec_push_in_arena", Some(region))
@@ -464,7 +508,7 @@ fn routed_vec_extern<'a>(
             region => ("__vow_string_from_i64_in_arena", Some(region)),
         },
         "__vow_string_push_str" => {
-            let region = first_arg_region(inst, inst_index, current_summary);
+            let region = first_arg_region(inst, inst_index, current_summary, phi_data);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_string_push_str_in_arena", Some(region))
@@ -473,7 +517,7 @@ fn routed_vec_extern<'a>(
             }
         }
         "__vow_string_push_byte" => {
-            let region = first_arg_region(inst, inst_index, current_summary);
+            let region = first_arg_region(inst, inst_index, current_summary, phi_data);
             match region {
                 RegionId::Block(_) | RegionId::Caller(_) => {
                     ("__vow_string_push_byte_in_arena", Some(region))
@@ -1234,8 +1278,13 @@ fn lower_inst(
                     fr
                 }
                 InstData::CallExtern(sym) => {
-                    let (routed_sym, target_region) =
-                        routed_vec_extern(sym, inst, ctx.inst_index, &ctx.ir_func.summary);
+                    let (routed_sym, target_region) = routed_vec_extern(
+                        sym,
+                        inst,
+                        ctx.inst_index,
+                        &ctx.ir_func.summary,
+                        ctx.phi_data,
+                    );
                     external_target_region = target_region;
                     let Some(&fr) = ctx.extern_func_refs.get(routed_sym) else {
                         return Err(CodegenError::UnsupportedOpcode(format!(
@@ -1362,7 +1411,9 @@ fn lower_inst(
                     let arg_region = inst
                         .args
                         .get(target_idx as usize)
-                        .map(|arg_id| arg_region(*arg_id, ctx.inst_index, &ctx.ir_func.summary))
+                        .map(|arg_id| {
+                            arg_region(*arg_id, ctx.inst_index, &ctx.ir_func.summary, ctx.phi_data)
+                        })
                         .unwrap_or(RegionId::Root);
                     push_hidden(builder, &mut call_args, arg_region)?;
                 }
@@ -2550,6 +2601,7 @@ impl Backend for CraneliftBackend {
         let mut extern_syms = HashSet::new();
         for func in &module.functions {
             let inst_index = build_inst_index(func);
+            let phi_data = build_phi_upsilon_data(func);
             for block in &func.blocks {
                 for inst in &block.insts {
                     if let InstData::CallExtern(sym) = &inst.data {
@@ -2557,7 +2609,7 @@ impl Backend for CraneliftBackend {
                             continue;
                         }
                         let (routed_sym, _) =
-                            routed_vec_extern(sym, inst, &inst_index, &func.summary);
+                            routed_vec_extern(sym, inst, &inst_index, &func.summary, &phi_data);
                         extern_syms.insert(routed_sym.to_string());
                     }
                 }
@@ -4409,6 +4461,130 @@ mod tests {
             source_file: String::new(),
         };
         let module = make_module("test", vec![grow_param]);
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+        assert!(symbols.contains("__vow_string_push_byte_in_arena"));
+        assert!(!symbols.contains("__vow_string_push_byte"));
+    }
+
+    #[test]
+    fn phi_parameter_region_string_push_byte_imports_arena_variant() {
+        let phi_id = InstId(8);
+        let grow_phi = Function {
+            id: FuncId(0),
+            name: "grow_phi".to_string(),
+            params: vec![Ty::Bool, Ty::Ptr],
+            param_names: vec!["cond".to_string(), "s".to_string()],
+            return_ty: Ty::Unit,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    insts: vec![
+                        inst(0, Opcode::GetArg, Ty::Bool, vec![], InstData::ArgIndex(0)),
+                        inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+                        inst(
+                            2,
+                            Opcode::Branch,
+                            Ty::Unit,
+                            vec![0],
+                            InstData::BranchTargets {
+                                then_block: BlockId(1),
+                                else_block: BlockId(2),
+                            },
+                        ),
+                    ],
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    insts: vec![
+                        inst(
+                            3,
+                            Opcode::Upsilon,
+                            Ty::Unit,
+                            vec![1],
+                            InstData::PhiTarget(phi_id),
+                        ),
+                        inst(
+                            4,
+                            Opcode::Jump,
+                            Ty::Unit,
+                            vec![],
+                            InstData::JumpTarget(BlockId(3)),
+                        ),
+                    ],
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    insts: vec![
+                        inst(
+                            5,
+                            Opcode::Upsilon,
+                            Ty::Unit,
+                            vec![1],
+                            InstData::PhiTarget(phi_id),
+                        ),
+                        inst(
+                            6,
+                            Opcode::Jump,
+                            Ty::Unit,
+                            vec![],
+                            InstData::JumpTarget(BlockId(3)),
+                        ),
+                    ],
+                },
+                BasicBlock {
+                    id: BlockId(3),
+                    insts: vec![
+                        Inst {
+                            id: phi_id,
+                            opcode: Opcode::Phi,
+                            ty: Ty::Ptr,
+                            args: vec![],
+                            data: InstData::None,
+                            origin: sp(),
+                            region: RegionId::Root,
+                        },
+                        inst(
+                            9,
+                            Opcode::ConstI64,
+                            Ty::I64,
+                            vec![],
+                            InstData::ConstI64(120),
+                        ),
+                        inst(
+                            10,
+                            Opcode::Call,
+                            Ty::Unit,
+                            vec![8, 9],
+                            InstData::CallExtern("__vow_string_push_byte".to_string()),
+                        ),
+                        inst(11, Opcode::Return, Ty::Unit, vec![], InstData::None),
+                    ],
+                },
+            ],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary {
+                param_regions: vec![],
+                return_region: RegionConstraint::ConstantGlobal,
+                store_effects: vec![StoreEffect {
+                    target: 1,
+                    source: RegionConstraint::ConstantGlobal,
+                }],
+            },
+            source_file: String::new(),
+        };
+        let module = make_module("test", vec![grow_phi]);
         let result =
             CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
         assert!(result.is_ok(), "{:?}", result.err());

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -509,6 +509,30 @@ fn routed_vec_extern<'a>(
             RegionId::Root => (sym, None),
             region => ("__vow_string_from_i64_in_arena", Some(region)),
         },
+        "__vow_string_split" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_split_in_arena", Some(region)),
+        },
+        "__vow_string_trim" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_trim_in_arena", Some(region)),
+        },
+        "__vow_string_to_upper" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_to_upper_in_arena", Some(region)),
+        },
+        "__vow_string_to_lower" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_to_lower_in_arena", Some(region)),
+        },
+        "__vow_string_replace" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_replace_in_arena", Some(region)),
+        },
+        "__vow_string_join" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_string_join_in_arena", Some(region)),
+        },
         "__vow_string_push_str" => {
             let region = first_arg_region(inst, inst_index, current_summary, phi_data);
             match region {
@@ -2302,6 +2326,12 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // separator ptr
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<String>
         }
+        "__vow_string_split_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // haystack ptr
+            sig.params.push(AbiParam::new(types::I64)); // separator ptr
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<String>
+        }
         "__vow_string_starts_with" => {
             sig.params.push(AbiParam::new(types::I64)); // string ptr
             sig.params.push(AbiParam::new(types::I64)); // prefix ptr
@@ -2316,11 +2346,26 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // string ptr
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
         }
+        "__vow_string_trim_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // string ptr
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
         "__vow_string_to_upper" => {
             sig.params.push(AbiParam::new(types::I64)); // string ptr
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
         }
+        "__vow_string_to_upper_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // string ptr
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
         "__vow_string_to_lower" => {
+            sig.params.push(AbiParam::new(types::I64)); // string ptr
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
+        "__vow_string_to_lower_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64)); // string ptr
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
         }
@@ -2330,7 +2375,20 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.params.push(AbiParam::new(types::I64)); // to ptr
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
         }
+        "__vow_string_replace_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.params.push(AbiParam::new(types::I64)); // string ptr
+            sig.params.push(AbiParam::new(types::I64)); // from ptr
+            sig.params.push(AbiParam::new(types::I64)); // to ptr
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
         "__vow_string_join" => {
+            sig.params.push(AbiParam::new(types::I64)); // vec ptr
+            sig.params.push(AbiParam::new(types::I64)); // separator ptr
+            sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
+        }
+        "__vow_string_join_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64)); // vec ptr
             sig.params.push(AbiParam::new(types::I64)); // separator ptr
             sig.returns.push(AbiParam::new(types::I64)); // *VowVec<u8>
@@ -4323,6 +4381,54 @@ mod tests {
             .collect();
         assert!(symbols.contains("__vow_string_from_cstr_in_arena"));
         assert!(!symbols.contains("__vow_string_from_cstr"));
+    }
+
+    #[test]
+    fn block_region_fresh_string_helpers_import_arena_variants() {
+        let cases = [
+            ("__vow_string_split", "__vow_string_split_in_arena", 2),
+            ("__vow_string_trim", "__vow_string_trim_in_arena", 1),
+            ("__vow_string_to_upper", "__vow_string_to_upper_in_arena", 1),
+            ("__vow_string_to_lower", "__vow_string_to_lower_in_arena", 1),
+            ("__vow_string_replace", "__vow_string_replace_in_arena", 3),
+            ("__vow_string_join", "__vow_string_join_in_arena", 2),
+        ];
+
+        let mut insts = vec![
+            inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+        ];
+        for (idx, (sym, _, arity)) in cases.iter().enumerate() {
+            let mut call = inst(
+                10 + idx as u32,
+                Opcode::Call,
+                Ty::Ptr,
+                (0..*arity).collect(),
+                InstData::CallExtern((*sym).to_string()),
+            );
+            call.region = RegionId::Block(BlockId(0));
+            insts.push(call);
+        }
+        insts.push(inst(90, Opcode::Return, Ty::Unit, vec![], InstData::None));
+
+        let module = make_module("test", vec![simple_fn(0, "f", vec![], Ty::Unit, insts)]);
+        let result =
+            CraneliftBackend::new().compile_module(&module, BuildMode::Debug, TraceMode::Off);
+        assert!(result.is_ok(), "{:?}", result.err());
+
+        let bytes = result.unwrap().bytes;
+        use object::{Object, ObjectSymbol};
+        let object = object::File::parse(bytes.as_slice()).expect("compiled object should parse");
+        let symbols: HashSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+
+        for (root, routed, _) in cases {
+            assert!(symbols.contains(routed), "{routed} should be imported");
+            assert!(!symbols.contains(root), "{root} should not be imported");
+        }
     }
 
     #[test]

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -1933,27 +1933,27 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &vow_syntax::ast::Expr) -> InstId {
                 ctx.inst_struct_type.insert(result, "String".to_string());
                 return result;
             }
-            // String::new() builtin — empty string via __vow_vec_new(1, 1)
+            // String::new() builtin — empty string via the String arena router.
             if enum_name == "String" && variant_name == "new" {
-                let size_val = ctx.emit(
+                let null_ptr = ctx.emit(
                     Opcode::ConstI64,
                     Ty::I64,
                     vec![],
-                    InstData::ConstI64(1),
+                    InstData::ConstI64(0),
                     span,
                 );
-                let align_val = ctx.emit(
+                let len_val = ctx.emit(
                     Opcode::ConstI64,
                     Ty::I64,
                     vec![],
-                    InstData::ConstI64(1),
+                    InstData::ConstI64(0),
                     span,
                 );
                 let result = ctx.emit(
                     Opcode::Call,
                     Ty::Ptr,
-                    vec![size_val, align_val],
-                    InstData::CallExtern("__vow_vec_new".to_string()),
+                    vec![null_ptr, len_val],
+                    InstData::CallExtern("__vow_string_new".to_string()),
                     span,
                 );
                 ctx.inst_struct_type.insert(result, "String".to_string());

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1494,6 +1494,20 @@ fn for_each_extern_store_edge(sym: &str, args: &[InstId], mut visit: impl FnMut(
     }
 }
 
+fn extern_growth_target(sym: &str, args: &[InstId]) -> Option<InstId> {
+    match sym {
+        "__vow_vec_push" if !args.is_empty() => Some(args[0]),
+        "__vow_vec_push_in_arena" | "__vow_vec_reserve_in_arena" if args.len() >= 2 => {
+            Some(args[1])
+        }
+        "__vow_string_push_str" | "__vow_string_push_byte" if !args.is_empty() => Some(args[0]),
+        "__vow_string_push_str_in_arena" | "__vow_string_push_byte_in_arena" if args.len() >= 2 => {
+            Some(args[1])
+        }
+        _ => None,
+    }
+}
+
 fn is_heap_producing(inst: &Inst, summaries: &[InternalSummary]) -> bool {
     matches!(inst.opcode, Opcode::RegionAlloc)
         || matches!(
@@ -1600,6 +1614,14 @@ fn handle_inst(
                         );
                     }
                 });
+                if let Some(target_id) = extern_growth_target(sym, &inst.args)
+                    && let Some(target_param) = trace_param(target_id, inst_lookup)
+                {
+                    summary.store_effects.insert((
+                        target_param,
+                        InternalReturnRegion::Published(RegionConstraint::ConstantGlobal),
+                    ));
+                }
             }
 
             // Look up callee summary and apply store-effects + return aliasing.
@@ -5010,6 +5032,44 @@ mod tests {
             source.region,
             RegionId::Caller(HiddenRegionIdx(0)),
             "source stored by explicit-arena Vec::push_val must inherit target escapes"
+        );
+    }
+
+    #[test]
+    fn string_push_byte_parameter_receiver_publishes_growth_store_effect() {
+        let insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(
+                1,
+                Opcode::ConstI64,
+                Ty::I64,
+                vec![],
+                InstData::ConstI64(120),
+            ),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Unit,
+                vec![0, 1],
+                InstData::CallExtern("__vow_string_push_byte".to_string()),
+            ),
+            inst(3, Opcode::Return, Ty::Unit, vec![], InstData::None),
+        ];
+        let f = function(
+            0,
+            "grow_string_param",
+            vec![Ty::Ptr],
+            Ty::Unit,
+            vec![block(0, insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert!(
+            m.functions[0].summary.store_effects.iter().any(|effect| {
+                effect.target == 0 && effect.source == RegionConstraint::ConstantGlobal
+            }),
+            "String::push_byte on a parameter receiver must request that receiver's hidden arena"
         );
     }
 

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1474,6 +1474,18 @@ fn string_creation_extern(sym: &str) -> bool {
             | "__vow_string_substring_in_arena"
             | "__vow_string_from_i64"
             | "__vow_string_from_i64_in_arena"
+            | "__vow_string_split"
+            | "__vow_string_split_in_arena"
+            | "__vow_string_trim"
+            | "__vow_string_trim_in_arena"
+            | "__vow_string_to_upper"
+            | "__vow_string_to_upper_in_arena"
+            | "__vow_string_to_lower"
+            | "__vow_string_to_lower_in_arena"
+            | "__vow_string_replace"
+            | "__vow_string_replace_in_arena"
+            | "__vow_string_join"
+            | "__vow_string_join_in_arena"
     )
 }
 
@@ -4401,6 +4413,58 @@ mod tests {
             RegionId::Block(BlockId(0)),
             "String::from_cstr should be treated as a fresh heap producer"
         );
+    }
+
+    #[test]
+    fn fresh_string_runtime_helpers_non_escaping_allocate_in_block_region() {
+        let cases = [
+            ("__vow_string_split", 2),
+            ("__vow_string_trim", 1),
+            ("__vow_string_to_upper", 1),
+            ("__vow_string_to_lower", 1),
+            ("__vow_string_replace", 3),
+            ("__vow_string_join", 2),
+        ];
+
+        for (sym, arity) in cases {
+            let mut insts = vec![
+                inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+                inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+                inst(2, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(2)),
+            ];
+            let args: Vec<u32> = (0..arity).collect();
+            insts.push(inst(
+                3,
+                Opcode::Call,
+                Ty::Ptr,
+                args,
+                InstData::CallExtern(sym.to_string()),
+            ));
+            insts.push(inst(
+                4,
+                Opcode::ConstI64,
+                Ty::I64,
+                vec![],
+                InstData::ConstI64(0),
+            ));
+            insts.push(inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None));
+
+            let f = function(
+                0,
+                "fresh_string_helper",
+                vec![Ty::Ptr, Ty::Ptr, Ty::Ptr],
+                Ty::I64,
+                vec![block(0, insts)],
+            );
+            let mut m = module(vec![f]);
+            infer_regions(&mut m);
+
+            assert_eq!(
+                m.functions[0].blocks[0].insts[3].region,
+                RegionId::Block(BlockId(0)),
+                "{sym} should be treated as a fresh heap producer"
+            );
+        }
     }
 
     #[test]

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1461,8 +1461,24 @@ fn vec_creation_extern(sym: &str) -> bool {
     matches!(sym, "__vow_vec_new" | "__vow_vec_new_val")
 }
 
+fn string_creation_extern(sym: &str) -> bool {
+    matches!(
+        sym,
+        "__vow_string_new"
+            | "__vow_string_new_in_arena"
+            | "__vow_string_from_cstr"
+            | "__vow_string_from_cstr_in_arena"
+            | "__vow_string_substr"
+            | "__vow_string_substr_in_arena"
+            | "__vow_string_substring"
+            | "__vow_string_substring_in_arena"
+            | "__vow_string_from_i64"
+            | "__vow_string_from_i64_in_arena"
+    )
+}
+
 fn heap_producing_extern(sym: &str) -> bool {
-    extern_fresh_in_caller(sym) || vec_creation_extern(sym)
+    extern_fresh_in_caller(sym) || vec_creation_extern(sym) || string_creation_extern(sym)
 }
 
 fn for_each_extern_store_edge(sym: &str, args: &[InstId], mut visit: impl FnMut(InstId, InstId)) {
@@ -4337,6 +4353,68 @@ mod tests {
                 .iter()
                 .all(|d| d.code != ErrorCode::RegionConflict),
             "routable Vec creation should not trip the block-local RegionAlloc conflict"
+        );
+    }
+
+    #[test]
+    fn string_from_cstr_non_escaping_allocates_in_block_region() {
+        let insts = vec![
+            inst(0, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+            inst(
+                1,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![0],
+                InstData::CallExtern("__vow_string_from_cstr".to_string()),
+            ),
+            inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+        ];
+        let f = function(0, "make_string", vec![], Ty::I64, vec![block(0, insts)]);
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[0].blocks[0].insts[1].region,
+            RegionId::Block(BlockId(0)),
+            "String::from_cstr should be treated as a fresh heap producer"
+        );
+    }
+
+    #[test]
+    fn string_substring_return_allocates_in_caller_region() {
+        let insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(1)),
+            inst(
+                3,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![0, 1, 2],
+                InstData::CallExtern("__vow_string_substring".to_string()),
+            ),
+            inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+        ];
+        let f = function(
+            0,
+            "slice_string",
+            vec![Ty::Ptr],
+            Ty::Ptr,
+            vec![block(0, insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[0].blocks[0].insts[3].region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "returned String::substring result should be caller-region allocated"
+        );
+        assert_eq!(
+            m.functions[0].summary.return_region,
+            RegionConstraint::FreshInCaller,
+            "String::substring return should publish FreshInCaller"
         );
     }
 

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -1129,30 +1129,6 @@ unsafe fn vec_push_no_sanitize_in_arena(
     v.len += 1;
 }
 
-// Inner push that assumes the caller has already run sanitize_on_push for
-// this pointer. Used by delegating wrappers (string_push_byte) that need a
-// type-specific operation name in the rodata trap without double-sanitizing.
-unsafe fn vec_push_no_sanitize(
-    vec: *mut u8,
-    elem: *const u8,
-    elem_size: usize,
-    elem_align: usize,
-    op: &'static str,
-) {
-    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
-    unsafe { ensure_root_arena_locked() };
-    unsafe {
-        vec_push_no_sanitize_in_arena(
-            &raw mut __vow_root_arena,
-            vec,
-            elem,
-            elem_size,
-            elem_align,
-            op,
-        )
-    };
-}
-
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_len(vec: *const u8) -> usize {
     sanitize_on_read(vec as usize, 0);
@@ -1270,10 +1246,17 @@ pub unsafe extern "C" fn __vow_vec_get_ptr(
 // ---------------------------------------------------------------------------
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_new(ptr: *const i8, len: usize) -> *mut u8 {
-    let vec_ptr = __vow_vec_new(1, 1);
+pub unsafe extern "C" fn __vow_string_new_in_arena(
+    arena: *mut VowArena,
+    ptr: *const i8,
+    len: usize,
+) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::new");
+    }
+    let vec_ptr = unsafe { __vow_vec_new_in_arena(arena, 1, 1) };
     if len > 0 && !ptr.is_null() {
-        unsafe { __vow_vec_reserve(vec_ptr, len, 1, 1) };
+        unsafe { __vow_vec_reserve_in_arena(arena, vec_ptr, len, 1, 1) };
         let v = unsafe { &mut *(vec_ptr as *mut VowVec) };
         unsafe { std::ptr::copy_nonoverlapping(ptr as *const u8, v.ptr, len) };
         v.len = len;
@@ -1282,13 +1265,33 @@ pub unsafe extern "C" fn __vow_string_new(ptr: *const i8, len: usize) -> *mut u8
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_from_cstr(ptr: *const i8) -> *mut u8 {
+pub unsafe extern "C" fn __vow_string_new(ptr: *const i8, len: usize) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_new_in_arena(&raw mut __vow_root_arena, ptr, len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_from_cstr_in_arena(
+    arena: *mut VowArena,
+    ptr: *const i8,
+) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::from_cstr");
+    }
     if ptr.is_null() {
-        return __vow_vec_new(1, 1);
+        return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) };
     }
     let s = unsafe { CStr::from_ptr(ptr) };
     let bytes = s.to_bytes();
-    unsafe { __vow_string_new(ptr, bytes.len()) }
+    unsafe { __vow_string_new_in_arena(arena, ptr, bytes.len()) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_from_cstr(ptr: *const i8) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_from_cstr_in_arena(&raw mut __vow_root_arena, ptr) }
 }
 
 /// Deep-copy `source` (a `VowString` / `Vec<u8>` descriptor) into `arena`,
@@ -1356,6 +1359,9 @@ pub unsafe extern "C" fn __vow_string_from_raw_parts_copy(
     ptr: *const u8,
     len: usize,
 ) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::from_raw_parts_copy");
+    }
     let header = unsafe { __vow_arena_alloc(arena, 24, 8) } as *mut VowVec;
     if len == 0 || ptr.is_null() {
         unsafe {
@@ -1429,7 +1435,14 @@ pub unsafe extern "C" fn __vow_string_contains(haystack: *const u8, needle: *con
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_push_str(dest: *mut u8, src: *const u8) {
+pub unsafe extern "C" fn __vow_string_push_str_in_arena(
+    arena: *mut VowArena,
+    dest: *mut u8,
+    src: *const u8,
+) {
+    if arena.is_null() {
+        null_arena_trap("String::push_str");
+    }
     sanitize_on_read(dest as usize, 0);
     sanitize_on_read(src as usize, 0);
     let vd0 = unsafe { &*(dest as *const VowVec) };
@@ -1440,16 +1453,33 @@ pub unsafe extern "C" fn __vow_string_push_str(dest: *mut u8, src: *const u8) {
     if vs.len == 0 {
         return;
     }
-    unsafe { __vow_vec_reserve(dest, vs.len, 1, 1) };
+    unsafe { __vow_vec_reserve_in_arena(arena, dest, vs.len, 1, 1) };
     let vd = unsafe { &mut *(dest as *mut VowVec) };
     unsafe { std::ptr::copy_nonoverlapping(vs.ptr, vd.ptr.add(vd.len), vs.len) };
     vd.len += vs.len;
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_from_i64(v: i64) -> *mut u8 {
+pub unsafe extern "C" fn __vow_string_push_str(dest: *mut u8, src: *const u8) {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_push_str_in_arena(&raw mut __vow_root_arena, dest, src) };
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_from_i64_in_arena(arena: *mut VowArena, v: i64) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::from_i64");
+    }
     let s = v.to_string();
-    unsafe { __vow_string_new(s.as_ptr() as *const i8, s.len()) }
+    unsafe { __vow_string_new_in_arena(arena, s.as_ptr() as *const i8, s.len()) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_from_i64(v: i64) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_from_i64_in_arena(&raw mut __vow_root_arena, v) }
 }
 
 #[unsafe(no_mangle)]
@@ -1473,14 +1503,28 @@ pub unsafe extern "C" fn __vow_string_byte_at(s: *const u8, idx: i64) -> i64 {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_push_byte(s: *mut u8, byte: i64) {
+pub unsafe extern "C" fn __vow_string_push_byte_in_arena(
+    arena: *mut VowArena,
+    s: *mut u8,
+    byte: i64,
+) {
+    if arena.is_null() {
+        null_arena_trap("String::push_byte");
+    }
     // Sanitize once here, then delegate to the no-sanitize inner helper with
     // a type-specific operation name. This keeps both orderings correct:
     // sanitizer runs before any dereference (UAF detected first), and the
     // shadow table records a single generation for the one appended byte.
     sanitize_on_push(s as usize);
     let b = byte as u8;
-    unsafe { vec_push_no_sanitize(s, &b as *const u8, 1, 1, "String::push_byte") };
+    unsafe { vec_push_no_sanitize_in_arena(arena, s, &b as *const u8, 1, 1, "String::push_byte") };
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_push_byte(s: *mut u8, byte: i64) {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_push_byte_in_arena(&raw mut __vow_root_arena, s, byte) };
 }
 
 // ---------------------------------------------------------------------------
@@ -1488,9 +1532,17 @@ pub unsafe extern "C" fn __vow_string_push_byte(s: *mut u8, byte: i64) {
 // ---------------------------------------------------------------------------
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_substr(s: *const u8, start: i64, len: i64) -> *mut u8 {
+pub unsafe extern "C" fn __vow_string_substr_in_arena(
+    arena: *mut VowArena,
+    s: *const u8,
+    start: i64,
+    len: i64,
+) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::substr");
+    }
     if s.is_null() {
-        return __vow_vec_new(1, 1);
+        return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) };
     }
     sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
@@ -1498,13 +1550,34 @@ pub unsafe extern "C" fn __vow_string_substr(s: *const u8, start: i64, len: i64)
     let clamped_start = start.clamp(0, slen) as usize;
     let clamped_len = len.clamp(0, slen - clamped_start as i64) as usize;
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
-    unsafe { __vow_string_new(bytes[clamped_start..].as_ptr() as *const i8, clamped_len) }
+    unsafe {
+        __vow_string_new_in_arena(
+            arena,
+            bytes[clamped_start..].as_ptr() as *const i8,
+            clamped_len,
+        )
+    }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_substring(s: *const u8, start: i64, end: i64) -> *mut u8 {
+pub unsafe extern "C" fn __vow_string_substr(s: *const u8, start: i64, len: i64) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_substr_in_arena(&raw mut __vow_root_arena, s, start, len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_substring_in_arena(
+    arena: *mut VowArena,
+    s: *const u8,
+    start: i64,
+    end: i64,
+) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::substring");
+    }
     if s.is_null() {
-        return __vow_vec_new(1, 1);
+        return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) };
     }
     sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
@@ -1513,7 +1586,14 @@ pub unsafe extern "C" fn __vow_string_substring(s: *const u8, start: i64, end: i
     let clamped_end = end.clamp(clamped_start as i64, slen) as usize;
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let len = clamped_end - clamped_start;
-    unsafe { __vow_string_new(bytes[clamped_start..].as_ptr() as *const i8, len) }
+    unsafe { __vow_string_new_in_arena(arena, bytes[clamped_start..].as_ptr() as *const i8, len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_substring(s: *const u8, start: i64, end: i64) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_substring_in_arena(&raw mut __vow_root_arena, s, start, end) }
 }
 
 #[unsafe(no_mangle)]
@@ -3321,6 +3401,39 @@ mod tests {
     }
 
     #[test]
+    fn explicit_arena_string_constructors_and_growth() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+
+        let hello = unsafe { __vow_string_new_in_arena(&mut a, c"hello".as_ptr(), "hello".len()) };
+        let comma = unsafe { __vow_string_from_cstr_in_arena(&mut a, c", ".as_ptr()) };
+        unsafe { __vow_string_push_str_in_arena(&mut a, hello, comma) };
+        unsafe { __vow_string_push_byte_in_arena(&mut a, hello, b'w' as i64) };
+
+        let header = unsafe { &*(hello as *const VowVec) };
+        let bytes = unsafe { std::slice::from_raw_parts(header.ptr, header.len) };
+        assert_eq!(bytes, b"hello, w");
+
+        let sub = unsafe { __vow_string_substring_in_arena(&mut a, hello, 7, 8) };
+        let sub_header = unsafe { &*(sub as *const VowVec) };
+        let sub_bytes = unsafe { std::slice::from_raw_parts(sub_header.ptr, sub_header.len) };
+        assert_eq!(sub_bytes, b"w");
+
+        let tail = unsafe { __vow_string_substr_in_arena(&mut a, hello, 5, 3) };
+        let tail_header = unsafe { &*(tail as *const VowVec) };
+        let tail_bytes = unsafe { std::slice::from_raw_parts(tail_header.ptr, tail_header.len) };
+        assert_eq!(tail_bytes, b", w");
+
+        let digits = unsafe { __vow_string_from_i64_in_arena(&mut a, -42) };
+        let digits_header = unsafe { &*(digits as *const VowVec) };
+        let digits_bytes =
+            unsafe { std::slice::from_raw_parts(digits_header.ptr, digits_header.len) };
+        assert_eq!(digits_bytes, b"-42");
+
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
     fn string_clone_into_arena_copies_bytes() {
         // Phase 4 / S5 return materialization: clones a String descriptor's
         // backing into the supplied arena, returning a fresh, mutable
@@ -3630,6 +3743,65 @@ mod tests {
             eprintln!("rodata_trap_worker: null arena push did NOT trap");
             std::process::exit(42);
         }
+        if op == "String::new_in_arena_null" {
+            let _ = unsafe { __vow_string_new_in_arena(std::ptr::null_mut(), c"x".as_ptr(), 1) };
+            eprintln!("rodata_trap_worker: null arena string constructor did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::from_cstr_in_arena_null" {
+            let _ = unsafe { __vow_string_from_cstr_in_arena(std::ptr::null_mut(), c"x".as_ptr()) };
+            eprintln!("rodata_trap_worker: null arena string from_cstr did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::push_str_in_arena_null" {
+            let mut dest = VowVec {
+                ptr: 8 as *mut u8,
+                len: 0,
+                cap: 0,
+            };
+            let src = VowVec {
+                ptr: 8 as *mut u8,
+                len: 0,
+                cap: 0,
+            };
+            unsafe {
+                __vow_string_push_str_in_arena(
+                    std::ptr::null_mut(),
+                    &mut dest as *mut _ as *mut u8,
+                    &src as *const _ as *const u8,
+                )
+            };
+            eprintln!("rodata_trap_worker: null arena string push_str did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::push_byte_in_arena_null" {
+            let mut s = VowVec {
+                ptr: 8 as *mut u8,
+                len: 0,
+                cap: 0,
+            };
+            unsafe {
+                __vow_string_push_byte_in_arena(
+                    std::ptr::null_mut(),
+                    &mut s as *mut _ as *mut u8,
+                    b'x' as i64,
+                )
+            };
+            eprintln!("rodata_trap_worker: null arena string push_byte did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::substring_in_arena_null" {
+            let _ = unsafe {
+                __vow_string_substring_in_arena(std::ptr::null_mut(), std::ptr::null(), 0, 0)
+            };
+            eprintln!("rodata_trap_worker: null arena string substring did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::from_i64_in_arena_null" {
+            let _ = unsafe { __vow_string_from_i64_in_arena(std::ptr::null_mut(), 1) };
+            eprintln!("rodata_trap_worker: null arena string from_i64 did NOT trap");
+            std::process::exit(42);
+        }
         let mut v = make_rodata_vec_val();
         let vp = &mut v as *mut _ as *mut u8;
         let mut m = make_rodata_map();
@@ -3748,6 +3920,36 @@ mod tests {
     #[test]
     fn explicit_arena_vec_push_null_arena_traps() {
         assert_runtime_invariant_null_arena("Vec::push_in_arena_null", "Vec::push");
+    }
+
+    #[test]
+    fn explicit_arena_string_new_null_arena_traps() {
+        assert_runtime_invariant_null_arena("String::new_in_arena_null", "String::new");
+    }
+
+    #[test]
+    fn explicit_arena_string_from_cstr_null_arena_traps() {
+        assert_runtime_invariant_null_arena("String::from_cstr_in_arena_null", "String::from_cstr");
+    }
+
+    #[test]
+    fn explicit_arena_string_push_str_null_arena_traps() {
+        assert_runtime_invariant_null_arena("String::push_str_in_arena_null", "String::push_str");
+    }
+
+    #[test]
+    fn explicit_arena_string_push_byte_null_arena_traps() {
+        assert_runtime_invariant_null_arena("String::push_byte_in_arena_null", "String::push_byte");
+    }
+
+    #[test]
+    fn explicit_arena_string_substring_null_arena_traps() {
+        assert_runtime_invariant_null_arena("String::substring_in_arena_null", "String::substring");
+    }
+
+    #[test]
+    fn explicit_arena_string_from_i64_null_arena_traps() {
+        assert_runtime_invariant_null_arena("String::from_i64_in_arena_null", "String::from_i64");
     }
 
     #[test]

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -1597,8 +1597,15 @@ pub unsafe extern "C" fn __vow_string_substring(s: *const u8, start: i64, end: i
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_split(haystack: *const u8, separator: *const u8) -> *mut u8 {
-    let result_vec = __vow_vec_new_val();
+pub unsafe extern "C" fn __vow_string_split_in_arena(
+    arena: *mut VowArena,
+    haystack: *const u8,
+    separator: *const u8,
+) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::split");
+    }
+    let result_vec = unsafe { __vow_vec_new_val_in_arena(arena) };
     if haystack.is_null() || separator.is_null() {
         return result_vec;
     }
@@ -1610,26 +1617,36 @@ pub unsafe extern "C" fn __vow_string_split(haystack: *const u8, separator: *con
     let s = unsafe { std::slice::from_raw_parts(vs.ptr, vs.len) };
 
     if s.is_empty() {
-        let str_vec = unsafe { __vow_string_new(h.as_ptr() as *const i8, h.len()) } as i64;
-        unsafe { __vow_vec_push_val(result_vec, str_vec) };
+        let str_vec =
+            unsafe { __vow_string_new_in_arena(arena, h.as_ptr() as *const i8, h.len()) } as i64;
+        unsafe { __vow_vec_push_val_in_arena(arena, result_vec, str_vec) };
         return result_vec;
     }
 
     let mut start = 0;
     while start <= h.len() {
         if let Some(pos) = h[start..].windows(s.len()).position(|w| w == s) {
-            let piece = unsafe { __vow_string_new(h[start..].as_ptr() as *const i8, pos) } as i64;
-            unsafe { __vow_vec_push_val(result_vec, piece) };
+            let piece =
+                unsafe { __vow_string_new_in_arena(arena, h[start..].as_ptr() as *const i8, pos) }
+                    as i64;
+            unsafe { __vow_vec_push_val_in_arena(arena, result_vec, piece) };
             start += pos + s.len();
         } else {
-            let piece =
-                unsafe { __vow_string_new(h[start..].as_ptr() as *const i8, h.len() - start) }
-                    as i64;
-            unsafe { __vow_vec_push_val(result_vec, piece) };
+            let piece = unsafe {
+                __vow_string_new_in_arena(arena, h[start..].as_ptr() as *const i8, h.len() - start)
+            } as i64;
+            unsafe { __vow_vec_push_val_in_arena(arena, result_vec, piece) };
             break;
         }
     }
     result_vec
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_split(haystack: *const u8, separator: *const u8) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_split_in_arena(&raw mut __vow_root_arena, haystack, separator) }
 }
 
 #[unsafe(no_mangle)]
@@ -1661,58 +1678,98 @@ pub unsafe extern "C" fn __vow_string_ends_with(s: *const u8, suffix: *const u8)
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_trim(s: *const u8) -> *mut u8 {
+pub unsafe extern "C" fn __vow_string_trim_in_arena(arena: *mut VowArena, s: *const u8) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::trim");
+    }
     if s.is_null() {
-        return __vow_vec_new(1, 1);
+        return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) };
     }
     sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let trimmed = match std::str::from_utf8(bytes) {
         Ok(s) => s.trim(),
-        Err(_) => return __vow_vec_new(1, 1),
+        Err(_) => return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) },
     };
-    unsafe { __vow_string_new(trimmed.as_ptr() as *const i8, trimmed.len()) }
+    unsafe { __vow_string_new_in_arena(arena, trimmed.as_ptr() as *const i8, trimmed.len()) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_to_upper(s: *const u8) -> *mut u8 {
+pub unsafe extern "C" fn __vow_string_trim(s: *const u8) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_trim_in_arena(&raw mut __vow_root_arena, s) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_to_upper_in_arena(
+    arena: *mut VowArena,
+    s: *const u8,
+) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::to_upper");
+    }
     if s.is_null() {
-        return __vow_vec_new(1, 1);
+        return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) };
     }
     sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let upper = match std::str::from_utf8(bytes) {
         Ok(s) => s.to_uppercase(),
-        Err(_) => return __vow_vec_new(1, 1),
+        Err(_) => return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) },
     };
-    unsafe { __vow_string_new(upper.as_ptr() as *const i8, upper.len()) }
+    unsafe { __vow_string_new_in_arena(arena, upper.as_ptr() as *const i8, upper.len()) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_to_lower(s: *const u8) -> *mut u8 {
+pub unsafe extern "C" fn __vow_string_to_upper(s: *const u8) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_to_upper_in_arena(&raw mut __vow_root_arena, s) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_to_lower_in_arena(
+    arena: *mut VowArena,
+    s: *const u8,
+) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::to_lower");
+    }
     if s.is_null() {
-        return __vow_vec_new(1, 1);
+        return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) };
     }
     sanitize_on_read(s as usize, 0);
     let v = unsafe { &*(s as *const VowVec) };
     let bytes = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
     let lower = match std::str::from_utf8(bytes) {
         Ok(s) => s.to_lowercase(),
-        Err(_) => return __vow_vec_new(1, 1),
+        Err(_) => return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) },
     };
-    unsafe { __vow_string_new(lower.as_ptr() as *const i8, lower.len()) }
+    unsafe { __vow_string_new_in_arena(arena, lower.as_ptr() as *const i8, lower.len()) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_replace(
+pub unsafe extern "C" fn __vow_string_to_lower(s: *const u8) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_to_lower_in_arena(&raw mut __vow_root_arena, s) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_replace_in_arena(
+    arena: *mut VowArena,
     s: *const u8,
     from: *const u8,
     to: *const u8,
 ) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::replace");
+    }
     if s.is_null() || from.is_null() || to.is_null() {
-        return __vow_vec_new(1, 1);
+        return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) };
     }
     sanitize_on_read(s as usize, 0);
     sanitize_on_read(from as usize, 0);
@@ -1729,30 +1786,55 @@ pub unsafe extern "C" fn __vow_string_replace(
         std::str::from_utf8(st),
     ) {
         (Ok(a), Ok(b), Ok(c)) => (a, b, c),
-        _ => return __vow_vec_new(1, 1),
+        _ => return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) },
     };
     let result = ss_str.replace(sf_str, st_str);
-    unsafe { __vow_string_new(result.as_ptr() as *const i8, result.len()) }
+    unsafe { __vow_string_new_in_arena(arena, result.as_ptr() as *const i8, result.len()) }
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_string_join(vec_ptr: *const u8, sep: *const u8) -> *mut u8 {
+pub unsafe extern "C" fn __vow_string_replace(
+    s: *const u8,
+    from: *const u8,
+    to: *const u8,
+) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_replace_in_arena(&raw mut __vow_root_arena, s, from, to) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_join_in_arena(
+    arena: *mut VowArena,
+    vec_ptr: *const u8,
+    sep: *const u8,
+) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("String::join");
+    }
     if vec_ptr.is_null() || sep.is_null() {
-        return __vow_vec_new(1, 1);
+        return unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) };
     }
     sanitize_on_read(vec_ptr as usize, 0);
     sanitize_on_read(sep as usize, 0);
     let v = unsafe { &*(vec_ptr as *const VowVec) };
     let ptrs = unsafe { std::slice::from_raw_parts(v.ptr as *const i64, v.len) };
 
-    let result = __vow_vec_new(1, 1);
+    let result = unsafe { __vow_string_new_in_arena(arena, std::ptr::null(), 0) };
     for (i, &str_ptr) in ptrs.iter().enumerate() {
         if i > 0 {
-            unsafe { __vow_string_push_str(result, sep) };
+            unsafe { __vow_string_push_str_in_arena(arena, result, sep) };
         }
-        unsafe { __vow_string_push_str(result, str_ptr as *const u8) };
+        unsafe { __vow_string_push_str_in_arena(arena, result, str_ptr as *const u8) };
     }
     result
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_string_join(vec_ptr: *const u8, sep: *const u8) -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_string_join_in_arena(&raw mut __vow_root_arena, vec_ptr, sep) }
 }
 
 #[unsafe(no_mangle)]
@@ -3809,6 +3891,53 @@ mod tests {
             eprintln!("rodata_trap_worker: null arena string from_i64 did NOT trap");
             std::process::exit(42);
         }
+        if op == "String::split_in_arena_null" {
+            let _ = unsafe {
+                __vow_string_split_in_arena(
+                    std::ptr::null_mut(),
+                    std::ptr::null(),
+                    std::ptr::null(),
+                )
+            };
+            eprintln!("rodata_trap_worker: null arena string split did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::trim_in_arena_null" {
+            let _ = unsafe { __vow_string_trim_in_arena(std::ptr::null_mut(), std::ptr::null()) };
+            eprintln!("rodata_trap_worker: null arena string trim did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::to_upper_in_arena_null" {
+            let _ =
+                unsafe { __vow_string_to_upper_in_arena(std::ptr::null_mut(), std::ptr::null()) };
+            eprintln!("rodata_trap_worker: null arena string to_upper did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::to_lower_in_arena_null" {
+            let _ =
+                unsafe { __vow_string_to_lower_in_arena(std::ptr::null_mut(), std::ptr::null()) };
+            eprintln!("rodata_trap_worker: null arena string to_lower did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::replace_in_arena_null" {
+            let _ = unsafe {
+                __vow_string_replace_in_arena(
+                    std::ptr::null_mut(),
+                    std::ptr::null(),
+                    std::ptr::null(),
+                    std::ptr::null(),
+                )
+            };
+            eprintln!("rodata_trap_worker: null arena string replace did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "String::join_in_arena_null" {
+            let _ = unsafe {
+                __vow_string_join_in_arena(std::ptr::null_mut(), std::ptr::null(), std::ptr::null())
+            };
+            eprintln!("rodata_trap_worker: null arena string join did NOT trap");
+            std::process::exit(42);
+        }
         let mut v = make_rodata_vec_val();
         let vp = &mut v as *mut _ as *mut u8;
         let mut m = make_rodata_map();
@@ -3962,6 +4091,21 @@ mod tests {
     #[test]
     fn explicit_arena_string_from_i64_null_arena_traps() {
         assert_runtime_invariant_null_arena("String::from_i64_in_arena_null", "String::from_i64");
+    }
+
+    #[test]
+    fn explicit_arena_string_fresh_helper_null_arena_traps() {
+        let cases = [
+            ("String::split_in_arena_null", "String::split"),
+            ("String::trim_in_arena_null", "String::trim"),
+            ("String::to_upper_in_arena_null", "String::to_upper"),
+            ("String::to_lower_in_arena_null", "String::to_lower"),
+            ("String::replace_in_arena_null", "String::replace"),
+            ("String::join_in_arena_null", "String::join"),
+        ];
+        for (op, expected) in cases {
+            assert_runtime_invariant_null_arena(op, expected);
+        }
     }
 
     #[test]

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -3790,6 +3790,13 @@ mod tests {
             eprintln!("rodata_trap_worker: null arena string push_byte did NOT trap");
             std::process::exit(42);
         }
+        if op == "String::substr_in_arena_null" {
+            let _ = unsafe {
+                __vow_string_substr_in_arena(std::ptr::null_mut(), std::ptr::null(), 0, 0)
+            };
+            eprintln!("rodata_trap_worker: null arena string substr did NOT trap");
+            std::process::exit(42);
+        }
         if op == "String::substring_in_arena_null" {
             let _ = unsafe {
                 __vow_string_substring_in_arena(std::ptr::null_mut(), std::ptr::null(), 0, 0)
@@ -3940,6 +3947,11 @@ mod tests {
     #[test]
     fn explicit_arena_string_push_byte_null_arena_traps() {
         assert_runtime_invariant_null_arena("String::push_byte_in_arena_null", "String::push_byte");
+    }
+
+    #[test]
+    fn explicit_arena_string_substr_null_arena_traps() {
+        assert_runtime_invariant_null_arena("String::substr_in_arena_null", "String::substr");
     }
 
     #[test]

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -339,7 +339,7 @@ pub fn is_modelable(
     }
 
     let vec_vars = collect_typed_vars(func, "__vow_vec_new", "__vow_vec_");
-    let string_vars = collect_typed_vars(func, "__vow_string_from_cstr", "__vow_string_");
+    let string_vars = collect_typed_vars(func, "__vow_string_new", "__vow_string_");
     let hashmap_vars = collect_typed_vars(func, "__vow_map_new", "__vow_map_");
     let btreemap_vars = collect_typed_vars(func, "__vow_btreemap_new", "__vow_btreemap_");
     let option_vars = collect_option_vars(func);
@@ -1533,7 +1533,7 @@ pub fn emit_c_function_full(
 ) -> String {
     let mut out = String::new();
     let vec_vars = collect_typed_vars(func, "__vow_vec_new", "__vow_vec_");
-    let string_vars = collect_typed_vars(func, "__vow_string_from_cstr", "__vow_string_");
+    let string_vars = collect_typed_vars(func, "__vow_string_new", "__vow_string_");
     let hashmap_vars = collect_typed_vars(func, "__vow_map_new", "__vow_map_");
     let btreemap_vars = collect_typed_vars(func, "__vow_btreemap_new", "__vow_btreemap_");
     let option_vars = collect_option_vars(func);

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -136,9 +136,14 @@ fn vec_model_receiver_arg(name: &str) -> Option<usize> {
 
 fn string_model_receiver_arg(name: &str) -> Option<usize> {
     match name {
-        "__vow_string_push_str_in_arena" | "__vow_string_push_byte_in_arena" => Some(1),
+        "__vow_string_push_str_in_arena"
+        | "__vow_string_push_byte_in_arena"
+        | "__vow_string_substr_in_arena"
+        | "__vow_string_substring_in_arena" => Some(1),
         "__vow_string_push_str"
         | "__vow_string_push_byte"
+        | "__vow_string_substr"
+        | "__vow_string_substring"
         | "__vow_string_len"
         | "__vow_string_clear"
         | "__vow_string_byte_at"
@@ -162,7 +167,8 @@ fn collect_typed_vars(func: &Function, creator: &str, prefix: &str) -> HashSet<u
                 let is_creator = name == creator || is_alt_creator;
                 if is_creator {
                     vars.insert(inst.id.0);
-                } else if name.starts_with(prefix) {
+                }
+                if name.starts_with(prefix) {
                     let receiver_arg = if prefix == "__vow_vec_" {
                         vec_model_receiver_arg(name)
                     } else if prefix == "__vow_string_" {
@@ -3399,6 +3405,103 @@ mod tests {
         );
         assert!(!c.contains("v0.keys = "), "no keys assignment: {c}");
         assert!(!c.contains("v0.vals = "), "no vals assignment: {c}");
+    }
+
+    #[test]
+    fn emit_string_substring_marks_parameter_receiver_as_string() {
+        use vow_ir::InstId;
+        let func = Function {
+            id: FuncId(0),
+            name: "slice_param".to_string(),
+            params: vec![Ty::Ptr],
+            param_names: vec!["s".to_string()],
+            return_ty: Ty::Ptr,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+                    inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(1)),
+                    Inst {
+                        id: InstId(3),
+                        opcode: Opcode::Call,
+                        ty: Ty::Ptr,
+                        args: vec![InstId(0), InstId(1), InstId(2)],
+                        data: InstData::CallExtern("__vow_string_substring".to_string()),
+                        origin: sp(),
+                        region: RegionId::Root,
+                    },
+                    inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        assert!(
+            c.contains("__vow_string_t v0;"),
+            "substring source receiver must be emitted as a String model value: {c}"
+        );
+        assert!(
+            !c.contains("int64_t v0;"),
+            "substring source receiver must not be emitted as scalar int64_t: {c}"
+        );
+        assert!(
+            c.contains("v3.len = v2 - v1"),
+            "substring result model should still be emitted: {c}"
+        );
+    }
+
+    #[test]
+    fn emit_string_substr_in_arena_marks_shifted_receiver_as_string() {
+        use vow_ir::InstId;
+        let func = Function {
+            id: FuncId(0),
+            name: "arena_slice_param".to_string(),
+            params: vec![Ty::Ptr],
+            param_names: vec!["s".to_string()],
+            return_ty: Ty::Ptr,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+                    inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(3, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(1)),
+                    Inst {
+                        id: InstId(4),
+                        opcode: Opcode::Call,
+                        ty: Ty::Ptr,
+                        args: vec![InstId(0), InstId(1), InstId(2), InstId(3)],
+                        data: InstData::CallExtern("__vow_string_substr_in_arena".to_string()),
+                        origin: sp(),
+                        region: RegionId::Root,
+                    },
+                    inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        assert!(
+            c.contains("__vow_string_t v1;"),
+            "arena substr source receiver must be emitted as a String model value: {c}"
+        );
+        assert!(
+            !c.contains("int64_t v1;"),
+            "arena substr source receiver must not be emitted as scalar int64_t: {c}"
+        );
+        assert!(
+            c.contains("v4.len = v3"),
+            "substr result model should still be emitted: {c}"
+        );
     }
 
     #[test]

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -105,6 +105,24 @@ fn is_vec_model_creator(name: &str) -> bool {
     )
 }
 
+fn is_string_model_creator(name: &str) -> bool {
+    matches!(
+        name,
+        "__vow_string_new"
+            | "__vow_string_new_in_arena"
+            | "__vow_string_from_cstr"
+            | "__vow_string_from_cstr_in_arena"
+            | "__vow_string_from_raw_parts_copy"
+            | "__vow_string_pin_to_root"
+            | "__vow_string_substr"
+            | "__vow_string_substr_in_arena"
+            | "__vow_string_substring"
+            | "__vow_string_substring_in_arena"
+            | "__vow_string_from_i64"
+            | "__vow_string_from_i64_in_arena"
+    )
+}
+
 fn vec_model_receiver_arg(name: &str) -> Option<usize> {
     match name {
         "__vow_vec_push_val" | "__vow_vec_get_val" | "__vow_vec_len" | "__vow_vec_pop"
@@ -112,6 +130,21 @@ fn vec_model_receiver_arg(name: &str) -> Option<usize> {
         "__vow_vec_push_in_arena"
         | "__vow_vec_push_val_in_arena"
         | "__vow_vec_reserve_in_arena" => Some(1),
+        _ => None,
+    }
+}
+
+fn string_model_receiver_arg(name: &str) -> Option<usize> {
+    match name {
+        "__vow_string_push_str_in_arena" | "__vow_string_push_byte_in_arena" => Some(1),
+        "__vow_string_push_str"
+        | "__vow_string_push_byte"
+        | "__vow_string_len"
+        | "__vow_string_clear"
+        | "__vow_string_byte_at"
+        | "__vow_string_eq"
+        | "__vow_string_contains"
+        | "__vow_string_print" => Some(0),
         _ => None,
     }
 }
@@ -124,20 +157,16 @@ fn collect_typed_vars(func: &Function, creator: &str, prefix: &str) -> HashSet<u
             if inst.opcode == Opcode::Call
                 && let InstData::CallExtern(ref name) = inst.data
             {
-                let is_alt_creator = (prefix == "__vow_vec_"
-                    && (name == "__vow_vec_from_raw_parts_copy_val"
-                        || name == "__vow_vec_pin_to_root_val"))
-                    || (prefix == "__vow_string_"
-                        && (name == "__vow_string_from_raw_parts_copy"
-                            || name == "__vow_string_pin_to_root"));
-                let is_creator = name == creator
-                    || is_alt_creator
-                    || (prefix == "__vow_vec_" && is_vec_model_creator(name));
+                let is_alt_creator = (prefix == "__vow_vec_" && is_vec_model_creator(name))
+                    || (prefix == "__vow_string_" && is_string_model_creator(name));
+                let is_creator = name == creator || is_alt_creator;
                 if is_creator {
                     vars.insert(inst.id.0);
                 } else if name.starts_with(prefix) {
                     let receiver_arg = if prefix == "__vow_vec_" {
                         vec_model_receiver_arg(name)
+                    } else if prefix == "__vow_string_" {
+                        string_model_receiver_arg(name)
                     } else {
                         Some(0)
                     };
@@ -239,17 +268,27 @@ fn is_known_builtin(name: &str) -> bool {
             | "__vow_vec_len"
             | "__vow_vec_pop"
             | "__vow_vec_set_val"
+            | "__vow_string_new"
+            | "__vow_string_new_in_arena"
             | "__vow_string_from_cstr"
+            | "__vow_string_from_cstr_in_arena"
             | "__vow_string_from_raw_parts_copy"
             | "__vow_string_pin_to_root"
             | "__vow_string_len"
             | "__vow_string_push_str"
+            | "__vow_string_push_str_in_arena"
             | "__vow_string_push_byte"
+            | "__vow_string_push_byte_in_arena"
             | "__vow_string_clear"
             | "__vow_string_byte_at"
             | "__vow_string_eq"
             | "__vow_string_contains"
+            | "__vow_string_substr"
+            | "__vow_string_substr_in_arena"
             | "__vow_string_substring"
+            | "__vow_string_substring_in_arena"
+            | "__vow_string_from_i64"
+            | "__vow_string_from_i64_in_arena"
             | "__vow_string_parse_i64_opt"
             | "__vow_string_parse_u64_opt"
             | "__vow_string_print"
@@ -926,7 +965,19 @@ fn emit_inst(
         Opcode::Call if matches!(&inst.data, InstData::CallExtern(n) if n.starts_with("__vow_string_")) => {
             if let InstData::CallExtern(ref name) = inst.data {
                 match name.as_str() {
-                    "__vow_string_from_cstr" => {
+                    "__vow_string_new" | "__vow_string_new_in_arena" => {
+                        let len_arg = if name == "__vow_string_new_in_arena" {
+                            2
+                        } else {
+                            1
+                        };
+                        let len = inst.args[len_arg].0;
+                        let string_max = limits.string_max;
+                        out.push_str(&format!(
+                            "  __ESBMC_assume(v{len} >= 0 && v{len} < {string_max});\n  v{id}.len = v{len};\n"
+                        ));
+                    }
+                    "__vow_string_from_cstr" | "__vow_string_from_cstr_in_arena" => {
                         let string_max = limits.string_max;
                         out.push_str(&format!(
                             "  v{id}.len = __VERIFIER_nondet_long();\n\
@@ -948,9 +999,21 @@ fn emit_inst(
                         let s = inst.args[0].0;
                         out.push_str(&format!("  v{id} = v{s}.len;\n"));
                     }
-                    "__vow_string_push_str" => {
-                        let dest = inst.args[0].0;
-                        let src = inst.args[1].0;
+                    "__vow_string_from_i64" | "__vow_string_from_i64_in_arena" => {
+                        let string_max = limits.string_max;
+                        out.push_str(&format!(
+                            "  v{id}.len = __VERIFIER_nondet_long();\n\
+                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {string_max});\n",
+                        ));
+                    }
+                    "__vow_string_push_str" | "__vow_string_push_str_in_arena" => {
+                        let (dest_arg, src_arg) = if name == "__vow_string_push_str_in_arena" {
+                            (1, 2)
+                        } else {
+                            (0, 1)
+                        };
+                        let dest = inst.args[dest_arg].0;
+                        let src = inst.args[src_arg].0;
                         let string_max = limits.string_max;
                         out.push_str(&format!(
                             "  __ESBMC_assert(v{dest}.len + v{src}.len <= {string_max}, \"string capacity\");\n\
@@ -958,9 +1021,14 @@ fn emit_inst(
                         ));
                         emit_string_eq_invalidate(dest, eq_pairs, out);
                     }
-                    "__vow_string_push_byte" => {
-                        let s = inst.args[0].0;
-                        let byte = inst.args[1].0;
+                    "__vow_string_push_byte" | "__vow_string_push_byte_in_arena" => {
+                        let (s_arg, byte_arg) = if name == "__vow_string_push_byte_in_arena" {
+                            (1, 2)
+                        } else {
+                            (0, 1)
+                        };
+                        let s = inst.args[s_arg].0;
+                        let byte = inst.args[byte_arg].0;
                         let string_max = limits.string_max;
                         out.push_str(&format!(
                             "  __ESBMC_assert(v{s}.len < {string_max}, \"string capacity\");\n\
@@ -1012,10 +1080,36 @@ fn emit_inst(
                              \x20 }}\n"
                         ));
                     }
-                    "__vow_string_substring" => {
-                        let s = inst.args[0].0;
-                        let start = inst.args[1].0;
-                        let end = inst.args[2].0;
+                    "__vow_string_substr" | "__vow_string_substr_in_arena" => {
+                        let (s_arg, start_arg, len_arg) = if name == "__vow_string_substr_in_arena"
+                        {
+                            (1, 2, 3)
+                        } else {
+                            (0, 1, 2)
+                        };
+                        let s = inst.args[s_arg].0;
+                        let start = inst.args[start_arg].0;
+                        let len = inst.args[len_arg].0;
+                        let string_max = limits.string_max;
+                        out.push_str(&format!(
+                            "  __ESBMC_assert(v{start} >= 0 && v{start} <= v{s}.len, \"substr start\");\n\
+                             \x20 __ESBMC_assert(v{len} >= 0 && v{start} + v{len} <= v{s}.len, \"substr len\");\n\
+                             \x20 v{id}.len = v{len};\n\
+                             \x20 for (int64_t __i = 0; __i < v{id}.len && __i < {string_max}; __i++) {{\n\
+                             \x20   v{id}.data[__i] = v{s}.data[v{start} + __i];\n\
+                             \x20 }}\n",
+                        ));
+                    }
+                    "__vow_string_substring" | "__vow_string_substring_in_arena" => {
+                        let (s_arg, start_arg, end_arg) =
+                            if name == "__vow_string_substring_in_arena" {
+                                (1, 2, 3)
+                            } else {
+                                (0, 1, 2)
+                            };
+                        let s = inst.args[s_arg].0;
+                        let start = inst.args[start_arg].0;
+                        let end = inst.args[end_arg].0;
                         let string_max = limits.string_max;
                         out.push_str(&format!(
                             "  __ESBMC_assert(v{start} >= 0 && v{start} <= v{s}.len, \"substring start\");\n\
@@ -3660,6 +3754,66 @@ mod tests {
             "push_str capacity expression: {c}"
         );
         assert!(c.contains("v1.len += v3.len;"), "push_str mutation: {c}");
+    }
+
+    #[test]
+    fn emit_explicit_arena_string_from_cstr_and_push_str() {
+        use vow_ir::InstId;
+        let func = make_func(
+            "cat_in_arena",
+            vec![],
+            Ty::Ptr,
+            vec![
+                inst(
+                    0,
+                    Opcode::ConstI64,
+                    Ty::I64,
+                    vec![],
+                    InstData::ConstI64(1000),
+                ),
+                inst(1, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(0)),
+                Inst {
+                    id: InstId(2),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(0), InstId(1)],
+                    data: InstData::CallExtern("__vow_string_from_cstr_in_arena".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(3, Opcode::ConstStr, Ty::Ptr, vec![], InstData::ConstStr(1)),
+                Inst {
+                    id: InstId(4),
+                    opcode: Opcode::Call,
+                    ty: Ty::Ptr,
+                    args: vec![InstId(0), InstId(3)],
+                    data: InstData::CallExtern("__vow_string_from_cstr_in_arena".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                Inst {
+                    id: InstId(5),
+                    opcode: Opcode::Call,
+                    ty: Ty::Unit,
+                    args: vec![InstId(0), InstId(2), InstId(4)],
+                    data: InstData::CallExtern("__vow_string_push_str_in_arena".to_string()),
+                    origin: sp(),
+                    region: RegionId::Root,
+                },
+                inst(6, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+            ],
+        );
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        assert!(c.contains("__vow_string_t v2;"), "dest string decl: {c}");
+        assert!(c.contains("__vow_string_t v4;"), "src string decl: {c}");
+        assert!(
+            !c.contains("__vow_string_t v0;"),
+            "arena pointer must not be tracked as a string: {c}"
+        );
+        assert!(
+            c.contains("v2.len += v4.len;"),
+            "arena push_str must use shifted dest/src args: {c}"
+        );
     }
 
     #[test]

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -1098,11 +1098,16 @@ fn emit_inst(
                         let len = inst.args[len_arg].0;
                         let string_max = limits.string_max;
                         out.push_str(&format!(
-                            "  __ESBMC_assert(v{start} >= 0 && v{start} <= v{s}.len, \"substr start\");\n\
-                             \x20 __ESBMC_assert(v{len} >= 0 && v{start} + v{len} <= v{s}.len, \"substr len\");\n\
-                             \x20 v{id}.len = v{len};\n\
+                            "  int64_t __substr_start_{id} = v{start};\n\
+                             \x20 if (__substr_start_{id} < 0) {{ __substr_start_{id} = 0; }}\n\
+                             \x20 if (__substr_start_{id} > v{s}.len) {{ __substr_start_{id} = v{s}.len; }}\n\
+                             \x20 int64_t __substr_len_{id} = v{len};\n\
+                             \x20 if (__substr_len_{id} < 0) {{ __substr_len_{id} = 0; }}\n\
+                             \x20 int64_t __substr_max_len_{id} = v{s}.len - __substr_start_{id};\n\
+                             \x20 if (__substr_len_{id} > __substr_max_len_{id}) {{ __substr_len_{id} = __substr_max_len_{id}; }}\n\
+                             \x20 v{id}.len = __substr_len_{id};\n\
                              \x20 for (int64_t __i = 0; __i < v{id}.len && __i < {string_max}; __i++) {{\n\
-                             \x20   v{id}.data[__i] = v{s}.data[v{start} + __i];\n\
+                             \x20   v{id}.data[__i] = v{s}.data[__substr_start_{id} + __i];\n\
                              \x20 }}\n",
                         ));
                     }
@@ -1118,11 +1123,15 @@ fn emit_inst(
                         let end = inst.args[end_arg].0;
                         let string_max = limits.string_max;
                         out.push_str(&format!(
-                            "  __ESBMC_assert(v{start} >= 0 && v{start} <= v{s}.len, \"substring start\");\n\
-                             \x20 __ESBMC_assert(v{end} >= v{start} && v{end} <= v{s}.len, \"substring end\");\n\
-                             \x20 v{id}.len = v{end} - v{start};\n\
+                            "  int64_t __substring_start_{id} = v{start};\n\
+                             \x20 if (__substring_start_{id} < 0) {{ __substring_start_{id} = 0; }}\n\
+                             \x20 if (__substring_start_{id} > v{s}.len) {{ __substring_start_{id} = v{s}.len; }}\n\
+                             \x20 int64_t __substring_end_{id} = v{end};\n\
+                             \x20 if (__substring_end_{id} < __substring_start_{id}) {{ __substring_end_{id} = __substring_start_{id}; }}\n\
+                             \x20 if (__substring_end_{id} > v{s}.len) {{ __substring_end_{id} = v{s}.len; }}\n\
+                             \x20 v{id}.len = __substring_end_{id} - __substring_start_{id};\n\
                              \x20 for (int64_t __i = 0; __i < v{id}.len && __i < {string_max}; __i++) {{\n\
-                             \x20   v{id}.data[__i] = v{s}.data[v{start} + __i];\n\
+                             \x20   v{id}.data[__i] = v{s}.data[__substring_start_{id} + __i];\n\
                              \x20 }}\n",
                         ));
                     }
@@ -3450,7 +3459,7 @@ mod tests {
             "substring source receiver must not be emitted as scalar int64_t: {c}"
         );
         assert!(
-            c.contains("v3.len = v2 - v1"),
+            c.contains("v3.len = __substring_end_3 - __substring_start_3"),
             "substring result model should still be emitted: {c}"
         );
     }
@@ -3499,8 +3508,116 @@ mod tests {
             "arena substr source receiver must not be emitted as scalar int64_t: {c}"
         );
         assert!(
-            c.contains("v4.len = v3"),
+            c.contains("v4.len = __substr_len_4"),
             "substr result model should still be emitted: {c}"
+        );
+    }
+
+    #[test]
+    fn emit_string_substr_models_runtime_clamping() {
+        use vow_ir::InstId;
+        let func = Function {
+            id: FuncId(0),
+            name: "substr_clamp".to_string(),
+            params: vec![Ty::Ptr],
+            param_names: vec!["s".to_string()],
+            return_ty: Ty::Ptr,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+                    inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(-1)),
+                    inst(
+                        2,
+                        Opcode::ConstI64,
+                        Ty::I64,
+                        vec![],
+                        InstData::ConstI64(999),
+                    ),
+                    Inst {
+                        id: InstId(3),
+                        opcode: Opcode::Call,
+                        ty: Ty::Ptr,
+                        args: vec![InstId(0), InstId(1), InstId(2)],
+                        data: InstData::CallExtern("__vow_string_substr".to_string()),
+                        origin: sp(),
+                        region: RegionId::Root,
+                    },
+                    inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        assert!(
+            !c.contains("\"substr start\"") && !c.contains("\"substr len\""),
+            "substr model should not assert inputs the runtime clamps: {c}"
+        );
+        assert!(
+            c.contains("__substr_start_3") && c.contains("__substr_len_3"),
+            "substr model should introduce clamped start/len temporaries: {c}"
+        );
+        assert!(
+            c.contains("v3.data[__i] = v0.data[__substr_start_3 + __i];"),
+            "substr copy should index with the clamped start: {c}"
+        );
+    }
+
+    #[test]
+    fn emit_string_substring_models_runtime_clamping() {
+        use vow_ir::InstId;
+        let func = Function {
+            id: FuncId(0),
+            name: "substring_clamp".to_string(),
+            params: vec![Ty::Ptr],
+            param_names: vec!["s".to_string()],
+            return_ty: Ty::Ptr,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+                    inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(-5)),
+                    inst(
+                        2,
+                        Opcode::ConstI64,
+                        Ty::I64,
+                        vec![],
+                        InstData::ConstI64(999),
+                    ),
+                    Inst {
+                        id: InstId(3),
+                        opcode: Opcode::Call,
+                        ty: Ty::Ptr,
+                        args: vec![InstId(0), InstId(1), InstId(2)],
+                        data: InstData::CallExtern("__vow_string_substring".to_string()),
+                        origin: sp(),
+                        region: RegionId::Root,
+                    },
+                    inst(4, Opcode::Return, Ty::Unit, vec![3], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        assert!(
+            !c.contains("\"substring start\"") && !c.contains("\"substring end\""),
+            "substring model should not assert inputs the runtime clamps: {c}"
+        );
+        assert!(
+            c.contains("__substring_start_3") && c.contains("__substring_end_3"),
+            "substring model should introduce clamped start/end temporaries: {c}"
+        );
+        assert!(
+            c.contains("v3.data[__i] = v0.data[__substring_start_3 + __i];"),
+            "substring copy should index with the clamped start: {c}"
         );
     }
 

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -102,25 +102,44 @@ fn is_vec_model_creator(name: &str) -> bool {
             | "__vow_vec_new_val_in_arena"
             | "__vow_vec_from_raw_parts_copy_val"
             | "__vow_vec_pin_to_root_val"
+            | "__vow_string_split"
+            | "__vow_string_split_in_arena"
+    )
+}
+
+fn is_string_fresh_helper(name: &str) -> bool {
+    matches!(
+        name,
+        "__vow_string_trim"
+            | "__vow_string_trim_in_arena"
+            | "__vow_string_to_upper"
+            | "__vow_string_to_upper_in_arena"
+            | "__vow_string_to_lower"
+            | "__vow_string_to_lower_in_arena"
+            | "__vow_string_replace"
+            | "__vow_string_replace_in_arena"
+            | "__vow_string_join"
+            | "__vow_string_join_in_arena"
     )
 }
 
 fn is_string_model_creator(name: &str) -> bool {
-    matches!(
-        name,
-        "__vow_string_new"
-            | "__vow_string_new_in_arena"
-            | "__vow_string_from_cstr"
-            | "__vow_string_from_cstr_in_arena"
-            | "__vow_string_from_raw_parts_copy"
-            | "__vow_string_pin_to_root"
-            | "__vow_string_substr"
-            | "__vow_string_substr_in_arena"
-            | "__vow_string_substring"
-            | "__vow_string_substring_in_arena"
-            | "__vow_string_from_i64"
-            | "__vow_string_from_i64_in_arena"
-    )
+    is_string_fresh_helper(name)
+        || matches!(
+            name,
+            "__vow_string_new"
+                | "__vow_string_new_in_arena"
+                | "__vow_string_from_cstr"
+                | "__vow_string_from_cstr_in_arena"
+                | "__vow_string_from_raw_parts_copy"
+                | "__vow_string_pin_to_root"
+                | "__vow_string_substr"
+                | "__vow_string_substr_in_arena"
+                | "__vow_string_substring"
+                | "__vow_string_substring_in_arena"
+                | "__vow_string_from_i64"
+                | "__vow_string_from_i64_in_arena"
+        )
 }
 
 fn vec_model_receiver_arg(name: &str) -> Option<usize> {
@@ -258,6 +277,10 @@ fn collect_option_vars(func: &Function) -> HashSet<u32> {
 // ---------------------------------------------------------------------------
 
 fn is_known_builtin(name: &str) -> bool {
+    if is_string_fresh_helper(name) {
+        return true;
+    }
+
     matches!(
         name,
         "__vow_vec_new"
@@ -274,6 +297,8 @@ fn is_known_builtin(name: &str) -> bool {
             | "__vow_vec_len"
             | "__vow_vec_pop"
             | "__vow_vec_set_val"
+            | "__vow_string_split"
+            | "__vow_string_split_in_arena"
             | "__vow_string_new"
             | "__vow_string_new_in_arena"
             | "__vow_string_from_cstr"
@@ -984,11 +1009,7 @@ fn emit_inst(
                         ));
                     }
                     "__vow_string_from_cstr" | "__vow_string_from_cstr_in_arena" => {
-                        let string_max = limits.string_max;
-                        out.push_str(&format!(
-                            "  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {string_max});\n",
-                        ));
+                        emit_nondet_string_len(id, limits.string_max, out);
                     }
                     "__vow_string_from_raw_parts_copy" => {
                         let len = inst.args[1].0;
@@ -1006,11 +1027,13 @@ fn emit_inst(
                         out.push_str(&format!("  v{id} = v{s}.len;\n"));
                     }
                     "__vow_string_from_i64" | "__vow_string_from_i64_in_arena" => {
-                        let string_max = limits.string_max;
-                        out.push_str(&format!(
-                            "  v{id}.len = __VERIFIER_nondet_long();\n\
-                             \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {string_max});\n",
-                        ));
+                        emit_nondet_string_len(id, limits.string_max, out);
+                    }
+                    "__vow_string_split" | "__vow_string_split_in_arena" => {
+                        emit_nondet_vec_len(id, limits.vec_max, out);
+                    }
+                    name if is_string_fresh_helper(name) => {
+                        emit_nondet_string_len(id, limits.string_max, out);
                     }
                     "__vow_string_push_str" | "__vow_string_push_str_in_arena" => {
                         let (dest_arg, src_arg) = if name == "__vow_string_push_str_in_arena" {
@@ -1456,6 +1479,20 @@ fn emit_string_eq_invalidate(operand: u32, eq_pairs: &[(u32, u32)], out: &mut St
             ));
         }
     }
+}
+
+fn emit_nondet_string_len(id: u32, string_max: usize, out: &mut String) {
+    out.push_str(&format!(
+        "  v{id}.len = __VERIFIER_nondet_long();\n\
+         \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {string_max});\n",
+    ));
+}
+
+fn emit_nondet_vec_len(id: u32, vec_max: usize, out: &mut String) {
+    out.push_str(&format!(
+        "  v{id}.len = __VERIFIER_nondet_long();\n\
+         \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {vec_max});\n",
+    ));
 }
 
 /// Sentinel `vow_id` reported when ESBMC fails on an
@@ -3619,6 +3656,116 @@ mod tests {
             c.contains("v3.data[__i] = v0.data[__substring_start_3 + __i];"),
             "substring copy should index with the clamped start: {c}"
         );
+    }
+
+    #[test]
+    fn emit_string_fresh_helpers_are_modelable() {
+        use vow_ir::InstId;
+
+        let cases = [
+            ("__vow_string_trim", 1, false),
+            ("__vow_string_trim_in_arena", 2, false),
+            ("__vow_string_to_upper", 1, false),
+            ("__vow_string_to_upper_in_arena", 2, false),
+            ("__vow_string_to_lower", 1, false),
+            ("__vow_string_to_lower_in_arena", 2, false),
+            ("__vow_string_replace", 3, false),
+            ("__vow_string_replace_in_arena", 4, false),
+            ("__vow_string_join", 2, false),
+            ("__vow_string_join_in_arena", 3, false),
+            ("__vow_string_split", 2, true),
+            ("__vow_string_split_in_arena", 3, true),
+        ];
+
+        for (idx, (name, argc, returns_vec)) in cases.iter().enumerate() {
+            let call_id = 20 + idx as u32;
+            let args: Vec<InstId> = (0..*argc).map(|i| InstId(i as u32)).collect();
+            let mut insts = Vec::new();
+            for i in 0..*argc {
+                insts.push(inst(
+                    i as u32,
+                    Opcode::ConstI64,
+                    Ty::I64,
+                    vec![],
+                    InstData::ConstI64(0),
+                ));
+            }
+            insts.push(Inst {
+                id: InstId(call_id),
+                opcode: Opcode::Call,
+                ty: Ty::Ptr,
+                args,
+                data: InstData::CallExtern((*name).to_string()),
+                origin: sp(),
+                region: RegionId::Root,
+            });
+            insts.push(inst(
+                call_id + 1,
+                Opcode::Return,
+                Ty::Unit,
+                vec![call_id],
+                InstData::None,
+            ));
+
+            let func = Function {
+                id: FuncId(idx as u32),
+                name: format!("helper_{idx}"),
+                params: vec![],
+                param_names: vec![],
+                return_ty: Ty::Ptr,
+                effects: vec![],
+                vows: vec![],
+                blocks: vec![BasicBlock {
+                    id: BlockId(0),
+                    insts,
+                }],
+                local_names: std::collections::HashMap::new(),
+                summary: RegionSummary::default(),
+                source_file: String::new(),
+            };
+            let module = Module {
+                name: "test".to_string(),
+                functions: vec![func.clone()],
+                strings: vec![],
+                struct_layouts: vec![],
+                enum_layouts: vec![],
+                warnings: vec![],
+            };
+            assert_eq!(
+                non_modelable_reason(&func, &module, &HashMap::new()),
+                None,
+                "{name} should be modelable"
+            );
+
+            let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+            assert!(
+                !c.contains("unsupported opcode in verifier model"),
+                "{name} should not fall through to unsupported: {c}"
+            );
+            if *returns_vec {
+                assert!(
+                    c.contains(&format!("__vow_vec_t v{call_id};")),
+                    "{name} result should use the Vec model: {c}"
+                );
+                assert!(
+                    c.contains(&format!(
+                        "__ESBMC_assume(v{call_id}.len >= 0 && v{call_id}.len < 128)"
+                    )),
+                    "{name} result length should be bounded by vec_max: {c}"
+                );
+            } else {
+                assert!(
+                    c.contains(&format!("__vow_string_t v{call_id};")),
+                    "{name} result should use the String model: {c}"
+                );
+                assert!(
+                    c.contains(&format!(
+                        "__ESBMC_assume(v{call_id}.len >= 0 && v{call_id}.len < 256)"
+                    )),
+                    "{name} result length should be bounded by string_max: {c}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add explicit-arena String runtime symbols and root wrappers that delegate through `__vow_root_arena`
- route String creation, growth, substring copies, and fresh String helper producers through inferred arenas in Rust codegen, the Clif shim, and the self-hosted compiler
- teach Rust and self-hosted verifier C models about the arena-prefixed String symbols
- use `__vow_string_new` as the canonical verifier-tracking constructor while still recognizing every String-producing runtime symbol
- align the verifier C model for `substr`/`substring` with runtime clamping semantics, avoiding false verification failures for valid clamped slices
- track String model constructor results and receiver arguments independently so `substr`/`substring` declare both the produced String and source receiver in generated C
- model fresh String helpers in both verifier emitters: `split` produces an abstract bounded Vec and `trim`/case conversion/`replace`/`join` produce abstract bounded Strings, including `_in_arena` forms
- document the String arena runtime API and String/Vec call-routing behavior

Fixes #293.

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test -p vow-verify`
- `cargo test -p vow-clif-shim hidden_region_for_store_target_uses_sorted_target_slots -- --nocapture`
- `cargo test --all`
- `build/vowc build --no-verify compiler/main.vow -o /tmp/vow_main_issue293_fresh_helpers2`
- `build/vowc build --no-verify compiler/main.vow -o /tmp/vow_main_issue293_clif_review`
- `scripts/bootstrap.sh` (`vowc2 == vowc3`, SHA-256 `6619870b5e3dc89cbcb33b18d631e7f73ff964ccd8b8c25fd2837204c52843a7`)
- `tests/run_tests.sh --no-bootstrap --no-verify --filter string`
- `tests/run_tests.sh --no-bootstrap --no-verify --filter cmdloop`
- `bench/memory/run.sh`
