### PR TITLE
Avoid arena routing for projected strings

### DIFF
--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -124,6 +124,14 @@ fn clif_hidden_store_target_region(f: IrFunction, target_param: i64) -> i64 {
     region_root()
 }
 
+// Projection results (IOP_FIELD_GET, IOP_LOAD, __vow_vec_get*) are intentionally
+// NOT traced through to their container here: a pointer-valued field or Vec
+// element does not share its container's arena lifetime, so routing string
+// mutation into the container's arena would create a use-after-free when the
+// container outlives the string (or vice versa). Only direct hidden-caller
+// parameters (IOP_GET_ARG with REGION_KIND_CALLER) and IOP_PHI merges over
+// safe sources are tracked. If safe projection semantics are ever added, extend
+// this function; do not re-introduce the unconditional projection tracing.
 fn clif_value_receiver_region(f: IrFunction, receiver: IrInst, seen: Vec<i64>) -> i64 {
     if receiver.id < 0 {
         return region_root();

--- a/compiler/clif.vow
+++ b/compiler/clif.vow
@@ -139,18 +139,6 @@ fn clif_value_receiver_region(f: IrFunction, receiver: IrInst, seen: Vec<i64>) -
             return hidden;
         }
     }
-    if (receiver.op == IOP_FIELD_GET() || receiver.op == IOP_LOAD()) && receiver.args.len() > 0 {
-        let src0: IrInst = clif_find_inst(f, receiver.args[0]);
-        return clif_value_receiver_region(f, src0, next_seen);
-    }
-    if receiver.op == IOP_CALL()
-        && receiver.dk == IDATA_CALL_EXTERN()
-        && (receiver.ds == String::from("__vow_vec_get_val") || receiver.ds == String::from("__vow_vec_get"))
-        && receiver.args.len() > 0
-    {
-        let src1: IrInst = clif_find_inst(f, receiver.args[0]);
-        return clif_value_receiver_region(f, src1, next_seen);
-    }
     if receiver.op == IOP_PHI() {
         let blocks: Vec<IrBlock> = f.blocks;
         let mut have: bool = false;

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -334,44 +334,6 @@ fn inst_region_for_value_inner(
     {
         return rgn;
     }
-    if matches!(
-        inst_op_by_id.get(&inst_id).copied(),
-        Some(IOP_FIELD_GET | IOP_LOAD)
-    ) && let Some(&source_id) = inst_first_arg_by_id.get(&inst_id)
-    {
-        return inst_region_for_value_inner(
-            source_id,
-            inst_region_by_id,
-            inst_data_by_id,
-            inst_op_by_id,
-            inst_ds_by_id,
-            inst_first_arg_by_id,
-            upsilon_sources_by_phi,
-            return_kind,
-            store_effects,
-            seen,
-        );
-    }
-    if inst_op_by_id.get(&inst_id).copied() == Some(IOP_CALL)
-        && let Some(&(dk, _)) = inst_data_by_id.get(&inst_id)
-        && dk == IDATA_CALL_EXTERN
-        && let Some(sym) = inst_ds_by_id.get(&inst_id)
-        && matches!(sym.as_str(), "__vow_vec_get_val" | "__vow_vec_get")
-        && let Some(&source_id) = inst_first_arg_by_id.get(&inst_id)
-    {
-        return inst_region_for_value_inner(
-            source_id,
-            inst_region_by_id,
-            inst_data_by_id,
-            inst_op_by_id,
-            inst_ds_by_id,
-            inst_first_arg_by_id,
-            upsilon_sources_by_phi,
-            return_kind,
-            store_effects,
-            seen,
-        );
-    }
     if inst_op_by_id.get(&inst_id).copied() == Some(IOP_PHI)
         && let Some(sources) = upsilon_sources_by_phi.get(&inst_id)
     {

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -289,8 +289,6 @@ fn inst_region_for_value(
     inst_region_by_id: &HashMap<i64, i64>,
     inst_data_by_id: &HashMap<i64, (i64, i64)>,
     inst_op_by_id: &HashMap<i64, i64>,
-    inst_ds_by_id: &HashMap<i64, String>,
-    inst_first_arg_by_id: &HashMap<i64, i64>,
     upsilon_sources_by_phi: &HashMap<i64, Vec<i64>>,
     return_kind: i64,
     store_effects: &[i64],
@@ -300,8 +298,6 @@ fn inst_region_for_value(
         inst_region_by_id,
         inst_data_by_id,
         inst_op_by_id,
-        inst_ds_by_id,
-        inst_first_arg_by_id,
         upsilon_sources_by_phi,
         return_kind,
         store_effects,
@@ -315,8 +311,6 @@ fn inst_region_for_value_inner(
     inst_region_by_id: &HashMap<i64, i64>,
     inst_data_by_id: &HashMap<i64, (i64, i64)>,
     inst_op_by_id: &HashMap<i64, i64>,
-    inst_ds_by_id: &HashMap<i64, String>,
-    inst_first_arg_by_id: &HashMap<i64, i64>,
     upsilon_sources_by_phi: &HashMap<i64, Vec<i64>>,
     return_kind: i64,
     store_effects: &[i64],
@@ -345,8 +339,6 @@ fn inst_region_for_value_inner(
                 inst_region_by_id,
                 inst_data_by_id,
                 inst_op_by_id,
-                inst_ds_by_id,
-                inst_first_arg_by_id,
                 upsilon_sources_by_phi,
                 return_kind,
                 store_effects,
@@ -1113,8 +1105,6 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
     let mut inst_region_by_id: HashMap<i64, i64> = HashMap::new();
     let mut inst_data_by_id: HashMap<i64, (i64, i64)> = HashMap::new();
     let mut inst_op_by_id: HashMap<i64, i64> = HashMap::new();
-    let mut inst_ds_by_id: HashMap<i64, String> = HashMap::new();
-    let mut inst_first_arg_by_id: HashMap<i64, i64> = HashMap::new();
     let mut upsilon_sources_by_phi: HashMap<i64, Vec<i64>> = HashMap::new();
     for bi in 0..nb {
         let start = block_starts[bi] as usize;
@@ -1128,15 +1118,6 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
             inst_op_by_id.insert(inst_ids[idx], inst_ops[idx]);
             let aoff = arg_offsets[idx] as usize;
             let alen = arg_lengths[idx] as usize;
-            if alen > 0 {
-                inst_first_arg_by_id.insert(inst_ids[idx], all_args[aoff]);
-            }
-            if inst_dks[idx] == IDATA_CALL_EXTERN {
-                inst_ds_by_id.insert(
-                    inst_ids[idx],
-                    unsafe { read_vow_string(inst_ds_ptrs[idx]) }.to_string(),
-                );
-            }
             if inst_ops[idx] == IOP_UPSILON && inst_dks[idx] == IDATA_PHI_TARGET && alen > 0 {
                 upsilon_sources_by_phi
                     .entry(inst_dvs[idx])
@@ -2196,8 +2177,6 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                                     &inst_region_by_id,
                                     &inst_data_by_id,
                                     &inst_op_by_id,
-                                    &inst_ds_by_id,
-                                    &inst_first_arg_by_id,
                                     &upsilon_sources_by_phi,
                                     decl.return_kind,
                                     &decl.store_effects,
@@ -2300,8 +2279,6 @@ fn compile_current_function(ctx: &mut ModuleContext) -> i64 {
                                         &inst_region_by_id,
                                         &inst_data_by_id,
                                         &inst_op_by_id,
-                                        &inst_ds_by_id,
-                                        &inst_first_arg_by_id,
                                         &upsilon_sources_by_phi,
                                         current_decl.return_kind,
                                         &current_decl.store_effects,

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -381,6 +381,14 @@ fn region_to_arena_value(
     }
 }
 
+// Projection results (`FieldGet`, `Load`, `__vow_vec_get*`) are intentionally
+// NOT traced through to their container here: a pointer-valued field or Vec
+// element does not share its container's arena lifetime, so routing string
+// mutation into the container's arena would create a use-after-free when the
+// container outlives the string (or vice versa). Only direct hidden-caller
+// parameters (`GetArg` → `Caller`) and Phi merges over safe sources are
+// tracked. If safe projection semantics are ever added, extend this function;
+// do not re-introduce the unconditional FieldGet/Load/vec_get tracing.
 fn source_value_region(
     source: &Inst,
     inst_index: &HashMap<InstId, &Inst>,

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -396,17 +396,6 @@ fn source_value_region(
     {
         return RegionId::Caller(hidden_idx);
     }
-    if matches!(source.opcode, Opcode::FieldGet | Opcode::Load)
-        && let Some(source_id) = source.args.first()
-    {
-        return arg_region_inner(*source_id, inst_index, current_summary, phi_data, seen);
-    }
-    if let (Opcode::Call, InstData::CallExtern(sym)) = (&source.opcode, &source.data)
-        && matches!(sym.as_str(), "__vow_vec_get_val" | "__vow_vec_get")
-        && let Some(source_id) = source.args.first()
-    {
-        return arg_region_inner(*source_id, inst_index, current_summary, phi_data, seen);
-    }
     if source.opcode == Opcode::Phi {
         let mut merged: Option<RegionId> = None;
         for upsilons in phi_data.block_upsilons.values() {
@@ -4596,7 +4585,7 @@ mod tests {
     }
 
     #[test]
-    fn projected_parameter_region_string_push_byte_imports_arena_variant() {
+    fn projected_parameter_region_string_push_byte_keeps_default_variant() {
         let grow_projection = Function {
             id: FuncId(0),
             name: "grow_projection".to_string(),
@@ -4685,8 +4674,8 @@ mod tests {
             .symbols()
             .filter_map(|symbol| symbol.name().ok().map(str::to_string))
             .collect();
-        assert!(symbols.contains("__vow_string_push_byte_in_arena"));
-        assert!(!symbols.contains("__vow_string_push_byte"));
+        assert!(symbols.contains("__vow_string_push_byte"));
+        assert!(!symbols.contains("__vow_string_push_byte_in_arena"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent a use-after-free risk where string mutation helpers (`push_byte`/`push_str`) were rewritten to in-arena variants using the container/ projection region, which can route growth into a shorter-lived arena and corrupt longer-lived string headers. 
- The unsafe projection-to-source tracing treated `FieldGet`/`Load` and `Vec::get` results as if they shared the container arena, which is not valid for pointer-valued fields or `Vec<String>` elements.

### Description
- Remove projection-based receiver-region tracing in the Rust Cranelift backend so `FieldGet`/`Load` and `__vow_vec_get_val`/`__vow_vec_get` results no longer inherit their container/address region; only direct hidden caller parameters and safe Phi merges are considered. (changed `vow-codegen/src/cranelift_backend.rs`)
- Mirror the conservative behavior in the self-hosted path by removing the same projection tracing from `compiler/clif.vow` so the self-hosted compiler does not route projected string receivers into container arenas. (changed `compiler/clif.vow`)
- Mirror the fix in the Cranelift shim used by the self-hosted backend so shim-side region inference no longer propagates container regions through projections. (changed `vow-clif-shim/src/lib.rs`)
- Update the codegen unit test to assert the default `__vow_string_push_byte` is kept for projected receivers (test renamed/updated to `projected_parameter_region_string_push_byte_keeps_default_variant`). (changed `vow-codegen/src/cranelift_backend.rs` tests)

### Testing
- Ran `cargo test -p vow-codegen projected_parameter_region_string_push_byte_keeps_default_variant` and it passed.
- Ran `cargo test -p vow-clif-shim` and it passed.
- Ran `cargo build -p vow-runtime && cargo test -p vow-codegen` and the `vow-codegen` test suite passed (all codegen tests green in this run).
- Compiled and ran the PoC (`./target/release/vow build --no-verify --mode debug /tmp/poc_vec_string_uaf.vow -o /tmp/poc_vec_string_uaf && /tmp/poc_vec_string_uaf`) and observed no SIGSEGV crash (program ran without triggering the prior UAF behavior in this environment).
- Full `cargo test --all` is affected by environment constraints (ESBMC not installed and some integration tests that run generated executables require additional setup), so several higher-level tests were not meaningful in this sandbox; targeted unit tests above were used to validate this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd3f9caac8332aa4ca9c35dccb9b2)