### PR TITLE
Surface link failures as CompileFailed across both compilers

### DIFF
--- a/bench/memory/run.sh
+++ b/bench/memory/run.sh
@@ -286,6 +286,14 @@ for source in "${PROGRAMS[@]}"; do
 
   if [[ "$build_exit" -ne 0 || ! -x "$binary" ]]; then
     emit_result "build_failed" "$name" "$source" "$binary" "$build_exit" "" "" "$bound" ""
+    if [[ -s "$build_stdout" ]]; then
+      printf '  build stdout (%s):\n' "$name" >&2
+      sed 's/^/    /' "$build_stdout" >&2
+    fi
+    if [[ -s "$build_stderr" ]]; then
+      printf '  build stderr (%s):\n' "$name" >&2
+      sed 's/^/    /' "$build_stderr" >&2
+    fi
     OVERALL=1
     continue
   fi

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -592,10 +592,9 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         return 1;
     }
     if result == -2 {
-        if !do_verify {
-            diag_emit_build_verify_json(String::from("Unverified"), String::from(""), dctx, Vec::new());
-            return 0;
-        }
+        eprintln_str(String::from("link failed"));
+        diag_emit_build_verify_json(String::from("CompileFailed"), String::from(""), dctx, Vec::new());
+        return 1;
     }
     if !do_verify {
         diag_emit_build_verify_json(String::from("Unverified"), out, dctx, Vec::new());
@@ -1041,13 +1040,15 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             let result: i64 = clif_emit_module(ir_mod, out, mode, trace);
             if result == -1 {
                 eprintln_str(String::from("compilation failed"));
+                diag_emit_build_json(String::from("CompileFailed"), String::from(""), dctx);
                 return 1;
             }
             if result == -2 {
-                diag_emit_build_json(String::from("Unverified"), String::from(""), dctx);
-            } else {
-                diag_emit_build_json(String::from("Unverified"), out, dctx);
+                eprintln_str(String::from("link failed"));
+                diag_emit_build_json(String::from("CompileFailed"), String::from(""), dctx);
+                return 1;
             }
+            diag_emit_build_json(String::from("Unverified"), out, dctx);
         } else {
             emit_ir_warnings(ir_mod, dctx);
             let ir_text: String = print_module(ir_mod);

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2609,16 +2609,20 @@ pub unsafe extern "C" fn __vow_clif_link(obj_path_ptr: i64, output_path_ptr: i64
     let obj_path = unsafe { read_vow_string(obj_path_ptr) };
     let output_path = unsafe { read_vow_string(output_path_ptr) };
 
-    let runtime_lib = find_lib("libvow_runtime.a");
+    let runtime_lib = match find_lib("libvow_runtime.a") {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "clif_shim: could not find libvow_runtime.a; build it with `cargo build --release --all` or set VOW_RUNTIME_PATH"
+            );
+            return -1;
+        }
+    };
     let shim_lib = find_lib("libvow_clif_shim.a");
 
     let mut cmd = std::process::Command::new("cc");
     cmd.arg(obj_path);
-    if let Some(ref rt) = runtime_lib {
-        cmd.arg(rt);
-    } else {
-        eprintln!("clif_shim: warning: could not find libvow_runtime.a");
-    }
+    cmd.arg(&runtime_lib);
     if let Some(ref sl) = shim_lib {
         cmd.arg(sl);
     }

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -5660,24 +5660,21 @@ fn run_verify_only_inner(
 // Full build pipeline (vow build / legacy)
 // ---------------------------------------------------------------------------
 
-fn link_obj(obj_path: &Path, output_path: &Path) -> Option<PathBuf> {
-    match find_runtime_lib() {
-        Some(runtime) => {
-            match link(
-                &[obj_path],
-                &runtime,
-                find_shim_lib().as_deref(),
-                output_path,
-            ) {
-                Ok(()) => {
-                    let _ = std::fs::remove_file(obj_path);
-                    Some(output_path.to_path_buf())
-                }
-                Err(_) => None,
-            }
-        }
-        None => None,
-    }
+fn link_obj(obj_path: &Path, output_path: &Path) -> Result<PathBuf, String> {
+    let runtime = find_runtime_lib().ok_or_else(|| {
+        "could not find libvow_runtime.a; build it with `cargo build --release --all` \
+         or set VOW_RUNTIME_PATH"
+            .to_string()
+    })?;
+    link(
+        &[obj_path],
+        &runtime,
+        find_shim_lib().as_deref(),
+        output_path,
+    )
+    .map_err(|e| format!("link failed: {e:?}"))?;
+    let _ = std::fs::remove_file(obj_path);
+    Ok(output_path.to_path_buf())
 }
 
 // Compile-object cache is only enabled when `--no-cache` is off and verification is off, so verified builds always link a fresh codegen output.
@@ -5822,7 +5819,20 @@ fn run_pipeline_from_frontend(
         && let Some(cached_obj) = cc.lookup(key)
         && std::fs::copy(&cached_obj, &obj_path).is_ok()
     {
-        let exe_path = link_obj(&obj_path, &output_path);
+        let exe_path = match link_obj(&obj_path, &output_path) {
+            Ok(p) => Some(p),
+            Err(message) => {
+                let _ = verify_handle.join();
+                return BuildOutput {
+                    status: BuildStatus::CompileFailed { message },
+                    executable: None,
+                    diagnostics: all_diagnostics,
+                    counterexamples: vec![],
+                    verify_status: None,
+                    verify_message: None,
+                };
+            }
+        };
         let (verify_outcome, skipped) = verify_handle
             .join()
             .unwrap_or((VerifyOutcome::Skipped, Vec::new()));
@@ -5878,7 +5888,20 @@ fn run_pipeline_from_frontend(
         cc.store(key, &obj_path);
     }
 
-    let exe_path = link_obj(&obj_path, &output_path);
+    let exe_path = match link_obj(&obj_path, &output_path) {
+        Ok(p) => Some(p),
+        Err(message) => {
+            let _ = verify_handle.join();
+            return BuildOutput {
+                status: BuildStatus::CompileFailed { message },
+                executable: None,
+                diagnostics: all_diagnostics,
+                counterexamples: vec![],
+                verify_status: None,
+                verify_message: None,
+            };
+        }
+    };
 
     let (verify_outcome, skipped) = verify_handle
         .join()


### PR DESCRIPTION
## Summary

Both compilers silently reported build success when the link step failed; this fixes them both and improves the bench harness diagnostics.

## Background

Discovered while running `bench/memory/run.sh` against a fresh worktree where `cargo build --release -p vow` had run but `libvow_runtime.a` (in `vow-runtime`) had not been built. All 13 bench programs reported `build_failed` with `build_exit=0` — no error message in stderr, no diagnostic in JSON. The compiler returned:

```json
{"status":"Unverified","executable":null,"diagnostics":[],"counterexamples":[]}
```

with exit 0, leaving the harness no way to distinguish "build worked" from "linker silently produced nothing."

## Changes

- **`vow/src/main.rs`** — `link_obj` returns `Result<PathBuf, String>` instead of `Option<PathBuf>`; both call sites propagate `Err` as `BuildStatus::CompileFailed { message }` after joining the verify thread. The error covers both failure modes (runtime not found, `cc` exited non-zero) with a useful message naming `cargo build --release --all` and `VOW_RUNTIME_PATH`.
- **`compiler/main.vow`** — both `clif_emit_module` call sites now emit `{"status":"CompileFailed","executable":""}` and return `1` when the result is `-2` (link failed). One of them additionally now emits a JSON diagnostic on the `-1` (codegen failure) branch instead of just `eprintln`-ing.
- **`vow-clif-shim/src/lib.rs`** — `__vow_clif_link` returns `-1` immediately if `libvow_runtime.a` cannot be found, instead of warning to stderr and proceeding with cc.
- **`bench/memory/run.sh`** — when emitting `build_failed`, also prints the build's stdout (compiler JSON) and stderr to the harness's own stderr, so the user sees the diagnostic inline.

## Verification

After the fix, hiding `libvow_runtime.a` and running the harness yields:

```
FAIL alloc_call_store           rss=null KiB bound=8528 KiB wall=nulls status=build_failed
{"program":"alloc_call_store",...,"build_exit":1,...,"status":"build_failed"}
  build stdout (alloc_call_store):
    {"status":"CompileFailed","executable":null,"diagnostics":[],
     "message":"could not find libvow_runtime.a; build it with `cargo build --release --all` or set VOW_RUNTIME_PATH",
     "counterexamples":[]}
```

- `cargo test --all`: pass.
- `cargo clippy --all -- -D warnings`: pass.
- `cargo fmt --all -- --check`: pass.
- `scripts/bootstrap.sh --skip-cargo`: byte-identical fixed point at SHA-256 `512d802464b26bea0c6120da13d6804b9ff29c86eeae1912ba6ab128ee5bd2b5`.
- `bench/memory/run.sh`: 13/13 PASS.

## Test plan

- [ ] CI passes (cargo test, clippy, fmt, bootstrap).
- [ ] Manually move `target/release/libvow_runtime.a` aside, run `target/release/vow build --no-verify examples/hello.vow -o /tmp/x` and verify exit code 1 + JSON `status: CompileFailed` with the helpful message.
- [ ] Manually run `bench/memory/run.sh` with no `libvow_runtime.a` present and confirm the harness now prints the compiler's diagnostic to stderr.