### PR TITLE
skill: install at .claude/skills/vow-toolchain/SKILL.md + auto-install on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ __pycache__/
 
 .claude/settings.local.json
 
+# Auto-installed by `vowc build`; regenerates from compiler source, so
+# tracking a snapshot would drift relative to the binary. Downstream
+# projects (per README) commit their own copy; vow-lang/vow does not.
+/.claude/skills/vow-toolchain/
+
 # vow-mutants outputs
 mutants.out
 mutants-shard-*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ This builds `./target/release/vow` (stage 0), then uses it to compile and verify
 The Claude Code skill document is embedded in the compiler and generated on demand:
 ```bash
 build/vowc skill print                            # print skill to stdout
-build/vowc skill install                          # install to .claude/commands/vow-toolchain.md
+build/vowc skill install                          # install to .claude/skills/vow-toolchain/SKILL.md
 ```
 
 After updating a spec file, regenerate `--help` / embedded skill and rebuild:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,57 @@ ulimit -v 2000000; build/vowc verify examples/divide.vow              # verify c
 ulimit -v 2000000; build/vowc build --mode debug examples/divide.vow  # runtime vow checks
 ```
 
+## Agent Setup (Claude Code Skill)
+
+Vow ships a Claude Code skill embedded in the compiler binary. The skill is the
+canonical reference an agent needs to author and fix Vow programs — grammar, CEGIS
+workflow, contract authoring, CLI surface, error catalogue, and JSON schemas — all
+in one self-contained markdown file.
+
+The skill is **the** source of truth for any harness writing Vow code. Because it
+is generated from the same compiler version that builds your programs, it cannot
+drift from the toolchain you are running.
+
+### Inside Claude Code
+
+The first time you run `vowc build` (or `vowc <source.vow>`) inside a project that
+already has a `.claude/` directory, the compiler installs the skill at:
+
+```
+.claude/skills/vow-toolchain/SKILL.md
+```
+
+Claude Code's skill matcher discovers it automatically via the `globs: "**/*.vow"`
+frontmatter, so the skill loads on demand whenever an agent reads, writes, or edits
+a `.vow` file. Auto-install is silent, runs at most once (it leaves any existing
+`SKILL.md` untouched), and is skipped entirely when `.claude/` is absent — so
+non-Claude-Code projects are never touched.
+
+To install the skill explicitly (for a fresh checkout, or when bringing a Vow
+toolchain into a project that does not yet have a `.claude/` directory):
+
+```bash
+mkdir -p .claude              # one-time, only if .claude/ does not exist
+build/vowc skill install      # writes .claude/skills/vow-toolchain/SKILL.md
+```
+
+Commit the resulting `SKILL.md` to your repository so collaborators (human and
+agent) get the same skill version on checkout.
+
+### Outside Claude Code (raw API harnesses)
+
+For any other harness — a custom agent loop, the bench runner, a one-off API call
+— pipe `vowc skill print` into the system prompt at session start:
+
+```bash
+SYSTEM_PROMPT="$(build/vowc skill print)"
+# ... feed $SYSTEM_PROMPT to your model along with the user task
+```
+
+The skill is a single self-contained markdown document, so no further loading is
+required. Loading once per session is enough; the skill describes a workflow, not
+per-task state.
+
 ## Vericoding Benchmark Suite
 
 The `benchmarks/` directory contains 40 formal verification benchmarks (15 Easy, 15 Medium, 10 Hard) for measuring how well AI agents can write verified code from natural-language specifications. This is Vow's implementation of the *vericoding* concept ([arXiv:2509.22908](https://arxiv.org/abs/2509.22908)).

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3166,12 +3166,14 @@ fn skill_full() -> String {
     r.push_str(String::from("```\n"));
     r.push_str(String::from("vow skill              # print skill document to stdout (default: print)\n"));
     r.push_str(String::from("vow skill print        # same as above\n"));
-    r.push_str(String::from("vow skill install      # install to .claude/commands/vow-toolchain.md\n"));
+    r.push_str(String::from("vow skill install      # install to .claude/skills/vow-toolchain/SKILL.md\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("`print` writes the complete skill markdown (with YAML frontmatter) to stdout. Pipe to a file or use `install` to place it directly.\n"));
+    r.push_str(String::from("`print` writes the complete skill markdown (with YAML frontmatter) to stdout. Pipe it into a system prompt for non–Claude Code harnesses.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("`install` creates `.claude/commands/` in the current directory if needed and writes the skill document there. Claude Code discovers it automatically.\n"));
+    r.push_str(String::from("`install` creates `.claude/skills/vow-toolchain/` in the current directory if needed and writes `SKILL.md` there. Claude Code's skill matcher auto-discovers it via the `globs: \"**/*.vow\"` frontmatter, so the skill loads on demand whenever an agent works with `.vow` files.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Auto-install on build.** The first time `vow build` (or the legacy `vow <source.vow>` form) runs in a directory that already contains a `.claude/` subtree but no `.claude/skills/vow-toolchain/SKILL.md`, the compiler installs the skill silently. This bootstraps Claude Code projects without requiring an explicit `vow skill install`. Auto-install is skipped when `.claude/` does not exist (so it never pollutes non–Claude Code projects) and when the skill file is already present (so user edits are never overwritten). Auto-install never fails the build.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow test`\n"));
     r.push_str(String::from("\n"));
@@ -5304,23 +5306,39 @@ fn run_skill(argv: Vec<String>) -> i32 [io, write] {
         }
     }
     if do_install {
-        let dir: String = String::from(".claude/commands");
+        let dir: String = String::from(".claude/skills/vow-toolchain");
         let mk: i64 = fs_mkdir(dir);
         if mk < 0 {
-            eprintln_str("vow skill install: cannot create .claude/commands/");
+            eprintln_str("vow skill install: cannot create .claude/skills/vow-toolchain/");
             return 1;
         }
-        let path: String = String::from(".claude/commands/vow-toolchain.md");
+        let path: String = String::from(".claude/skills/vow-toolchain/SKILL.md");
         let wr: i64 = fs_write(path, skill_full());
         if wr < 0 {
-            eprintln_str("vow skill install: cannot write .claude/commands/vow-toolchain.md");
+            eprintln_str("vow skill install: cannot write .claude/skills/vow-toolchain/SKILL.md");
             return 1;
         }
-        eprintln_str("installed skill to .claude/commands/vow-toolchain.md");
+        eprintln_str("installed skill to .claude/skills/vow-toolchain/SKILL.md");
         return 0;
     }
     print_str(skill_full());
     0
+}
+
+fn maybe_auto_install_skill() [io, write] {
+    if fs_is_dir(String::from(".claude")) != 1 {
+        return;
+    }
+    let target: String = String::from(".claude/skills/vow-toolchain/SKILL.md");
+    if fs_exists(target) == 1 {
+        return;
+    }
+    let dir: String = String::from(".claude/skills/vow-toolchain");
+    let mk: i64 = fs_mkdir(dir);
+    if mk < 0 {
+        return;
+    }
+    fs_write(target, skill_full());
 }
 
 fn vow_kind_from_desc(desc: String) -> String {
@@ -5564,6 +5582,7 @@ fn main() -> i32 [io, write] {
         return run_skill(argv);
     }
     if cmd == CMD_BUILD() {
+        maybe_auto_install_skill();
         return run_build(argv);
     }
     if cmd == CMD_VERIFY() {
@@ -5575,5 +5594,6 @@ fn main() -> i32 [io, write] {
     if cmd == CMD_MUTANTS() {
         return run_mutants(argv);
     }
+    maybe_auto_install_skill();
     run_legacy(argv)
 }

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -86,12 +86,14 @@ Generate or install the Claude Code skill document for the current compiler vers
 ```
 vow skill              # print skill document to stdout (default: print)
 vow skill print        # same as above
-vow skill install      # install to .claude/commands/vow-toolchain.md
+vow skill install      # install to .claude/skills/vow-toolchain/SKILL.md
 ```
 
-`print` writes the complete skill markdown (with YAML frontmatter) to stdout. Pipe to a file or use `install` to place it directly.
+`print` writes the complete skill markdown (with YAML frontmatter) to stdout. Pipe it into a system prompt for non–Claude Code harnesses.
 
-`install` creates `.claude/commands/` in the current directory if needed and writes the skill document there. Claude Code discovers it automatically.
+`install` creates `.claude/skills/vow-toolchain/` in the current directory if needed and writes `SKILL.md` there. Claude Code's skill matcher auto-discovers it via the `globs: "**/*.vow"` frontmatter, so the skill loads on demand whenever an agent works with `.vow` files.
+
+**Auto-install on build.** The first time `vow build` (or the legacy `vow <source.vow>` form) runs in a directory that already contains a `.claude/` subtree but no `.claude/skills/vow-toolchain/SKILL.md`, the compiler installs the skill silently. This bootstraps Claude Code projects without requiring an explicit `vow skill install`. Auto-install is skipped when `.claude/` does not exist (so it never pollutes non–Claude Code projects) and when the skill file is already present (so user edits are never overwritten). Auto-install never fails the build.
 
 ### `vow test`
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -321,7 +321,7 @@ struct SkillArgs {
 enum SkillAction {
     /// Print the skill document to stdout (default)
     Print,
-    /// Install the skill to .claude/commands/vow-toolchain.md
+    /// Install the skill to .claude/skills/vow-toolchain/SKILL.md
     Install,
 }
 
@@ -2447,12 +2447,14 @@ Generate or install the Claude Code skill document for the current compiler vers
 ```
 vow skill              # print skill document to stdout (default: print)
 vow skill print        # same as above
-vow skill install      # install to .claude/commands/vow-toolchain.md
+vow skill install      # install to .claude/skills/vow-toolchain/SKILL.md
 ```
 
-`print` writes the complete skill markdown (with YAML frontmatter) to stdout. Pipe to a file or use `install` to place it directly.
+`print` writes the complete skill markdown (with YAML frontmatter) to stdout. Pipe it into a system prompt for non–Claude Code harnesses.
 
-`install` creates `.claude/commands/` in the current directory if needed and writes the skill document there. Claude Code discovers it automatically.
+`install` creates `.claude/skills/vow-toolchain/` in the current directory if needed and writes `SKILL.md` there. Claude Code's skill matcher auto-discovers it via the `globs: "**/*.vow"` frontmatter, so the skill loads on demand whenever an agent works with `.vow` files.
+
+**Auto-install on build.** The first time `vow build` (or the legacy `vow <source.vow>` form) runs in a directory that already contains a `.claude/` subtree but no `.claude/skills/vow-toolchain/SKILL.md`, the compiler installs the skill silently. This bootstraps Claude Code projects without requiring an explicit `vow skill install`. Auto-install is skipped when `.claude/` does not exist (so it never pollutes non–Claude Code projects) and when the skill file is already present (so user edits are never overwritten). Auto-install never fails the build.
 
 ### `vow test`
 
@@ -4572,11 +4574,11 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
 // GENERATE:SKILL_FULL:END
 
 fn install_skill_to(root: &Path) -> std::io::Result<PathBuf> {
-    let dir = root.join(".claude/commands");
+    let dir = root.join(".claude/skills/vow-toolchain");
     std::fs::create_dir_all(&dir).map_err(|e| {
         std::io::Error::new(e.kind(), format!("cannot create {}: {}", dir.display(), e))
     })?;
-    let path = dir.join("vow-toolchain.md");
+    let path = dir.join("SKILL.md");
     std::fs::write(&path, skill_full_markdown()).map_err(|e| {
         std::io::Error::new(e.kind(), format!("cannot write {}: {}", path.display(), e))
     })?;
@@ -4591,6 +4593,21 @@ fn run_skill_install() {
             std::process::exit(1);
         }
     }
+}
+
+/// First-run auto-install: when `.claude/` already exists in the working
+/// directory but the Vow skill is not yet installed, drop a fresh copy in
+/// place. Silent on success, silent on failure — must never fail the build.
+fn maybe_auto_install_skill(cwd: &Path) {
+    let claude_dir = cwd.join(".claude");
+    if !claude_dir.is_dir() {
+        return;
+    }
+    let target = claude_dir.join("skills/vow-toolchain/SKILL.md");
+    if target.exists() {
+        return;
+    }
+    let _ = install_skill_to(cwd);
 }
 
 // ---------------------------------------------------------------------------
@@ -6783,6 +6800,9 @@ fn main() {
             validate_limits(&limits);
             let jobs = resolve_verify_jobs(b.verify_jobs);
             let bconfig = make_solver_config(b.solver, b.encoding, b.timeout);
+            if let Ok(cwd) = std::env::current_dir() {
+                maybe_auto_install_skill(&cwd);
+            }
             run_build_command(
                 &source,
                 b.output.as_deref(),
@@ -6976,6 +6996,9 @@ fn main() {
             validate_limits(&limits);
             let jobs = resolve_verify_jobs(args.verify_jobs);
             let config = make_solver_config(args.solver, args.encoding, args.timeout);
+            if let Ok(cwd) = std::env::current_dir() {
+                maybe_auto_install_skill(&cwd);
+            }
             run_build_command(
                 &source,
                 args.output.as_deref(),
@@ -7306,14 +7329,49 @@ fn main() -> i32 [io] {
     }
 
     #[test]
-    fn skill_install_writes_claude_command_file() {
+    fn skill_install_writes_claude_skill_file() {
         let dir = TempDir::new().unwrap();
         install_skill_to(dir.path()).unwrap();
 
-        let installed = dir.path().join(".claude/commands/vow-toolchain.md");
+        let installed = dir.path().join(".claude/skills/vow-toolchain/SKILL.md");
         let contents = std::fs::read_to_string(installed).unwrap();
         assert!(contents.starts_with("---\nname: vow-toolchain\n"));
         assert!(contents.contains("# Vow Language Reference"));
+    }
+
+    #[test]
+    fn auto_install_skill_skips_when_no_claude_dir() {
+        let dir = TempDir::new().unwrap();
+        maybe_auto_install_skill(dir.path());
+        let claude_dir = dir.path().join(".claude");
+        assert!(
+            !claude_dir.exists(),
+            "auto-install must not create .claude/ when absent"
+        );
+    }
+
+    #[test]
+    fn auto_install_skill_installs_when_claude_dir_present() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        maybe_auto_install_skill(dir.path());
+        let installed = dir.path().join(".claude/skills/vow-toolchain/SKILL.md");
+        assert!(
+            installed.exists(),
+            "auto-install must populate the skill when .claude/ is present"
+        );
+    }
+
+    #[test]
+    fn auto_install_skill_leaves_existing_file_untouched() {
+        let dir = TempDir::new().unwrap();
+        let target_dir = dir.path().join(".claude/skills/vow-toolchain");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let target = target_dir.join("SKILL.md");
+        std::fs::write(&target, "user-managed content").unwrap();
+        maybe_auto_install_skill(dir.path());
+        let contents = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(contents, "user-managed content");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #336.

## Summary

- `vowc skill install` now writes to `.claude/skills/vow-toolchain/SKILL.md` instead of `.claude/commands/vow-toolchain.md`. The embedded document already has Claude Code skill frontmatter (`name: vow-toolchain`, `description:`, `globs: "**/*.vow"`), but it lived in the slash-command path, so its description and globs never triggered. Moving it under `.claude/skills/` lets Claude Code's skill matcher auto-discover it on demand whenever an agent touches a `.vow` file.
- `vowc build` (and the legacy `vowc <source.vow>` form) self-installs the skill the first time it runs in a directory that already has a `.claude/` subtree but no `.claude/skills/vow-toolchain/SKILL.md`. Skipped when `.claude/` is absent so non-Claude-Code projects are never touched. Skipped when the file is already present so user edits are never clobbered. Auto-install never fails the build.
- `README.md` gains an "Agent Setup (Claude Code Skill)" section that explains both the in-Claude-Code flow and the `vowc skill print` path for raw API harnesses (the latter is what `bench/` should use to stay version-locked to the binary).
- `docs/spec/cli.md` documents the new install path and the auto-install behaviour; embedded help/skill text regenerated via `scripts/generate_help.py`.

Self-hosted compiler mirrors all behaviour, including a new `maybe_auto_install_skill()` called from `main` before `run_build` / `run_legacy`.

## Test plan

- [x] `cargo test --all` — pass (4 new skill tests cover the install path, auto-install with `.claude/`, no-pollution without `.claude/`, and no-clobber when the file exists)
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `scripts/bootstrap.sh --skip-cargo` — bootstrap fixed point matches (vowc2 == vowc3)
- [x] `scripts/full_test.sh` — same 6 baseline failures with or without this branch (5 pre-existing verify counterexample tests + one mutants T13-name-format unicode quirk on Rust-built stage 1); zero new regressions
- [x] Manual verification: running `vowc build examples/divide.vow` in this worktree silently created `.claude/skills/vow-toolchain/SKILL.md`; Claude Code auto-discovered it as the `vow-toolchain` skill on next session
- [x] Codex review pass (suggested cleaning up the self-hosted unit-return idiom, applied)