### PR TITLE
parser: emit non-zero span length on AST item nodes (#316)

### DIFF
--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -108,10 +108,6 @@ fn span_pack(start: i64, len: i64) -> i64 vow {
     start * 65536 + len
 }
 
-// Span end of the last consumed token (or 0 before any token has been
-// advanced past). Pairs with `span_pack_to_here` to give AST nodes a
-// real span length instead of the zero-length placeholder that older
-// callsites packed.
 fn span_end_here(p: Parser) -> i64 {
     if p.pos > 0 {
         let prev: Token = p.tokens[p.pos - 1];
@@ -121,11 +117,7 @@ fn span_end_here(p: Parser) -> i64 {
     }
 }
 
-// Pack a span from `span_start` to the end of the last consumed token.
-// Length is clamped to [0, 65535] to fit the 16-bit `len` slot used by
-// `span_pack`. Without this, AST nodes whose construction site originally
-// passed `len=0` produced diagnostics with `length: 0`, hiding the
-// extent of the offending construct.
+// Length clamped to [0, 65535] to fit span_pack's 16-bit len slot.
 fn span_pack_to_here(p: Parser, span_start: i64) -> i64 {
     let end: i64 = span_end_here(p);
     let mut len: i64 = end - span_start;

--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -108,6 +108,32 @@ fn span_pack(start: i64, len: i64) -> i64 vow {
     start * 65536 + len
 }
 
+// Span end of the last consumed token (or 0 before any token has been
+// advanced past). Pairs with `span_pack_to_here` to give AST nodes a
+// real span length instead of the zero-length placeholder that older
+// callsites packed.
+fn span_end_here(p: Parser) -> i64 {
+    if p.pos > 0 {
+        let prev: Token = p.tokens[p.pos - 1];
+        prev.span_start + prev.span_len
+    } else {
+        0
+    }
+}
+
+// Pack a span from `span_start` to the end of the last consumed token.
+// Length is clamped to [0, 65535] to fit the 16-bit `len` slot used by
+// `span_pack`. Without this, AST nodes whose construction site originally
+// passed `len=0` produced diagnostics with `length: 0`, hiding the
+// extent of the offending construct.
+fn span_pack_to_here(p: Parser, span_start: i64) -> i64 {
+    let end: i64 = span_end_here(p);
+    let mut len: i64 = end - span_start;
+    if len < 0 { len = 0; }
+    if len > 65535 { len = 65535; }
+    span_pack(span_start, len)
+}
+
 fn push_error(p: Parser, msg: String) {
     let t: Token = peek(p);
     let d: Diagnostic = diag_error(EC_UNEXPECTED_TOKEN(), msg, p.file, t.span_start, t.span_len);
@@ -244,7 +270,7 @@ fn parse_fn_def(p: Parser) -> i64 {
     let eff: i64 = parse_effects(p);
     let vow_lid: i64 = parse_vow_block(p);
     let body_bid: i64 = parse_block(p);
-    let span: i64 = span_pack(span_start, 0);
+    let span: i64 = span_pack_to_here(p, span_start);
     arena_add_fn(p.arena, name_sid, params_lid, ret_tid, eff, body_bid, vow_lid, span)
 }
 
@@ -269,7 +295,7 @@ fn parse_struct_def(p: Parser, is_linear: i64) -> i64 {
     }
     let _rb: bool = expect(p, tok_rbrace());
     let fields_lid: i64 = arena_add_list(p.arena, field_items);
-    let span: i64 = span_pack(span_start, 0);
+    let span: i64 = span_pack_to_here(p, span_start);
     arena_add_sdef(p.arena, name_sid, fields_lid, is_linear, span)
 }
 
@@ -321,7 +347,7 @@ fn parse_enum_def(p: Parser) -> i64 {
     }
     let _rb: bool = expect(p, tok_rbrace());
     let variants_lid: i64 = arena_add_list(p.arena, variant_items);
-    let span: i64 = span_pack(span_start, 0);
+    let span: i64 = span_pack_to_here(p, span_start);
     arena_add_edef(p.arena, name_sid, variants_lid, span)
 }
 
@@ -497,7 +523,7 @@ fn parse_block(p: Parser) -> i64 {
     }
     let _rb: bool = expect(p, tok_rbrace());
     let stmts_lid: i64 = arena_add_list(p.arena, stmt_items);
-    let span: i64 = span_pack(span_start, 0);
+    let span: i64 = span_pack_to_here(p, span_start);
     arena_add_blk(p.arena, stmts_lid, -1, span)
 }
 
@@ -540,7 +566,7 @@ fn parse_let_stmt(p: Parser) -> i64 {
         let _sc: Token = advance(p);
     }
     let pat_pid: i64 = arena_add_pat(p.arena, PAT_IDENT(), name_sid, is_mut, 0);
-    let span: i64 = span_pack(span_start, 0);
+    let span: i64 = span_pack_to_here(p, span_start);
     arena_add_stmt(p.arena, STMT_LET(), pat_pid, annot_tid, init_eid, span)
 }
 

--- a/tests/error/linear_region_branch_partial.vow
+++ b/tests/error/linear_region_branch_partial.vow
@@ -1,5 +1,5 @@
 // TEST: error-code RegionLinear
-// TEST: stderr-json x['span']['length'] > 0
+// TEST: build-json x['span']['length'] > 0
 module LinearRegionBranchPartial
 
 linear struct Handle {

--- a/tests/error/linear_region_branch_partial.vow
+++ b/tests/error/linear_region_branch_partial.vow
@@ -1,4 +1,5 @@
 // TEST: error-code RegionLinear
+// TEST: stderr-json x['span']['length'] > 0
 module LinearRegionBranchPartial
 
 linear struct Handle {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -492,11 +492,7 @@ print('|'.join(codes))
     fi
   fi
 
-  # JSON-shape assertion. The annotation supplies a Python boolean expression
-  # evaluated with `d` bound to the full parsed build_json, `xs` to its
-  # `diagnostics` array, and `x` to `xs[0]` if present. Keeps existing
-  # `error_code` and substring checks composable with structural assertions
-  # (e.g. span/length, hint contents).
+  # build-json: Python expr; d=full JSON, xs=diagnostics array, x=xs[0] or {}.
   if [[ -n "$TEST_BUILD_JSON" ]]; then
     json_check="$(EXPR="$TEST_BUILD_JSON" python3 -c "
 import json, sys, os

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -72,7 +72,15 @@ skip() {
 json_field() {
   local json="$1"
   local field="$2"
-  python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('$field',''))" <<< "$json"
+  python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    print('')
+    sys.exit(0)
+print(d.get('$field', '') if isinstance(d, dict) else '')
+" <<< "$json"
 }
 
 json_path_field() {
@@ -122,6 +130,7 @@ parse_annotations() {
   TEST_SKIP=""
   TEST_STDIN=""
   TEST_STDIN_FILE=""
+  TEST_STDERR_JSON=""
 
   while IFS= read -r line; do
     if [[ "$line" =~ ^//\ TEST:\ exit\ ([0-9]+) ]]; then
@@ -148,6 +157,8 @@ parse_annotations() {
       TEST_STDIN_FILE="$(dirname "$file")/${BASH_REMATCH[1]}"
     elif [[ "$line" =~ ^//\ TEST:\ skip\ \"(.+)\" ]]; then
       TEST_SKIP="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^//\ TEST:\ stderr-json\ (.+) ]]; then
+      TEST_STDERR_JSON="${BASH_REMATCH[1]}"
     elif [[ ! "$line" =~ ^// ]]; then
       break
     fi
@@ -477,6 +488,36 @@ print('|'.join(codes))
     expected_stderr="$(echo -e "$TEST_STDERR")"
     if [[ "$actual_stderr" != *"$expected_stderr"* ]]; then
       fail "$name" "stderr missing: $expected_stderr"
+      continue
+    fi
+  fi
+
+  # JSON-shape assertion. The annotation supplies a Python boolean expression
+  # evaluated with `d` bound to the full parsed build_json, `xs` to its
+  # `diagnostics` array, and `x` to `xs[0]` if present. Keeps existing
+  # `error_code` and substring checks composable with structural assertions
+  # (e.g. span/length, hint contents).
+  if [[ -n "$TEST_STDERR_JSON" ]]; then
+    json_check="$(EXPR="$TEST_STDERR_JSON" python3 -c "
+import json, sys, os
+expr = os.environ['EXPR']
+try:
+    d = json.loads(sys.stdin.read())
+except Exception as e:
+    print('false'); print(f'json parse: {e}'); sys.exit(0)
+xs = d.get('diagnostics', []) or []
+x = xs[0] if xs else {}
+try:
+    ok = bool(eval(expr))
+except Exception as e:
+    print('false'); print(f'expr error: {e}'); sys.exit(0)
+print('true' if ok else 'false')
+print(json.dumps(x))
+" <<< "$build_json")"
+    json_pass="$(echo "$json_check" | head -1)"
+    json_detail="$(echo "$json_check" | tail -1)"
+    if [[ "$json_pass" != "true" ]]; then
+      fail "$name" "stderr-json failed: $TEST_STDERR_JSON (x=$json_detail)"
       continue
     fi
   fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -130,7 +130,7 @@ parse_annotations() {
   TEST_SKIP=""
   TEST_STDIN=""
   TEST_STDIN_FILE=""
-  TEST_STDERR_JSON=""
+  TEST_BUILD_JSON=""
 
   while IFS= read -r line; do
     if [[ "$line" =~ ^//\ TEST:\ exit\ ([0-9]+) ]]; then
@@ -157,8 +157,8 @@ parse_annotations() {
       TEST_STDIN_FILE="$(dirname "$file")/${BASH_REMATCH[1]}"
     elif [[ "$line" =~ ^//\ TEST:\ skip\ \"(.+)\" ]]; then
       TEST_SKIP="${BASH_REMATCH[1]}"
-    elif [[ "$line" =~ ^//\ TEST:\ stderr-json\ (.+) ]]; then
-      TEST_STDERR_JSON="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^//\ TEST:\ build-json\ (.+) ]]; then
+      TEST_BUILD_JSON="${BASH_REMATCH[1]}"
     elif [[ ! "$line" =~ ^// ]]; then
       break
     fi
@@ -497,8 +497,8 @@ print('|'.join(codes))
   # `diagnostics` array, and `x` to `xs[0]` if present. Keeps existing
   # `error_code` and substring checks composable with structural assertions
   # (e.g. span/length, hint contents).
-  if [[ -n "$TEST_STDERR_JSON" ]]; then
-    json_check="$(EXPR="$TEST_STDERR_JSON" python3 -c "
+  if [[ -n "$TEST_BUILD_JSON" ]]; then
+    json_check="$(EXPR="$TEST_BUILD_JSON" python3 -c "
 import json, sys, os
 expr = os.environ['EXPR']
 try:
@@ -517,7 +517,7 @@ print(json.dumps(x))
     json_pass="$(echo "$json_check" | head -1)"
     json_detail="$(echo "$json_check" | tail -1)"
     if [[ "$json_pass" != "true" ]]; then
-      fail "$name" "stderr-json failed: $TEST_STDERR_JSON (x=$json_detail)"
+      fail "$name" "build-json failed: $TEST_BUILD_JSON (x=$json_detail)"
       continue
     fi
   fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -158,6 +158,7 @@ parse_annotations() {
     elif [[ "$line" =~ ^//\ TEST:\ skip\ \"(.+)\" ]]; then
       TEST_SKIP="${BASH_REMATCH[1]}"
     elif [[ "$line" =~ ^//\ TEST:\ build-json\ (.+) ]]; then
+      # Only enforced by Phase 5 (error/) — annotation is parsed elsewhere but not checked.
       TEST_BUILD_JSON="${BASH_REMATCH[1]}"
     elif [[ ! "$line" =~ ^// ]]; then
       break

--- a/vow-syntax/src/parser/items.rs
+++ b/vow-syntax/src/parser/items.rs
@@ -380,6 +380,22 @@ mod tests {
     }
 
     #[test]
+    fn item_spans_carry_nonzero_length() {
+        // Pins parity with the self-hosted parser fix for issue #316: every
+        // top-level item must carry a span whose `len` covers the item's
+        // textual extent. A regression that drops back to `len = 0` would
+        // produce diagnostics with `length: 0`, which is what #316 was about.
+        let src = "struct Point { x: i32, y: i32 }";
+        let s = match parse_item(src) {
+            Item::Struct(s) => s,
+            other => panic!("expected struct, got {:?}", other),
+        };
+        assert_eq!(s.span.start, 0);
+        assert_eq!(s.span.len as usize, src.len());
+        assert!(s.span.len > 0);
+    }
+
+    #[test]
     fn parse_linear_struct() {
         let src = "linear struct Handle { fd: i32 }";
         let item = parse_item(src);

--- a/vow-syntax/src/parser/items.rs
+++ b/vow-syntax/src/parser/items.rs
@@ -381,10 +381,7 @@ mod tests {
 
     #[test]
     fn item_spans_carry_nonzero_length() {
-        // Pins parity with the self-hosted parser fix for issue #316: every
-        // top-level item must carry a span whose `len` covers the item's
-        // textual extent. A regression that drops back to `len = 0` would
-        // produce diagnostics with `length: 0`, which is what #316 was about.
+        // Parity pin for #316: top-level item span.len must cover its textual extent.
         let src = "struct Point { x: i32, y: i32 }";
         let s = match parse_item(src) {
             Item::Struct(s) => s,


### PR DESCRIPTION
## Summary

- Fixes `span.length: 0` on region-pass and type-checker diagnostics. The self-hosted parser was hardcoding `span_pack(span_start, 0)` at five item construction sites — a new `span_pack_to_here` helper computes the length from the end of the last consumed token (clamped to the encoding's 16-bit slot).
- Adds a `// TEST: build-json EXPR` directive to the shell harness for structural JSON assertions, plus the corresponding regression on `linear_region_branch_partial.vow`. Hardens `json_field` so a single broken test no longer aborts the whole runner. (The directive was originally posted as `stderr-json` in `7f6c690`; renamed to `build-json` in `6090cc3` after review noted that `build_json` is captured from compiler stdout, not stderr.)
- Mirrors the invariant on the Rust side with a `vow-syntax` parity test (the Rust parser already used `start.merge(end)` and was unaffected).

## Out of scope

The investigation surfaced a few related-but-distinct bugs that this PR does not touch and that would benefit from their own issues:

1. The `linear_region_branch_partial.vow` diagnostic still ships a corrupted `hints[0]` (literal `,\"length\":` from `diag_to_json`). Rewriting `diag_add_hint` from `let h = d.hints; h.push(hint)` to `d.hints.push(hint)` produces byte-identical IR, so the corruption is upstream of the diag emitter — most likely a region-inference UAF on the hint `String`.
2. `linear_region_unconsumed.vow` segfaults under absolute paths (path-length-dependent memory corruption).
3. `linear_region_branch_phi_leak.vow` OOMs in the arena allocator on `Vec<Handle>::push(choose(...))`.
4. `const` items in the self-hosted AST lack a span field — pre-existing parity gap with Rust `ConstDef`. Filed as #324.

All four pre-date this PR.

## Test plan

- [x] `cargo test -p vow-syntax --lib` passes (161 tests, including the new `item_spans_carry_nonzero_length`).
- [x] `scripts/bootstrap.sh --skip-cargo` succeeds with the SHA-256 fixed point intact (`stage2 == stage3`).
- [x] `tests/run_tests.sh --no-bootstrap --no-verify` runs to completion: 108 passed, 2 pre-existing failures (listed above), 1 skipped (verify-gated).
- [x] `linear_region_branch_partial.vow` now passes the new `build-json` assertion (`x['span']['length'] > 0`); reverting the parser change makes it fail with `length: 0`.