### PR TITLE
region: extend RegionRootEscape skip-set through FieldSet initializers (#319)

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -4209,7 +4209,7 @@ fn skill_full() -> String {
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("**Fix:** Often none -- if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value or any allocation installed as a field of the returned struct (e.g. `Item { name: String::from(\"hi\") }`).\n"));
+    r.push_str(String::from("**Fix:** Often none -- if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value or any allocation installed as a field of the returned struct (e.g. `Item { name: String::from(\"hi\") }`). Note: this exemption is conservative -- if a field is overwritten before the return (`x.f = A; x.f = B; return x`), the overwritten allocation A is also suppressed (issue #326).\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### VerificationSkipped\n"));
     r.push_str(String::from("\n"));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -4209,7 +4209,7 @@ fn skill_full() -> String {
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("**Fix:** Often none -- if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value itself.\n"));
+    r.push_str(String::from("**Fix:** Often none -- if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value or any allocation installed as a field of the returned struct (e.g. `Item { name: String::from(\"hi\") }`).\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### VerificationSkipped\n"));
     r.push_str(String::from("\n"));

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1193,28 +1193,11 @@ fn emit_root_escape_notes_module(
     }
 }
 
-// Collect the IDs of every value reachable from a Return — directly,
-// through Phi nodes via their Upsilon arms, and through struct field
-// initializers (FieldSet insts whose target pointer is itself a fresh
-// RegionAlloc already in the skip-set). Used by
-// `emit_root_escape_notes_module` to skip notes on the canonical
-// FreshInCaller return path, including:
-//   - conditional-construction patterns
-//     (`if cond { X{..} } else { X{..} }`) where the Phi is returned but
-//     the underlying RegionAllocs in each arm are the actual heap
-//     producers; and
-//   - struct field initializers of a freshly-allocated returned struct
-//     (`Item { name: String::from("hi") }` from `make_item`) where the
-//     inner allocation shares the parent struct's caller-arena lifetime
-//     per spec §4.4.
-//
-// The exemption deliberately does NOT extend to FieldSets whose target
-// is a parameter or other non-fresh pointer (e.g.
-// `target.name = String::from("hi"); return target`): mutations into a
-// caller-owned container are genuine store-effect escapes, not field
-// initializers, and must keep firing the note. We distinguish the two
-// cases by checking that the target id was produced by IOP_REGION_ALLOC
-// — only then is it a fresh aggregate.
+// Build the FreshInCaller return-value skip-set used by
+// `emit_root_escape_notes_module`. The FieldSet edge is gated on
+// `region_alloc_ids` so it follows initializers of a fresh struct
+// (`Item { name: ... }`) but not mutations into a parameter
+// (`target.name = ...; return target`); spec §4.4.
 fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
     let mut out: Vec<i64> = Vec::new();
     // First gather direct Return arguments.
@@ -1232,11 +1215,6 @@ fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
         }
         bi = bi + 1;
     }
-    // Pre-collect RegionAlloc-produced IDs so the FieldSet edge below
-    // can gate on "target is a fresh aggregate" without re-scanning per
-    // pop. Linear scan via `region_vec_contains_i64` is consistent with
-    // the existing `out` skip check (Vow's stdlib has no ordered-set
-    // type — same caveat as the perf note above on `returned_ids`).
     let mut region_alloc_ids: Vec<i64> = Vec::new();
     let mut rai: i64 = 0;
     while rai < bks.len() {
@@ -1251,9 +1229,6 @@ fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
         }
         rai = rai + 1;
     }
-    // DFS expansion through Phi arms (via Upsilon) and through struct
-    // field initializers (via FieldSet whose target pointer is itself a
-    // fresh RegionAlloc already in the skip-set).
     while stack.len() > 0 {
         let id: i64 = stack[stack.len() - 1];
         stack.pop();

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1242,16 +1242,16 @@ fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
             let sblk: IrBlock = bks[sbi];
             let mut sii: i64 = 0;
             while sii < sblk.insts.len() {
-                let up: IrInst = sblk.insts[sii];
-                if up.op == IOP_UPSILON() && up.dk == IDATA_PHI_TARGET()
-                    && up.dv == id && up.args.len() > 0
+                let inst: IrInst = sblk.insts[sii];
+                if inst.op == IOP_UPSILON() && inst.dk == IDATA_PHI_TARGET()
+                    && inst.dv == id && inst.args.len() > 0
                 {
-                    stack.push(up.args[0]);
+                    stack.push(inst.args[0]);
                 }
-                if id_is_fresh_alloc && up.op == IOP_FIELD_SET()
-                    && up.args.len() >= 2 && up.args[0] == id
+                if id_is_fresh_alloc && inst.op == IOP_FIELD_SET()
+                    && inst.args.len() >= 2 && inst.args[0] == id
                 {
-                    stack.push(up.args[1]);
+                    stack.push(inst.args[1]);
                 }
                 sii = sii + 1;
             }

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1193,12 +1193,18 @@ fn emit_root_escape_notes_module(
     }
 }
 
-// Collect the IDs of every value reachable from a Return — directly, and
-// through Phi nodes via their Upsilon arms. Used by
-// `emit_root_escape_notes_module` to skip notes on the canonical
-// FreshInCaller return path, including conditional-construction patterns
-// (`if cond { X{..} } else { X{..} }`) where the Phi is returned but the
-// underlying RegionAllocs in each arm are the actual heap producers.
+// Collect the IDs of every value reachable from a Return — directly,
+// through Phi nodes via their Upsilon arms, and through struct field
+// initializers via FieldSet insts whose target pointer is already in the
+// skip-set. Used by `emit_root_escape_notes_module` to skip notes on the
+// canonical FreshInCaller return path, including:
+//   - conditional-construction patterns
+//     (`if cond { X{..} } else { X{..} }`) where the Phi is returned but
+//     the underlying RegionAllocs in each arm are the actual heap
+//     producers; and
+//   - struct field initializers (`Item { name: String::from("hi") }` from
+//     `make_item`) where the inner allocation shares the parent struct's
+//     caller-arena lifetime per spec §4.4.
 fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
     let mut out: Vec<i64> = Vec::new();
     // First gather direct Return arguments.
@@ -1216,7 +1222,8 @@ fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
         }
         bi = bi + 1;
     }
-    // DFS expansion through Phi arms via Upsilon insts.
+    // DFS expansion through Phi arms (via Upsilon) and struct fields
+    // (via FieldSet whose target pointer is already in the skip-set).
     while stack.len() > 0 {
         let id: i64 = stack[stack.len() - 1];
         stack.pop();
@@ -1234,6 +1241,11 @@ fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
                     && up.dv == id && up.args.len() > 0
                 {
                     stack.push(up.args[0]);
+                }
+                if up.op == IOP_FIELD_SET() && up.args.len() >= 2
+                    && up.args[0] == id
+                {
+                    stack.push(up.args[1]);
                 }
                 sii = sii + 1;
             }

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1200,8 +1200,10 @@ fn emit_root_escape_notes_module(
 // (`target.name = ...; return target`); spec §4.4.
 fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
     let mut out: Vec<i64> = Vec::new();
-    // First gather direct Return arguments.
     let mut stack: Vec<i64> = Vec::new();
+    let mut region_alloc_ids: Vec<i64> = Vec::new();
+    // Single setup pass: gather Return-arg seeds and the RegionAlloc-id
+    // gate set in the same scan over `bks`.
     let mut bi: i64 = 0;
     while bi < bks.len() {
         let blk: IrBlock = bks[bi];
@@ -1211,23 +1213,12 @@ fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
             if inst.op == IOP_RETURN() && inst.args.len() > 0 {
                 stack.push(inst.args[0]);
             }
+            if inst.op == IOP_REGION_ALLOC() {
+                region_alloc_ids.push(inst.id);
+            }
             ii = ii + 1;
         }
         bi = bi + 1;
-    }
-    let mut region_alloc_ids: Vec<i64> = Vec::new();
-    let mut rai: i64 = 0;
-    while rai < bks.len() {
-        let rblk: IrBlock = bks[rai];
-        let mut rii: i64 = 0;
-        while rii < rblk.insts.len() {
-            let rinst: IrInst = rblk.insts[rii];
-            if rinst.op == IOP_REGION_ALLOC() {
-                region_alloc_ids.push(rinst.id);
-            }
-            rii = rii + 1;
-        }
-        rai = rai + 1;
     }
     while stack.len() > 0 {
         let id: i64 = stack[stack.len() - 1];

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -1195,16 +1195,26 @@ fn emit_root_escape_notes_module(
 
 // Collect the IDs of every value reachable from a Return — directly,
 // through Phi nodes via their Upsilon arms, and through struct field
-// initializers via FieldSet insts whose target pointer is already in the
-// skip-set. Used by `emit_root_escape_notes_module` to skip notes on the
-// canonical FreshInCaller return path, including:
+// initializers (FieldSet insts whose target pointer is itself a fresh
+// RegionAlloc already in the skip-set). Used by
+// `emit_root_escape_notes_module` to skip notes on the canonical
+// FreshInCaller return path, including:
 //   - conditional-construction patterns
 //     (`if cond { X{..} } else { X{..} }`) where the Phi is returned but
 //     the underlying RegionAllocs in each arm are the actual heap
 //     producers; and
-//   - struct field initializers (`Item { name: String::from("hi") }` from
-//     `make_item`) where the inner allocation shares the parent struct's
-//     caller-arena lifetime per spec §4.4.
+//   - struct field initializers of a freshly-allocated returned struct
+//     (`Item { name: String::from("hi") }` from `make_item`) where the
+//     inner allocation shares the parent struct's caller-arena lifetime
+//     per spec §4.4.
+//
+// The exemption deliberately does NOT extend to FieldSets whose target
+// is a parameter or other non-fresh pointer (e.g.
+// `target.name = String::from("hi"); return target`): mutations into a
+// caller-owned container are genuine store-effect escapes, not field
+// initializers, and must keep firing the note. We distinguish the two
+// cases by checking that the target id was produced by IOP_REGION_ALLOC
+// — only then is it a fresh aggregate.
 fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
     let mut out: Vec<i64> = Vec::new();
     // First gather direct Return arguments.
@@ -1222,8 +1232,28 @@ fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
         }
         bi = bi + 1;
     }
-    // DFS expansion through Phi arms (via Upsilon) and struct fields
-    // (via FieldSet whose target pointer is already in the skip-set).
+    // Pre-collect RegionAlloc-produced IDs so the FieldSet edge below
+    // can gate on "target is a fresh aggregate" without re-scanning per
+    // pop. Linear scan via `region_vec_contains_i64` is consistent with
+    // the existing `out` skip check (Vow's stdlib has no ordered-set
+    // type — same caveat as the perf note above on `returned_ids`).
+    let mut region_alloc_ids: Vec<i64> = Vec::new();
+    let mut rai: i64 = 0;
+    while rai < bks.len() {
+        let rblk: IrBlock = bks[rai];
+        let mut rii: i64 = 0;
+        while rii < rblk.insts.len() {
+            let rinst: IrInst = rblk.insts[rii];
+            if rinst.op == IOP_REGION_ALLOC() {
+                region_alloc_ids.push(rinst.id);
+            }
+            rii = rii + 1;
+        }
+        rai = rai + 1;
+    }
+    // DFS expansion through Phi arms (via Upsilon) and through struct
+    // field initializers (via FieldSet whose target pointer is itself a
+    // fresh RegionAlloc already in the skip-set).
     while stack.len() > 0 {
         let id: i64 = stack[stack.len() - 1];
         stack.pop();
@@ -1231,6 +1261,7 @@ fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
             continue;
         }
         out.push(id);
+        let id_is_fresh_alloc: bool = region_vec_contains_i64(region_alloc_ids, id);
         let mut sbi: i64 = 0;
         while sbi < bks.len() {
             let sblk: IrBlock = bks[sbi];
@@ -1242,8 +1273,8 @@ fn collect_returned_ids(bks: Vec<IrBlock>) -> Vec<i64> {
                 {
                     stack.push(up.args[0]);
                 }
-                if up.op == IOP_FIELD_SET() && up.args.len() >= 2
-                    && up.args[0] == id
+                if id_is_fresh_alloc && up.op == IOP_FIELD_SET()
+                    && up.args.len() >= 2 && up.args[0] == id
                 {
                     stack.push(up.args[1]);
                 }

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -849,7 +849,19 @@ the diagnostic is non-blocking and informational.
 The note SHOULD NOT fire for the canonical `FreshInCaller`
 return-value pattern (`fn make_X() -> X`), where the alloc is the
 return value — that's the documented mechanism for producing values
-in a caller's arena and carries no hidden surprise.
+in a caller's arena and carries no hidden surprise. The exemption
+extends transitively to allocations installed as fields of the
+returned struct via field initializers (`Item { name:
+String::from("hi") }` from `make_item() -> Item`): those field
+allocations share the parent struct's caller-arena lifetime, and
+the parent's note (when applicable) already conveys the full
+escape information — surfacing the children adds noise without
+information. The exemption is strictly structural: it follows the
+return value through Phi arms (via Upsilon) and through field
+initializers (via the lowered FieldSet whose target pointer is in
+the skip-set). It does NOT extend to post-allocation mutation
+through Store, nor to values routed through callee store-effect
+chains, both of which represent genuine side-effect escapes.
 
 Rationale: structured rejection on genuine constraint failures is
 the CEGIS feedback signal; structured visibility on root routing

--- a/docs/design/arena_memory.md
+++ b/docs/design/arena_memory.md
@@ -857,11 +857,21 @@ allocations share the parent struct's caller-arena lifetime, and
 the parent's note (when applicable) already conveys the full
 escape information — surfacing the children adds noise without
 information. The exemption is strictly structural: it follows the
-return value through Phi arms (via Upsilon) and through field
-initializers (via the lowered FieldSet whose target pointer is in
-the skip-set). It does NOT extend to post-allocation mutation
-through Store, nor to values routed through callee store-effect
-chains, both of which represent genuine side-effect escapes.
+return value through Phi arms (via Upsilon) and through FieldSet
+edges, gated on the FieldSet target pointer being itself a fresh
+`RegionAlloc` (not a `GetArg` parameter alias or other non-fresh
+value). The structural test is **`GetArg` vs `RegionAlloc` as the
+FieldSet target**, not `Store` vs `FieldSet`: parameter mutation
+(`target.name = ...; return target`) and callee store-effect routing
+both correctly fall outside the exemption. One known conservative
+approximation: when a fresh struct's same field is overwritten
+before the return (`x.f = A; x.f = B; return x`), the overwritten
+allocation A also enters the skip-set and is not flagged, even
+though it is no longer reachable from the returned value (tracked in
+issue #326). `Store` is also out of scope for the exemption: it
+represents arbitrary post-allocation mutation through a pointer with
+unknown aliasing, semantically distinct from constructor-time field
+initialization.
 
 Rationale: structured rejection on genuine constraint failures is
 the CEGIS feedback signal; structured visibility on root routing

--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -297,7 +297,7 @@ The note is conservative — it fires for any `Caller`-region allocation in a fu
 }
 ```
 
-**Fix:** Often none — if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value or any allocation installed as a field of the returned struct (e.g. `Item { name: String::from("hi") }`).
+**Fix:** Often none — if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value or any allocation installed as a field of the returned struct (e.g. `Item { name: String::from("hi") }`). Note: this exemption is conservative — if a field is overwritten before the return (`x.f = A; x.f = B; return x`), the overwritten allocation A is also suppressed (issue #326).
 
 ### VerificationSkipped
 

--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -297,7 +297,7 @@ The note is conservative — it fires for any `Caller`-region allocation in a fu
 }
 ```
 
-**Fix:** Often none — if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value itself.
+**Fix:** Often none — if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value or any allocation installed as a field of the returned struct (e.g. `Item { name: String::from("hi") }`).
 
 ### VerificationSkipped
 

--- a/tests/run/region_param_field_mutation.vow
+++ b/tests/run/region_param_field_mutation.vow
@@ -1,0 +1,23 @@
+// TEST: stdout ""
+// Issue #319 regression — the FieldSet skip-set extension must NOT
+// suppress notes for FieldSets into a parameter (caller-owned) container.
+// `fill` mutates `target.name` with a fresh String allocation and then
+// returns `target`. The `String::from("hi")` is a genuine store-effect
+// escape into a caller-owned container — exactly what RegionRootEscape
+// exists to flag — and must keep firing the note.
+module Repro
+
+pub struct Box {
+    name: String,
+}
+
+fn fill(target: Box) -> Box {
+    target.name = String::from("hi");
+    target
+}
+
+fn main() -> i32 {
+    let b: Box = Box { name: String::from("init") };
+    let b2: Box = fill(b);
+    0
+}

--- a/tests/run/region_param_field_mutation.vow
+++ b/tests/run/region_param_field_mutation.vow
@@ -5,6 +5,14 @@
 // returns `target`. The `String::from("hi")` is a genuine store-effect
 // escape into a caller-owned container — exactly what RegionRootEscape
 // exists to flag — and must keep firing the note.
+//
+// The diagnostic-count assertion (>=1 RegionRootEscape note) lives in
+// `vow/tests/region_summary_equivalence.rs` (`rust_*` and `self_hosted_*`
+// param_field_mutation tests). The `// TEST: stdout ""` annotation here
+// only validates that the program compiles and runs cleanly under the
+// run-suite shell harness; it does NOT guard the negative diagnostic
+// case. If the self-hosted parity tests skip (no `build/vowc`), the
+// self-hosted half of this guarantee is unchecked.
 module Repro
 
 pub struct Box {

--- a/tests/run/region_skip_struct_field.vow
+++ b/tests/run/region_skip_struct_field.vow
@@ -1,0 +1,22 @@
+// TEST: stdout ""
+// Issue #319 — RegionRootEscape skip-set extends through StructNew
+// field initializers. `make_item` returns an `Item` whose `name` field
+// is a fresh `String::from("hi")` allocation. Because the parent `Item`
+// is on the canonical FreshInCaller return path, the inner `String`
+// allocation should not fire a RegionRootEscape note: it shares the
+// caller-arena lifetime of the parent struct, and the parent's note
+// (when applicable) already conveys the escape information.
+module Repro
+
+pub struct Item {
+    name: String,
+}
+
+fn make_item() -> Item {
+    Item { name: String::from("hi") }
+}
+
+fn main() -> i32 {
+    let item: Item = make_item();
+    0
+}

--- a/tests/run/region_skip_struct_field.vow
+++ b/tests/run/region_skip_struct_field.vow
@@ -1,6 +1,7 @@
 // TEST: stdout ""
-// Issue #319 — RegionRootEscape skip-set extends through StructNew
-// field initializers. `make_item` returns an `Item` whose `name` field
+// Issue #319 — RegionRootEscape skip-set extends through struct field
+// initializers (the FieldSet insts produced by struct literal lowering).
+// `make_item` returns an `Item` whose `name` field
 // is a fresh `String::from("hi")` allocation. Because the parent `Item`
 // is on the canonical FreshInCaller return path, the inner `String`
 // allocation should not fire a RegionRootEscape note: it shares the

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1571,6 +1571,10 @@ fn collect_return_value_sources(
         if !out.insert(id) {
             continue;
         }
+        // Hoist the FieldSet gate's `id`-dependent component out of the
+        // inner loop — it's constant for this BFS iteration and matches
+        // the structural pattern in self-hosted `collect_returned_ids`.
+        let id_is_fresh_alloc = region_alloc_ids.contains(&id);
         for blk in &func.blocks {
             for inst in &blk.insts {
                 if inst.opcode == Opcode::Upsilon
@@ -1579,10 +1583,10 @@ fn collect_return_value_sources(
                 {
                     stack.push(arm);
                 }
-                if inst.opcode == Opcode::FieldSet
+                if id_is_fresh_alloc
+                    && inst.opcode == Opcode::FieldSet
                     && inst.args.len() >= 2
                     && inst.args[0] == id
-                    && region_alloc_ids.contains(&id)
                 {
                     stack.push(inst.args[1]);
                 }

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1537,24 +1537,25 @@ fn analyze_function(
 }
 
 /// Walk back from a Return-argument id, recording the id itself plus every
-/// Upsilon arm source for any Phi reached. Used to expand
-/// `emit_root_escape_notes`'s skip-set so the underlying `RegionAlloc`s
-/// merged through a Phi for conditional-construction patterns
-/// (`if cond { X{..} } else { X{..} }`) are recognised as canonical
-/// FreshInCaller return values rather than side-effect escapes.
+/// source that flows into it through Phi arms (via Upsilon insts) or struct
+/// field initializers (via FieldSet insts whose target pointer is already in
+/// the skip-set). Used to expand `emit_root_escape_notes`'s skip-set so the
+/// underlying `RegionAlloc`s merged through a Phi (`if cond { X{..} } else
+/// { X{..} }`) or installed as a field of a returned struct
+/// (`Item { name: String::from("hi") }` from `make_item`) are recognised as
+/// canonical FreshInCaller return values rather than side-effect escapes.
 ///
-/// Conservative scope: this walk follows Phi → Upsilon chains only.
-/// Sub-allocations that form fields of a returned struct
-/// (e.g. the `String::from("hi")` heap allocation inside
-/// `Item { name: String::from("hi") }` returned from `make_item`) are
-/// NOT reachable via this walk and WILL fire `RegionRootEscape` notes
-/// even though they travel together with the canonical FreshInCaller
-/// return value. That's intentional and permitted by spec §4.4: the
-/// "alloc is the return value" exemption covers only the top-level
-/// return argument itself. Field allocations escape to the caller's
-/// arena along with the parent struct, and surfacing them as notes
-/// keeps the agent aware of every allocation that lives for the
-/// caller-chain lifetime.
+/// Per spec §4.4, the "alloc is the return value" exemption covers the
+/// top-level return argument and any allocation it transitively owns via
+/// `FieldSet` initializers — those field allocations share the parent
+/// struct's caller-arena lifetime, so the parent's escape note (when
+/// applicable) already conveys the full lifetime story; surfacing the
+/// children adds noise without information.
+///
+/// Safety: expansion is rooted at confirmed skip-set members. The FieldSet
+/// edge fires only when `args[0]` (the struct pointer) is already in
+/// `out`, and the BFS pushes `args[1]` (the field value); the existing
+/// `out.insert(id)` cycle guard handles any reconvergence.
 fn collect_return_value_sources(start: InstId, func: &Function, out: &mut BTreeSet<InstId>) {
     let mut stack = vec![start];
     while let Some(id) = stack.pop() {
@@ -1568,6 +1569,12 @@ fn collect_return_value_sources(start: InstId, func: &Function, out: &mut BTreeS
                     && let Some(&arm) = inst.args.first()
                 {
                     stack.push(arm);
+                }
+                if inst.opcode == Opcode::FieldSet
+                    && inst.args.len() >= 2
+                    && inst.args[0] == id
+                {
+                    stack.push(inst.args[1]);
                 }
             }
         }

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1536,30 +1536,11 @@ fn analyze_function(
     summary
 }
 
-/// Walk back from a Return-argument id, recording the id itself plus every
-/// source that flows into it through Phi arms (via Upsilon insts) or struct
-/// field initializers (via FieldSet insts whose target pointer is itself a
-/// fresh `RegionAlloc` already in the skip-set). Used to expand
-/// `emit_root_escape_notes`'s skip-set so the underlying `RegionAlloc`s
-/// merged through a Phi (`if cond { X{..} } else { X{..} }`) or installed
-/// as a field of a freshly-allocated returned struct
-/// (`Item { name: String::from("hi") }` from `make_item`) are recognised
-/// as canonical FreshInCaller return values rather than side-effect
-/// escapes.
-///
-/// Per spec §4.4, the "alloc is the return value" exemption covers the
-/// top-level return argument and any allocation it transitively owns via
-/// FieldSet initializers of a freshly-allocated struct. Critically, the
-/// exemption does NOT extend to FieldSets whose target is a parameter or
-/// other non-fresh pointer (e.g. `target.name = String::from("hi")`
-/// followed by `return target`): mutations into a caller-owned container
-/// are genuine store-effect escapes, not field initializers, and must keep
-/// firing the note. We distinguish the two cases by checking that the
-/// target id was produced by `Opcode::RegionAlloc` — only then is it a
-/// fresh aggregate and its FieldSet a constructor-style initialization.
-/// `region_alloc_ids` is precomputed once per function in
-/// `emit_root_escape_notes` and threaded in, so functions with multiple
-/// `Return` instructions don't rebuild it per call.
+/// Build the FreshInCaller return-value skip-set used by
+/// `emit_root_escape_notes`. The FieldSet edge is gated on
+/// `region_alloc_ids` so it follows initializers of a fresh struct
+/// (`Item { name: ... }`) but not mutations into a parameter
+/// (`target.name = ...; return target`); spec §4.4.
 fn collect_return_value_sources(
     start: InstId,
     func: &Function,
@@ -1571,9 +1552,6 @@ fn collect_return_value_sources(
         if !out.insert(id) {
             continue;
         }
-        // Hoist the FieldSet gate's `id`-dependent component out of the
-        // inner loop — it's constant for this BFS iteration and matches
-        // the structural pattern in self-hosted `collect_returned_ids`.
         let id_is_fresh_alloc = region_alloc_ids.contains(&id);
         for blk in &func.blocks {
             for inst in &blk.insts {
@@ -1609,21 +1587,7 @@ fn emit_root_escape_notes(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let source_file: &str = &func.source_file;
-    // Pre-collect IDs of every value reachable from a `Return` — directly,
-    // through Phi nodes via their Upsilon arms, and through field
-    // initializers (via FieldSet insts whose target pointer is itself a
-    // fresh RegionAlloc already in the skip-set). Allocations on the
-    // canonical FreshInCaller return path — Phi-merged arms in
-    // `if cond { Foo{..} } else { Foo{..} }` and field initializers in
-    // `Foo { name: String::from("hi") }` from a returning function —
-    // shouldn't fire the note; only side-effect escapes through
-    // store-effect chains (FieldSets into parameter-rooted containers,
-    // calls into caller-owned aggregates) should.
     let mut returned_ids: BTreeSet<InstId> = BTreeSet::new();
-    // Pre-compute the RegionAlloc-id set once per function. The FieldSet
-    // edge inside `collect_return_value_sources` uses it to gate "target
-    // is a fresh aggregate"; lifting it out of the per-Return helper
-    // avoids rebuilding for functions with multiple `Return` insts.
     let region_alloc_ids: BTreeSet<InstId> = func
         .blocks
         .iter()

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1557,17 +1557,15 @@ fn analyze_function(
 /// firing the note. We distinguish the two cases by checking that the
 /// target id was produced by `Opcode::RegionAlloc` — only then is it a
 /// fresh aggregate and its FieldSet a constructor-style initialization.
-fn collect_return_value_sources(start: InstId, func: &Function, out: &mut BTreeSet<InstId>) {
-    // Pre-compute the set of ids produced by RegionAlloc so the FieldSet
-    // edge below can gate on "target is a fresh aggregate" in O(1) rather
-    // than re-scanning every iteration of the worklist.
-    let region_alloc_ids: BTreeSet<InstId> = func
-        .blocks
-        .iter()
-        .flat_map(|b| b.insts.iter())
-        .filter(|i| i.opcode == Opcode::RegionAlloc)
-        .map(|i| i.id)
-        .collect();
+/// `region_alloc_ids` is precomputed once per function in
+/// `emit_root_escape_notes` and threaded in, so functions with multiple
+/// `Return` instructions don't rebuild it per call.
+fn collect_return_value_sources(
+    start: InstId,
+    func: &Function,
+    region_alloc_ids: &BTreeSet<InstId>,
+    out: &mut BTreeSet<InstId>,
+) {
     let mut stack = vec![start];
     while let Some(id) = stack.pop() {
         if !out.insert(id) {
@@ -1618,12 +1616,23 @@ fn emit_root_escape_notes(
     // store-effect chains (FieldSets into parameter-rooted containers,
     // calls into caller-owned aggregates) should.
     let mut returned_ids: BTreeSet<InstId> = BTreeSet::new();
+    // Pre-compute the RegionAlloc-id set once per function. The FieldSet
+    // edge inside `collect_return_value_sources` uses it to gate "target
+    // is a fresh aggregate"; lifting it out of the per-Return helper
+    // avoids rebuilding for functions with multiple `Return` insts.
+    let region_alloc_ids: BTreeSet<InstId> = func
+        .blocks
+        .iter()
+        .flat_map(|b| b.insts.iter())
+        .filter(|i| i.opcode == Opcode::RegionAlloc)
+        .map(|i| i.id)
+        .collect();
     for block in &func.blocks {
         for inst in &block.insts {
             if inst.opcode == Opcode::Return
                 && let Some(&rv) = inst.args.first()
             {
-                collect_return_value_sources(rv, func, &mut returned_ids);
+                collect_return_value_sources(rv, func, &region_alloc_ids, &mut returned_ids);
             }
         }
     }

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1538,25 +1538,36 @@ fn analyze_function(
 
 /// Walk back from a Return-argument id, recording the id itself plus every
 /// source that flows into it through Phi arms (via Upsilon insts) or struct
-/// field initializers (via FieldSet insts whose target pointer is already in
-/// the skip-set). Used to expand `emit_root_escape_notes`'s skip-set so the
-/// underlying `RegionAlloc`s merged through a Phi (`if cond { X{..} } else
-/// { X{..} }`) or installed as a field of a returned struct
-/// (`Item { name: String::from("hi") }` from `make_item`) are recognised as
-/// canonical FreshInCaller return values rather than side-effect escapes.
+/// field initializers (via FieldSet insts whose target pointer is itself a
+/// fresh `RegionAlloc` already in the skip-set). Used to expand
+/// `emit_root_escape_notes`'s skip-set so the underlying `RegionAlloc`s
+/// merged through a Phi (`if cond { X{..} } else { X{..} }`) or installed
+/// as a field of a freshly-allocated returned struct
+/// (`Item { name: String::from("hi") }` from `make_item`) are recognised
+/// as canonical FreshInCaller return values rather than side-effect
+/// escapes.
 ///
 /// Per spec §4.4, the "alloc is the return value" exemption covers the
 /// top-level return argument and any allocation it transitively owns via
-/// `FieldSet` initializers — those field allocations share the parent
-/// struct's caller-arena lifetime, so the parent's escape note (when
-/// applicable) already conveys the full lifetime story; surfacing the
-/// children adds noise without information.
-///
-/// Safety: expansion is rooted at confirmed skip-set members. The FieldSet
-/// edge fires only when `args[0]` (the struct pointer) is already in
-/// `out`, and the BFS pushes `args[1]` (the field value); the existing
-/// `out.insert(id)` cycle guard handles any reconvergence.
+/// FieldSet initializers of a freshly-allocated struct. Critically, the
+/// exemption does NOT extend to FieldSets whose target is a parameter or
+/// other non-fresh pointer (e.g. `target.name = String::from("hi")`
+/// followed by `return target`): mutations into a caller-owned container
+/// are genuine store-effect escapes, not field initializers, and must keep
+/// firing the note. We distinguish the two cases by checking that the
+/// target id was produced by `Opcode::RegionAlloc` — only then is it a
+/// fresh aggregate and its FieldSet a constructor-style initialization.
 fn collect_return_value_sources(start: InstId, func: &Function, out: &mut BTreeSet<InstId>) {
+    // Pre-compute the set of ids produced by RegionAlloc so the FieldSet
+    // edge below can gate on "target is a fresh aggregate" in O(1) rather
+    // than re-scanning every iteration of the worklist.
+    let region_alloc_ids: BTreeSet<InstId> = func
+        .blocks
+        .iter()
+        .flat_map(|b| b.insts.iter())
+        .filter(|i| i.opcode == Opcode::RegionAlloc)
+        .map(|i| i.id)
+        .collect();
     let mut stack = vec![start];
     while let Some(id) = stack.pop() {
         if !out.insert(id) {
@@ -1573,6 +1584,7 @@ fn collect_return_value_sources(start: InstId, func: &Function, out: &mut BTreeS
                 if inst.opcode == Opcode::FieldSet
                     && inst.args.len() >= 2
                     && inst.args[0] == id
+                    && region_alloc_ids.contains(&id)
                 {
                     stack.push(inst.args[1]);
                 }
@@ -1596,10 +1608,15 @@ fn emit_root_escape_notes(
 ) {
     let source_file: &str = &func.source_file;
     // Pre-collect IDs of every value reachable from a `Return` — directly,
-    // and through Phi nodes via their Upsilon arms. Allocations on the
-    // canonical FreshInCaller return path (including Phi-merged arms in
-    // `if cond { Foo{..} } else { Foo{..} }`) shouldn't fire the note;
-    // only side-effect escapes through store-effect chains should.
+    // through Phi nodes via their Upsilon arms, and through field
+    // initializers (via FieldSet insts whose target pointer is itself a
+    // fresh RegionAlloc already in the skip-set). Allocations on the
+    // canonical FreshInCaller return path — Phi-merged arms in
+    // `if cond { Foo{..} } else { Foo{..} }` and field initializers in
+    // `Foo { name: String::from("hi") }` from a returning function —
+    // shouldn't fire the note; only side-effect escapes through
+    // store-effect chains (FieldSets into parameter-rooted containers,
+    // calls into caller-owned aggregates) should.
     let mut returned_ids: BTreeSet<InstId> = BTreeSet::new();
     for block in &func.blocks {
         for inst in &block.insts {

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -3490,7 +3490,7 @@ The note is conservative — it fires for any `Caller`-region allocation in a fu
 }
 ```
 
-**Fix:** Often none — if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value or any allocation installed as a field of the returned struct (e.g. `Item { name: String::from("hi") }`).
+**Fix:** Often none — if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value or any allocation installed as a field of the returned struct (e.g. `Item { name: String::from("hi") }`). Note: this exemption is conservative — if a field is overwritten before the return (`x.f = A; x.f = B; return x`), the overwritten allocation A is also suppressed (issue #326).
 
 ### VerificationSkipped
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -3490,7 +3490,7 @@ The note is conservative — it fires for any `Caller`-region allocation in a fu
 }
 ```
 
-**Fix:** Often none — if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value itself.
+**Fix:** Often none — if the program is short-lived (a checker, a CLI tool) or the values are genuinely program-lifetime, the note is informational. To free the allocation earlier, restructure so the value is **returned** from the constructing function rather than stored into a parameter container; the canonical `FreshInCaller` return path (`fn make_X() -> X`) does not trigger the note for the returned value or any allocation installed as a field of the returned struct (e.g. `Item { name: String::from("hi") }`).
 
 ### VerificationSkipped
 

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -38,7 +38,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use vow_diag::Severity;
-use vow_ir::{decode_module, encode_module, RegionConstraint};
+use vow_ir::{RegionConstraint, decode_module, encode_module};
 
 /// Assert canonical-form invariants on every function's summary.
 fn assert_canonical_summaries(module: &vow_ir::Module) {
@@ -150,8 +150,8 @@ fn small_module_uninit_never_leaks_after_round_trip() {
     // run the pass, encode + decode via the public .vmod path, and
     // assert canonical-form invariants survive the round trip.
     use vow_ir::{
-        infer_regions, BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData,
-        InstId, Module, Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId,
+        BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData, InstId, Module,
+        Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId, infer_regions,
     };
     use vow_syntax::ast::Effect;
     use vow_syntax::span::Span;
@@ -595,5 +595,58 @@ fn rust_struct_field_initializer_alloc_skipped() {
         "field-initializer allocations of a returned struct must not \
          fire RegionRootEscape; got {} note(s): {notes:?}",
         notes.len(),
+    );
+}
+
+/// Issue #319 regression: the FieldSet skip-set extension must distinguish
+/// a fresh struct's field initializer from a mutation into a caller-owned
+/// container. `fn fill(target: Box) -> Box { target.name = ...; target }`
+/// returns the parameter `target` after mutating its field — the stored
+/// String is a genuine store-effect escape (caller-owned container), not
+/// a field initializer of a freshly-allocated struct, and the
+/// `RegionRootEscape` note must keep firing. The BFS gates the FieldSet
+/// edge on `args[0]` being produced by `Opcode::RegionAlloc`, which
+/// excludes parameter (`GetArg`) targets.
+#[test]
+fn rust_param_field_mutation_emits_root_escape_note() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let fixture = root
+        .join("tests")
+        .join("run")
+        .join("region_param_field_mutation.vow");
+    let out = Command::new(env!("CARGO_BIN_EXE_vow"))
+        .args(["build", "--no-verify"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run vow");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("failed to parse vow stdout as JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+    });
+    let status = parsed["status"].as_str();
+    let runtime_link_failure = status == Some("CompileFailed")
+        && parsed["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("libvow_runtime.a"));
+    assert!(
+        matches!(status, Some("Verified") | Some("Unverified")) || runtime_link_failure,
+        "expected Verified/Unverified status (or link-only failure on \
+         missing libvow_runtime.a), got {status:?}\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let diagnostics = parsed["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array");
+    let notes: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["error_code"].as_str() == Some("RegionRootEscape"))
+        .collect();
+    assert!(
+        !notes.is_empty(),
+        "FieldSet into a parameter container must keep firing \
+         RegionRootEscape; got 0 notes: {diagnostics:?}",
     );
 }

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -38,7 +38,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use vow_diag::Severity;
-use vow_ir::{decode_module, encode_module, RegionConstraint};
+use vow_ir::{RegionConstraint, decode_module, encode_module};
 
 /// Assert canonical-form invariants on every function's summary.
 fn assert_canonical_summaries(module: &vow_ir::Module) {
@@ -150,8 +150,8 @@ fn small_module_uninit_never_leaks_after_round_trip() {
     // run the pass, encode + decode via the public .vmod path, and
     // assert canonical-form invariants survive the round trip.
     use vow_ir::{
-        infer_regions, BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData,
-        InstId, Module, Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId,
+        BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData, InstId, Module,
+        Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId, infer_regions,
     };
     use vow_syntax::ast::Effect;
     use vow_syntax::span::Span;

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -38,7 +38,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use vow_diag::Severity;
-use vow_ir::{RegionConstraint, decode_module, encode_module};
+use vow_ir::{decode_module, encode_module, RegionConstraint};
 
 /// Assert canonical-form invariants on every function's summary.
 fn assert_canonical_summaries(module: &vow_ir::Module) {
@@ -150,8 +150,8 @@ fn small_module_uninit_never_leaks_after_round_trip() {
     // run the pass, encode + decode via the public .vmod path, and
     // assert canonical-form invariants survive the round trip.
     use vow_ir::{
-        BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData, InstId, Module,
-        Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId, infer_regions,
+        infer_regions, BasicBlock, BlockId, FuncId, Function, HiddenRegionIdx, Inst, InstData,
+        InstId, Module, Opcode, RegionId, RegionSummary, Ty, VowEntry, VowId,
     };
     use vow_syntax::ast::Effect;
     use vow_syntax::span::Span;
@@ -362,7 +362,6 @@ fn rust_routed_aggregate_via_callee_store_effect_compiles() {
          diagnostics: {diagnostics:?}"
     );
 }
-<<<<<<< HEAD
 
 /// Issue #320 regression guard: an internal `Call` whose callee returns
 /// `FreshInCaller`, routed into a parameter container via a sibling callee's
@@ -775,6 +774,12 @@ fn rust_arena_push_fixture_pins_note_count() {
         .iter()
         .filter(|d| d["error_code"].as_str() == Some("RegionRootEscape"))
         .collect();
+    // 2 is the post-#319 expected floor: Item + String in `add_named`,
+    // both consumed by push_item not returned. A future suppression
+    // improvement (e.g. #326's per-block last-write tracking, or
+    // following Call results through the skip-set for factory-function
+    // fields) may legitimately reduce this — update the count alongside
+    // the relevant change rather than treating it as a regression.
     assert_eq!(
         notes.len(),
         2,

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -741,3 +741,46 @@ fn self_hosted_struct_field_initializer_alloc_skipped() {
         notes.len(),
     );
 }
+
+/// Issue #319: pin the post-change note count for the original fixture
+/// (`tests/run/region_helper_arena_push.vow`). The inner `Vec::new()` from
+/// `arena_new() -> Arena { entries: Vec::new() }` is suppressed (returned
+/// struct's field initializer); `add_named`'s `Item` and `String::from(..)`
+/// allocations remain (consumed by `push_item`, not returned). Catches
+/// both over-suppression (count drops below 2) and under-suppression
+/// (count exceeds 2 — would indicate the field-initializer skip-set
+/// regressed).
+#[test]
+fn rust_arena_push_fixture_pins_note_count() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let fixture = root
+        .join("tests")
+        .join("run")
+        .join("region_helper_arena_push.vow");
+    let out = Command::new(env!("CARGO_BIN_EXE_vow"))
+        .args(["build", "--no-verify"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run vow");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("failed to parse vow stdout as JSON: {e}\nstdout: {stdout}"));
+    let diagnostics = parsed["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array");
+    let notes: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["error_code"].as_str() == Some("RegionRootEscape"))
+        .collect();
+    assert_eq!(
+        notes.len(),
+        2,
+        "region_helper_arena_push.vow should emit exactly 2 RegionRootEscape notes \
+         (Item + String in add_named, both consumed by push_item not returned). \
+         Got {} note(s): {notes:?}",
+        notes.len(),
+    );
+}

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -362,6 +362,7 @@ fn rust_routed_aggregate_via_callee_store_effect_compiles() {
          diagnostics: {diagnostics:?}"
     );
 }
+<<<<<<< HEAD
 
 /// Issue #320 regression guard: an internal `Call` whose callee returns
 /// `FreshInCaller`, routed into a parameter container via a sibling callee's
@@ -534,5 +535,65 @@ fn rust_split_targets_repro_compiles() {
         conflicts.is_empty(),
         "issue #317 repro must not trip RegionConflict; diagnostics: \
          {diagnostics:?}"
+    );
+}
+
+/// Issue #319: the `RegionRootEscape` skip-set's BFS must trace through
+/// `FieldSet` instructions, so an allocation that flows into a field of
+/// a returned struct does not fire a note. The fixture's
+/// `make_item() -> Item { Item { name: String::from("hi") } }` should
+/// emit zero notes — the parent `Item` is on the canonical FreshInCaller
+/// return path, and the inner `String` allocation shares its lifetime.
+#[test]
+fn rust_struct_field_initializer_alloc_skipped() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let fixture = root
+        .join("tests")
+        .join("run")
+        .join("region_skip_struct_field.vow");
+    let out = Command::new(env!("CARGO_BIN_EXE_vow"))
+        .args(["build", "--no-verify"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run vow");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("failed to parse vow stdout as JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+    });
+    let status = parsed["status"].as_str();
+    let runtime_link_failure = status == Some("CompileFailed")
+        && parsed["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("libvow_runtime.a"));
+    assert!(
+        matches!(status, Some("Verified") | Some("Unverified")) || runtime_link_failure,
+        "expected Verified/Unverified status (or link-only failure on \
+         missing libvow_runtime.a), got {status:?}\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let diagnostics = parsed["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array");
+    let conflicts: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["error_code"].as_str() == Some("RegionConflict"))
+        .collect();
+    assert!(
+        conflicts.is_empty(),
+        "field-initializer fixture must not trip RegionConflict; \
+         diagnostics: {diagnostics:?}"
+    );
+    let notes: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["error_code"].as_str() == Some("RegionRootEscape"))
+        .collect();
+    assert!(
+        notes.is_empty(),
+        "field-initializer allocations of a returned struct must not \
+         fire RegionRootEscape; got {} note(s): {notes:?}",
+        notes.len(),
     );
 }

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -650,3 +650,94 @@ fn rust_param_field_mutation_emits_root_escape_note() {
          RegionRootEscape; got 0 notes: {diagnostics:?}",
     );
 }
+
+/// Issue #319 regression (self-hosted parity): confirms the self-hosted
+/// `collect_returned_ids` mirrors the Rust gate. Without this, a regression
+/// where the self-hosted FieldSet edge was inadvertently un-gated (or the
+/// `IOP_REGION_ALLOC` predicate was inverted) would slip past the `tests/run/`
+/// shell harness — that harness only validates exit + stdout, not diagnostic
+/// counts. Skips when `build/vowc` is absent (e.g. fresh clone without
+/// bootstrap).
+#[test]
+fn self_hosted_param_field_mutation_emits_root_escape_note() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let vowc = repo_root.join("build").join("vowc");
+    if !vowc.exists() {
+        eprintln!("SKIP: build/vowc not present (run scripts/bootstrap.sh first)");
+        return;
+    }
+    let fixture = repo_root
+        .join("tests")
+        .join("run")
+        .join("region_param_field_mutation.vow");
+    let out = Command::new(&vowc)
+        .args(["build", "--no-verify"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run build/vowc");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("failed to parse build/vowc stdout as JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+    });
+    let diagnostics = parsed["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array");
+    let notes: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["error_code"].as_str() == Some("RegionRootEscape"))
+        .collect();
+    assert!(
+        !notes.is_empty(),
+        "self-hosted: FieldSet into a parameter container must keep firing \
+         RegionRootEscape; got 0 notes: {diagnostics:?}",
+    );
+}
+
+/// Issue #319 self-hosted parity (positive case): confirms the self-hosted
+/// compiler still suppresses the note for the canonical
+/// `make_item() -> Item { Item { name: ... } }` pattern after the gate
+/// change. Pairs with `rust_struct_field_initializer_alloc_skipped` to
+/// keep both compilers structurally aligned.
+#[test]
+fn self_hosted_struct_field_initializer_alloc_skipped() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let vowc = repo_root.join("build").join("vowc");
+    if !vowc.exists() {
+        eprintln!("SKIP: build/vowc not present (run scripts/bootstrap.sh first)");
+        return;
+    }
+    let fixture = repo_root
+        .join("tests")
+        .join("run")
+        .join("region_skip_struct_field.vow");
+    let out = Command::new(&vowc)
+        .args(["build", "--no-verify"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run build/vowc");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("failed to parse build/vowc stdout as JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+    });
+    let diagnostics = parsed["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array");
+    let notes: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["error_code"].as_str() == Some("RegionRootEscape"))
+        .collect();
+    assert!(
+        notes.is_empty(),
+        "self-hosted: field-initializer allocations of a returned struct must \
+         not fire RegionRootEscape; got {} note(s): {notes:?}",
+        notes.len(),
+    );
+}


### PR DESCRIPTION
Closes #319.

## Summary

- Extends the BFS in both `collect_return_value_sources` (Rust) and `collect_returned_ids` (self-hosted) to follow `FieldSet` edges, so allocations that flow into a field of a returned struct no longer fire `RegionRootEscape` notes.
- Amends spec §4.4 (`docs/design/arena_memory.md`) and the cross-reference in `docs/spec/errors.md` to broaden the "alloc is the return value" exemption to allocations transitively owned via field initializers.
- Adds a fixture and Rust integration test that drive the new behavior.

## Why

PR #315 already suppresses notes on Phi-merged return values (`if cond { X{..} } else { X{..} }`). This change closes the natural follow-up: the inner `String::from("hi")` in `Item { name: String::from("hi") }` returned from `make_item() -> Item` now correctly shares the parent's exemption. Those field allocations live with the parent struct in the caller's arena; surfacing them as separate notes was noise. Aimed at materially reducing the 116 informational notes from vow-lean-kernel cited in the issue.

## What changed (mechanically)

- `vow-ir/src/region.rs:1517-1532` — sibling `if` to the existing `Opcode::Upsilon` check inside `collect_return_value_sources`. When `inst.opcode == Opcode::FieldSet && inst.args[0] == id`, push `inst.args[1]` onto the BFS stack.
- `compiler/region.vow:1224-1244` — same edge added inside `collect_returned_ids`'s inner block scan.
- `docs/design/arena_memory.md` — spec §4.4 paragraph extended (transitive exemption + scope boundary that excludes Store).
- `docs/spec/errors.md` — `RegionRootEscape` "Fix" paragraph updated to reflect the broader exemption.

Struct construction lowers to `RegionAlloc + FieldSet*` in both compilers (no dedicated `StructNew` opcode), so the new edge covers struct literals, nested constructors, and enum variant payloads (which use the same `FieldSet` opcode at `vow-ir/src/lower/mod.rs:2070-2079`) without additional code.

## Safety

Expansion is structurally rooted at confirmed skip-set members. The FieldSet edge fires only when `args[0]` is already in the skip-set; the existing `out.insert(id)` / `region_vec_contains_i64` cycle guard handles reconvergence. `Store` instructions are intentionally **not** walked — they represent post-allocation mutation through a pointer that may have arbitrary aliasing, semantically distinct from initializing a field of a fresh struct in the same straight-line sequence as the allocation.

## Test plan

- [x] `cargo test -p vow --test region_summary_equivalence` — 4/4 pass, including:
  - new `rust_struct_field_initializer_alloc_skipped` (asserts 0 `RegionRootEscape` notes on the new fixture)
  - existing `rust_routed_aggregate_via_callee_store_effect_compiles` (asserts ≥1 note on `Payload{n:1}` — confirms no over-suppression)
- [x] New fixture `tests/run/region_skip_struct_field.vow` produces zero diagnostics under both compilers.
- [x] Bootstrap fixed-point holds: `vowc2` == `vowc3` byte-identical (sha256 `b538e76c…`).
- [x] Existing `region_helper_arena_push.vow` notes drop (the inner `Vec::new()` from `arena_new() -> Arena { entries: Vec::new() }` is now suppressed; `add_named`'s allocations correctly remain since they're consumed by `push_item`, not returned).
- [ ] vow-lean-kernel note-count measurement (target <50 from 116) — to be measured before merge.