### PR TITLE
region: resolve CallerReturn through AliasOf return summaries (#369)

### DIFF
--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -3028,15 +3028,6 @@ fn is_caller_ambiguous(rgn: i64) -> bool {
     rgn >= 0 && region_kind(rgn) == REGION_KIND_CALLER() && region_val(rgn) == AMBIGUOUS_SLOT()
 }
 
-// Slot of the return arena: `Some(0)` iff the function returns FreshInCaller,
-// else `-1` (no slot — the marker contributes no hidden-slot constraint).
-fn slot_of_return(rsum_return_kind: i64) -> i64 {
-    if rsum_return_kind == RSUM_KIND_FRESH_IN_CALLER() {
-        return 0;
-    }
-    -1
-}
-
 // Issue #369: hidden caller-arena slots that the return value escapes
 // through. Pushes the resolved slots into `caller_slots` (deduped, kept
 // sorted by `linear_insert_i64`) and returns true iff at least one slot

--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2467,6 +2467,16 @@ fn value_lub_region(
     } else {
         RSUM_INTERNAL_UNINIT()
     };
+    let own_return_aux: i64 = if fi >= 0 && fi < int_auxs.len() {
+        int_auxs[fi]
+    } else {
+        0
+    };
+    let own_return_aliases: Vec<i64> = if fi >= 0 && fi < int_aliases_list.len() {
+        int_aliases_list[fi]
+    } else {
+        Vec::new()
+    };
     let own_se_targets: Vec<i64> = if fi >= 0 && fi < int_se_targets.len() {
         int_se_targets[fi]
     } else {
@@ -2474,13 +2484,14 @@ fn value_lub_region(
     };
     region_lub_from_markers(
         markers, defining_block, block_parent, block_depth,
-        own_return_kind, own_se_targets,
+        own_return_kind, own_return_aux, own_return_aliases, own_se_targets,
     )
 }
 
 fn region_lub_from_markers(
     markers: Vec<i64>, defining_block: i64, block_parent: Vec<i64>, block_depth: Vec<i64>,
-    own_return_kind: i64, own_se_targets: Vec<i64>
+    own_return_kind: i64, own_return_aux: i64, own_return_aliases: Vec<i64>,
+    own_se_targets: Vec<i64>
 ) -> i64 {
     let blocks: Vec<i64> = Vec::new();
     // Issue #317: distinct hidden caller slots accumulated from
@@ -2501,10 +2512,14 @@ fn region_lub_from_markers(
             let v: i64 = region_val(marker);
             if v == 0 {
                 // CallerReturn (or pre-#317 legacy VirtualCaller).
-                let rs: i64 = slot_of_return(own_return_kind);
-                if rs >= 0 {
-                    linear_insert_i64(caller_slots, rs);
-                } else {
+                // Issue #369: resolve through AliasOf/AliasOfAny return
+                // summaries to the hidden caller slot(s) they alias.
+                let added: bool = collect_return_escape_slots(
+                    caller_slots,
+                    own_return_kind, own_return_aux, own_return_aliases,
+                    own_se_targets
+                );
+                if !added {
                     has_legacy_caller = true;
                 }
             } else if v == AMBIGUOUS_SLOT() {
@@ -3020,6 +3035,45 @@ fn slot_of_return(rsum_return_kind: i64) -> i64 {
         return 0;
     }
     -1
+}
+
+// Issue #369: hidden caller-arena slots that the return value escapes
+// through. Pushes the resolved slots into `caller_slots` (deduped, kept
+// sorted by `linear_insert_i64`) and returns true iff at least one slot
+// was contributed. Mirrors `InternalSummary::return_escape_slots` in
+// vow-ir/src/region.rs.
+fn collect_return_escape_slots(
+    caller_slots: Vec<i64>,
+    rsum_return_kind: i64, rsum_return_aux: i64, rsum_return_aliases: Vec<i64>,
+    se_targets: Vec<i64>
+) -> bool {
+    if rsum_return_kind == RSUM_KIND_FRESH_IN_CALLER() {
+        linear_insert_i64(caller_slots, 0);
+        return true;
+    }
+    if rsum_return_kind == RSUM_KIND_ALIAS_OF() {
+        let s: i64 = slot_of_store_target(rsum_return_kind, se_targets, rsum_return_aux);
+        if s >= 0 {
+            linear_insert_i64(caller_slots, s);
+            return true;
+        }
+        return false;
+    }
+    if rsum_return_kind == RSUM_KIND_ALIAS_OF_ANY() {
+        let mut added: bool = false;
+        let mut i: i64 = 0;
+        while i < rsum_return_aliases.len() {
+            let p: i64 = rsum_return_aliases[i];
+            let s: i64 = slot_of_store_target(rsum_return_kind, se_targets, p);
+            if s >= 0 {
+                linear_insert_i64(caller_slots, s);
+                added = true;
+            }
+            i = i + 1;
+        }
+        return added;
+    }
+    false
 }
 
 // Slot of `target_param` in the codegen layout

--- a/tests/run/region_caller_return_alias_of_param.vow
+++ b/tests/run/region_caller_return_alias_of_param.vow
@@ -1,0 +1,45 @@
+// TEST: stdout ""
+// Issue #369 reproducer — the lower_function_vow shape. A helper takes a
+// container by-ref, stores a fresh allocation into one of the container's
+// nested vectors, and returns an alias of the container itself. The fresh
+// allocation accumulates two markers (CallerStoreTarget(p) and CallerReturn)
+// but both denote the same hidden caller arena — the one attached to `p`.
+// Pre-#369 the LUB lost this information because `return_slot()` only fired
+// for FreshInCaller returns; with the alias-aware escape resolution the
+// marker contributes the same slot as the store target, so the resolved
+// region is a clean single-slot Caller(_).
+module CallerReturnAliasOfParam
+
+pub struct Inst {
+    op: i64,
+    args: Vec<i64>,
+}
+
+pub struct Block {
+    insts: Vec<Inst>,
+}
+
+pub struct Func {
+    blocks: Vec<Block>,
+}
+
+pub struct Ctx {
+    func: Func,
+}
+
+fn emit(c: Ctx, op: i64, args: Vec<i64>) -> Func {
+    let i: Inst = Inst { op: op, args: args };
+    let b: Block = c.func.blocks[0];
+    b.insts.push(i);
+    c.func
+}
+
+fn main() -> i32 {
+    let f: Func = Func { blocks: Vec::new() };
+    f.blocks.push(Block { insts: Vec::new() });
+    let c: Ctx = Ctx { func: f };
+    let args: Vec<i64> = Vec::new();
+    args.push(42);
+    let _g: Func = emit(c, 7, args);
+    0
+}

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1303,17 +1303,41 @@ impl InternalSummary {
         None
     }
 
-    /// Slot of the return arena (`Some(HiddenRegionIdx(0))` iff the function
-    /// returns `FreshInCaller`). Returns must always live at slot 0.
-    fn return_slot(&self) -> Option<HiddenRegionIdx> {
-        if matches!(
-            self.return_region,
-            InternalReturnRegion::Published(RegionConstraint::FreshInCaller)
-        ) {
-            Some(HiddenRegionIdx(0))
-        } else {
-            None
+    /// Hidden caller-arena slots that the return value can escape through.
+    ///
+    /// Issue #369: a `CallerReturn` marker on an allocation means the value
+    /// reaches the caller via the function's return path. Codegen routes
+    /// such a value into the slot dictated by the return summary:
+    ///
+    /// * `FreshInCaller` — slot 0 (the return arena).
+    /// * `AliasOf(p)` — same arena as param `p`'s store-target slot, when
+    ///   `p` is a recorded store target. If `p` is not a store target the
+    ///   set is empty and the caller-side fallback applies.
+    /// * `AliasOfAny(ps)` — union of `store_target_slot(p)` for known `p`.
+    /// * `ConstantGlobal` / `Uninit` — no caller slot (return is not in
+    ///   any caller arena).
+    fn return_escape_slots(&self) -> BTreeSet<HiddenRegionIdx> {
+        let mut slots = BTreeSet::new();
+        match &self.return_region {
+            InternalReturnRegion::Published(RegionConstraint::FreshInCaller) => {
+                slots.insert(HiddenRegionIdx(0));
+            }
+            InternalReturnRegion::Published(RegionConstraint::AliasOf(p)) => {
+                if let Some(slot) = self.store_target_slot(*p) {
+                    slots.insert(slot);
+                }
+            }
+            InternalReturnRegion::Published(RegionConstraint::AliasOfAny(ps)) => {
+                for p in ps {
+                    if let Some(slot) = self.store_target_slot(*p) {
+                        slots.insert(slot);
+                    }
+                }
+            }
+            InternalReturnRegion::Published(RegionConstraint::ConstantGlobal)
+            | InternalReturnRegion::Uninit => {}
         }
+        slots
     }
 
     fn to_published(&self, n_params: usize) -> RegionSummary {
@@ -2590,11 +2614,20 @@ fn lub_to_region_id(
             MustOutliveMarker::Block(b) => blocks.push(*b),
             MustOutliveMarker::VirtualCaller => has_legacy_caller = true,
             MustOutliveMarker::CallerReturn => {
-                if let Some(slot) = summary.return_slot() {
-                    caller_slots.insert(slot);
+                // Issue #369: resolve through AliasOf/AliasOfAny return
+                // summaries to the hidden caller slots they alias, so a
+                // wrapper that returns `AliasOf(p)` and also stores into
+                // `p` produces a single slot, not slot-less legacy evidence.
+                let slots = summary.return_escape_slots();
+                if slots.is_empty() {
+                    // The return summary doesn't pin a hidden slot (alias
+                    // points to a non-store-target param, or return is
+                    // ConstantGlobal/Uninit). Preserve the pre-#369 slot-less
+                    // caller widening so the marker still contributes some
+                    // caller-region evidence.
+                    has_legacy_caller = true;
                 } else {
-                    // Non-FreshInCaller return — marker contributes no
-                    // hidden-slot constraint. Fall through to block/root.
+                    caller_slots.extend(slots);
                 }
             }
             MustOutliveMarker::CallerStoreTarget(p) => {
@@ -4680,6 +4713,132 @@ mod tests {
             MustOutliveMarker::CallerStoreTarget(0),
             MustOutliveMarker::CallerStoreTarget(1),
         ]);
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(0), &tree, &summary),
+            RegionId::Caller(HiddenRegionIdx(0)),
+        );
+    }
+
+    #[test]
+    fn caller_return_resolves_alias_of_to_store_target_slot() {
+        // Issue #369: when the return summary is AliasOf(p) and `p` is a
+        // recorded store-target parameter, a `CallerReturn` marker must
+        // contribute the hidden caller slot that `p`'s store target maps to —
+        // not nothing (which is what the previous `return_slot()`-only path
+        // did). The return path and the store-target path denote the same
+        // hidden arena attached to `p`.
+        let f = function(
+            0,
+            "ret_alias_of_param0",
+            vec![Ty::Ptr],
+            Ty::Ptr,
+            vec![block(0, vec![return_unit_inst(0)])],
+        );
+        let tree = BlockTree::from_function(&f);
+        let mut summary = InternalSummary::seed(1);
+        summary.return_region = InternalReturnRegion::Published(RegionConstraint::AliasOf(0));
+        summary.store_effects.insert((
+            0,
+            InternalReturnRegion::Published(RegionConstraint::FreshInCaller),
+        ));
+        let markers = marker_set(&[MustOutliveMarker::CallerReturn]);
+        // store_target_slot(0) is HiddenRegionIdx(0): return is AliasOf, not
+        // FreshInCaller, so the return-arena slot is not allocated; param 0
+        // is the only store target.
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(0), &tree, &summary),
+            RegionId::Caller(HiddenRegionIdx(0)),
+        );
+    }
+
+    #[test]
+    fn caller_return_resolves_alias_of_any_to_union_of_store_target_slots() {
+        // Issue #369: an `AliasOfAny([p, q])` return that flows into a
+        // `CallerReturn` marker must contribute both `store_target_slot(p)`
+        // and `store_target_slot(q)`. With two distinct recorded store
+        // targets the slot set has cardinality two, so the LUB picks the
+        // lowest (until AMBIGUOUS minting is enabled in PR #342).
+        let f = function(
+            0,
+            "ret_alias_of_any_two_params",
+            vec![Ty::Ptr, Ty::Ptr],
+            Ty::Ptr,
+            vec![block(0, vec![return_unit_inst(0)])],
+        );
+        let tree = BlockTree::from_function(&f);
+        let mut summary = InternalSummary::seed(2);
+        summary.return_region =
+            InternalReturnRegion::Published(RegionConstraint::AliasOfAny(vec![0, 1]));
+        summary.store_effects.insert((
+            0,
+            InternalReturnRegion::Published(RegionConstraint::FreshInCaller),
+        ));
+        summary.store_effects.insert((
+            1,
+            InternalReturnRegion::Published(RegionConstraint::FreshInCaller),
+        ));
+        // store_target_slot layout (return is not FreshInCaller, so no
+        // return-arena slot): slot 0 = param 0's store target,
+        // slot 1 = param 1's store target.
+        let markers = marker_set(&[MustOutliveMarker::CallerReturn]);
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(0), &tree, &summary),
+            RegionId::Caller(HiddenRegionIdx(0)),
+        );
+    }
+
+    #[test]
+    fn caller_return_and_store_target_on_same_param_collapse_to_one_slot() {
+        // Issue #369: the literal lower_function_vow shape. A fresh value
+        // accumulates two markers — `CallerStoreTarget(0)` (it is stored
+        // through param 0) and `CallerReturn` (it escapes through the
+        // function's return). The return summary is `AliasOf(0)`. Both
+        // markers must resolve to the same hidden slot (param 0's store
+        // target), so `caller_slots` has cardinality one and the LUB
+        // produces a clean slot rather than slot-less legacy evidence.
+        let f = function(
+            0,
+            "ctx_mutate_and_return_alias",
+            vec![Ty::Ptr],
+            Ty::Ptr,
+            vec![block(0, vec![return_unit_inst(0)])],
+        );
+        let tree = BlockTree::from_function(&f);
+        let mut summary = InternalSummary::seed(1);
+        summary.return_region = InternalReturnRegion::Published(RegionConstraint::AliasOf(0));
+        summary.store_effects.insert((
+            0,
+            InternalReturnRegion::Published(RegionConstraint::FreshInCaller),
+        ));
+        let markers = marker_set(&[
+            MustOutliveMarker::CallerReturn,
+            MustOutliveMarker::CallerStoreTarget(0),
+        ]);
+        assert_eq!(
+            lub_to_region_id(&markers, BlockId(0), &tree, &summary),
+            RegionId::Caller(HiddenRegionIdx(0)),
+        );
+    }
+
+    #[test]
+    fn caller_return_alias_of_non_store_target_falls_back_to_legacy_caller() {
+        // Issue #369: if the return summary is `AliasOf(p)` but `p` is not
+        // a recorded store-target parameter, `return_escape_slots()` is
+        // empty. The marker must still contribute caller-region evidence
+        // (the value does escape to the caller), so we fall back to the
+        // slot-less legacy widening — currently `Caller(HiddenRegionIdx(0))`.
+        let f = function(
+            0,
+            "ret_alias_of_non_store_target",
+            vec![Ty::Ptr],
+            Ty::Ptr,
+            vec![block(0, vec![return_unit_inst(0)])],
+        );
+        let tree = BlockTree::from_function(&f);
+        let mut summary = InternalSummary::seed(1);
+        summary.return_region = InternalReturnRegion::Published(RegionConstraint::AliasOf(0));
+        // Note: no store_effects entry for param 0.
+        let markers = marker_set(&[MustOutliveMarker::CallerReturn]);
         assert_eq!(
             lub_to_region_id(&markers, BlockId(0), &tree, &summary),
             RegionId::Caller(HiddenRegionIdx(0)),


### PR DESCRIPTION
## Summary

- Closes #369. Fixes the false-positive `Caller(AMBIGUOUS)` minting that PR #342's strict store-conflict check produced on 13 sites in `lower_function_vow` (compiler/lower.vow).
- Implements Codex's Path 3 from the issue triage: instead of adding a new "return aliases param N" axis to the summary, `CallerReturn` is now resolved through the existing `RegionConstraint::AliasOf` / `AliasOfAny` summary information — the same data codegen already uses to lay out hidden caller arenas.
- Unblocks PR #342: once that PR rebases on top of this commit, the bootstrap will stay clean while the genuine wrong-arena UAF fixture (`tests/error/region_ambiguous_caller_slots.vow`) continues to reject.

## What changed

`InternalSummary::return_slot()` (`Option<HiddenRegionIdx>`, only `FreshInCaller`) is replaced by `return_escape_slots()` returning a `BTreeSet<HiddenRegionIdx>`:

```
FreshInCaller   -> { 0 }
AliasOf(p)      -> { store_target_slot(p) }   if defined, else {}
AliasOfAny(ps)  -> union of store_target_slot(p) over known p
ConstantGlobal  -> {}
Uninit          -> {}
```

`lub_to_region_id`'s `CallerReturn` arm extends `caller_slots` with all returned slots. The slot-less legacy-caller fallback now fires only when the resolved set is empty (alias points to a non-store-target param, or the return is `ConstantGlobal` / `Uninit`).

Mirrored in `compiler/region.vow` (new `collect_return_escape_slots` helper; `region_lub_from_markers` + `value_lub_region` thread `own_return_aux` / `own_return_aliases` through). Binary fixed point preserved.

## Why this design

From Codex's second-opinion review:

> Path 1 is closer, but I'd phrase it as a Path 3: resolve `CallerReturn` into hidden destination slots using the existing `RegionConstraint`, rather than adding a new summary axis. `RegionConstraint::AliasOf` and `AliasOfAny` already exist, and codegen already computes store-target hidden slots from the same summary layout. So this is not a new type-system axis; it is making the LUB respect the alias summary it already trusts elsewhere.

This aligns with CLAUDE.md's crisp rule: no new type-system axis.

## Test plan

- [x] `cargo test -p vow-ir --lib` — 169/169 green, including 4 new region-LUB tests covering each branch of the resolution lattice plus the literal `lower_function_vow` shape.
- [x] `cargo test --all` — workspace green.
- [x] `scripts/bootstrap.sh --skip-cargo` — clean exit with byte-identical fixed point.
- [x] `scripts/full_test.sh` — 372 passed, 1 skipped. 5 pre-existing failures (ESBMC `VERIFICATION UNKNOWN` parsing on `examples/{search,sum_range,vec_fill,gc,math}.vow`) confirmed pre-existing on `origin/main` via stash-and-rerun; tracked separately in #370.
- [x] New runtime fixture `tests/run/region_caller_return_alias_of_param.vow` exercises the `ctx`-mutate-and-return-alias shape through both compilers and runs cleanly.
- [x] Manually rebuilt and re-ran the literal #369 shape against the self-hosted compiler — accepted and produces a working executable.

## Out of scope

This PR is intentionally the precision fix only — no AMBIGUOUS minting or strict conflict check (that is PR #342's job, which can rebase on top of this).
