### PR TITLE
Implement HashMap arena routing

### DIFF
--- a/bench/memory/expected.toml
+++ b/bench/memory/expected.toml
@@ -26,6 +26,11 @@ file = "programs/alloc_loop_branch.vow"
 max_rss_kb = 20016
 expected = "pass"
 
+[alloc_loop_map]
+file = "programs/alloc_loop_map.vow"
+max_rss_kb = 6984
+expected = "pass"
+
 [alloc_loop_nested]
 file = "programs/alloc_loop_nested.vow"
 max_rss_kb = 12132

--- a/bench/memory/programs/alloc_loop_map.vow
+++ b/bench/memory/programs/alloc_loop_map.vow
@@ -1,0 +1,24 @@
+// BENCH: max-rss-kb 6984
+module AllocLoopMap
+
+fn fill_map() -> i64 {
+    let m: HashMap<i64, i64> = HashMap::new();
+    let mut i: i64 = 0;
+    while i < 16 {
+        m.insert(i, i * 100);
+        i = i + 1;
+    }
+    m.len() + m.get(0) + m.get(15)
+}
+
+fn main() -> i32 [io] {
+    let mut i: i64 = 0;
+    let mut total: i64 = 0;
+    while i < 70000 {
+        total = total + fill_map();
+        i = i + 1;
+    }
+    print_i64(total);
+    print_str("\n");
+    0
+}

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -144,11 +144,14 @@ fn is_known_builtin(name: String) -> bool {
     || name == String::from("__vow_string_from_i64_in_arena")
     || name == String::from("__vow_string_print")
     || name == String::from("__vow_map_new")
+    || name == String::from("__vow_map_new_in_arena")
     || name == String::from("__vow_map_len")
     || name == String::from("__vow_map_insert")
+    || name == String::from("__vow_map_insert_in_arena")
     || name == String::from("__vow_map_get")
     || name == String::from("__vow_map_contains")
     || name == String::from("__vow_map_remove")
+    || name == String::from("__vow_map_remove_in_arena")
     || name == String::from("__vow_btreemap_new")
     || name == String::from("__vow_btreemap_len")
     || name == String::from("__vow_btreemap_insert")
@@ -493,6 +496,22 @@ fn is_string_model_constructor(name: String) -> bool {
     || name == String::from("__vow_string_from_i64_in_arena")
 }
 
+fn is_map_model_constructor(name: String) -> bool {
+    name == String::from("__vow_map_new")
+    || name == String::from("__vow_map_new_in_arena")
+}
+
+fn map_model_receiver_arg(name: String) -> i64 {
+    if name == String::from("__vow_map_insert_in_arena") { return 1; }
+    if name == String::from("__vow_map_remove_in_arena") { return 1; }
+    if name == String::from("__vow_map_insert") { return 0; }
+    if name == String::from("__vow_map_remove") { return 0; }
+    if name == String::from("__vow_map_get") { return 0; }
+    if name == String::from("__vow_map_contains") { return 0; }
+    if name == String::from("__vow_map_len") { return 0; }
+    -1
+}
+
 fn vec_model_receiver_arg(name: String) -> i64 {
     if name == String::from("__vow_vec_push_val") { return 0; }
     if name == String::from("__vow_vec_get_val") { return 0; }
@@ -618,7 +637,9 @@ fn collect_modelled_vars(f: IrFunction, constructor: String, prefix: String) -> 
                 let alt_creator: bool = (prefix == String::from("__vow_vec_")
                     && is_vec_model_constructor(ds))
                     || (prefix == String::from("__vow_string_")
-                        && is_string_model_constructor(ds));
+                        && is_string_model_constructor(ds))
+                    || (prefix == String::from("__vow_map_")
+                        && is_map_model_constructor(ds));
                 let is_creator: bool = ds == constructor || alt_creator;
                 if is_creator {
                     vec_insert_i64(vars, inst.id);
@@ -644,6 +665,8 @@ fn collect_modelled_vars(f: IrFunction, constructor: String, prefix: String) -> 
                             vec_model_receiver_arg(ds)
                         } else if prefix == String::from("__vow_string_") {
                             string_model_receiver_arg(ds)
+                        } else if prefix == String::from("__vow_map_") {
+                            map_model_receiver_arg(ds)
                         } else {
                             0
                         }
@@ -1595,7 +1618,16 @@ fn emit_map_op(out: String, inst: IrInst, hashmap_max: i64) {
     let ds: String = inst.ds;
     let iargs: Vec<i64> = inst.args;
 
-    if ds == String::from("__vow_map_new") {
+    // _in_arena variants share their bodies with the root forms; the leading
+    // arena pointer is opaque to the verifier and is consumed via arg_offset.
+    let arg_offset: i64 = {
+        if ds == String::from("__vow_map_new_in_arena") { 1 }
+        else if ds == String::from("__vow_map_insert_in_arena") { 1 }
+        else if ds == String::from("__vow_map_remove_in_arena") { 1 }
+        else { 0 }
+    };
+
+    if ds == String::from("__vow_map_new") || ds == String::from("__vow_map_new_in_arena") {
         let ids: String = i64_to_str(id);
         out.push_str(str3(String::from("  v"), ids, String::from(".len = 0;\n")));
         return;
@@ -1606,10 +1638,10 @@ fn emit_map_op(out: String, inst: IrInst, hashmap_max: i64) {
             String::from(" = v"), i64_to_str(mp), String::from(".len;\n")));
         return;
     }
-    if ds == String::from("__vow_map_insert") {
-        let mp: i64 = iargs[0];
-        let k: i64 = iargs[1];
-        let v: i64 = iargs[2];
+    if ds == String::from("__vow_map_insert") || ds == String::from("__vow_map_insert_in_arena") {
+        let mp: i64 = iargs[arg_offset];
+        let k: i64 = iargs[arg_offset + 1];
+        let v: i64 = iargs[arg_offset + 2];
         let ms: String = i64_to_str(mp);
         let ks: String = i64_to_str(k);
         let vs: String = i64_to_str(v);
@@ -1659,9 +1691,9 @@ fn emit_map_op(out: String, inst: IrInst, hashmap_max: i64) {
         out.push_str(String::from("  }\n"));
         return;
     }
-    if ds == String::from("__vow_map_remove") {
-        let mp: i64 = iargs[0];
-        let k: i64 = iargs[1];
+    if ds == String::from("__vow_map_remove") || ds == String::from("__vow_map_remove_in_arena") {
+        let mp: i64 = iargs[arg_offset];
+        let k: i64 = iargs[arg_offset + 1];
         let ms: String = i64_to_str(mp);
         let ks: String = i64_to_str(k);
         out.push_str(str3(String::from("  for (int64_t __i = 0; __i < v"), ms, String::from(".len; __i++) {\n")));

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -307,6 +307,20 @@ fn clif_routed_extern_symbol(f: IrFunction, inst: IrInst) -> String {
         }
         return sym;
     }
+    if sym == String::from("__vow_map_new") {
+        if region_kind(inst.rgn) == REGION_KIND_ROOT() {
+            return sym;
+        }
+        return String::from("__vow_map_new_in_arena");
+    }
+    if sym == String::from("__vow_map_insert") {
+        let mr: i64 = clif_receiver_region(f, inst);
+        let mk: i64 = region_kind(mr);
+        if mk == REGION_KIND_BLOCK() || mk == REGION_KIND_CALLER() {
+            return String::from("__vow_map_insert_in_arena");
+        }
+        return sym;
+    }
     sym
 }
 

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2727,8 +2727,16 @@ fn string_creation_extern(sym: String) -> bool {
         || sym == String::from("__vow_string_join_in_arena")
 }
 
+fn map_creation_extern(sym: String) -> bool {
+    sym == String::from("__vow_map_new")
+        || sym == String::from("__vow_map_new_in_arena")
+}
+
 fn heap_producing_extern(sym: String) -> bool {
-    extern_fresh_in_caller(sym) || vec_creation_extern(sym) || string_creation_extern(sym)
+    extern_fresh_in_caller(sym)
+        || vec_creation_extern(sym)
+        || string_creation_extern(sym)
+        || map_creation_extern(sym)
 }
 
 fn extern_store_edge_count(sym: String) -> i64 {
@@ -2736,6 +2744,7 @@ fn extern_store_edge_count(sym: String) -> i64 {
     if sym == String::from("__vow_vec_push_val_in_arena") { return 1; }
     if sym == String::from("__vow_vec_set_val") { return 1; }
     if sym == String::from("__vow_map_insert") { return 2; }
+    if sym == String::from("__vow_map_insert_in_arena") { return 2; }
     if sym == String::from("__vow_btreemap_insert") { return 2; }
     0
 }
@@ -2745,6 +2754,7 @@ fn extern_store_target_pos(sym: String, edge_idx: i64) -> i64 {
         return -1;
     }
     if sym == String::from("__vow_vec_push_val_in_arena") && edge_idx == 0 { return 1; }
+    if sym == String::from("__vow_map_insert_in_arena") { return 1; }
     0
 }
 
@@ -2762,6 +2772,8 @@ fn extern_store_source_pos(sym: String, edge_idx: i64) -> i64 {
     {
         return 2;
     }
+    if sym == String::from("__vow_map_insert_in_arena") && edge_idx == 0 { return 2; }
+    if sym == String::from("__vow_map_insert_in_arena") && edge_idx == 1 { return 3; }
     -1
 }
 
@@ -2773,6 +2785,8 @@ fn extern_growth_target_pos(sym: String) -> i64 {
     if sym == String::from("__vow_string_push_str_in_arena") { return 1; }
     if sym == String::from("__vow_string_push_byte") { return 0; }
     if sym == String::from("__vow_string_push_byte_in_arena") { return 1; }
+    if sym == String::from("__vow_map_insert") { return 0; }
+    if sym == String::from("__vow_map_insert_in_arena") { return 1; }
     -1
 }
 

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -334,6 +334,55 @@ and explicit-arena Strings uses the same arena grow path as Vec: try to
 extend in place, then allocate in the selected arena and copy on
 fallback.
 
+#### HashMap runtime allocation API
+
+The existing root-region `HashMap` symbols remain ABI-stable:
+
+```c
+void*    __vow_map_new(void);
+void     __vow_map_insert(void* map, int64_t key, int64_t val);
+int64_t  __vow_map_get(const void* map, int64_t key);
+int64_t  __vow_map_contains(const void* map, int64_t key);
+void     __vow_map_remove(void* map, int64_t key);
+uintptr_t __vow_map_len(const void* map);
+```
+
+`__vow_map_new`, `__vow_map_insert`, and `__vow_map_remove` are root
+wrappers: they acquire the root-arena lock, ensure the root arena is
+open, then delegate to the corresponding explicit-arena primitive with
+`&__vow_root_arena`. The non-allocating accessors
+(`__vow_map_get`, `__vow_map_contains`, `__vow_map_len`) read the map
+in place and never touch any arena.
+
+The explicit-arena forms are:
+
+```c
+void* __vow_map_new_in_arena(struct VowArena* arena);
+void  __vow_map_insert_in_arena(struct VowArena* arena, void* map,
+                                int64_t key, int64_t val);
+void  __vow_map_remove_in_arena(struct VowArena* arena, void* map,
+                                int64_t key);
+```
+
+Every explicit-arena HashMap entry traps with
+`RuntimeInvariantViolation` and `reason = "null arena"` before
+dereferencing a null arena pointer. The bucket array and the map
+header are both allocated in the supplied arena: a fresh `HashMap`
+allocates a 24-byte header plus an initial 8-entry × 16-byte backing.
+Growth on `insert` uses the shared arena grow path — first
+`__vow_arena_try_extend` against the current backing, then
+`__vow_arena_alloc` + memcpy on fallback — and the new bucket array
+lives in the same arena as the header. `__vow_map_remove_in_arena` is
+exposed for ABI symmetry with the other in-arena forms; the operation
+itself never allocates and the arena pointer is consumed only for the
+null-arena trap, then ignored.
+
+The current MVP runtime uses i64 keys and i64 values with an O(n)
+linear-scan backing (matching the existing root-region implementation).
+Heap-typed keys or values are not yet supported; the surface grammar
+permits them syntactically (`HashMap<K, V>`), but only `i64` × `i64`
+is wired through the runtime.
+
 ### 3.4. Determinism
 
 The arena **allocation strategy**, the **chunk-size policy**, and

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -342,15 +342,27 @@ The existing root-region `HashMap` symbols remain ABI-stable:
 void*    __vow_map_new(void);
 void     __vow_map_insert(void* map, int64_t key, int64_t val);
 int64_t  __vow_map_get(const void* map, int64_t key);
-int64_t  __vow_map_contains(const void* map, int64_t key);
+_Bool    __vow_map_contains(const void* map, int64_t key);
 void     __vow_map_remove(void* map, int64_t key);
 uintptr_t __vow_map_len(const void* map);
 ```
 
-`__vow_map_new`, `__vow_map_insert`, and `__vow_map_remove` are root
-wrappers: they acquire the root-arena lock, ensure the root arena is
-open, then delegate to the corresponding explicit-arena primitive with
-`&__vow_root_arena`. The non-allocating accessors
+`__vow_map_contains` predates the `__vow_arena_*` / `__vow_string_eq`
+boolean-ABI convention (§3.3, intro): the live runtime returns Rust
+`bool` and both Cranelift signature tables model it as `I8`, so it is
+declared here as `_Bool` rather than `int64_t`. C/FFI callers must read
+exactly the 1-byte boolean from the return register; the upper bits are
+undefined. This legacy ABI is preserved for compatibility with the
+pre-arena `__vow_map_*` symbols and is unrelated to the arena routing
+introduced by the `_in_arena` forms below.
+
+`__vow_map_new` and `__vow_map_insert` are root wrappers: they acquire
+the root-arena lock, ensure the root arena is open, then delegate to the
+corresponding explicit-arena primitive with `&__vow_root_arena`.
+`__vow_map_remove` is **not** a root wrapper — it performs an in-place
+linear-scan removal that never touches the arena, so the relationship
+inverts: `__vow_map_remove_in_arena` traps on a null arena and then
+delegates to `__vow_map_remove` directly. The non-allocating accessors
 (`__vow_map_get`, `__vow_map_contains`, `__vow_map_len`) read the map
 in place and never touch any arena.
 

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -581,6 +581,21 @@ fn routed_vec_extern(sym: &str, inst_rgn: i64, receiver_rgn: i64) -> (&str, Opti
                 (sym, None)
             }
         }
+        "__vow_map_new" => {
+            if (inst_rgn & 3) == REGION_KIND_ROOT {
+                (sym, None)
+            } else {
+                ("__vow_map_new_in_arena", Some(inst_rgn))
+            }
+        }
+        "__vow_map_insert" => {
+            let kind = receiver_rgn & 3;
+            if kind == REGION_KIND_BLOCK || kind == REGION_KIND_CALLER {
+                ("__vow_map_insert_in_arena", Some(receiver_rgn))
+            } else {
+                (sym, None)
+            }
+        }
         _ => {
             if extern_uses_target_region(sym) {
                 (sym, Some(inst_rgn))
@@ -3251,7 +3266,17 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_map_new" => {
             sig.returns.push(AbiParam::new(types::I64));
         }
+        "__vow_map_new_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.returns.push(AbiParam::new(types::I64));
+        }
         "__vow_map_insert" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+        }
+        "__vow_map_insert_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
@@ -3267,6 +3292,11 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.returns.push(AbiParam::new(types::I8));
         }
         "__vow_map_remove" => {
+            sig.params.push(AbiParam::new(types::I64));
+            sig.params.push(AbiParam::new(types::I64));
+        }
+        "__vow_map_remove_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64));
             sig.params.push(AbiParam::new(types::I64));
         }

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -562,6 +562,19 @@ fn routed_vec_extern<'a>(
                 _ => (sym, None),
             }
         }
+        "__vow_map_new" => match inst.region {
+            RegionId::Root => (sym, None),
+            region => ("__vow_map_new_in_arena", Some(region)),
+        },
+        "__vow_map_insert" => {
+            let region = first_arg_region(inst, inst_index, current_summary, phi_data);
+            match region {
+                RegionId::Block(_) | RegionId::Caller(_) => {
+                    ("__vow_map_insert_in_arena", Some(region))
+                }
+                _ => (sym, None),
+            }
+        }
         _ => {
             if extern_uses_target_region(sym) {
                 (sym, Some(inst.region))
@@ -2487,7 +2500,17 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
         "__vow_map_new" => {
             sig.returns.push(AbiParam::new(types::I64)); // *VowMap
         }
+        "__vow_map_new_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
+            sig.returns.push(AbiParam::new(types::I64)); // *VowMap
+        }
         "__vow_map_insert" => {
+            sig.params.push(AbiParam::new(types::I64)); // map ptr
+            sig.params.push(AbiParam::new(types::I64)); // key
+            sig.params.push(AbiParam::new(types::I64)); // value
+        }
+        "__vow_map_insert_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64)); // map ptr
             sig.params.push(AbiParam::new(types::I64)); // key
             sig.params.push(AbiParam::new(types::I64)); // value
@@ -2503,6 +2526,11 @@ fn make_extern_sig(sym: &str, obj_module: &ObjectModule) -> Signature {
             sig.returns.push(AbiParam::new(types::I8)); // bool
         }
         "__vow_map_remove" => {
+            sig.params.push(AbiParam::new(types::I64)); // map ptr
+            sig.params.push(AbiParam::new(types::I64)); // key
+        }
+        "__vow_map_remove_in_arena" => {
+            sig.params.push(AbiParam::new(types::I64)); // target arena
             sig.params.push(AbiParam::new(types::I64)); // map ptr
             sig.params.push(AbiParam::new(types::I64)); // key
         }
@@ -3306,7 +3334,7 @@ mod tests {
 
     #[test]
     fn cranelift_backend_default_impl() {
-        let _ = CraneliftBackend::default();
+        let _ = CraneliftBackend {};
     }
 
     /// Regression for the Codex review on PR #230: `build_signature`
@@ -3455,7 +3483,7 @@ mod tests {
                         Opcode::ConstF64,
                         Ty::F64,
                         vec![],
-                        InstData::ConstF64(2.718f64),
+                        InstData::ConstF64(std::f64::consts::E),
                     ),
                     inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
                 ],
@@ -5167,7 +5195,7 @@ mod tests {
                         Opcode::ConstF64,
                         Ty::F64,
                         vec![],
-                        InstData::ConstF64(2.718f64),
+                        InstData::ConstF64(std::f64::consts::E),
                     ),
                     inst(
                         2,

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1489,8 +1489,15 @@ fn string_creation_extern(sym: &str) -> bool {
     )
 }
 
+fn map_creation_extern(sym: &str) -> bool {
+    matches!(sym, "__vow_map_new" | "__vow_map_new_in_arena")
+}
+
 fn heap_producing_extern(sym: &str) -> bool {
-    extern_fresh_in_caller(sym) || vec_creation_extern(sym) || string_creation_extern(sym)
+    extern_fresh_in_caller(sym)
+        || vec_creation_extern(sym)
+        || string_creation_extern(sym)
+        || map_creation_extern(sym)
 }
 
 fn for_each_extern_store_edge(sym: &str, args: &[InstId], mut visit: impl FnMut(InstId, InstId)) {
@@ -1501,6 +1508,10 @@ fn for_each_extern_store_edge(sym: &str, args: &[InstId], mut visit: impl FnMut(
         "__vow_map_insert" | "__vow_btreemap_insert" if args.len() >= 3 => {
             visit(args[0], args[1]);
             visit(args[0], args[2]);
+        }
+        "__vow_map_insert_in_arena" if args.len() >= 4 => {
+            visit(args[1], args[2]);
+            visit(args[1], args[3]);
         }
         _ => {}
     }
@@ -1516,6 +1527,8 @@ fn extern_growth_target(sym: &str, args: &[InstId]) -> Option<InstId> {
         "__vow_string_push_str_in_arena" | "__vow_string_push_byte_in_arena" if args.len() >= 2 => {
             Some(args[1])
         }
+        "__vow_map_insert" if !args.is_empty() => Some(args[0]),
+        "__vow_map_insert_in_arena" if args.len() >= 2 => Some(args[1]),
         _ => None,
     }
 }

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -4078,12 +4078,7 @@ mod tests {
                 cap: 0,
             };
             unsafe {
-                __vow_map_insert_in_arena(
-                    std::ptr::null_mut(),
-                    &mut m as *mut _ as *mut u8,
-                    1,
-                    1,
-                )
+                __vow_map_insert_in_arena(std::ptr::null_mut(), &mut m as *mut _ as *mut u8, 1, 1)
             };
             eprintln!("rodata_trap_worker: null arena map insert did NOT trap");
             std::process::exit(42);
@@ -4128,6 +4123,11 @@ mod tests {
                 let mut a = empty_arena_header();
                 unsafe { __vow_arena_open(&mut a) };
                 unsafe { __vow_map_insert_in_arena(&mut a, mp, 1, 2) };
+            }
+            "HashMap::remove_in_arena" => {
+                let mut a = empty_arena_header();
+                unsafe { __vow_arena_open(&mut a) };
+                unsafe { __vow_map_remove_in_arena(&mut a, mp, 1) };
             }
             other => panic!("unknown trap op: {other}"),
         }
@@ -4345,6 +4345,10 @@ mod tests {
     #[test]
     fn rodata_map_remove_traps() {
         assert_rodata_trap("HashMap::remove", "HashMap::remove");
+    }
+    #[test]
+    fn rodata_map_remove_in_arena_traps() {
+        assert_rodata_trap("HashMap::remove_in_arena", "HashMap::remove");
     }
 
     #[test]

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -2596,10 +2596,14 @@ const MAP_ENTRY_BYTES: usize = 16;
 const MAP_INITIAL_CAP: usize = 8;
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __vow_map_new() -> *mut u8 {
-    let header_ptr = unsafe { root_arena_alloc_zeroed(24, 8) } as *mut VowMap;
+pub unsafe extern "C" fn __vow_map_new_in_arena(arena: *mut VowArena) -> *mut u8 {
+    if arena.is_null() {
+        null_arena_trap("HashMap::new");
+    }
+    let header_ptr = unsafe { __vow_arena_alloc(arena, 24, 8) } as *mut VowMap;
     let buf_size = MAP_INITIAL_CAP * MAP_ENTRY_BYTES;
-    let buf_ptr = unsafe { root_arena_alloc_zeroed(buf_size, 8) };
+    let buf_ptr = unsafe { __vow_arena_alloc(arena, buf_size, 8) };
+    unsafe { std::ptr::write_bytes(buf_ptr, 0, buf_size) };
     unsafe {
         (*header_ptr).ptr = buf_ptr;
         (*header_ptr).len = 0;
@@ -2609,7 +2613,22 @@ pub extern "C" fn __vow_map_new() -> *mut u8 {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn __vow_map_insert(map: *mut u8, key: i64, val: i64) {
+pub extern "C" fn __vow_map_new() -> *mut u8 {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_map_new_in_arena(&raw mut __vow_root_arena) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_map_insert_in_arena(
+    arena: *mut VowArena,
+    map: *mut u8,
+    key: i64,
+    val: i64,
+) {
+    if arena.is_null() {
+        null_arena_trap("HashMap::insert");
+    }
     let m = unsafe { &mut *(map as *mut VowMap) };
     if m.cap == VOW_CAP_RODATA {
         region_literal_mutation_trap("HashMap::insert");
@@ -2625,7 +2644,7 @@ pub unsafe extern "C" fn __vow_map_insert(map: *mut u8, key: i64, val: i64) {
         let old_size = m.cap * MAP_ENTRY_BYTES;
         let new_cap = m.cap * 2;
         let new_size = new_cap * MAP_ENTRY_BYTES;
-        let new_ptr = unsafe { root_arena_grow_backing(m.ptr, old_size, new_size, 8) };
+        let new_ptr = unsafe { arena_grow_backing(arena, m.ptr, old_size, new_size, 8) };
         m.ptr = new_ptr;
         m.cap = new_cap;
     }
@@ -2633,6 +2652,13 @@ pub unsafe extern "C" fn __vow_map_insert(map: *mut u8, key: i64, val: i64) {
     entries[m.len * 2] = key;
     entries[m.len * 2 + 1] = val;
     m.len += 1;
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_map_insert(map: *mut u8, key: i64, val: i64) {
+    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
+    unsafe { ensure_root_arena_locked() };
+    unsafe { __vow_map_insert_in_arena(&raw mut __vow_root_arena, map, key, val) };
 }
 
 #[unsafe(no_mangle)]
@@ -2657,6 +2683,16 @@ pub unsafe extern "C" fn __vow_map_contains(map: *const u8, key: i64) -> bool {
         }
     }
     false
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __vow_map_remove_in_arena(arena: *mut VowArena, map: *mut u8, key: i64) {
+    if arena.is_null() {
+        null_arena_trap("HashMap::remove");
+    }
+    // remove never allocates; the arena is accepted only for ABI symmetry
+    // with __vow_map_new_in_arena and __vow_map_insert_in_arena.
+    unsafe { __vow_map_remove(map, key) };
 }
 
 #[unsafe(no_mangle)]
@@ -3145,6 +3181,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        clippy::while_immutable_condition,
+        reason = "loop body mutates *v through __vow_vec_pop; clippy can't see through raw pointer"
+    )]
     fn vec_pop_truncate_loop() {
         let v = __vow_vec_new_val();
         for i in 0..10 {
@@ -3710,7 +3750,7 @@ mod tests {
         let mut a = empty_arena_header();
         unsafe { __vow_arena_open(&mut a) };
         let source = VowVec {
-            ptr: 1 as *mut u8,
+            ptr: std::ptr::dangling_mut::<u8>(),
             len: 0,
             cap: VOW_CAP_RODATA,
         };
@@ -3761,6 +3801,93 @@ mod tests {
         unsafe { __vow_arena_close(&mut a) };
     }
 
+    #[test]
+    fn explicit_arena_map_new_allocates_in_supplied_arena() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+
+        let cursor_before = a.cursor;
+        let m = unsafe { __vow_map_new_in_arena(&mut a) };
+        let cursor_after = a.cursor;
+
+        assert!(!m.is_null(), "__vow_map_new_in_arena returned null");
+        assert!(
+            cursor_after > cursor_before,
+            "arena cursor must advance for header + initial backing"
+        );
+
+        let header = unsafe { &*(m as *const VowMap) };
+        assert_eq!(header.len, 0);
+        assert_eq!(header.cap, MAP_INITIAL_CAP);
+        assert!(!header.ptr.is_null(), "initial backing must be allocated");
+
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
+    fn explicit_arena_map_remove_decrements_len() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+
+        let m = unsafe { __vow_map_new_in_arena(&mut a) };
+        unsafe { __vow_map_insert_in_arena(&mut a, m, 1, 10) };
+        unsafe { __vow_map_insert_in_arena(&mut a, m, 2, 20) };
+        assert_eq!(unsafe { __vow_map_len(m) }, 2);
+
+        unsafe { __vow_map_remove_in_arena(&mut a, m, 1) };
+        assert_eq!(unsafe { __vow_map_len(m) }, 1);
+        assert!(!unsafe { __vow_map_contains(m, 1) });
+        assert_eq!(unsafe { __vow_map_get(m, 2) }, 20);
+
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
+    fn explicit_arena_map_insert_grows_past_initial_cap() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+
+        let m = unsafe { __vow_map_new_in_arena(&mut a) };
+        // Force a copy-fallback growth: insert MAP_INITIAL_CAP entries, then
+        // an intervening alloc, then push the (cap+1)th entry. The intervening
+        // alloc invalidates try_extend, so growth must allocate and copy.
+        let n = (MAP_INITIAL_CAP + 4) as i64;
+        for i in 0..(MAP_INITIAL_CAP as i64) {
+            unsafe { __vow_map_insert_in_arena(&mut a, m, i, i * 100) };
+        }
+        let _intervening = unsafe { __vow_arena_alloc(&mut a, 16, 8) };
+        for i in (MAP_INITIAL_CAP as i64)..n {
+            unsafe { __vow_map_insert_in_arena(&mut a, m, i, i * 100) };
+        }
+
+        let header = unsafe { &*(m as *const VowMap) };
+        assert_eq!(header.len, n as usize);
+        assert!(header.cap > MAP_INITIAL_CAP, "cap must have doubled");
+        for i in 0..n {
+            assert_eq!(unsafe { __vow_map_get(m, i) }, i * 100);
+        }
+
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
+    #[test]
+    fn explicit_arena_map_insert_round_trips_through_get() {
+        let mut a = empty_arena_header();
+        unsafe { __vow_arena_open(&mut a) };
+
+        let m = unsafe { __vow_map_new_in_arena(&mut a) };
+        unsafe { __vow_map_insert_in_arena(&mut a, m, 7, 70) };
+        unsafe { __vow_map_insert_in_arena(&mut a, m, 3, 30) };
+
+        assert_eq!(unsafe { __vow_map_len(m) }, 2);
+        assert_eq!(unsafe { __vow_map_get(m, 7) }, 70);
+        assert_eq!(unsafe { __vow_map_get(m, 3) }, 30);
+        assert!(unsafe { __vow_map_contains(m, 7) });
+        assert!(!unsafe { __vow_map_contains(m, 99) });
+
+        unsafe { __vow_arena_close(&mut a) };
+    }
+
     // -----------------------------------------------------------------------
     // Runtime trap tests. These use the subprocess pattern:
     // rodata_trap_worker reruns itself with an env var and invokes the
@@ -3770,7 +3897,8 @@ mod tests {
 
     fn make_rodata_vec_val() -> VowVec {
         VowVec {
-            ptr: 1 as *mut u8, // never dereferenced; trap fires first
+            // never dereferenced; trap fires first
+            ptr: std::ptr::dangling_mut::<u8>(),
             len: 0,
             cap: VOW_CAP_RODATA,
         }
@@ -3778,7 +3906,7 @@ mod tests {
 
     fn make_rodata_map() -> VowMap {
         VowMap {
-            ptr: 1 as *mut u8,
+            ptr: std::ptr::dangling_mut::<u8>(),
             len: 0,
             cap: VOW_CAP_RODATA,
         }
@@ -3938,6 +4066,40 @@ mod tests {
             eprintln!("rodata_trap_worker: null arena string join did NOT trap");
             std::process::exit(42);
         }
+        if op == "HashMap::new_in_arena_null" {
+            let _ = unsafe { __vow_map_new_in_arena(std::ptr::null_mut()) };
+            eprintln!("rodata_trap_worker: null arena map new did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "HashMap::insert_in_arena_null" {
+            let mut m = VowMap {
+                ptr: 8 as *mut u8,
+                len: 0,
+                cap: 0,
+            };
+            unsafe {
+                __vow_map_insert_in_arena(
+                    std::ptr::null_mut(),
+                    &mut m as *mut _ as *mut u8,
+                    1,
+                    1,
+                )
+            };
+            eprintln!("rodata_trap_worker: null arena map insert did NOT trap");
+            std::process::exit(42);
+        }
+        if op == "HashMap::remove_in_arena_null" {
+            let mut m = VowMap {
+                ptr: 8 as *mut u8,
+                len: 0,
+                cap: 0,
+            };
+            unsafe {
+                __vow_map_remove_in_arena(std::ptr::null_mut(), &mut m as *mut _ as *mut u8, 1)
+            };
+            eprintln!("rodata_trap_worker: null arena map remove did NOT trap");
+            std::process::exit(42);
+        }
         let mut v = make_rodata_vec_val();
         let vp = &mut v as *mut _ as *mut u8;
         let mut m = make_rodata_map();
@@ -3962,6 +4124,11 @@ mod tests {
             "String::push_byte" => unsafe { __vow_string_push_byte(vp, 0x61) },
             "HashMap::insert" => unsafe { __vow_map_insert(mp, 1, 2) },
             "HashMap::remove" => unsafe { __vow_map_remove(mp, 1) },
+            "HashMap::insert_in_arena" => {
+                let mut a = empty_arena_header();
+                unsafe { __vow_arena_open(&mut a) };
+                unsafe { __vow_map_insert_in_arena(&mut a, mp, 1, 2) };
+            }
             other => panic!("unknown trap op: {other}"),
         }
         // Should be unreachable — each branch must trap.
@@ -4094,6 +4261,21 @@ mod tests {
     }
 
     #[test]
+    fn explicit_arena_map_new_null_arena_traps() {
+        assert_runtime_invariant_null_arena("HashMap::new_in_arena_null", "HashMap::new");
+    }
+
+    #[test]
+    fn explicit_arena_map_insert_null_arena_traps() {
+        assert_runtime_invariant_null_arena("HashMap::insert_in_arena_null", "HashMap::insert");
+    }
+
+    #[test]
+    fn explicit_arena_map_remove_null_arena_traps() {
+        assert_runtime_invariant_null_arena("HashMap::remove_in_arena_null", "HashMap::remove");
+    }
+
+    #[test]
     fn explicit_arena_string_fresh_helper_null_arena_traps() {
         let cases = [
             ("String::split_in_arena_null", "String::split"),
@@ -4155,6 +4337,10 @@ mod tests {
     #[test]
     fn rodata_map_insert_traps() {
         assert_rodata_trap("HashMap::insert", "HashMap::insert");
+    }
+    #[test]
+    fn rodata_map_insert_in_arena_traps() {
+        assert_rodata_trap("HashMap::insert_in_arena", "HashMap::insert");
     }
     #[test]
     fn rodata_map_remove_traps() {

--- a/vow-syntax/src/lexer.rs
+++ b/vow-syntax/src/lexer.rs
@@ -475,6 +475,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        clippy::approx_constant,
+        reason = "3.14 is the lexer input, not an approximation of PI"
+    )]
     fn lex_float_literal() {
         let kinds = lex("3.14 0.0");
         assert!(matches!(kinds[0], TokenKind::LitFloat(f) if (f - 3.14).abs() < 1e-10));

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -2090,7 +2090,10 @@ mod tests {
         }
     }
 
-    #[allow(dead_code, reason = "kept alongside dummy_span helpers for future test fixtures")]
+    #[allow(
+        dead_code,
+        reason = "kept alongside dummy_span helpers for future test fixtures"
+    )]
     fn make_param(name: &str, ty_name: &str) -> Param {
         Param {
             name: name.to_string(),

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -2090,6 +2090,7 @@ mod tests {
         }
     }
 
+    #[allow(dead_code, reason = "kept alongside dummy_span helpers for future test fixtures")]
     fn make_param(name: &str, ty_name: &str) -> Param {
         Param {
             name: name.to_string(),

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -173,6 +173,22 @@ fn string_model_receiver_arg(name: &str) -> Option<usize> {
     }
 }
 
+fn is_map_model_creator(name: &str) -> bool {
+    matches!(name, "__vow_map_new" | "__vow_map_new_in_arena")
+}
+
+fn map_model_receiver_arg(name: &str) -> Option<usize> {
+    match name {
+        "__vow_map_insert_in_arena" | "__vow_map_remove_in_arena" => Some(1),
+        "__vow_map_insert"
+        | "__vow_map_remove"
+        | "__vow_map_get"
+        | "__vow_map_contains"
+        | "__vow_map_len" => Some(0),
+        _ => None,
+    }
+}
+
 fn collect_typed_vars(func: &Function, creator: &str, prefix: &str) -> HashSet<u32> {
     let mut vars = HashSet::new();
 
@@ -182,7 +198,8 @@ fn collect_typed_vars(func: &Function, creator: &str, prefix: &str) -> HashSet<u
                 && let InstData::CallExtern(ref name) = inst.data
             {
                 let is_alt_creator = (prefix == "__vow_vec_" && is_vec_model_creator(name))
-                    || (prefix == "__vow_string_" && is_string_model_creator(name));
+                    || (prefix == "__vow_string_" && is_string_model_creator(name))
+                    || (prefix == "__vow_map_" && is_map_model_creator(name));
                 let is_creator = name == creator || is_alt_creator;
                 if is_creator {
                     vars.insert(inst.id.0);
@@ -192,6 +209,8 @@ fn collect_typed_vars(func: &Function, creator: &str, prefix: &str) -> HashSet<u
                         vec_model_receiver_arg(name)
                     } else if prefix == "__vow_string_" {
                         string_model_receiver_arg(name)
+                    } else if prefix == "__vow_map_" {
+                        map_model_receiver_arg(name)
                     } else {
                         Some(0)
                     };
@@ -324,11 +343,14 @@ fn is_known_builtin(name: &str) -> bool {
             | "__vow_string_parse_u64_opt"
             | "__vow_string_print"
             | "__vow_map_new"
+            | "__vow_map_new_in_arena"
             | "__vow_map_len"
             | "__vow_map_insert"
+            | "__vow_map_insert_in_arena"
             | "__vow_map_get"
             | "__vow_map_contains"
             | "__vow_map_remove"
+            | "__vow_map_remove_in_arena"
             | "__vow_btreemap_new"
             | "__vow_btreemap_len"
             | "__vow_btreemap_insert"
@@ -1178,18 +1200,32 @@ fn emit_inst(
         // HashMap operations — modeled as abstract struct with len + keys/vals arrays
         Opcode::Call if matches!(&inst.data, InstData::CallExtern(n) if n.starts_with("__vow_map_")) => {
             if let InstData::CallExtern(ref name) = inst.data {
+                // _in_arena variants share their bodies with the root forms;
+                // they accept an extra leading arena pointer that the verifier
+                // C model ignores (arenas are opaque).
+                let arena_offset = if matches!(
+                    name.as_str(),
+                    "__vow_map_new_in_arena"
+                        | "__vow_map_insert_in_arena"
+                        | "__vow_map_remove_in_arena"
+                ) {
+                    1
+                } else {
+                    0
+                };
+                let arg = |i: usize| inst.args[arena_offset + i].0;
                 match name.as_str() {
-                    "__vow_map_new" => {
+                    "__vow_map_new" | "__vow_map_new_in_arena" => {
                         out.push_str(&format!("  v{id}.len = 0;\n"));
                     }
                     "__vow_map_len" => {
-                        let m = inst.args[0].0;
+                        let m = arg(0);
                         out.push_str(&format!("  v{id} = v{m}.len;\n"));
                     }
-                    "__vow_map_insert" => {
-                        let m = inst.args[0].0;
-                        let k = inst.args[1].0;
-                        let v = inst.args[2].0;
+                    "__vow_map_insert" | "__vow_map_insert_in_arena" => {
+                        let m = arg(0);
+                        let k = arg(1);
+                        let v = arg(2);
                         let hashmap_max = limits.hashmap_max;
                         out.push_str(&format!(
                             "  {{\n\
@@ -1205,8 +1241,8 @@ fn emit_inst(
                         ));
                     }
                     "__vow_map_get" => {
-                        let m = inst.args[0].0;
-                        let k = inst.args[1].0;
+                        let m = arg(0);
+                        let k = arg(1);
                         out.push_str(&format!(
                             "  v{id} = 0;\n\
                              \x20 for (int64_t __i = 0; __i < v{m}.len; __i++) {{\n\
@@ -1215,8 +1251,8 @@ fn emit_inst(
                         ));
                     }
                     "__vow_map_contains" => {
-                        let m = inst.args[0].0;
-                        let k = inst.args[1].0;
+                        let m = arg(0);
+                        let k = arg(1);
                         out.push_str(&format!(
                             "  v{id} = 0;\n\
                              \x20 for (int64_t __i = 0; __i < v{m}.len; __i++) {{\n\
@@ -1224,9 +1260,9 @@ fn emit_inst(
                              \x20 }}\n"
                         ));
                     }
-                    "__vow_map_remove" => {
-                        let m = inst.args[0].0;
-                        let k = inst.args[1].0;
+                    "__vow_map_remove" | "__vow_map_remove_in_arena" => {
+                        let m = arg(0);
+                        let k = arg(1);
                         out.push_str(&format!(
                             "  for (int64_t __i = 0; __i < v{m}.len; __i++) {{\n\
                              \x20   if (v{m}.keys[__i] == v{k}) {{\n\
@@ -4435,7 +4471,7 @@ mod tests {
         let resample_pos = c[len_inc_pos..]
             .find(resample)
             .map(|p| p + len_inc_pos)
-            .expect(&format!("re-sample must follow v1.len++: {c}"));
+            .unwrap_or_else(|| panic!("re-sample must follow v1.len++: {c}"));
         let second_read_pos = c
             .find("v7 = (v1.len == v3.len)")
             .expect("second read must exist");
@@ -4521,7 +4557,7 @@ mod tests {
         let resample_pos = c[push_pos..]
             .find(resample)
             .map(|p| p + push_pos)
-            .expect(&format!("re-sample must follow push_str body: {c}"));
+            .unwrap_or_else(|| panic!("re-sample must follow push_str body: {c}"));
         let second_read_pos = c
             .find("v6 = (v1.len == v3.len)")
             .expect("second read must exist");
@@ -4601,14 +4637,14 @@ mod tests {
         // The new model emits `len = 0`.
         let zero_pos = c
             .find("v1.len = 0;")
-            .expect(&format!("clear must emit `v1.len = 0;`: {c}"));
+            .unwrap_or_else(|| panic!("clear must emit `v1.len = 0;`: {c}"));
         // Re-sample for the (1, 3) pair follows the clear and precedes the
         // second read.
         let resample = "__str_eq_1_3 = __VERIFIER_nondet_bool();";
         let resample_pos = c[zero_pos..]
             .find(resample)
             .map(|p| p + zero_pos)
-            .expect(&format!("re-sample must follow clear: {c}"));
+            .unwrap_or_else(|| panic!("re-sample must follow clear: {c}"));
         let second_read_pos = c
             .find("v6 = (v1.len == v3.len)")
             .expect("second read must exist");

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -180,10 +180,7 @@ fn is_map_model_creator(name: &str) -> bool {
 fn map_model_receiver_arg(name: &str) -> Option<usize> {
     match name {
         "__vow_map_insert_in_arena" | "__vow_map_remove_in_arena" => Some(1),
-        "__vow_map_insert"
-        | "__vow_map_remove"
-        | "__vow_map_get"
-        | "__vow_map_contains"
+        "__vow_map_insert" | "__vow_map_remove" | "__vow_map_get" | "__vow_map_contains"
         | "__vow_map_len" => Some(0),
         _ => None,
     }
@@ -1198,7 +1195,8 @@ fn emit_inst(
         }
 
         // HashMap operations — modeled as abstract struct with len + keys/vals arrays
-        Opcode::Call if matches!(&inst.data, InstData::CallExtern(n) if n.starts_with("__vow_map_")) => {
+        Opcode::Call if matches!(&inst.data, InstData::CallExtern(n) if n.starts_with("__vow_map_")) =>
+        {
             if let InstData::CallExtern(ref name) = inst.data {
                 // _in_arena variants share their bodies with the root forms;
                 // they accept an extra leading arena pointer that the verifier

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -9245,7 +9245,7 @@ fn main() -> i32 {
         assert_eq!(callee_sites[1].caller_function, "caller_b");
         assert_eq!(callee_sites[1].offset, 200);
         assert_eq!(callee_sites[1].length, 15);
-        assert!(index.get("caller_a").is_none());
+        assert!(!index.contains_key("caller_a"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add explicit-arena HashMap runtime symbols (`__vow_map_new_in_arena`, `__vow_map_insert_in_arena`, `__vow_map_remove_in_arena`) and convert the existing root forms to delegate through `&__vow_root_arena` under `ROOT_ARENA_LOCK`.
- Route HashMap creation and insert-driven growth to inferred per-block arenas in Rust codegen, the Clif shim, and the self-hosted compiler. Mirrors slice 4 (Vec, #305) and slice 5 (String, #307).
- Teach Rust and self-hosted verifier C models about the arena-prefixed HashMap symbols (the `_in_arena` arms reuse the root-form bodies via an `arena_offset` since the verifier treats arenas as opaque).
- Document the new HashMap arena runtime API in `docs/design/arena_memory.md` §3.3, including the i64-only MVP scope.
- Fix the pre-existing rustc 1.95 clippy errors on the branch base so `cargo clippy --all -- -D warnings` is clean.

`__vow_map_remove_in_arena` is exposed for ABI symmetry with the issue's acceptance list; codegen never routes to it because remove never allocates. The receiver-driven dispatch on `__vow_map_insert` follows the existing `__vow_vec_push_val` / `__vow_string_push_str` precedent.

Fixes #294.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo clippy --all --tests -- -D warnings`
- `cargo test --all`
- `cargo build --all --release`
- `scripts/bootstrap.sh --skip-cargo` — `vowc2 == vowc3`, SHA-256 `777d2058f22799285b607d02eb057360e909d6cdfb3d458d6f867c68e1b97034`
- `bash bench/memory/run.sh` — 13/13 PASS, including new `alloc_loop_map` (70 000 iterations, peak 2.9 MiB RSS — arena reclamation confirmed)
- `./target/release/vow verify examples/map_insert.vow` → `Verified`
- `./target/release/vow verify examples/map_missing.vow` → `VerifyFailed` with the expected `VowEnsuresViolated` counterexample