### PR TITLE
parser: emit non-zero span length on const items (#324)

### DIFF
--- a/compiler/ast.vow
+++ b/compiler/ast.vow
@@ -206,9 +206,9 @@ fn sdef_fields_lid(a: AstArena, sid: i64) -> i64 { a.sdef_data[sid * 4 + 1] }
 fn edef_name_sid(a: AstArena, eid: i64) -> i64 { a.edef_data[eid * 3] }
 fn edef_variants_lid(a: AstArena, eid: i64) -> i64 { a.edef_data[eid * 3 + 1] }
 
-fn cdef_name_sid(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 3] }
-fn cdef_type_tid(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 3 + 1] }
-fn cdef_value_eid(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 3 + 2] }
+fn cdef_name_sid(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 4] }
+fn cdef_type_tid(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 4 + 1] }
+fn cdef_value_eid(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 4 + 2] }
 
 fn clone_string(src: String) -> String {
     let out: String = String::from("");
@@ -231,6 +231,7 @@ fn type_span(a: AstArena, tid: i64) -> i64 { a.type_data[tid * 4 + 3] }
 fn pat_span(a: AstArena, pid: i64) -> i64 { a.pat_data[pid * 4 + 3] }
 fn sdef_span(a: AstArena, sid: i64) -> i64 { a.sdef_data[sid * 4 + 3] }
 fn edef_span(a: AstArena, eid: i64) -> i64 { a.edef_data[eid * 3 + 2] }
+fn cdef_span(a: AstArena, cid: i64) -> i64 { a.cdef_data[cid * 4 + 3] }
 
 fn arena_add_stmt(a: AstArena, tag: i64, av: i64, bv: i64, cv: i64, span: i64) -> i64 {
     let sid: i64 = a.stmt_data.len() / 5;
@@ -299,11 +300,12 @@ fn arena_add_edef(a: AstArena, name_sid: i64, variants_lid: i64, span: i64) -> i
     eid
 }
 
-fn arena_add_cdef(a: AstArena, name_sid: i64, type_tid: i64, value_eid: i64) -> i64 {
-    let cid: i64 = a.cdef_data.len() / 3;
+fn arena_add_cdef(a: AstArena, name_sid: i64, type_tid: i64, value_eid: i64, span: i64) -> i64 {
+    let cid: i64 = a.cdef_data.len() / 4;
     a.cdef_data.push(name_sid);
     a.cdef_data.push(type_tid);
     a.cdef_data.push(value_eid);
+    a.cdef_data.push(span);
     cid
 }
 

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -258,7 +258,7 @@ fn register_const(e: CheckEnv, m: Module, cid: i64) [io] {
             expr_a(a, val_eid)
         } else if val_tag == EXPR_LIT_BOOL() {
             if resolved_tid != CTY_BOOL() {
-                env_emit_error(e, String::from("const has bool value but non-bool type"), expr_span(a, val_eid));
+                env_emit_error(e, String::from("const has bool value but non-bool type"), cdef_span(a, cid));
             }
             expr_a(a, val_eid)
         } else if val_tag == EXPR_UNOP() {
@@ -268,7 +268,7 @@ fn register_const(e: CheckEnv, m: Module, cid: i64) [io] {
                 0
             } else {
                 if resolved_tid != CTY_I64() && resolved_tid != CTY_I32() {
-                    env_emit_error(e, String::from("const has negated value but non-integer type"), expr_span(a, val_eid));
+                    env_emit_error(e, String::from("const has negated value but non-integer type"), cdef_span(a, cid));
                 }
                 let inner_eid: i64 = expr_b(a, val_eid);
                 let inner_tag: i64 = expr_tag(a, inner_eid);

--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -253,7 +253,7 @@ fn register_const(e: CheckEnv, m: Module, cid: i64) [io] {
     let val: i64 = {
         if val_tag == EXPR_LIT_INT() {
             if resolved_tid != CTY_I64() && resolved_tid != CTY_I32() {
-                env_emit_error(e, String::from("const has integer value but non-integer type"), expr_span(a, val_eid));
+                env_emit_error(e, String::from("const has integer value but non-integer type"), cdef_span(a, cid));
             }
             expr_a(a, val_eid)
         } else if val_tag == EXPR_LIT_BOOL() {

--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -194,6 +194,10 @@ fn parse_path(p: Parser) -> i64 {
 }
 
 fn parse_const_def(p: Parser) -> i64 {
+    let span_start: i64 = {
+        let t: Token = peek(p);
+        t.span_start
+    };
     let _kw: bool = expect(p, tok_kw_const());
     let name_sid: i64 = expect_ident(p);
     let _colon: bool = expect(p, tok_colon());
@@ -201,7 +205,8 @@ fn parse_const_def(p: Parser) -> i64 {
     let _eq: bool = expect(p, tok_eq());
     let value_eid: i64 = parse_expr(p);
     let _semi: bool = expect(p, tok_semicolon());
-    arena_add_cdef(p.arena, name_sid, type_tid, value_eid)
+    let span: i64 = span_pack_to_here(p, span_start);
+    arena_add_cdef(p.arena, name_sid, type_tid, value_eid, span)
 }
 
 fn parse_item(p: Parser) -> i64 {

--- a/tests/error/const_type_mismatch.vow
+++ b/tests/error/const_type_mismatch.vow
@@ -1,0 +1,5 @@
+// TEST: error-code TypeMismatch
+// TEST: build-json x['span']['length'] > 0
+module ConstTypeMismatch
+
+const BAD: bool = 42;

--- a/tests/error/const_type_mismatch_bool.vow
+++ b/tests/error/const_type_mismatch_bool.vow
@@ -1,0 +1,5 @@
+// TEST: error-code TypeMismatch
+// TEST: build-json x['span']['length'] > 0
+module ConstTypeMismatchBool
+
+const BAD: i64 = true;

--- a/tests/error/const_type_mismatch_negated.vow
+++ b/tests/error/const_type_mismatch_negated.vow
@@ -1,0 +1,5 @@
+// TEST: error-code TypeMismatch
+// TEST: build-json x['span']['length'] > 0
+module ConstTypeMismatchNegated
+
+const BAD: bool = -42;

--- a/vow-syntax/src/parser/items.rs
+++ b/vow-syntax/src/parser/items.rs
@@ -393,6 +393,19 @@ mod tests {
     }
 
     #[test]
+    fn const_def_span_carries_nonzero_length() {
+        // Parity pin for #324: ConstDef span.len must cover its textual extent.
+        let src = "const X: i32 = 42;";
+        let c = match parse_item(src) {
+            Item::Const(c) => c,
+            other => panic!("expected const, got {:?}", other),
+        };
+        assert_eq!(c.span.start, 0);
+        assert_eq!(c.span.len as usize, src.len());
+        assert!(c.span.len > 0);
+    }
+
+    #[test]
     fn parse_linear_struct() {
         let src = "linear struct Handle { fd: i32 }";
         let item = parse_item(src);


### PR DESCRIPTION
## Summary

Closes the parity gap between Rust `ConstDef.span` and the self-hosted compiler's `cdef_*` records, surfaced during review of #323. PRs #316/#323 closed this for fn / struct / enum / block / let-stmt; const was missed because `arena_add_cdef` did not accept a span at all (rather than packing a literal zero like the others did pre-#316).

- `arena_add_cdef` now takes a `span` parameter; per-cdef stride bumps from 3 to 4. New `cdef_span(a, cid)` accessor mirrors `sdef_span`.
- `parse_const_def` captures `span_start` at entry and threads `span_pack_to_here(p, span_start)` through `arena_add_cdef`.
- Re-anchors all three type-mismatch diagnostics in `register_const` (`compiler/checker.vow:256`, `:261`, `:271`) from `expr_span(a, val_eid)` to `cdef_span(a, cid)`, matching the Rust checker at `vow-types/src/check.rs:326`, `:337`, `:354`. The three remaining `expr_span` callsites in `register_const` are all "const value must be a literal" diagnostics — those legitimately stay value-anchored, matching Rust's `c.value.span` at `vow-types/src/check.rs:364`.
- Mirrors the invariant on the Rust side with a `vow-syntax` parity test (`const_def_span_carries_nonzero_length`); the Rust parser already used `start.merge(end)` and was unaffected.

## Test plan

- [x] `cargo test -p vow-syntax --lib`: 162 passed (was 161).
- [x] `cargo test --all`, `cargo clippy --all -- -D warnings`, `cargo fmt --all -- --check`: clean.
- [x] `scripts/bootstrap.sh --skip-cargo`: SHA-256 fixed point holds (`stage2 == stage3`).
- [x] `tests/run_tests.sh --filter const_type_mismatch` passes for all three paths (`const_type_mismatch.vow`, `const_type_mismatch_bool.vow`, `const_type_mismatch_negated.vow`); reverting any of the three checker re-anchors makes the corresponding test fail with `length: 0`.
- [x] `scripts/full_test.sh`: identical pass/fail set to baseline (verified by stash + re-run; all pre-existing failures unrelated to this PR).

Closes #324.