### PR TITLE
parser+lower: span heap-producer expressions for RegionRootEscape notes (#316)

### DIFF
--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -853,6 +853,10 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         let call_args: Vec<i64> = Vec::new();
         call_args.push(str_id);
         let result: i64 = lctx_emit(ctx, IOP_CALL(), ITY_PTR(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_from_cstr"));
+        // Issue #316: anchor the string-allocation Call to the literal so
+        // RegionRootEscape notes (and any future call-anchored diagnostic)
+        // resolve back to the source string instead of offset 0.
+        lctx_set_inst_span(ctx, result, expr_span(a, eid));
         lctx_tag(ctx, result, String::from("String"));
         return result;
     }

--- a/compiler/lower.vow
+++ b/compiler/lower.vow
@@ -853,9 +853,9 @@ fn lower_expr(ctx: LowerCtx, eid: i64) -> i64 {
         let call_args: Vec<i64> = Vec::new();
         call_args.push(str_id);
         let result: i64 = lctx_emit(ctx, IOP_CALL(), ITY_PTR(), call_args, IDATA_CALL_EXTERN(), 0, 0, String::from("__vow_string_from_cstr"));
-        // Issue #316: anchor the string-allocation Call to the literal so
-        // RegionRootEscape notes (and any future call-anchored diagnostic)
-        // resolve back to the source string instead of offset 0.
+        // Anchor this Call to the literal span: the IOP_CONST_STR above is
+        // not the heap producer, so the call needs its own span for
+        // call-anchored diagnostics.
         lctx_set_inst_span(ctx, result, expr_span(a, eid));
         lctx_tag(ctx, result, String::from("String"));
         return result;

--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -688,9 +688,9 @@ fn parse_postfix(p: Parser) -> i64 {
     // Capture span_start before the leading primary expression is parsed
     // so postfix-extended expressions (calls, methods, indexes, casts)
     // can stamp `arena_add_expr` with a span covering the whole chain.
-    // Issue #316: `EXPR_CALL` previously packed `0`, which the lowerer
-    // forwarded into `IrInst.ostart/olen`, leaving region-pass diagnostics
-    // anchored to offset 0.
+    // `EXPR_CALL` previously packed `0` here, which the lowerer forwarded
+    // into `IrInst.ostart/olen`, leaving region-pass diagnostics anchored
+    // to offset 0.
     let span_start: i64 = peek(p).span_start;
     let mut e: i64 = parse_primary(p);
     let mut cont: bool = true;
@@ -751,9 +751,9 @@ fn parse_call_args(p: Parser) -> i64 {
 fn parse_primary(p: Parser) -> i64 {
     let t: Token = peek(p);
     let tag: i64 = t.tag;
-    // Issue #316: heap-producing expressions (struct literals, calls,
-    // namespaced enum/struct ctors via parse_path_expr) need real spans
-    // so the region pass's `RegionRootEscape` notes anchor to source.
+    // Heap-producing expressions (struct literals, calls, namespaced
+    // enum/struct ctors via parse_path_expr) need real spans so the
+    // region pass's `RegionRootEscape` notes anchor to source.
     let span_start: i64 = t.span_start;
     if tag == tok_lit_int() {
         let _adv: Token = advance(p);
@@ -872,7 +872,6 @@ fn parse_primary(p: Parser) -> i64 {
 // `span_start` is the offset of the path's first identifier (captured by
 // the caller in `parse_primary` before that ident was advanced past), so
 // the resulting `EXPR_ECTOR`/`EXPR_SLIT` node spans the whole construct.
-// Issue #316: see parse_postfix / parse_primary comments for context.
 fn parse_path_expr(p: Parser, first_sid: i64, span_start: i64) -> i64 {
     let path_items: Vec<i64> = Vec::new();
     path_items.push(first_sid);

--- a/compiler/parser.vow
+++ b/compiler/parser.vow
@@ -685,6 +685,13 @@ fn parse_unary(p: Parser) -> i64 {
 }
 
 fn parse_postfix(p: Parser) -> i64 {
+    // Capture span_start before the leading primary expression is parsed
+    // so postfix-extended expressions (calls, methods, indexes, casts)
+    // can stamp `arena_add_expr` with a span covering the whole chain.
+    // Issue #316: `EXPR_CALL` previously packed `0`, which the lowerer
+    // forwarded into `IrInst.ostart/olen`, leaving region-pass diagnostics
+    // anchored to offset 0.
+    let span_start: i64 = peek(p).span_start;
     let mut e: i64 = parse_primary(p);
     let mut cont: bool = true;
     while cont {
@@ -694,9 +701,9 @@ fn parse_postfix(p: Parser) -> i64 {
                 let fname: i64 = expect_ident(p);
                 if at(p, tok_lparen()) {
                     let args_lid: i64 = parse_call_args(p);
-                    e = arena_add_expr(p.arena, EXPR_METHOD(), e, fname, args_lid, 0);
+                    e = arena_add_expr(p.arena, EXPR_METHOD(), e, fname, args_lid, span_pack_to_here(p, span_start));
                 } else {
-                    e = arena_add_expr(p.arena, EXPR_FIELD(), e, fname, 0, 0);
+                    e = arena_add_expr(p.arena, EXPR_FIELD(), e, fname, 0, span_pack_to_here(p, span_start));
                 }
             } else {
                 cont = false;
@@ -705,21 +712,21 @@ fn parse_postfix(p: Parser) -> i64 {
             let _lb: Token = advance(p);
             let idx: i64 = parse_expr(p);
             let _rb: bool = expect(p, tok_rbracket());
-            e = arena_add_expr(p.arena, EXPR_INDEX(), e, idx, 0, 0);
+            e = arena_add_expr(p.arena, EXPR_INDEX(), e, idx, 0, span_pack_to_here(p, span_start));
         } else if at(p, tok_lparen()) {
             let args_lid: i64 = parse_call_args(p);
-            e = arena_add_expr(p.arena, EXPR_CALL(), e, args_lid, 0, 0);
+            e = arena_add_expr(p.arena, EXPR_CALL(), e, args_lid, 0, span_pack_to_here(p, span_start));
         } else if at(p, tok_question()) {
             let _q: Token = advance(p);
-            e = arena_add_expr(p.arena, EXPR_QUESTION(), e, 0, 0, 0);
+            e = arena_add_expr(p.arena, EXPR_QUESTION(), e, 0, 0, span_pack_to_here(p, span_start));
         } else if at(p, tok_kw_as()) {
             let _as: Token = advance(p);
             let target_tid: i64 = parse_type(p);
-            e = arena_add_expr(p.arena, EXPR_CAST(), e, target_tid, 0, 0);
+            e = arena_add_expr(p.arena, EXPR_CAST(), e, target_tid, 0, span_pack_to_here(p, span_start));
         } else if at(p, tok_eq()) {
             let _eq: Token = advance(p);
             let rhs: i64 = parse_expr(p);
-            e = arena_add_expr(p.arena, EXPR_ASSIGN(), e, rhs, 0, 0);
+            e = arena_add_expr(p.arena, EXPR_ASSIGN(), e, rhs, 0, span_pack_to_here(p, span_start));
             cont = false;
         } else {
             cont = false;
@@ -744,6 +751,10 @@ fn parse_call_args(p: Parser) -> i64 {
 fn parse_primary(p: Parser) -> i64 {
     let t: Token = peek(p);
     let tag: i64 = t.tag;
+    // Issue #316: heap-producing expressions (struct literals, calls,
+    // namespaced enum/struct ctors via parse_path_expr) need real spans
+    // so the region pass's `RegionRootEscape` notes anchor to source.
+    let span_start: i64 = t.span_start;
     if tag == tok_lit_int() {
         let _adv: Token = advance(p);
         arena_add_expr(p.arena, EXPR_LIT_INT(), t.int_val, 0, 0, 0)
@@ -763,7 +774,7 @@ fn parse_primary(p: Parser) -> i64 {
     } else if tag == tok_lit_string() {
         let _adv: Token = advance(p);
         let sid: i64 = arena_intern_str(p.arena, t.str_val);
-        arena_add_expr(p.arena, EXPR_LIT_STR(), sid, 0, 0, 0)
+        arena_add_expr(p.arena, EXPR_LIT_STR(), sid, 0, 0, span_pack_to_here(p, span_start))
     } else if tag == tok_ident() {
         let name_str: String = t.str_val;
         if p.in_ensures == 1 && name_str == String::from("result") {
@@ -774,7 +785,7 @@ fn parse_primary(p: Parser) -> i64 {
         let _adv: Token = advance(p);
         let sid: i64 = arena_intern_str(p.arena, name_str);
         if at(p, tok_colon_colon()) {
-            parse_path_expr(p, sid)
+            parse_path_expr(p, sid, span_start)
         } else if at(p, tok_lbrace()) && first_byte >= 65 && first_byte <= 90 && looks_like_struct_literal(p) {
             let path_items: Vec<i64> = Vec::new();
             path_items.push(sid);
@@ -793,7 +804,7 @@ fn parse_primary(p: Parser) -> i64 {
             }
             let _rb: bool = expect(p, tok_rbrace());
             let fields_lid: i64 = arena_add_list(p.arena, field_items);
-            arena_add_expr(p.arena, EXPR_SLIT(), path_lid, fields_lid, 0, 0)
+            arena_add_expr(p.arena, EXPR_SLIT(), path_lid, fields_lid, 0, span_pack_to_here(p, span_start))
         } else {
             arena_add_expr(p.arena, EXPR_IDENT(), sid, 0, 0, 0)
         }
@@ -858,7 +869,11 @@ fn parse_primary(p: Parser) -> i64 {
     }
 }
 
-fn parse_path_expr(p: Parser, first_sid: i64) -> i64 {
+// `span_start` is the offset of the path's first identifier (captured by
+// the caller in `parse_primary` before that ident was advanced past), so
+// the resulting `EXPR_ECTOR`/`EXPR_SLIT` node spans the whole construct.
+// Issue #316: see parse_postfix / parse_primary comments for context.
+fn parse_path_expr(p: Parser, first_sid: i64, span_start: i64) -> i64 {
     let path_items: Vec<i64> = Vec::new();
     path_items.push(first_sid);
     while at(p, tok_colon_colon()) {
@@ -883,7 +898,7 @@ fn parse_path_expr(p: Parser, first_sid: i64) -> i64 {
             }
             let _rb: bool = expect(p, tok_rbrace());
             let vals_lid: i64 = arena_add_list(p.arena, val_items);
-            arena_add_expr(p.arena, EXPR_ECTOR(), path_lid, vals_lid, 0, 0)
+            arena_add_expr(p.arena, EXPR_ECTOR(), path_lid, vals_lid, 0, span_pack_to_here(p, span_start))
         } else if looks_like_struct_literal(p) {
             let _lb: Token = advance(p);
             let field_items: Vec<i64> = Vec::new();
@@ -899,15 +914,15 @@ fn parse_path_expr(p: Parser, first_sid: i64) -> i64 {
             }
             let _rb: bool = expect(p, tok_rbrace());
             let fields_lid: i64 = arena_add_list(p.arena, field_items);
-            arena_add_expr(p.arena, EXPR_SLIT(), path_lid, fields_lid, 0, 0)
+            arena_add_expr(p.arena, EXPR_SLIT(), path_lid, fields_lid, 0, span_pack_to_here(p, span_start))
         } else {
-            arena_add_expr(p.arena, EXPR_ECTOR(), path_lid, arena_add_list(p.arena, Vec::new()), 0, 0)
+            arena_add_expr(p.arena, EXPR_ECTOR(), path_lid, arena_add_list(p.arena, Vec::new()), 0, span_pack_to_here(p, span_start))
         }
     } else if at(p, tok_lparen()) {
         let args_lid: i64 = parse_call_args(p);
-        arena_add_expr(p.arena, EXPR_ECTOR(), path_lid, args_lid, 0, 0)
+        arena_add_expr(p.arena, EXPR_ECTOR(), path_lid, args_lid, 0, span_pack_to_here(p, span_start))
     } else {
-        arena_add_expr(p.arena, EXPR_ECTOR(), path_lid, arena_add_list(p.arena, Vec::new()), 0, 0)
+        arena_add_expr(p.arena, EXPR_ECTOR(), path_lid, arena_add_list(p.arena, Vec::new()), 0, span_pack_to_here(p, span_start))
     }
 }
 

--- a/vow/tests/region_summary_equivalence.rs
+++ b/vow/tests/region_summary_equivalence.rs
@@ -790,6 +790,68 @@ fn rust_arena_push_fixture_pins_note_count() {
     );
 }
 
+/// Issue #316 acceptance criterion #1: every `RegionRootEscape` note must
+/// carry a non-zero `span.length` when the underlying IR instruction has a
+/// span set. The Rust pipeline already does this; the self-hosted compiler
+/// emits `length: 0` (and often `offset: 0`) on the `region_helper_arena_push`
+/// fixture's notes, leaving the diagnostic unanchored to source.
+///
+/// Skips cleanly if `build/vowc` is absent (the self-hosted binary is
+/// produced by `scripts/bootstrap.sh`, not a `cargo test` prerequisite).
+#[test]
+fn selfhosted_region_root_escape_notes_carry_nonzero_span_length() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let fixture = root
+        .join("tests")
+        .join("run")
+        .join("region_helper_arena_push.vow");
+    let vowc = root.join("build").join("vowc");
+    if !vowc.exists() {
+        eprintln!(
+            "skipping {}: build/vowc not present (run scripts/bootstrap.sh)",
+            module_path!()
+        );
+        return;
+    }
+
+    let out = Command::new(&vowc)
+        .args(["build", "--no-verify"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run build/vowc");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("failed to parse build/vowc stdout as JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+    });
+    let diagnostics = parsed["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array");
+    let notes: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["error_code"].as_str() == Some("RegionRootEscape"))
+        .collect();
+    assert!(
+        !notes.is_empty(),
+        "fixture should emit at least one RegionRootEscape note (matches \
+         rust_arena_push_fixture_pins_note_count); got 0"
+    );
+    let zero_len: Vec<_> = notes
+        .iter()
+        .filter(|n| n["span"]["length"].as_i64() == Some(0))
+        .collect();
+    assert!(
+        zero_len.is_empty(),
+        "every RegionRootEscape note must carry span.length > 0 (issue #316 \
+         acceptance #1); {} of {} notes had length=0: {zero_len:?}",
+        zero_len.len(),
+        notes.len()
+    );
+}
+
 /// Issue #318 regression guard — Rust↔self-hosted RegionRootEscape
 /// note-count parity on a fixture exercising mixed store-effect source
 /// kinds (ConstantGlobal + AliasOf).


### PR DESCRIPTION
## Summary

Closes the remaining gap from issue #316: self-hosted `RegionRootEscape` notes were anchored to `(offset=0, length=0)` because the parser packed `0` into the span slot at most expression construction sites.

## Background

PR #323 fixed the same defect class for top-level **item** nodes (fn/struct/enum/block/let-stmt) by switching from `span_pack(start, 0)` to `span_pack_to_here`. The defect persisted at the **expression** level: most `arena_add_expr` callers in `parse_postfix`, `parse_primary`, and `parse_path_expr` packed `0` for the span slot. That zero flowed via `expr_span(a, eid)` → `lctx_set_inst_span` → `IrInst.ostart/olen`, and the `RegionRootEscape` note emitter at `compiler/region.vow:1182-1183` reads exactly those fields.

The Rust pipeline already produced correct expression spans (`start.merge(end)`), so this was purely a self-hosted parity gap. PR #323 left it explicitly out of scope; #324 (const items) and #326 (RegionRootEscape skip-set tightening) cover orthogonal slices and were checked for non-overlap.

## Changes

**`compiler/parser.vow`** — capture `span_start` from the leading token in `parse_postfix` (chain start) and `parse_primary` (literal/ident/path), thread it into `parse_path_expr`. Switch construction sites to `span_pack_to_here(p, span_start)` for: `EXPR_METHOD`, `EXPR_FIELD`, `EXPR_INDEX`, `EXPR_CALL`, `EXPR_QUESTION`, `EXPR_CAST`, `EXPR_ASSIGN`, `EXPR_LIT_STR`, `EXPR_SLIT`, and all `EXPR_ECTOR` variants.

**`compiler/lower.vow`** — `String::from("...")` lowers via a special case in `lower_expr` that emits an extra `__vow_string_from_cstr` call as the actual heap producer. That call wasn't span-tagged. Add `lctx_set_inst_span(ctx, result, expr_span(a, eid))` after the `lctx_emit` so the literal anchor reaches the resulting `IrInst`.

**`vow/tests/region_summary_equivalence.rs`** — new test `selfhosted_region_root_escape_notes_carry_nonzero_span_length` next to `rust_arena_push_fixture_pins_note_count`. Runs the self-hosted compiler against `tests/run/region_helper_arena_push.vow` and asserts every emitted `RegionRootEscape` note carries `span.length > 0`. RED without this commit (both notes have length=0); GREEN with it (spans match the Rust pipeline exactly: `offset=693 length=33` for the `Item { name: ... }` literal; `offset=719 length=4` for the `"hi"` string literal).

## Test plan

- [x] New test `selfhosted_region_root_escape_notes_carry_nonzero_span_length` passes; reverting either `compiler/` change locally turns it back to RED.
- [x] `cargo test --all` clean (700+ tests).
- [x] `tests/run_tests.sh --no-bootstrap --no-verify` — **116 passed, 0 failed**, 1 skipped.
- [x] `tests/run_tests.sh --no-bootstrap --no-verify --filter linear_region` — 6/6 PASS.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all -- -D warnings` clean.
- [x] Bootstrap fixed point holds (`scripts/bootstrap.sh --skip-cargo`, SHA-256 stage2 == stage3).
- [ ] CI green.

`scripts/full_test.sh` reports 6 failures unrelated to this change: 5 ESBMC counterexample-emission parity flakes (`search/verify`, `sum_range/verify`, `vec_fill/verify`, `gc/verify`, `math/verify`) and 1 vowc-mutants T13-name-format check. All reproduce on the pre-fix state.

Closes #316.
