### PR TITLE
Restore typed-container reclamation: heap-backed Vec/Map and real typed frees

### DIFF
--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -2138,6 +2138,10 @@ pub unsafe extern "C" fn __vow_vec_free_val(v: *mut u8) {
     if v.is_null() {
         return;
     }
+    // Mark the shadow entry freed before deallocating so a later use of
+    // the stale pointer is diagnosed by sanitize mode (UseAfterFree) rather
+    // than dereferencing freed memory inside __vow_vec_push_val and friends.
+    sanitize_on_free(v as usize);
     let vec = unsafe { &mut *(v as *mut VowVec) };
     if vec.cap != 0 && vec.cap != VOW_CAP_RODATA {
         unsafe { __vow_free(vec.ptr, vec.cap * 8, 8) };
@@ -2207,6 +2211,17 @@ fn sanitize_on_vec_new(vec_addr: usize) {
             freed: false,
         },
     );
+}
+
+fn sanitize_on_free(vec_addr: usize) {
+    if !sanitize_is_enabled() {
+        return;
+    }
+    let mut table = SHADOW_TABLE.lock().unwrap();
+    let map = shadow_table_get_or_init(&mut table);
+    if let Some(shadow) = map.get_mut(&vec_addr) {
+        shadow.freed = true;
+    }
 }
 
 fn sanitize_on_push(vec_addr: usize) {
@@ -2574,6 +2589,26 @@ mod tests {
         let v4 = __vow_vec_new_val();
         unsafe { __vow_vec_push_val(v4, 42) };
         unsafe { __vow_vec_free_val(v4) };
+
+        // -- __vow_vec_free_val marks shadow entry freed --
+        // Capture the address before the free; the shadow entry must
+        // outlive the deallocation so a later use of the stale pointer
+        // can be diagnosed as UseAfterFree.
+        let v5 = __vow_vec_new_val();
+        unsafe { __vow_vec_push_val(v5, 7) };
+        let v5_addr = v5 as usize;
+        unsafe { __vow_vec_free_val(v5) };
+        {
+            let table = SHADOW_TABLE.lock().unwrap();
+            let shadow = table
+                .as_ref()
+                .and_then(|m| m.get(&v5_addr))
+                .expect("freed Vec must remain in SHADOW_TABLE");
+            assert!(
+                shadow.freed,
+                "sanitize_on_free should mark shadow entry as freed"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -776,56 +776,6 @@ unsafe fn ensure_root_arena_locked() {
     }
 }
 
-unsafe fn root_arena_alloc(bytes: usize, align: usize) -> *mut u8 {
-    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
-    unsafe { ensure_root_arena_locked() };
-    unsafe { __vow_arena_alloc(&raw mut __vow_root_arena, bytes, align) }
-}
-
-unsafe fn root_arena_alloc_zeroed(bytes: usize, align: usize) -> *mut u8 {
-    let ptr = unsafe { root_arena_alloc(bytes, align) };
-    unsafe { std::ptr::write_bytes(ptr, 0, bytes) };
-    ptr
-}
-
-/// Grow a backing buffer that lives in `__vow_root_arena`. Implements the
-/// spec §7.2 zero-copy fast path: try `__vow_arena_try_extend` first; if
-/// the backing is the most recent allocation in the chunk and the new
-/// size still fits, growth is O(1) with no copy and no orphaned backing.
-/// Otherwise fall back to a fresh allocation + memcpy of the prefix.
-///
-/// Phase 4 / S6 status: this fast path is wired for **root-arena-backed**
-/// containers — the only kind today, since `__vow_vec_new` /
-/// `__vow_string_new` / `__vow_map_new` all allocate from
-/// `__vow_root_arena`. Threading a per-container arena pointer through
-/// the descriptor (so block-arena-backed `Vec`/`String`/`HashMap` also
-/// benefit from try_extend) is a much larger API change deferred to
-/// Phase 9 (performance), per `docs/design/arena_memory.md` §15.
-unsafe fn root_arena_grow_backing(
-    ptr: *mut u8,
-    old_size: usize,
-    new_size: usize,
-    align: usize,
-) -> *mut u8 {
-    let _guard = ROOT_ARENA_LOCK.lock().unwrap();
-    unsafe { ensure_root_arena_locked() };
-    if old_size > 0
-        && unsafe {
-            __vow_arena_try_extend(&raw mut __vow_root_arena, ptr, old_size, new_size) != 0
-        }
-    {
-        unsafe { std::ptr::write_bytes(ptr.add(old_size), 0, new_size - old_size) };
-        return ptr;
-    }
-
-    let new_ptr = unsafe { __vow_arena_alloc(&raw mut __vow_root_arena, new_size, align) };
-    if old_size > 0 {
-        unsafe { std::ptr::copy_nonoverlapping(ptr, new_ptr, old_size) };
-    }
-    unsafe { std::ptr::write_bytes(new_ptr.add(old_size), 0, new_size - old_size) };
-    new_ptr
-}
-
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_runtime_start() {
     unsafe { ensure_root_arena() };

--- a/vow-runtime/src/lib.rs
+++ b/vow-runtime/src/lib.rs
@@ -843,7 +843,7 @@ const VEC_INITIAL_CAP: usize = 8;
 #[unsafe(no_mangle)]
 pub extern "C" fn __vow_vec_new(elem_size: usize, align: usize) -> *mut u8 {
     let _ = elem_size;
-    let header_ptr = unsafe { root_arena_alloc_zeroed(24, 8) } as *mut VowVec;
+    let header_ptr = __vow_malloc(24, 8) as *mut VowVec;
     // Lazy allocation: don't allocate buffer until first push.
     // Use a dangling aligned pointer so from_raw_parts with len=0 is safe.
     unsafe {
@@ -875,7 +875,11 @@ unsafe fn __vow_vec_reserve(vec: *mut u8, additional: usize, elem_size: usize, e
     }
     let old_size = v.cap * elem_size;
     let new_size = new_cap * elem_size;
-    let new_ptr = unsafe { root_arena_grow_backing(v.ptr, old_size, new_size, elem_align) };
+    let new_ptr = __vow_malloc(new_size, elem_align);
+    if old_size > 0 {
+        unsafe { std::ptr::copy_nonoverlapping(v.ptr, new_ptr, old_size) };
+        unsafe { __vow_free(v.ptr, old_size, elem_align) };
+    }
     v.ptr = new_ptr;
     v.cap = new_cap;
 }
@@ -2073,9 +2077,9 @@ const MAP_INITIAL_CAP: usize = 8;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __vow_map_new() -> *mut u8 {
-    let header_ptr = unsafe { root_arena_alloc_zeroed(24, 8) } as *mut VowMap;
+    let header_ptr = __vow_malloc(24, 8) as *mut VowMap;
     let buf_size = MAP_INITIAL_CAP * MAP_ENTRY_BYTES;
-    let buf_ptr = unsafe { root_arena_alloc_zeroed(buf_size, 8) };
+    let buf_ptr = __vow_malloc(buf_size, 8);
     unsafe {
         (*header_ptr).ptr = buf_ptr;
         (*header_ptr).len = 0;
@@ -2101,7 +2105,9 @@ pub unsafe extern "C" fn __vow_map_insert(map: *mut u8, key: i64, val: i64) {
         let old_size = m.cap * MAP_ENTRY_BYTES;
         let new_cap = m.cap * 2;
         let new_size = new_cap * MAP_ENTRY_BYTES;
-        let new_ptr = unsafe { root_arena_grow_backing(m.ptr, old_size, new_size, 8) };
+        let new_ptr = __vow_malloc(new_size, 8);
+        unsafe { std::ptr::copy_nonoverlapping(m.ptr, new_ptr, old_size) };
+        unsafe { __vow_free(m.ptr, old_size, 8) };
         m.ptr = new_ptr;
         m.cap = new_cap;
     }
@@ -2167,17 +2173,38 @@ pub unsafe extern "C" fn __vow_map_len(map: *const u8) -> usize {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_string_free(s: *mut u8) {
-    let _ = s;
+    if s.is_null() {
+        return;
+    }
+    let vec = unsafe { &mut *(s as *mut VowVec) };
+    if vec.cap != 0 && vec.cap != VOW_CAP_RODATA {
+        unsafe { __vow_free(vec.ptr, vec.cap, 1) };
+    }
+    unsafe { __vow_free(s, 24, 8) };
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_vec_free_val(v: *mut u8) {
-    let _ = v;
+    if v.is_null() {
+        return;
+    }
+    let vec = unsafe { &mut *(v as *mut VowVec) };
+    if vec.cap != 0 && vec.cap != VOW_CAP_RODATA {
+        unsafe { __vow_free(vec.ptr, vec.cap * 8, 8) };
+    }
+    unsafe { __vow_free(v, 24, 8) };
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn __vow_map_free(m: *mut u8) {
-    let _ = m;
+    if m.is_null() {
+        return;
+    }
+    let map = unsafe { &mut *(m as *mut VowMap) };
+    if map.cap != 0 && map.cap != VOW_CAP_RODATA {
+        unsafe { __vow_free(map.ptr, map.cap * MAP_ENTRY_BYTES, 8) };
+    }
+    unsafe { __vow_free(m, 24, 8) };
 }
 
 // ---------------------------------------------------------------------------
@@ -2829,34 +2856,31 @@ mod tests {
     }
 
     #[test]
-    fn legacy_typed_free_noop_worker() {
-        if std::env::var("VOW_LEGACY_FREE_NOOP_WORKER").is_err() {
+    fn typed_free_worker() {
+        if std::env::var("VOW_TYPED_FREE_WORKER").is_err() {
             return;
         }
-        __vow_sanitize_init();
         let v = __vow_vec_new_val();
         unsafe { __vow_vec_push_val(v, 1) };
         unsafe { __vow_vec_free_val(v) };
-        unsafe { __vow_vec_free_val(v) };
-        unsafe { __vow_vec_push_val(v, 2) };
-        assert_eq!(unsafe { __vow_vec_len(v) }, 2);
+        let s = unsafe { __vow_string_new(b"ok".as_ptr() as *const i8, 2) };
+        unsafe { __vow_string_free(s) };
+        let m = __vow_map_new();
+        unsafe { __vow_map_insert(m, 1, 2) };
+        unsafe { __vow_map_free(m) };
     }
 
     #[test]
-    fn legacy_typed_free_symbols_are_noops() {
+    fn typed_free_symbols_release_allocations() {
         let exe = std::env::current_exe().expect("current test exe");
         let output = std::process::Command::new(exe)
-            .env("VOW_LEGACY_FREE_NOOP_WORKER", "1")
-            .args([
-                "tests::legacy_typed_free_noop_worker",
-                "--exact",
-                "--nocapture",
-            ])
+            .env("VOW_TYPED_FREE_WORKER", "1")
+            .args(["tests::typed_free_worker", "--exact", "--nocapture"])
             .output()
-            .expect("spawn legacy free worker");
+            .expect("spawn typed free worker");
         assert!(
             output.status.success(),
-            "legacy free worker failed\nstdout:\n{}\nstderr:\n{}",
+            "typed free worker failed\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );


### PR DESCRIPTION
### Motivation
- The arena Phase‑4 cutover left per‑value typed frees as no‑ops while many container buffers remained allocated in the root arena, enabling unbounded memory growth in long‑running processes.
- The intent of this change is to restore reclamation of container storage for `VowVec`/`VowMap`/`VowString` without changing the compiler lowering pipeline or region semantics.
- Preserve existing `VOW_CAP_RODATA` semantics so rodata‑backed descriptors still trap on mutation and are not freed.

### Description
- Switch `VowVec` header allocation from root arena to heap by using `__vow_malloc(24, 8)` in `__vow_vec_new` and make buffer growth allocate via `__vow_malloc`, copy the old data, and free the old buffer with `__vow_free` (in `vow-runtime/src/lib.rs`).
- Switch `VowMap` header and backing buffer creation/growth to heap allocations and free old backing buffers during resize.
- Implement real typed deallocations: `__vow_string_free`, `__vow_vec_free_val`, and `__vow_map_free` now release owned backing buffers and headers while guarding `VOW_CAP_RODATA` and null pointers.
- Update runtime tests that previously assumed legacy no‑op free symbols to exercise and validate the new free behavior and worker env var name (`VOW_TYPED_FREE_WORKER`).

### Testing
- Ran `cargo test -p vow-runtime`, which completed successfully with all runtime tests passing (`48 passed; 0 failed`).
- Tests exercise allocation, growth, clone‑into‑arena, rodata traps, and the new typed free worker path, and they passed.
- The build emits warnings for now‑unused root arena helper functions (expected; no functional regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee297afd4083328af98721bd77c72e)