### PR TITLE
Fix arena aliasing for Vec-indexed String elements (string_split)

### DIFF
--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2691,6 +2691,11 @@ fn direct_markers_collect_regions(
                             linear_insert_i64(markers, target_marker2);
                             push_region_work(work, seen, inst.args[target_pos2]);
                         }
+                        if (inst.ds == String::from("__vow_vec_get_val") || inst.ds == String::from("__vow_vec_get"))
+                            && ai == 0
+                        {
+                            push_region_work(work, seen, inst.id);
+                        }
                     }
                 }
                 ai = ai + 1;
@@ -2831,22 +2836,27 @@ fn direct_markers_collect_concrete_blocks(
                             push_region_work(work, seen, inst.id);
                         }
                     }
-	                    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
-	                        let target_pos2: i64 = extern_store_target_for_source(inst.ds, ai);
-	                        if target_pos2 >= 0 && target_pos2 < inst.args.len() {
-	                            let target_block2: i64 = target_marker_concrete_block(
-	                                id_to_inst,
-	                                id_to_block,
-	                                inst.args[target_pos2],
-	                                int_kinds
-	                            );
-	                            if target_block2 < 0 {
-	                                return false;
-	                            }
-	                            linear_insert_i64(markers, target_block2);
-	                            push_region_work(work, seen, inst.args[target_pos2]);
-	                        }
-	                    }
+                    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() {
+                        let target_pos2: i64 = extern_store_target_for_source(inst.ds, ai);
+                        if target_pos2 >= 0 && target_pos2 < inst.args.len() {
+                            let target_block2: i64 = target_marker_concrete_block(
+                                id_to_inst,
+                                id_to_block,
+                                inst.args[target_pos2],
+                                int_kinds
+                            );
+                            if target_block2 < 0 {
+                                return false;
+                            }
+                            linear_insert_i64(markers, target_block2);
+                            push_region_work(work, seen, inst.args[target_pos2]);
+                        }
+                        if (inst.ds == String::from("__vow_vec_get_val") || inst.ds == String::from("__vow_vec_get"))
+                            && ai == 0
+                        {
+                            push_region_work(work, seen, inst.id);
+                        }
+                    }
                 }
                 ai = ai + 1;
             }
@@ -4228,6 +4238,14 @@ fn lookup_inst_or_default(id_to_inst: Vec<IrInst>, id: i64) -> IrInst {
 }
 
 fn trace_origin_shallow(id_to_inst: Vec<IrInst>, id: i64) -> DeepRet {
+    let visiting: Vec<i64> = Vec::new();
+    trace_origin_shallow_inner(id_to_inst, id, visiting)
+}
+
+fn trace_origin_shallow_inner(id_to_inst: Vec<IrInst>, id: i64, visiting: Vec<i64>) -> DeepRet {
+    if region_vec_contains_i64(visiting, id) {
+        return deep_ret_const_global();
+    }
     let inst: IrInst = lookup_inst_or_default(id_to_inst, id);
     if inst.id < 0 {
         return deep_ret_const_global();
@@ -4240,6 +4258,15 @@ fn trace_origin_shallow(id_to_inst: Vec<IrInst>, id: i64) -> DeepRet {
     }
     if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN() && heap_producing_extern(inst.ds) {
         return DeepRet { kind: RSUM_KIND_FRESH_IN_CALLER(), aux: 0, aliases: Vec::new() };
+    }
+    if inst.op == IOP_CALL() && inst.dk == IDATA_CALL_EXTERN()
+        && (inst.ds == String::from("__vow_vec_get_val") || inst.ds == String::from("__vow_vec_get"))
+        && inst.args.len() > 0
+    {
+        visiting.push(id);
+        let r: DeepRet = trace_origin_shallow_inner(id_to_inst, inst.args[0], visiting);
+        visiting.pop();
+        return r;
     }
     if is_const_op(inst.op) {
         return deep_ret_const_global();

--- a/tests/run/string_split_returned_element.vow
+++ b/tests/run/string_split_returned_element.vow
@@ -1,0 +1,17 @@
+// TEST: stdout "a=AA b=CCCC\n"
+module StringSplitReturnedElement
+
+fn first_part(s: String) -> String {
+    let parts: Vec<String> = string_split(s, String::from(","));
+    parts[0]
+}
+
+fn main() [io] {
+    let a: String = first_part(String::from("AA,BB"));
+    let b: String = first_part(String::from("CCCC,DDDD"));
+    print_str(String::from("a="));
+    print_str(a);
+    print_str(String::from(" b="));
+    print_str(b);
+    print_str(String::from("\n"));
+}

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -2464,6 +2464,11 @@ fn propagate_alias_markers(
                         for_each_extern_store_edge(sym, &inst.args, |target_id, source_id| {
                             alias_edges.push((target_id, source_id));
                         });
+                        if matches!(sym.as_str(), "__vow_vec_get_val" | "__vow_vec_get")
+                            && let Some(&source) = inst.args.first()
+                        {
+                            alias_edges.push((inst.id, source));
+                        }
                     }
                     let InstData::CallTarget(callee_id) = &inst.data else {
                         continue;
@@ -2791,10 +2796,24 @@ fn origin_to_internal_inner(
         | Opcode::ConstBool
         | Opcode::ConstUnit => InternalReturnRegion::Published(RegionConstraint::ConstantGlobal),
         Opcode::Call => {
-            if let InstData::CallExtern(sym) = &inst.data
-                && heap_producing_extern(sym)
-            {
-                return InternalReturnRegion::Published(RegionConstraint::FreshInCaller);
+            if let InstData::CallExtern(sym) = &inst.data {
+                if heap_producing_extern(sym) {
+                    return InternalReturnRegion::Published(RegionConstraint::FreshInCaller);
+                }
+                if matches!(sym.as_str(), "__vow_vec_get_val" | "__vow_vec_get")
+                    && let Some(&source) = inst.args.first()
+                {
+                    visiting.push_back(id);
+                    let r = origin_to_internal_inner(
+                        source,
+                        inst_lookup,
+                        phi_arms,
+                        summaries,
+                        visiting,
+                    );
+                    visiting.pop_back();
+                    return r;
+                }
             }
             if let InstData::CallExtern(sym) = &inst.data
                 && matches!(sym.as_str(), "__vow_vec_get_val" | "__vow_vec_get")
@@ -2905,30 +2924,47 @@ enum ValueOrigin {
 }
 
 fn trace_origin(id: InstId, inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>) -> ValueOrigin {
+    let mut visiting = VecDeque::new();
+    trace_origin_inner(id, inst_lookup, &mut visiting)
+}
+
+fn trace_origin_inner(
+    id: InstId,
+    inst_lookup: &BTreeMap<InstId, (BlockId, &Inst)>,
+    visiting: &mut VecDeque<InstId>,
+) -> ValueOrigin {
+    if visiting.contains(&id) {
+        return ValueOrigin::Other;
+    }
     let (_, inst) = match inst_lookup.get(&id) {
         Some(v) => v,
         None => return ValueOrigin::Other,
     };
-    match inst.opcode {
-        Opcode::GetArg => {
-            if let InstData::ArgIndex(i) = inst.data {
-                ValueOrigin::Param(i)
-            } else {
-                ValueOrigin::Other
-            }
-        }
-        Opcode::RegionAlloc => ValueOrigin::RegionAlloc,
-        Opcode::Call if matches!(&inst.data, InstData::CallExtern(sym) if heap_producing_extern(sym)) => {
+    match (&inst.opcode, &inst.data) {
+        (Opcode::GetArg, InstData::ArgIndex(i)) => ValueOrigin::Param(*i),
+        (Opcode::RegionAlloc, _) => ValueOrigin::RegionAlloc,
+        (Opcode::Call, InstData::CallExtern(sym)) if heap_producing_extern(sym) => {
             ValueOrigin::RegionAlloc
         }
-        Opcode::ConstStr
-        | Opcode::ConstI32
-        | Opcode::ConstI64
-        | Opcode::ConstU64
-        | Opcode::ConstF32
-        | Opcode::ConstF64
-        | Opcode::ConstBool
-        | Opcode::ConstUnit => ValueOrigin::Constant,
+        (Opcode::Call, InstData::CallExtern(sym))
+            if matches!(sym.as_str(), "__vow_vec_get_val" | "__vow_vec_get") =>
+        {
+            let Some(&source) = inst.args.first() else {
+                return ValueOrigin::Other;
+            };
+            visiting.push_back(id);
+            let result = trace_origin_inner(source, inst_lookup, visiting);
+            visiting.pop_back();
+            result
+        }
+        (Opcode::ConstStr, _)
+        | (Opcode::ConstI32, _)
+        | (Opcode::ConstI64, _)
+        | (Opcode::ConstU64, _)
+        | (Opcode::ConstF32, _)
+        | (Opcode::ConstF64, _)
+        | (Opcode::ConstBool, _)
+        | (Opcode::ConstUnit, _) => ValueOrigin::Constant,
         _ => ValueOrigin::Other,
     }
 }
@@ -6346,6 +6382,50 @@ mod tests {
                 "{sym} should be treated as a fresh heap producer"
             );
         }
+    }
+
+    #[test]
+    fn returning_element_from_fresh_string_split_lifts_split_to_caller_region() {
+        let insts = vec![
+            inst(0, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(0)),
+            inst(1, Opcode::GetArg, Ty::Ptr, vec![], InstData::ArgIndex(1)),
+            inst(
+                2,
+                Opcode::Call,
+                Ty::Ptr,
+                vec![0, 1],
+                InstData::CallExtern("__vow_string_split".to_string()),
+            ),
+            inst(3, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+            inst(
+                4,
+                Opcode::Call,
+                Ty::I64,
+                vec![2, 3],
+                InstData::CallExtern("__vow_vec_get_val".to_string()),
+            ),
+            inst(5, Opcode::Return, Ty::Unit, vec![4], InstData::None),
+        ];
+        let f = function(
+            0,
+            "first_split_part",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Ptr,
+            vec![block(0, insts)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+
+        assert_eq!(
+            m.functions[0].blocks[0].insts[2].region,
+            RegionId::Caller(HiddenRegionIdx(0)),
+            "String::split elements can escape through Vec indexing, so the split allocation must outlive the caller"
+        );
+        assert_eq!(
+            m.functions[0].summary.return_region,
+            RegionConstraint::FreshInCaller,
+            "returning a Vec-indexed split element should publish FreshInCaller"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- `string_split` gained an arena-aware variant that allocates the result `Vec` and its element `String`s in a caller/block arena, but `__vow_vec_get_val` results were not modelled as aliases of the source vector so returned elements could point into a closed arena, producing use-after-free.

### Description

- Treat `__vow_vec_get_val` / `__vow_vec_get` results as aliases of their source vector during alias-marker propagation so Vec-indexed values inherit the container's origin (`vow-ir/src/region.rs` changes to `propagate_alias_markers`).
- When resolving a call's return origin, descend through Vec-get externs so `CallExtern("__vow_vec_get_val")` returns the origin of the vector element instead of the conservative `ConstantGlobal` (`origin_to_internal_inner` / `trace_origin` updates in `vow-ir/src/region.rs`).
- Port the same alias/trace handling to the self-hosted compiler pass (`compiler/region.vow`) so both compilers infer the same safe regions and insert `RegionOpen`/`RegionClose` properly for `string_split` paths.
- Add a unit regression in `vow-ir` and a runtime test `tests/run/string_split_returned_element.vow` that returns `parts[0]` from two splits and asserts the first returned `String` remains stable, plus minor formatting.

### Testing

- Ran `cargo fmt --all` (formatting applied) and `cargo test -p vow-ir` which passed and included the new `returning_element_from_fresh_string_split_lifts_split_to_caller_region` test (ok).
- Built and ran a `--no-verify` executable for the added runtime test via `cargo build -p vow-runtime && cargo run -q -p vow -- build --no-verify --no-cache tests/run/string_split_returned_element.vow -o /tmp/string_split_returned_element && /tmp/string_split_returned_element`, which produced the expected output `a=AA b=CCCC`.
- Ran `cargo run -q -p vow -- build --dump-ir` to inspect lowered IR changes (used while validating the fix).
- `cargo test --all` was attempted but verifier-dependent tests failed in this environment due to ESBMC being unavailable (tests unrelated to the region fix ran and passed); verifier failures are environmental, not regressions introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd8927d5c8332b99ccd40bfabbc5c)