### PR TITLE
[codex] Add nightly cargo-mutants workflow

### DIFF
--- a/.github/workflows/cargo-mutants.yml
+++ b/.github/workflows/cargo-mutants.yml
@@ -1,0 +1,73 @@
+name: cargo-mutants
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  ESBMC_VERSION: "8.1"
+  ESBMC_SHA256: daec35870fdee07e1298676646ae6cf1d631c6272594e7e86479cdb9caa67ec5
+
+jobs:
+  cargo-mutants:
+    name: shard ${{ matrix.shard }}/8
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+      - name: Cache ESBMC
+        id: cache-esbmc
+        uses: actions/cache@v5
+        with:
+          path: ~/esbmc
+          key: esbmc-${{ env.ESBMC_VERSION }}-${{ env.ESBMC_SHA256 }}-ubuntu-24.04
+      - name: Install ESBMC
+        if: steps.cache-esbmc.outputs.cache-hit != 'true'
+        env:
+          ESBMC_ZIP: release-ubuntu-24.04--b.RelWithDebInfo.-e.OFF.zip
+        run: |
+          ESBMC_URL="https://github.com/esbmc/esbmc/releases/download/v$ESBMC_VERSION/$ESBMC_ZIP"
+
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+            -o "/tmp/$ESBMC_ZIP" "$ESBMC_URL"
+
+          echo "$ESBMC_SHA256  /tmp/$ESBMC_ZIP" | sha256sum --check --strict -
+
+          unzip -q "/tmp/$ESBMC_ZIP" -d ~/esbmc
+          rm "/tmp/$ESBMC_ZIP"
+      - run: echo "$HOME/esbmc/bin" >> "$GITHUB_PATH"
+      - name: Baseline build and tests
+        run: |
+          cargo build --all
+          cargo test --workspace
+      - name: Run cargo-mutants shard
+        continue-on-error: true
+        run: |
+          cargo mutants \
+            --workspace \
+            --test-workspace=true \
+            --no-shuffle \
+            -vV \
+            --shard "${{ matrix.shard }}/8" \
+            --sharding round-robin \
+            --baseline=skip \
+            --timeout 180 \
+            --in-place \
+            -- --workspace --all-targets
+      - name: Upload mutants.out
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: mutants-shard-${{ matrix.shard }}
+          path: mutants.out
+          if-no-files-found: ignore

--- a/.github/workflows/cargo-mutants.yml
+++ b/.github/workflows/cargo-mutants.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -3521,6 +3521,101 @@ mod tests {
     }
 
     #[test]
+    fn debug_builtins_lower_to_runtime_symbols() {
+        let cases = [
+            ("debug_str", "__vow_debug_str", Ty::Unit),
+            ("debug_i64", "__vow_debug_i64", Ty::Unit),
+            ("debug_u64", "__vow_debug_u64", Ty::Unit),
+        ];
+        for (name, symbol, ty) in cases {
+            assert_eq!(vow_debug_builtin_to_runtime(name), Some((symbol, ty)));
+        }
+        assert_eq!(vow_debug_builtin_to_runtime("debug_missing"), None);
+    }
+
+    #[test]
+    fn builtins_lower_to_runtime_symbols_and_return_types() {
+        let cases = [
+            ("print_str", "__vow_string_print", Ty::Unit),
+            ("print_i64", "__vow_print_i64", Ty::Unit),
+            ("print_u64", "__vow_print_u64", Ty::Unit),
+            ("eprintln_str", "__vow_eprintln_str", Ty::Unit),
+            ("fs_read", "__vow_fs_read", Ty::Ptr),
+            ("fs_open", "__vow_fs_open", Ty::I64),
+            ("fs_read_line", "__vow_fs_read_line", Ty::Ptr),
+            ("fs_status", "__vow_fs_status", Ty::I64),
+            ("fs_close", "__vow_fs_close", Ty::I64),
+            ("fs_write", "__vow_fs_write", Ty::I64),
+            ("fs_exists", "__vow_fs_exists", Ty::I64),
+            ("fs_mkdir", "__vow_fs_mkdir", Ty::I64),
+            ("fs_listdir", "__vow_fs_listdir", Ty::Ptr),
+            ("fs_remove", "__vow_fs_remove", Ty::I64),
+            ("fs_remove_dir", "__vow_fs_remove_dir", Ty::I64),
+            ("fs_is_dir", "__vow_fs_is_dir", Ty::I64),
+            ("fs_rename", "__vow_fs_rename", Ty::I64),
+            ("string_substr", "__vow_string_substr", Ty::Ptr),
+            ("string_split", "__vow_string_split", Ty::Ptr),
+            ("string_starts_with", "__vow_string_starts_with", Ty::I64),
+            ("string_ends_with", "__vow_string_ends_with", Ty::I64),
+            ("string_trim", "__vow_string_trim", Ty::Ptr),
+            ("string_to_upper", "__vow_string_to_upper", Ty::Ptr),
+            ("string_to_lower", "__vow_string_to_lower", Ty::Ptr),
+            ("string_replace", "__vow_string_replace", Ty::Ptr),
+            ("string_join", "__vow_string_join", Ty::Ptr),
+            ("parse_i64", "__vow_parse_i64", Ty::I64),
+            ("i64_to_string", "__vow_string_from_i64", Ty::Ptr),
+            ("vec_sort", "__vow_vec_sort", Ty::Ptr),
+            ("time_unix", "__vow_time_unix", Ty::I64),
+            ("time_unix_ms", "__vow_time_unix_ms", Ty::I64),
+            ("num_cpus", "__vow_num_cpus", Ty::I64),
+            ("hex_encode", "__vow_hex_encode", Ty::Ptr),
+            ("hex_decode", "__vow_hex_decode", Ty::Ptr),
+            ("args", "__vow_args", Ty::Ptr),
+            ("stdin_read", "__vow_stdin_read", Ty::Ptr),
+            ("stdin_read_line", "__vow_stdin_read_line", Ty::Ptr),
+            ("stdin_ready", "__vow_stdin_ready", Ty::Bool),
+            ("process_exit", "__vow_process_exit", Ty::Unit),
+            ("process_run", "__vow_process_run", Ty::I64),
+            ("process_get_stdout", "__vow_process_get_stdout", Ty::Ptr),
+            ("process_get_stderr", "__vow_process_get_stderr", Ty::Ptr),
+            ("process_start", "__vow_process_start", Ty::I64),
+            ("process_wait", "__vow_process_wait", Ty::I64),
+            (
+                "process_wait_timeout",
+                "__vow_process_wait_timeout",
+                Ty::I64,
+            ),
+            ("process_kill", "__vow_process_kill", Ty::I64),
+            ("process_stdout_for", "__vow_process_stdout_for", Ty::Ptr),
+            ("process_stderr_for", "__vow_process_stderr_for", Ty::Ptr),
+            ("__vow_clif_create", "__vow_clif_create", Ty::I64),
+            ("__vow_clif_add_string", "__vow_clif_add_string", Ty::Unit),
+            (
+                "__vow_clif_declare_extern",
+                "__vow_clif_declare_extern",
+                Ty::Unit,
+            ),
+            (
+                "__vow_clif_declare_function",
+                "__vow_clif_declare_function",
+                Ty::Unit,
+            ),
+            ("__vow_clif_fn_begin", "__vow_clif_fn_begin", Ty::I64),
+            ("__vow_clif_fn_block", "__vow_clif_fn_block", Ty::I64),
+            ("__vow_clif_fn_inst", "__vow_clif_fn_inst", Ty::I64),
+            ("__vow_clif_fn_vow", "__vow_clif_fn_vow", Ty::I64),
+            ("__vow_clif_fn_end", "__vow_clif_fn_end", Ty::I64),
+            ("__vow_clif_finish", "__vow_clif_finish", Ty::I64),
+            ("__vow_clif_link", "__vow_clif_link", Ty::I64),
+            ("__vow_clif_destroy", "__vow_clif_destroy", Ty::Unit),
+        ];
+        for (name, symbol, ty) in cases {
+            assert_eq!(vow_builtin_to_runtime(name), Some((symbol, ty)));
+        }
+        assert_eq!(vow_builtin_to_runtime("missing_builtin"), None);
+    }
+
+    #[test]
     fn lower_const_i64() {
         let body = Block {
             stmts: vec![],
@@ -3645,6 +3740,62 @@ mod tests {
         assert!(ret.is_some());
         let const_id = const_inst.unwrap().id;
         assert_eq!(ret.unwrap().args, vec![const_id]);
+    }
+
+    #[test]
+    fn lower_assignment_updates_identifier_binding() {
+        let let_stmt = Stmt::Let {
+            pattern: Pat {
+                kind: PatKind::Ident {
+                    name: "x".to_string(),
+                    is_mut: true,
+                },
+                span: sp(),
+            },
+            ty: None,
+            init: Box::new(int_expr(1)),
+            span: sp(),
+        };
+        let assign_stmt = Stmt::Expr {
+            expr: Expr {
+                kind: ExprKind::Assign {
+                    lhs: Box::new(ident_expr("x")),
+                    rhs: Box::new(int_expr(2)),
+                },
+                span: sp(),
+            },
+            has_semicolon: true,
+            span: sp(),
+        };
+        let body = Block {
+            stmts: vec![let_stmt, assign_stmt],
+            trailing_expr: Some(Box::new(ident_expr("x"))),
+            span: sp(),
+        };
+        let fn_def = make_fn("assign_fn", vec![], i64_ty(), body, vec![]);
+        let (func, _, _) = lower_function(
+            &fn_def,
+            "",
+            &HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            HashMap::new(),
+            HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        let all_insts: Vec<_> = func.blocks.iter().flat_map(|b| b.insts.iter()).collect();
+        let assigned_const = all_insts
+            .iter()
+            .find(|i| i.data == InstData::ConstI64(2))
+            .expect("assignment RHS should lower to ConstI64(2)");
+        let ret = all_insts
+            .iter()
+            .find(|i| i.opcode == Opcode::Return)
+            .expect("expected Return");
+        assert_eq!(ret.args, vec![assigned_const.id]);
     }
 
     #[test]

--- a/vow-ir/src/lower/mod.rs
+++ b/vow-ir/src/lower/mod.rs
@@ -3535,6 +3535,7 @@ mod tests {
 
     #[test]
     fn builtins_lower_to_runtime_symbols_and_return_types() {
+        // Keep this table in lockstep with every arm of vow_builtin_to_runtime.
         let cases = [
             ("print_str", "__vow_string_print", Ty::Unit),
             ("print_i64", "__vow_print_i64", Ty::Unit),

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -4347,6 +4347,60 @@ mod tests {
         assert!(m.warnings.is_empty());
     }
 
+    #[test]
+    fn build_call_graph_deduplicates_and_ignores_out_of_range_targets() {
+        let f0 = function(
+            0,
+            "caller",
+            vec![],
+            Ty::Unit,
+            vec![block(
+                0,
+                vec![
+                    inst(
+                        0,
+                        Opcode::Call,
+                        Ty::Unit,
+                        vec![],
+                        InstData::CallTarget(FuncId(1)),
+                    ),
+                    inst(
+                        1,
+                        Opcode::Call,
+                        Ty::Unit,
+                        vec![],
+                        InstData::CallTarget(FuncId(1)),
+                    ),
+                    inst(
+                        2,
+                        Opcode::Call,
+                        Ty::Unit,
+                        vec![],
+                        InstData::CallTarget(FuncId(99)),
+                    ),
+                    return_unit_inst(3),
+                ],
+            )],
+        );
+        let f1 = function(
+            1,
+            "callee",
+            vec![],
+            Ty::Unit,
+            vec![block(0, vec![return_unit_inst(4)])],
+        );
+        let graph = build_call_graph(&module(vec![f0, f1]));
+        assert_eq!(graph, vec![vec![1], vec![]]);
+    }
+
+    #[test]
+    fn tarjan_sccs_groups_cycles_and_leaves_first() {
+        let mut sccs = tarjan_sccs(&[vec![1], vec![2], vec![0, 3], vec![]]);
+        assert_eq!(sccs.remove(0), vec![3]);
+        assert_eq!(sccs.remove(0), vec![0, 1, 2]);
+        assert!(sccs.is_empty());
+    }
+
     /// A callee that stores its second arg into its first arg publishes
     /// `(0, AliasOf(1))` store-effect. A caller passing `(some_param,
     /// fresh_alloc)` exhibits the alloc→param-via-callee shape that

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -7103,6 +7103,33 @@ fn main() -> i32 [io] {
     }
 
     #[test]
+    fn skill_full_markdown_contains_installable_skill_document() {
+        let out = skill_full_markdown();
+        assert!(out.starts_with("---\nname: vow-toolchain\n"));
+        assert!(out.contains("# Vow Language Reference"));
+        assert!(out.contains("## `vow skill`"));
+        assert!(out.contains("schemas/build-result.schema.json"));
+    }
+
+    #[test]
+    fn skill_install_writes_claude_command_file() {
+        static CWD_LOCK: StdMutex<()> = StdMutex::new(());
+
+        let _guard = CWD_LOCK.lock().unwrap();
+        let old_cwd = std::env::current_dir().unwrap();
+        let dir = TempDir::new().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let result = std::panic::catch_unwind(run_skill_install);
+        std::env::set_current_dir(old_cwd).unwrap();
+        result.unwrap();
+
+        let installed = dir.path().join(".claude/commands/vow-toolchain.md");
+        let contents = std::fs::read_to_string(installed).unwrap();
+        assert!(contents.starts_with("---\nname: vow-toolchain\n"));
+        assert!(contents.contains("# Vow Language Reference"));
+    }
+
+    #[test]
     fn agent_capability_test_skill_json_is_parseable_and_complete() {
         // Verify the --help JSON contains enough information for an LLM agent
         // to write correct Vow code without additional context.
@@ -9805,6 +9832,108 @@ fn main() -> i32 {
         assert_eq!(sce.branch_decisions[0].taken, "else");
         assert_eq!(sce.branch_decisions[0].condition_offset, 20);
         assert_eq!(sce.branch_decisions[0].condition_length, 8);
+    }
+
+    #[test]
+    fn discover_test_files_accepts_file_and_sorted_test_names() {
+        let dir = TempDir::new().unwrap();
+        let single = write_source(&dir, "plain.vow", "module Plain fn main() -> i32 { 0 }");
+        assert_eq!(discover_test_files(&single), vec![single.clone()]);
+
+        write_source(&dir, "notes.vow", "module Notes");
+        let beta = write_source(&dir, "beta_test.vow", "module Beta");
+        let alpha = write_source(&dir, "test_alpha.vow", "module Alpha");
+        let files = discover_test_files(dir.path());
+        assert_eq!(files, vec![beta, alpha]);
+    }
+
+    #[test]
+    fn count_contract_density_ignores_main_and_reports_tenths() {
+        use vow_ir::{BasicBlock, BlockId, FuncId, RegionSummary, Ty, VowEntry, VowId};
+
+        let make_func = |id, name: &str, vows| vow_ir::Function {
+            id: FuncId(id),
+            name: name.to_string(),
+            params: vec![],
+            param_names: vec![],
+            return_ty: Ty::Unit,
+            effects: vec![],
+            vows,
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        let vowed = VowEntry {
+            id: VowId(0),
+            description: "ensures: true".to_string(),
+            blame: vow_diag::Blame::Callee,
+            bindings: vec![],
+            file: "test.vow".to_string(),
+            offset: 0,
+        };
+        let module = vow_ir::Module {
+            name: "Density".to_string(),
+            functions: vec![
+                make_func(0, "main", vec![vowed.clone()]),
+                make_func(1, "with_vow", vec![vowed]),
+                make_func(2, "without_vow", vec![]),
+            ],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+            warnings: vec![],
+        };
+
+        let density = count_contract_density(&module);
+        assert_eq!(density.functions_total, 2);
+        assert_eq!(density.functions_with_vows, 1);
+        assert_eq!(density.density_pct, 50.0);
+    }
+
+    #[test]
+    fn resolve_verify_jobs_preserves_explicit_value() {
+        assert_eq!(resolve_verify_jobs(Some(3)), 3);
+    }
+
+    #[test]
+    fn build_contracts_summary_counts_each_status_bucket() {
+        let source = ContractSourceJson {
+            file: "test.vow".to_string(),
+            offset: 0,
+        };
+        let entry = |status: &str| ContractEntryJson {
+            vow_id: 0,
+            function: "f".to_string(),
+            function_id: 0,
+            kind: "ensures".to_string(),
+            description: "ensures: true".to_string(),
+            blame: "callee".to_string(),
+            source: source.clone(),
+            status: status.to_string(),
+        };
+        let summary = build_contracts_summary(&[
+            entry("proven"),
+            entry("proven-ir"),
+            entry("failed"),
+            entry("unknown"),
+            entry("timeout"),
+            entry("error"),
+            entry("skipped"),
+            entry("not-run"),
+        ]);
+
+        assert_eq!(summary.total, 8);
+        assert_eq!(summary.proven, 2);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.unknown, 1);
+        assert_eq!(summary.timeout, 1);
+        assert_eq!(summary.error, 1);
+        assert_eq!(summary.skipped, 1);
+        assert_eq!(summary.not_verified, 1);
     }
 
     #[test]

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -4415,18 +4415,26 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
 }
 // GENERATE:SKILL_FULL:END
 
-fn run_skill_install() {
-    let dir = Path::new(".claude/commands");
-    if let Err(e) = std::fs::create_dir_all(dir) {
-        eprintln!("vow skill install: cannot create {}: {}", dir.display(), e);
-        std::process::exit(1);
-    }
+fn install_skill_to(root: &Path) -> std::io::Result<PathBuf> {
+    let dir = root.join(".claude/commands");
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        std::io::Error::new(e.kind(), format!("cannot create {}: {}", dir.display(), e))
+    })?;
     let path = dir.join("vow-toolchain.md");
-    if let Err(e) = std::fs::write(&path, skill_full_markdown()) {
-        eprintln!("vow skill install: cannot write {}: {}", path.display(), e);
-        std::process::exit(1);
+    std::fs::write(&path, skill_full_markdown()).map_err(|e| {
+        std::io::Error::new(e.kind(), format!("cannot write {}: {}", path.display(), e))
+    })?;
+    Ok(path)
+}
+
+fn run_skill_install() {
+    match install_skill_to(Path::new("")) {
+        Ok(path) => eprintln!("installed skill to {}", path.display()),
+        Err(e) => {
+            eprintln!("vow skill install: {}", e);
+            std::process::exit(1);
+        }
     }
-    eprintln!("installed skill to {}", path.display());
 }
 
 // ---------------------------------------------------------------------------
@@ -7113,15 +7121,8 @@ fn main() -> i32 [io] {
 
     #[test]
     fn skill_install_writes_claude_command_file() {
-        static CWD_LOCK: StdMutex<()> = StdMutex::new(());
-
-        let _guard = CWD_LOCK.lock().unwrap();
-        let old_cwd = std::env::current_dir().unwrap();
         let dir = TempDir::new().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-        let result = std::panic::catch_unwind(run_skill_install);
-        std::env::set_current_dir(old_cwd).unwrap();
-        result.unwrap();
+        install_skill_to(dir.path()).unwrap();
 
         let installed = dir.path().join(".claude/commands/vow-toolchain.md");
         let contents = std::fs::read_to_string(installed).unwrap();
@@ -9896,6 +9897,7 @@ fn main() -> i32 {
 
     #[test]
     fn resolve_verify_jobs_preserves_explicit_value() {
+        assert_eq!(resolve_verify_jobs(Some(1)), 1);
         assert_eq!(resolve_verify_jobs(Some(3)), 3);
     }
 


### PR DESCRIPTION
## Summary

Adds a scheduled cargo-mutants workflow for issue #304 and converts the first immediately actionable missed-mutant clusters from the local run into focused Rust tests.

The workflow runs nightly and on manual dispatch, shards cargo-mutants across eight round-robin jobs, keeps the mutant run non-blocking, and uploads each shard's `mutants.out` artifact for inspection. It also reuses the ESBMC install/cache setup from CI so workspace tests have the same verifier dependency available.

The test additions cover builtin lowering, assignment lowering, call-graph/SCC behavior, skill installation output, test discovery, contract density, verify job resolution, and contract summary bucketing.

Closes #304.

## Validation

- `cargo build --all && cargo test --workspace`
- `cargo clippy --all -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`