### PR TITLE
[codex] Fix CEGIS requires feedback

### DIFF
--- a/bench/prompts.py
+++ b/bench/prompts.py
@@ -60,6 +60,58 @@ def _format_values(values: dict[str, str]) -> str:
     return ", ".join(f"{k}={v}" for k, v in values.items())
 
 
+def _format_source_span(source: object) -> str:
+    """Format a structured source span while tolerating older JSON shapes."""
+    if not source:
+        return ""
+    if not isinstance(source, dict):
+        return str(source)
+
+    file = source.get("file", "?")
+    offset = source.get("offset")
+    length = source.get("length")
+    if offset is None:
+        return str(file)
+    if length is None:
+        return f"{file}@{offset}"
+    return f"{file}@{offset}+{length}"
+
+
+def _format_call_sites(call_sites: object) -> str:
+    if not isinstance(call_sites, list):
+        return ""
+
+    formatted = []
+    for call_site in call_sites:
+        if not isinstance(call_site, dict):
+            continue
+        caller = call_site.get("caller_function", "?")
+        span = _format_source_span(call_site)
+        formatted.append(f"{caller} in {span}" if span else str(caller))
+    return "; ".join(formatted)
+
+
+def _format_violating_args(violating_args: object) -> str:
+    if not isinstance(violating_args, list):
+        return ""
+
+    formatted = []
+    for arg in violating_args:
+        if not isinstance(arg, dict):
+            continue
+        param = arg.get("param", "?")
+        value = arg.get("value", "?")
+        offset = arg.get("arg_offset")
+        length = arg.get("arg_length")
+        if offset is None:
+            formatted.append(f"{param}={value}")
+        elif length is None:
+            formatted.append(f"{param}={value} at arg@{offset}")
+        else:
+            formatted.append(f"{param}={value} at arg@{offset}+{length}")
+    return "; ".join(formatted)
+
+
 def curate_verify_output(
     parsed_json: dict,
     iteration: int,
@@ -104,6 +156,18 @@ def curate_verify_output(
             parts.append(f"- Violation: `{vtype}: {violation}` (vow_id={vow_id}, blame={blame})")
             parts.append(f"- Variable values at failure: {_format_values(values)}")
 
+            source = _format_source_span(ce.get("source"))
+            if source:
+                parts.append(f"- Violated contract source: {source}")
+
+            call_sites = _format_call_sites(ce.get("call_sites"))
+            if call_sites:
+                parts.append(f"- Caller context: {call_sites}")
+
+            violating_args = _format_violating_args(ce.get("violating_args"))
+            if violating_args:
+                parts.append(f"- Violating arguments: {violating_args}")
+
             exec_path = ce.get("execution_path", [])
             if exec_path:
                 blocks = [str(step.get("block_id", "?")) for step in exec_path]
@@ -139,9 +203,17 @@ def curate_verify_output(
                 f"{', '.join(var_hints)}. Tighten the invariant or strengthen the loop guard."
             )
         elif vtype == "requires" and values:
+            context_hint = ""
+            if (
+                _format_call_sites(ce0.get("call_sites"))
+                or _format_violating_args(ce0.get("violating_args"))
+            ):
+                context_hint = " Use the caller context above to locate the bad call and argument values."
             parts.append(
                 f"**Hint:** The precondition `{violation}` was violated by the caller. "
-                f"Add bounds to the function's `requires` clause to exclude this input."
+                f"To repair it, fix the call site, guard before the call, or correct the precondition "
+                f"only if the precondition itself is semantically wrong."
+                f"{context_hint}"
             )
         elif vtype == "ensures" and values:
             parts.append(

--- a/bench/prompts.py
+++ b/bench/prompts.py
@@ -202,7 +202,7 @@ def curate_verify_output(
                 f"**Hint:** The loop invariant `{violation}` was falsified with "
                 f"{', '.join(var_hints)}. Tighten the invariant or strengthen the loop guard."
             )
-        elif vtype == "requires" and values:
+        elif vtype == "requires":
             context_hint = ""
             if (
                 _format_call_sites(ce0.get("call_sites"))
@@ -211,8 +211,7 @@ def curate_verify_output(
                 context_hint = " Use the caller context above to locate the bad call and argument values."
             parts.append(
                 f"**Hint:** The precondition `{violation}` was violated by the caller. "
-                f"To repair it, fix the call site, guard before the call, or correct the precondition "
-                f"only if the precondition itself is semantically wrong."
+                f"To repair it, fix the call site or guard before the call."
                 f"{context_hint}"
             )
         elif vtype == "ensures" and values:

--- a/bench/test_prompts.py
+++ b/bench/test_prompts.py
@@ -24,6 +24,7 @@ class CegisPromptTests(unittest.TestCase):
 
         self.assertNotIn("Add bounds", prompt)
         self.assertNotIn("exclude this input", prompt)
+        self.assertNotIn("correct the precondition", prompt)
         self.assertIn("fix the call site", prompt)
         self.assertIn("guard before the call", prompt)
 
@@ -65,6 +66,36 @@ class CegisPromptTests(unittest.TestCase):
         self.assertIn("test.vow@12+8", prompt)
         self.assertIn("main in test.vow@50+15", prompt)
         self.assertIn("y=0 at arg@59+1", prompt)
+        self.assertIn("Use the caller context", prompt)
+
+    def test_requires_context_hint_does_not_require_variable_values(self):
+        prompt = curate_verify_output(
+            {
+                "status": "VerifyFailed",
+                "function": "main",
+                "counterexamples": [
+                    {
+                        "violation": "requires: y != 0",
+                        "blame": "Caller",
+                        "vow_id": 3,
+                        "values": {},
+                        "call_sites": [
+                            {
+                                "caller_function": "main",
+                                "file": "test.vow",
+                                "offset": 50,
+                                "length": 15,
+                            }
+                        ],
+                    }
+                ],
+            },
+            iteration=1,
+            previous_violations=[],
+        )
+
+        self.assertIn("precondition", prompt)
+        self.assertIn("fix the call site", prompt)
         self.assertIn("Use the caller context", prompt)
 
     def test_ensures_feedback_still_points_to_algorithm_logic(self):

--- a/bench/test_prompts.py
+++ b/bench/test_prompts.py
@@ -1,0 +1,94 @@
+import unittest
+
+from prompts import curate_verify_output
+
+
+class CegisPromptTests(unittest.TestCase):
+    def test_requires_feedback_repairs_caller_instead_of_weakening_contract(self):
+        prompt = curate_verify_output(
+            {
+                "status": "VerifyFailed",
+                "function": "main",
+                "counterexamples": [
+                    {
+                        "violation": "requires: n > 0",
+                        "blame": "Caller",
+                        "vow_id": 7,
+                        "values": {"n": "0"},
+                    }
+                ],
+            },
+            iteration=1,
+            previous_violations=[],
+        )
+
+        self.assertNotIn("Add bounds", prompt)
+        self.assertNotIn("exclude this input", prompt)
+        self.assertIn("fix the call site", prompt)
+        self.assertIn("guard before the call", prompt)
+
+    def test_requires_counterexample_includes_structured_caller_context(self):
+        prompt = curate_verify_output(
+            {
+                "status": "VerifyFailed",
+                "function": "main",
+                "counterexamples": [
+                    {
+                        "violation": "requires: y != 0",
+                        "blame": "Caller",
+                        "vow_id": 3,
+                        "values": {"y": "0"},
+                        "source": {"file": "test.vow", "offset": 12, "length": 8},
+                        "call_sites": [
+                            {
+                                "caller_function": "main",
+                                "file": "test.vow",
+                                "offset": 50,
+                                "length": 15,
+                            }
+                        ],
+                        "violating_args": [
+                            {
+                                "param": "y",
+                                "value": "0",
+                                "arg_offset": 59,
+                                "arg_length": 1,
+                            }
+                        ],
+                    }
+                ],
+            },
+            iteration=1,
+            previous_violations=[],
+        )
+
+        self.assertIn("test.vow@12+8", prompt)
+        self.assertIn("main in test.vow@50+15", prompt)
+        self.assertIn("y=0 at arg@59+1", prompt)
+        self.assertIn("Use the caller context", prompt)
+
+    def test_ensures_feedback_still_points_to_algorithm_logic(self):
+        prompt = curate_verify_output(
+            {
+                "status": "VerifyFailed",
+                "function": "abs",
+                "counterexamples": [
+                    {
+                        "violation": "ensures: result >= 0",
+                        "blame": "Callee",
+                        "vow_id": 9,
+                        "values": {"x": "-5", "result": "-5"},
+                    }
+                ],
+            },
+            iteration=2,
+            previous_violations=[],
+        )
+
+        self.assertIn("postcondition", prompt)
+        self.assertIn("Check the algorithm logic", prompt)
+        self.assertIn("x=-5, result=-5", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the benchmark CEGIS feedback for caller-blame `requires` failures so it no longer tells agents to weaken preconditions by adding bounds.

## What Changed

- Surface structured verifier context in CEGIS prompts: violated contract span, caller call sites, and violating argument values/spans.
- Replace the `requires` hint with blame-aware guidance to fix or guard the caller, only correcting the precondition when the precondition itself is semantically wrong.
- Add focused prompt unit tests for caller-blame `requires` feedback, structured caller context, and existing `ensures` guidance.

## Root Cause

The previous prompt correctly identified caller blame, but then instructed the model to modify the callee contract with extra bounds to exclude the counterexample input. That contradicted Vow's contract doctrine and trained the benchmark repair loop toward verifier-driven contract weakening.

## Validation

- `uv run --project bench python -m unittest discover -s bench -p 'test_*.py'`
- `uv run --project bench python -m py_compile bench/prompts.py bench/test_prompts.py`
- `git diff --check`

Closes #333