### PR TITLE
region: align self-hosted RegionRootEscape gate with Rust's Published filter (#318)

### DIFF
--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -982,12 +982,14 @@ fn unique_store_target_count(flat: Vec<i64>) -> i64 {
 
 // Mirrors Rust's `any_published_store` filter at vow-ir/src/region.rs:1481-1484.
 // Returns true if the parallel `int_se_src_kinds[fi]` array contains any
-// kind other than RSUM_INTERNAL_UNINIT(). Today every entry is in {0..3}
-// (no Uninit ever leaks into the published parallel arrays via
-// `add_store_effect`), so this is structurally equivalent to
-// `kinds.len() > 0` — but locks in the Published(_) discriminator the
-// way Rust does, so a future code path that publishes a non-Published
-// kind cannot silently widen the gate.
+// kind other than RSUM_INTERNAL_UNINIT(). This is exact (not merely
+// conservative) because the integer encoding is closed: Published kinds
+// map to {0..3} and RSUM_INTERNAL_UNINIT = -1 is the only non-Published
+// value. As long as that invariant holds, `!= UNINIT` ≡ `is Published`,
+// and `add_store_effect` is the single chokepoint that writes
+// `int_se_src_kinds`, so adding a future non-Published kind requires
+// either extending the encoding past {0..3} or adding a new sentinel —
+// both of which would force this gate's review.
 fn any_published_se_kind(kinds: Vec<i64>) -> bool {
     let mut i: i64 = 0;
     while i < kinds.len() {

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -277,7 +277,8 @@ fn infer_regions_module(m: IrModule, dctx: DiagCtx) -> IrModule {
     // to a caller. See arena_memory.md §4.4.
     emit_root_escape_notes_module(m, region_keys, region_vals,
                                    note_region_keys, note_region_vals,
-                                   int_kinds, int_se_targets, dctx);
+                                   int_kinds, int_se_targets, int_se_src_kinds,
+                                   dctx);
 
     // Commit per-inst regions.
     let mut fi2: i64 = 0;
@@ -979,6 +980,23 @@ fn unique_store_target_count(flat: Vec<i64>) -> i64 {
     count
 }
 
+// Mirrors Rust's `any_published_store` filter at vow-ir/src/region.rs:1481-1484.
+// Returns true if the parallel `int_se_src_kinds[fi]` array contains any
+// kind other than RSUM_INTERNAL_UNINIT(). Today every entry is in {0..3}
+// (no Uninit ever leaks into the published parallel arrays via
+// `add_store_effect`), so this is structurally equivalent to
+// `kinds.len() > 0` — but locks in the Published(_) discriminator the
+// way Rust does, so a future code path that publishes a non-Published
+// kind cannot silently widen the gate.
+fn any_published_se_kind(kinds: Vec<i64>) -> bool {
+    let mut i: i64 = 0;
+    while i < kinds.len() {
+        if kinds[i] != RSUM_INTERNAL_UNINIT() { return true; }
+        i = i + 1;
+    }
+    false
+}
+
 fn check_region_store_conflicts_module(
     m: IrModule, id_to_inst_per_fn: Vec<Vec<IrInst>>,
     region_keys: Vec<Vec<i64>>, region_vals: Vec<Vec<i64>>,
@@ -1093,26 +1111,20 @@ fn emit_root_escape_notes_module(
     note_region_keys: Vec<Vec<i64>>, note_region_vals: Vec<Vec<i64>>,
     int_kinds: Vec<i64>,
     int_se_targets: Vec<Vec<i64>>,
+    int_se_src_kinds: Vec<Vec<i64>>,
     dctx: DiagCtx
 ) {
     let mut fi: i64 = 0;
     while fi < m.functions.len() {
         let f: IrFunction = m.functions[fi];
         let return_kind: i64 = int_kinds[fi];
-        // Divergence from Rust's mirror: Rust filters
-        // `summary.store_effects` to `Published(_)` constraints (excludes
-        // Unresolved/NotPublished); self-hosted's flat `int_se_targets`
-        // doesn't carry that distinction, so any non-empty entry triggers
-        // the gate. Conservative over-approximation — fires the note for
-        // a few functions Rust would skip — and spec-allowed for non-
-        // blocking notes. Same family as the
-        // `unique_store_target_count` adjacency-dedup asymmetry.
-        // TODO(#318): when the .vmod schema gains a publication
-        // discriminator at this layer, re-align with Rust's
-        // `Published(_)` filter so both compilers emit the same set
-        // of `RegionRootEscape` notes.
+        // Mirrors Rust's `any_published_store` filter at
+        // vow-ir/src/region.rs:1481-1484: only count store_effects whose
+        // source constraint is `Published(_)` (excludes the Uninit seed).
+        // `int_se_src_kinds` already carries the discriminator, written
+        // in lockstep with `int_se_targets` via `add_store_effect`.
         let has_publishable: bool = return_kind == RSUM_KIND_FRESH_IN_CALLER()
-            || int_se_targets[fi].len() > 0;
+            || any_published_se_kind(int_se_src_kinds[fi]);
         if !has_publishable {
             fi = fi + 1;
             continue;

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -277,8 +277,7 @@ fn infer_regions_module(m: IrModule, dctx: DiagCtx) -> IrModule {
     // to a caller. See arena_memory.md §4.4.
     emit_root_escape_notes_module(m, region_keys, region_vals,
                                    note_region_keys, note_region_vals,
-                                   int_kinds, int_se_targets, int_se_src_kinds,
-                                   dctx);
+                                   int_kinds, int_se_src_kinds, dctx);
 
     // Commit per-inst regions.
     let mut fi2: i64 = 0;
@@ -1112,7 +1111,6 @@ fn emit_root_escape_notes_module(
     region_keys: Vec<Vec<i64>>, region_vals: Vec<Vec<i64>>,
     note_region_keys: Vec<Vec<i64>>, note_region_vals: Vec<Vec<i64>>,
     int_kinds: Vec<i64>,
-    int_se_targets: Vec<Vec<i64>>,
     int_se_src_kinds: Vec<Vec<i64>>,
     dctx: DiagCtx
 ) {

--- a/tests/run/region_root_escape_parity.vow
+++ b/tests/run/region_root_escape_parity.vow
@@ -1,0 +1,31 @@
+// TEST: stdout ""
+// Issue #318 — Rust↔self-hosted RegionRootEscape note-emission parity guard.
+// Exercises a single helper whose store_effects span two distinct source
+// kinds: ConstantGlobal (extern Vec growth on `s.entries.push(extra)`) and
+// AliasOf(s) (param alias on `s.latest = pinned`). A caller routes fresh
+// inline aggregates through the helper. Both compilers must emit the same
+// number of RegionRootEscape diagnostics on this fixture; full_test.sh
+// compares total diagnostic counts at lines 110-114.
+module Issue318Parity
+
+pub struct Item {
+    name: String,
+}
+
+pub struct Sink {
+    entries: Vec<Item>,
+    latest: Item,
+}
+
+fn record(s: Sink, extra: Item, pinned: Item) {
+    s.entries.push(extra);
+    s.latest = pinned;
+}
+
+pub fn run(s: Sink) {
+    record(s, Item { name: String::from("hi") }, Item { name: String::from("hi") });
+}
+
+fn main() -> i32 {
+    0
+}

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -847,6 +847,15 @@ fn region_root_escape_note_count_parity_rust_vs_self_hosted() {
 
     let rust_count = count_notes(std::path::Path::new(env!("CARGO_BIN_EXE_vow")), "rust vow");
     let self_hosted_count = count_notes(&vowc, "build/vowc");
+    // Floor: the fixture is constructed to trigger at least one note in each
+    // compiler. A joint regression to zero (e.g. gate logic accidentally
+    // suppressed everywhere) would make the parity assertion below pass
+    // silently; this assertion catches that.
+    assert!(
+        rust_count > 0,
+        "rust vow emitted 0 RegionRootEscape notes on region_root_escape_parity.vow — \
+         gate may be suppressed"
+    );
     assert_eq!(
         rust_count, self_hosted_count,
         "RegionRootEscape note-count parity broken: rust={rust_count}, self-hosted={self_hosted_count} \

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -839,12 +839,10 @@ fn region_root_escape_note_count_parity_rust_vs_self_hosted() {
         });
         parsed["diagnostics"]
             .as_array()
-            .map(|d| {
-                d.iter()
-                    .filter(|x| x["error_code"].as_str() == Some("RegionRootEscape"))
-                    .count()
-            })
-            .unwrap_or(0)
+            .expect("diagnostics should be an array in compiler JSON output")
+            .iter()
+            .filter(|x| x["error_code"].as_str() == Some("RegionRootEscape"))
+            .count()
     };
 
     let rust_count = count_notes(std::path::Path::new(env!("CARGO_BIN_EXE_vow")), "rust vow");

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -789,3 +789,69 @@ fn rust_arena_push_fixture_pins_note_count() {
         notes.len(),
     );
 }
+
+/// Issue #318 regression guard — Rust↔self-hosted RegionRootEscape
+/// note-count parity on a fixture exercising mixed store-effect source
+/// kinds (ConstantGlobal + AliasOf).
+///
+/// The divergence the gate alignment closes is structural: today both
+/// compilers' `add_store_effect` paths supply only `Published(_)`-equivalent
+/// kinds, so this test passes both before and after the alignment. Its
+/// value is forward-looking — a future code path that publishes a
+/// non-Published kind on either side cannot silently widen the
+/// note-emission gate without also tripping this assertion.
+///
+/// Skips cleanly if `build/vowc` is absent (the self-hosted binary is
+/// produced by `scripts/bootstrap.sh`, which is not a `cargo test`
+/// prerequisite).
+#[test]
+fn region_root_escape_note_count_parity_rust_vs_self_hosted() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let fixture = root
+        .join("tests")
+        .join("run")
+        .join("region_root_escape_parity.vow");
+    let vowc = root.join("build").join("vowc");
+    if !vowc.exists() {
+        eprintln!(
+            "skipping {}: build/vowc not present (run scripts/bootstrap.sh)",
+            module_path!()
+        );
+        return;
+    }
+
+    let count_notes = |bin: &std::path::Path, label: &str| -> usize {
+        let out = Command::new(bin)
+            .args(["build", "--no-verify"])
+            .arg(&fixture)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run {label}: {e}"));
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+            panic!(
+                "failed to parse {label} stdout as JSON: {e}\n\
+                     stdout: {stdout}\nstderr: {stderr}"
+            )
+        });
+        parsed["diagnostics"]
+            .as_array()
+            .map(|d| {
+                d.iter()
+                    .filter(|x| x["error_code"].as_str() == Some("RegionRootEscape"))
+                    .count()
+            })
+            .unwrap_or(0)
+    };
+
+    let rust_count = count_notes(std::path::Path::new(env!("CARGO_BIN_EXE_vow")), "rust vow");
+    let self_hosted_count = count_notes(&vowc, "build/vowc");
+    assert_eq!(
+        rust_count, self_hosted_count,
+        "RegionRootEscape note-count parity broken: rust={rust_count}, self-hosted={self_hosted_count} \
+         on tests/run/region_root_escape_parity.vow"
+    );
+}


### PR DESCRIPTION
## Summary

- Closes #318. Lifts the `Published(_)` source-constraint distinction into the self-hosted `emit_root_escape_notes_module` gate so it mirrors Rust's `any_published_store` filter (`vow-ir/src/region.rs:1481-1484`). The discriminator already lives in `int_se_src_kinds`, written in lockstep with `int_se_targets` via the single `add_store_effect` chokepoint, so the change is surgical: new `any_published_se_kind` helper, one extra signature parameter, one gate-line change, one call-site update, plus a doc-comment rewrite.
- Adds `tests/run/region_root_escape_parity.vow` — fixture exercising mixed `ConstantGlobal` (Vec extern growth) + `AliasOf` (param FieldSet) source kinds in a single helper.
- Adds `region_root_escape_note_count_parity_rust_vs_self_hosted` integration test in `vow/tests/region_summary_equivalence.rs` that asserts equal `RegionRootEscape` note counts between both compilers on the new fixture; skips cleanly when the self-hosted binary is absent.

## Why this matters (and why it is structural insurance)

Today every `add_store_effect` call site on **both** compilers supplies a `Published`-equivalent kind, so the new self-hosted gate produces identical decisions to the old one on every constructible input. Rust's `any_published_store` filter is currently a tautology too. The change locks in alignment so that a future code path that publishes a non-`Published` kind on either side cannot silently widen the self-hosted note-emission gate without also tripping the new parity test.

## Test plan
- [x] `cargo test --release -p vow-ir region` — 77 passed, 0 failed
- [x] `cargo test --release -p vow --test region_summary_equivalence` — 4 passed, 0 failed (includes the new parity test)
- [x] `scripts/bootstrap.sh` — binary fixed point holds (`vowc2 == vowc3`)
- [x] Manual verification: both compilers emit 4 `RegionRootEscape` notes on `tests/run/region_root_escape_parity.vow`
- [x] `scripts/full_test.sh` — zero new failures vs main (the 168 reported failures are an environmental `python3 → uv run python3` hook intercept that pre-exists on `main`, identical pass/fail/skip counts on both runs)