### PR TITLE
Fix unsound verifier models for expanding string helpers

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -97,10 +97,6 @@ fn is_string_fresh_helper(name: String) -> bool {
     || name == String::from("__vow_string_to_upper_in_arena")
     || name == String::from("__vow_string_to_lower")
     || name == String::from("__vow_string_to_lower_in_arena")
-    || name == String::from("__vow_string_replace")
-    || name == String::from("__vow_string_replace_in_arena")
-    || name == String::from("__vow_string_join")
-    || name == String::from("__vow_string_join_in_arena")
 }
 
 fn is_known_builtin(name: String) -> bool {
@@ -119,8 +115,6 @@ fn is_known_builtin(name: String) -> bool {
     || name == String::from("__vow_vec_len")
     || name == String::from("__vow_vec_pop")
     || name == String::from("__vow_vec_set_val")
-    || name == String::from("__vow_string_split")
-    || name == String::from("__vow_string_split_in_arena")
     || name == String::from("__vow_string_new")
     || name == String::from("__vow_string_new_in_arena")
     || name == String::from("__vow_string_literal")
@@ -480,8 +474,6 @@ fn is_vec_model_constructor(name: String) -> bool {
     || name == String::from("__vow_vec_new_val_in_arena")
     || name == String::from("__vow_vec_from_raw_parts_copy_val")
     || name == String::from("__vow_vec_pin_to_root_val")
-    || name == String::from("__vow_string_split")
-    || name == String::from("__vow_string_split_in_arena")
 }
 
 fn is_string_model_constructor(name: String) -> bool {
@@ -1411,14 +1403,6 @@ fn emit_nondet_string_len(out: String, id: i64, string_max: i64) {
         str3(String::from(".len < "), i64_to_str(string_max), String::from(");\n"))));
 }
 
-fn emit_nondet_vec_len(out: String, id: i64, vec_max: i64) {
-    let ids: String = i64_to_str(id);
-    out.push_str(str3(String::from("  v"), ids, String::from(".len = __VERIFIER_nondet_long();\n")));
-    out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
-        String::from(".len >= 0 && v"), ids,
-        str3(String::from(".len < "), i64_to_str(vec_max), String::from(");\n"))));
-}
-
 fn const_str_index_for(ids: Vec<i64>, idxs: Vec<i64>, id: i64) -> i64 {
     let mut i: i64 = 0;
     while i < ids.len() {
@@ -1501,10 +1485,6 @@ fn emit_string_op(out: String, inst: IrInst, f: IrFunction, m: IrModule, vec_max
         out.push_str(str5(String::from("  __ESBMC_assume(v"), ids,
             String::from(".len >= 0 && v"), ids,
             str3(String::from(".len < "), i64_to_str(string_max), String::from(");\n"))));
-        return;
-    }
-    if ds == String::from("__vow_string_split") || ds == String::from("__vow_string_split_in_arena") {
-        emit_nondet_vec_len(out, id, vec_max);
         return;
     }
     if is_string_fresh_helper(ds) {

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -102,8 +102,6 @@ fn is_vec_model_creator(name: &str) -> bool {
             | "__vow_vec_new_val_in_arena"
             | "__vow_vec_from_raw_parts_copy_val"
             | "__vow_vec_pin_to_root_val"
-            | "__vow_string_split"
-            | "__vow_string_split_in_arena"
     )
 }
 
@@ -116,10 +114,6 @@ fn is_string_fresh_helper(name: &str) -> bool {
             | "__vow_string_to_upper_in_arena"
             | "__vow_string_to_lower"
             | "__vow_string_to_lower_in_arena"
-            | "__vow_string_replace"
-            | "__vow_string_replace_in_arena"
-            | "__vow_string_join"
-            | "__vow_string_join_in_arena"
     )
 }
 
@@ -334,8 +328,6 @@ fn is_known_builtin(name: &str) -> bool {
             | "__vow_vec_len"
             | "__vow_vec_pop"
             | "__vow_vec_set_val"
-            | "__vow_string_split"
-            | "__vow_string_split_in_arena"
             | "__vow_string_new"
             | "__vow_string_new_in_arena"
             | "__vow_string_literal"
@@ -1097,9 +1089,6 @@ fn emit_inst(
                     "__vow_string_from_i64" | "__vow_string_from_i64_in_arena" => {
                         emit_nondet_string_len(id, limits.string_max, out);
                     }
-                    "__vow_string_split" | "__vow_string_split_in_arena" => {
-                        emit_nondet_vec_len(id, limits.vec_max, out);
-                    }
                     name if is_string_fresh_helper(name) => {
                         emit_nondet_string_len(id, limits.string_max, out);
                     }
@@ -1602,13 +1591,6 @@ fn emit_nondet_string_len(id: u32, string_max: usize, out: &mut String) {
     out.push_str(&format!(
         "  v{id}.len = __VERIFIER_nondet_long();\n\
          \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {string_max});\n",
-    ));
-}
-
-fn emit_nondet_vec_len(id: u32, vec_max: usize, out: &mut String) {
-    out.push_str(&format!(
-        "  v{id}.len = __VERIFIER_nondet_long();\n\
-         \x20 __ESBMC_assume(v{id}.len >= 0 && v{id}.len < {vec_max});\n",
     ));
 }
 
@@ -3864,25 +3846,19 @@ mod tests {
     }
 
     #[test]
-    fn emit_string_fresh_helpers_are_modelable() {
+    fn emit_non_expanding_string_helpers_are_modelable() {
         use vow_ir::InstId;
 
         let cases = [
-            ("__vow_string_trim", 1, false),
-            ("__vow_string_trim_in_arena", 2, false),
-            ("__vow_string_to_upper", 1, false),
-            ("__vow_string_to_upper_in_arena", 2, false),
-            ("__vow_string_to_lower", 1, false),
-            ("__vow_string_to_lower_in_arena", 2, false),
-            ("__vow_string_replace", 3, false),
-            ("__vow_string_replace_in_arena", 4, false),
-            ("__vow_string_join", 2, false),
-            ("__vow_string_join_in_arena", 3, false),
-            ("__vow_string_split", 2, true),
-            ("__vow_string_split_in_arena", 3, true),
+            ("__vow_string_trim", 1),
+            ("__vow_string_trim_in_arena", 2),
+            ("__vow_string_to_upper", 1),
+            ("__vow_string_to_upper_in_arena", 2),
+            ("__vow_string_to_lower", 1),
+            ("__vow_string_to_lower_in_arena", 2),
         ];
 
-        for (idx, (name, argc, returns_vec)) in cases.iter().enumerate() {
+        for (idx, (name, argc)) in cases.iter().enumerate() {
             let call_id = 20 + idx as u32;
             let args: Vec<InstId> = (0..*argc).map(|i| InstId(i as u32)).collect();
             let mut insts = Vec::new();
@@ -3947,29 +3923,91 @@ mod tests {
                 !c.contains("unsupported opcode in verifier model"),
                 "{name} should not fall through to unsupported: {c}"
             );
-            if *returns_vec {
-                assert!(
-                    c.contains(&format!("__vow_vec_t v{call_id};")),
-                    "{name} result should use the Vec model: {c}"
-                );
-                assert!(
-                    c.contains(&format!(
-                        "__ESBMC_assume(v{call_id}.len >= 0 && v{call_id}.len < 128)"
-                    )),
-                    "{name} result length should be bounded by vec_max: {c}"
-                );
-            } else {
-                assert!(
-                    c.contains(&format!("__vow_string_t v{call_id};")),
-                    "{name} result should use the String model: {c}"
-                );
-                assert!(
-                    c.contains(&format!(
-                        "__ESBMC_assume(v{call_id}.len >= 0 && v{call_id}.len < 256)"
-                    )),
-                    "{name} result length should be bounded by string_max: {c}"
-                );
+            assert!(
+                c.contains(&format!("__vow_string_t v{call_id};")),
+                "{name} result should use the String model: {c}"
+            );
+            assert!(
+                c.contains(&format!(
+                    "__ESBMC_assume(v{call_id}.len >= 0 && v{call_id}.len < 256)"
+                )),
+                "{name} result length should be bounded by string_max: {c}"
+            );
+        }
+    }
+
+    #[test]
+    fn emit_expanding_string_helpers_are_not_modelable() {
+        use vow_ir::InstId;
+
+        let cases = [
+            ("__vow_string_replace", 3),
+            ("__vow_string_replace_in_arena", 4),
+            ("__vow_string_join", 2),
+            ("__vow_string_join_in_arena", 3),
+            ("__vow_string_split", 2),
+            ("__vow_string_split_in_arena", 3),
+        ];
+
+        for (idx, (name, argc)) in cases.iter().enumerate() {
+            let call_id = 40 + idx as u32;
+            let args: Vec<InstId> = (0..*argc).map(|i| InstId(i as u32)).collect();
+            let mut insts = Vec::new();
+            for i in 0..*argc {
+                insts.push(inst(
+                    i as u32,
+                    Opcode::ConstI64,
+                    Ty::I64,
+                    vec![],
+                    InstData::ConstI64(0),
+                ));
             }
+            insts.push(Inst {
+                id: InstId(call_id),
+                opcode: Opcode::Call,
+                ty: Ty::Ptr,
+                args,
+                data: InstData::CallExtern((*name).to_string()),
+                origin: sp(),
+                region: RegionId::Root,
+            });
+            insts.push(inst(
+                call_id + 1,
+                Opcode::Return,
+                Ty::Unit,
+                vec![call_id],
+                InstData::None,
+            ));
+
+            let func = Function {
+                id: FuncId(idx as u32),
+                name: format!("expanding_helper_{idx}"),
+                params: vec![],
+                param_names: vec![],
+                return_ty: Ty::Ptr,
+                effects: vec![],
+                vows: vec![],
+                blocks: vec![BasicBlock {
+                    id: BlockId(0),
+                    insts,
+                }],
+                local_names: std::collections::HashMap::new(),
+                summary: RegionSummary::default(),
+                source_file: String::new(),
+            };
+            let module = Module {
+                name: "test".to_string(),
+                functions: vec![func.clone()],
+                strings: vec![],
+                struct_layouts: vec![],
+                enum_layouts: vec![],
+                warnings: vec![],
+            };
+            let reason = non_modelable_reason(&func, &module, &HashMap::new());
+            assert!(
+                matches!(reason.as_deref(), Some(text) if text.contains(name)),
+                "{name} should stay non-modelable until its expanding length semantics are modeled; reason: {reason:?}"
+            );
         }
     }
 


### PR DESCRIPTION
### Motivation
- The verifier emitted bounded nondeterministic lengths for `string_split`, `string_replace`, and `string_join`, which is unsound because their runtime implementations can expand outputs beyond the verifier limits and thus allow false proofs.

### Description
- Stop classifying `__vow_string_split` as a Vec model creator / known builtin so calls using it remain non-modelable until a sound expanding-model is provided.
- Remove `__vow_string_replace` and `__vow_string_join` from the fresh-string helper set so they are not modeled as bounded nondeterministic Strings.
- Remove emission of a nondeterministic bounded `vec.len` for `string_split` and keep nondet-bounded modeling only for non-expanding helpers (e.g., `trim`, `to_upper`, `to_lower`).
- Apply the same parity changes to the self-hosted compiler emitter (`compiler/c_emitter.vow`) so the self-hosted compiler and Rust verifier behave consistently.
- Add regression tests in `vow-verify` that assert non-expanding helpers remain modelable and that expanding helpers (`replace`, `join`, `split`) are reported non-modelable until modeled soundly.

### Testing
- Ran `cargo fmt --all` (formatting completed successfully).
- Ran `cargo test -p vow-verify string_helpers` and `cargo test -p vow-verify`; the `vow-verify` unit test suite passed (tests exercising the new/non-modelable helpers passed).
- Attempted `build/vowc verify compiler/c_emitter.vow` but `build/vowc` is not present in this checkout so the self-hosted verification step could not be executed here.
- Ran `cargo test --all` where unrelated integration tests failed in this environment due to missing external tooling/runtime artifacts (ESBMC / `build/vowc`), not because of the verifier-model changes; `vow-verify` tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd32ac2c483328bd222573441b144)