### PR TITLE
fix: surface ESBMC VERIFICATION UNKNOWN as soft verify failure (#370)

### DIFF
--- a/compiler/diag.vow
+++ b/compiler/diag.vow
@@ -462,17 +462,26 @@ fn diag_ce_to_json(ce: VerifyCE) -> String {
 }
 
 fn diag_emit_verify_json(status: String, dctx: DiagCtx, ces: Vec<VerifyCE>) [io] {
-    diag_emit_verify_json_full(status, dctx, ces, String::from(""), String::from(""));
+    diag_emit_verify_json_full(status, dctx, ces, String::from(""), String::from(""), String::from(""), String::from(""));
 }
 
 // Extended variant: when `verify_status` is non-empty, emit the
 // `verify_status` and `verify_message` fields. Used to surface soft ESBMC
-// outcomes (timeout / unknown / error / tool_not_found).
-fn diag_emit_verify_json_full(status: String, dctx: DiagCtx, ces: Vec<VerifyCE>, verify_status: String, verify_message: String) [io] {
+// outcomes (timeout / unknown / error / tool_not_found). When status is
+// "VerifyFailed", also emit the schema-required `function` and
+// `counterexample` (legacy single-string) top-level fields.
+fn diag_emit_verify_json_full(status: String, dctx: DiagCtx, ces: Vec<VerifyCE>, verify_status: String, verify_message: String, vf_function: String, vf_counterexample: String) [io] {
     let r: String = String::from("{\"status\":\"");
     r.push_str(status);
     r.push_str(String::from("\",\"executable\":null,\"diagnostics\":"));
     r.push_str(diag_ctx_to_json(dctx));
+    if status == String::from("VerifyFailed") {
+        r.push_str(String::from(",\"function\":\""));
+        r.push_str(diag_json_escape_str(vf_function));
+        r.push_str(String::from("\",\"counterexample\":\""));
+        r.push_str(diag_json_escape_str(vf_counterexample));
+        r.push_str(String::from("\""));
+    }
     r.push_str(String::from(",\"counterexamples\":["));
     let nc: i64 = ces.len();
     let mut i: i64 = 0;
@@ -518,13 +527,15 @@ fn diag_emit_build_json(status: String, exec_path: String, dctx: DiagCtx) [io] {
 }
 
 fn diag_emit_build_verify_json(status: String, exec_path: String, dctx: DiagCtx, ces: Vec<VerifyCE>) [io] {
-    diag_emit_build_verify_json_full(status, exec_path, dctx, ces, String::from(""), String::from(""));
+    diag_emit_build_verify_json_full(status, exec_path, dctx, ces, String::from(""), String::from(""), String::from(""), String::from(""));
 }
 
 // Extended variant: when `verify_status` is non-empty, emit the
 // `verify_status` and `verify_message` fields. Used to surface soft ESBMC
-// outcomes (timeout / unknown / error / tool_not_found).
-fn diag_emit_build_verify_json_full(status: String, exec_path: String, dctx: DiagCtx, ces: Vec<VerifyCE>, verify_status: String, verify_message: String) [io] {
+// outcomes (timeout / unknown / error / tool_not_found). When status is
+// "VerifyFailed", also emit the schema-required `function` and
+// `counterexample` (legacy single-string) top-level fields.
+fn diag_emit_build_verify_json_full(status: String, exec_path: String, dctx: DiagCtx, ces: Vec<VerifyCE>, verify_status: String, verify_message: String, vf_function: String, vf_counterexample: String) [io] {
     let r: String = String::from("{\"status\":\"");
     r.push_str(status);
     r.push_str(String::from("\",\"executable\":"));
@@ -537,6 +548,13 @@ fn diag_emit_build_verify_json_full(status: String, exec_path: String, dctx: Dia
     }
     r.push_str(String::from(",\"diagnostics\":"));
     r.push_str(diag_ctx_to_json(dctx));
+    if status == String::from("VerifyFailed") {
+        r.push_str(String::from(",\"function\":\""));
+        r.push_str(diag_json_escape_str(vf_function));
+        r.push_str(String::from("\",\"counterexample\":\""));
+        r.push_str(diag_json_escape_str(vf_counterexample));
+        r.push_str(String::from("\""));
+    }
     r.push_str(String::from(",\"counterexamples\":["));
     let nc: i64 = ces.len();
     let mut i: i64 = 0;

--- a/compiler/diag.vow
+++ b/compiler/diag.vow
@@ -462,6 +462,13 @@ fn diag_ce_to_json(ce: VerifyCE) -> String {
 }
 
 fn diag_emit_verify_json(status: String, dctx: DiagCtx, ces: Vec<VerifyCE>) [io] {
+    diag_emit_verify_json_full(status, dctx, ces, String::from(""), String::from(""));
+}
+
+// Extended variant: when `verify_status` is non-empty, emit the
+// `verify_status` and `verify_message` fields. Used to surface soft ESBMC
+// outcomes (timeout / unknown / error / tool_not_found).
+fn diag_emit_verify_json_full(status: String, dctx: DiagCtx, ces: Vec<VerifyCE>, verify_status: String, verify_message: String) [io] {
     let r: String = String::from("{\"status\":\"");
     r.push_str(status);
     r.push_str(String::from("\",\"executable\":null,\"diagnostics\":"));
@@ -476,7 +483,18 @@ fn diag_emit_verify_json(status: String, dctx: DiagCtx, ces: Vec<VerifyCE>) [io]
         r.push_str(diag_ce_to_json(ces[i]));
         i = i + 1;
     }
-    r.push_str(String::from("]}"));
+    r.push_str(String::from("]"));
+    if verify_status.len() > 0 {
+        r.push_str(String::from(",\"verify_status\":\""));
+        r.push_str(diag_json_escape_str(verify_status));
+        r.push_str(String::from("\""));
+        if verify_message.len() > 0 {
+            r.push_str(String::from(",\"verify_message\":\""));
+            r.push_str(diag_json_escape_str(verify_message));
+            r.push_str(String::from("\""));
+        }
+    }
+    r.push_str(String::from("}"));
     print_str(r);
     print_str(String::from("\n"));
 }
@@ -500,6 +518,13 @@ fn diag_emit_build_json(status: String, exec_path: String, dctx: DiagCtx) [io] {
 }
 
 fn diag_emit_build_verify_json(status: String, exec_path: String, dctx: DiagCtx, ces: Vec<VerifyCE>) [io] {
+    diag_emit_build_verify_json_full(status, exec_path, dctx, ces, String::from(""), String::from(""));
+}
+
+// Extended variant: when `verify_status` is non-empty, emit the
+// `verify_status` and `verify_message` fields. Used to surface soft ESBMC
+// outcomes (timeout / unknown / error / tool_not_found).
+fn diag_emit_build_verify_json_full(status: String, exec_path: String, dctx: DiagCtx, ces: Vec<VerifyCE>, verify_status: String, verify_message: String) [io] {
     let r: String = String::from("{\"status\":\"");
     r.push_str(status);
     r.push_str(String::from("\",\"executable\":"));
@@ -522,7 +547,18 @@ fn diag_emit_build_verify_json(status: String, exec_path: String, dctx: DiagCtx,
         r.push_str(diag_ce_to_json(ces[i]));
         i = i + 1;
     }
-    r.push_str(String::from("]}"));
+    r.push_str(String::from("]"));
+    if verify_status.len() > 0 {
+        r.push_str(String::from(",\"verify_status\":\""));
+        r.push_str(diag_json_escape_str(verify_status));
+        r.push_str(String::from("\""));
+        if verify_message.len() > 0 {
+            r.push_str(String::from(",\"verify_message\":\""));
+            r.push_str(diag_json_escape_str(verify_message));
+            r.push_str(String::from("\""));
+        }
+    }
+    r.push_str(String::from("}"));
     print_str(r);
     print_str(String::from("\n"));
 }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -389,10 +389,7 @@ fn verify_collect_and_report(
         let bv_is_unknown: bool = st == VERIFY_UNKNOWN();
         let bv_label: String = { if bv_is_unknown { String::from("unknown") } else { String::from("timeout") } };
         let bv_label_upper: String = { if bv_is_unknown { String::from("UNKNOWN") } else { String::from("TIMEOUT") } };
-        // For Timeout, leave the message empty — Rust's VerifyOutcome::Timeout
-        // arm in vow/src/main.rs returns None for verify_message, and the
-        // verify_status="timeout" key already carries the same information.
-        // For Unknown, ESBMC's own explanation is meaningful.
+        // Timeout: empty message to match Rust's None; Unknown: include ESBMC's own explanation.
         let bv_msg_initial: String = {
             if bv_is_unknown { parse_unknown_reason(vr.raw_output) }
             else { String::from("") }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -389,9 +389,13 @@ fn verify_collect_and_report(
         let bv_is_unknown: bool = st == VERIFY_UNKNOWN();
         let bv_label: String = { if bv_is_unknown { String::from("unknown") } else { String::from("timeout") } };
         let bv_label_upper: String = { if bv_is_unknown { String::from("UNKNOWN") } else { String::from("TIMEOUT") } };
+        // For Timeout, leave the message empty — Rust's VerifyOutcome::Timeout
+        // arm in vow/src/main.rs returns None for verify_message, and the
+        // verify_status="timeout" key already carries the same information.
+        // For Unknown, ESBMC's own explanation is meaningful.
         let bv_msg_initial: String = {
             if bv_is_unknown { parse_unknown_reason(vr.raw_output) }
-            else { String::from("verification timed out") }
+            else { String::from("") }
         };
         let bv_solver: String = resolve_auto_bv_solver(solver);
         let auto_enc: bool = is_auto_encoding(encoding);
@@ -414,7 +418,8 @@ fn verify_collect_and_report(
             }
             if st2 == VERIFY_TIMEOUT() {
                 eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT (BV and IR)")));
-                record_soft_fail(soft_meta, String::from("timeout"), String::from("verification timed out (BV and IR)"));
+                // Empty verify_message — match Rust's verify_status="timeout" + None shape.
+                record_soft_fail(soft_meta, String::from("timeout"), String::from(""));
                 return 0;
             }
             if st2 == VERIFY_UNKNOWN() {

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -340,14 +340,57 @@ fn vec_i64_remove_front(v: Vec<i64>) {
     v.pop();
 }
 
-// Record the first soft-fail ESBMC outcome (status/message) into `meta`.
-// Convention: meta is `[]` until the first soft-fail, then `[status, message]`.
-// Subsequent calls are no-ops to preserve the first-observed signal.
-fn record_soft_fail(meta: Vec<String>, status: String, message: String) {
+// Record the first soft-fail ESBMC outcome (status/message/function) into `meta`.
+// Convention: meta is `[]` until the first soft-fail, then `[status, message, function]`.
+// The function name is needed to populate the schema-required top-level
+// `function` field on VerifyFailed JSON output.
+fn record_soft_fail(meta: Vec<String>, status: String, message: String, function: String) {
     if meta.len() == 0 {
         meta.push(status);
         meta.push(message);
+        meta.push(function);
     }
+}
+
+// Compute (function, counterexample) for the VerifyFailed top-level JSON fields.
+// Mirrors Rust's BuildStatus::VerifyFailed { function, description } shape so
+// schema validators see the same fields from either compiler. Returns [func, desc].
+fn vf_legacy_fields(ces: Vec<VerifyCE>, soft_meta: Vec<String>) -> Vec<String> {
+    let result: Vec<String> = Vec::new();
+    if ces.len() > 0 {
+        let ce: VerifyCE = ces[0];
+        result.push(ce.function);
+        // Mirrors Rust's CE description: "VerifyFailed: <violation>".
+        let desc: String = String::from("VerifyFailed: ");
+        desc.push_str(ce.violation);
+        result.push(desc);
+        return result;
+    }
+    if soft_meta.len() >= 3 {
+        let status: String = soft_meta[0];
+        let message: String = soft_meta[1];
+        let func: String = soft_meta[2];
+        result.push(func);
+        let desc: String = String::from("");
+        if status == String::from("timeout") {
+            desc.push_str(String::from("verification timed out"));
+        } else if status == String::from("unknown") {
+            desc.push_str(String::from("verification result unknown: "));
+            desc.push_str(message);
+        } else if status == String::from("error") {
+            desc.push_str(String::from("esbmc error: "));
+            desc.push_str(message);
+        } else if status == String::from("tool_not_found") {
+            desc.push_str(String::from("ESBMC not found"));
+        } else {
+            desc.push_str(message);
+        }
+        result.push(desc);
+        return result;
+    }
+    result.push(String::from(""));
+    result.push(String::from(""));
+    result
 }
 
 fn verify_collect_and_report(
@@ -360,7 +403,7 @@ fn verify_collect_and_report(
         // is distinct from "no vows", which the caller already filters.
         // Silently skipping would mis-report an un-verified function as proven.
         eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR (failed to start ESBMC)")));
-        record_soft_fail(soft_meta, String::from("error"), String::from("failed to start ESBMC"));
+        record_soft_fail(soft_meta, String::from("error"), String::from("failed to start ESBMC"), f.name);
         return 0;
     }
     let effective_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
@@ -410,41 +453,41 @@ fn verify_collect_and_report(
                 // the original BV outcome instead. Mirrors solver_strategy's
                 // demote-IR-FAILED rule.
                 eprintln_str(str4(String::from("  "), f.name, String::from(": "), bv_label_upper));
-                record_soft_fail(soft_meta, bv_label, bv_msg_initial);
+                record_soft_fail(soft_meta, bv_label, bv_msg_initial, f.name);
                 return 0;
             }
             if st2 == VERIFY_TIMEOUT() {
                 eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT (BV and IR)")));
                 // Empty verify_message — match Rust's verify_status="timeout" + None shape.
-                record_soft_fail(soft_meta, String::from("timeout"), String::from(""));
+                record_soft_fail(soft_meta, String::from("timeout"), String::from(""), f.name);
                 return 0;
             }
             if st2 == VERIFY_UNKNOWN() {
                 let reason2: String = parse_unknown_reason(vr2.raw_output);
                 eprintln_str(str3(String::from("  "), f.name, String::from(": UNKNOWN (BV and IR)")));
-                record_soft_fail(soft_meta, String::from("unknown"), reason2);
+                record_soft_fail(soft_meta, String::from("unknown"), reason2, f.name);
                 return 0;
             }
             if st2 == VERIFY_NOT_FOUND() {
                 eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
-                record_soft_fail(soft_meta, String::from("tool_not_found"), String::from("ESBMC not found"));
+                record_soft_fail(soft_meta, String::from("tool_not_found"), String::from("ESBMC not found"), f.name);
                 return 0;
             }
             eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
-            record_soft_fail(soft_meta, String::from("error"), String::from("ESBMC error during IR fallback"));
+            record_soft_fail(soft_meta, String::from("error"), String::from("ESBMC error during IR fallback"), f.name);
             return 0;
         }
         eprintln_str(str4(String::from("  "), f.name, String::from(": "), bv_label_upper));
-        record_soft_fail(soft_meta, bv_label, bv_msg_initial);
+        record_soft_fail(soft_meta, bv_label, bv_msg_initial, f.name);
         return 0;
     }
     if st == VERIFY_NOT_FOUND() {
         eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
-        record_soft_fail(soft_meta, String::from("tool_not_found"), String::from("ESBMC not found"));
+        record_soft_fail(soft_meta, String::from("tool_not_found"), String::from("ESBMC not found"), f.name);
         return 0;
     }
     eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
-    record_soft_fail(soft_meta, String::from("error"), String::from("unrecognized ESBMC outcome"));
+    record_soft_fail(soft_meta, String::from("error"), String::from("unrecognized ESBMC outcome"), f.name);
     0
 }
 
@@ -510,7 +553,8 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     };
     let vstatus: String = { if soft_meta.len() >= 1 { soft_meta[0] } else { String::from("") } };
     let vmsg: String = { if soft_meta.len() >= 2 { soft_meta[1] } else { String::from("") } };
-    diag_emit_verify_json_full(status_str, dctx, ces, vstatus, vmsg);
+    let legacy: Vec<String> = vf_legacy_fields(ces, soft_meta);
+    diag_emit_verify_json_full(status_str, dctx, ces, vstatus, vmsg, legacy[0], legacy[1]);
     if all_proven == 0 {
         return 1;
     }
@@ -669,7 +713,8 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     };
     let vstatus: String = { if soft_meta.len() >= 1 { soft_meta[0] } else { String::from("") } };
     let vmsg: String = { if soft_meta.len() >= 2 { soft_meta[1] } else { String::from("") } };
-    diag_emit_build_verify_json_full(status_str, out, dctx, ces, vstatus, vmsg);
+    let legacy: Vec<String> = vf_legacy_fields(ces, soft_meta);
+    diag_emit_build_verify_json_full(status_str, out, dctx, ces, vstatus, vmsg, legacy[0], legacy[1]);
     if all_proven == 0 {
         return 1;
     }
@@ -1074,7 +1119,8 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             };
             let vstatus_leg: String = { if soft_meta_leg.len() >= 1 { soft_meta_leg[0] } else { String::from("") } };
             let vmsg_leg: String = { if soft_meta_leg.len() >= 2 { soft_meta_leg[1] } else { String::from("") } };
-            diag_emit_verify_json_full(status_str, dctx, ces, vstatus_leg, vmsg_leg);
+            let legacy_leg: Vec<String> = vf_legacy_fields(ces, soft_meta_leg);
+            diag_emit_verify_json_full(status_str, dctx, ces, vstatus_leg, vmsg_leg, legacy_leg[0], legacy_leg[1]);
             if all_proven == 0 {
                 return 1;
             }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -894,6 +894,13 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                         let ovr: VerifyResult = verify_collect(oh, ovf, t_eff);
                         if ovr.status == VERIFY_FAILED() {
                             verify_failed = true;
+                        } else if ovr.status == VERIFY_TIMEOUT() || ovr.status == VERIFY_UNKNOWN() {
+                            // Mirror the bounded-pool drain: retry IR before treating Timeout/Unknown as passing.
+                            // Without this, the common nfns <= t_jobs case silently accepts unverified functions.
+                            let ovr2: VerifyResult = verify_function_ir_fallback(ovf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
+                            if ovr2.status != VERIFY_PROVEN() && ovr2.status != VERIFY_PROVEN_IR() {
+                                verify_failed = true;
+                            }
                         }
                     }
                 }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -353,43 +353,37 @@ fn record_soft_fail(meta: Vec<String>, status: String, message: String, function
 }
 
 // Compute (function, counterexample) for the VerifyFailed top-level JSON fields.
-// Mirrors Rust's BuildStatus::VerifyFailed { function, description } shape so
-// schema validators see the same fields from either compiler. Returns [func, desc].
+// Precondition: status is VerifyFailed (i.e. ces non-empty OR soft_meta has 3 entries).
+// Mirrors Rust's BuildStatus::VerifyFailed { function, description } shape.
 fn vf_legacy_fields(ces: Vec<VerifyCE>, soft_meta: Vec<String>) -> Vec<String> {
     let result: Vec<String> = Vec::new();
     if ces.len() > 0 {
         let ce: VerifyCE = ces[0];
         result.push(ce.function);
-        // Mirrors Rust's CE description: "VerifyFailed: <violation>".
         let desc: String = String::from("VerifyFailed: ");
         desc.push_str(ce.violation);
         result.push(desc);
         return result;
     }
-    if soft_meta.len() >= 3 {
-        let status: String = soft_meta[0];
-        let message: String = soft_meta[1];
-        let func: String = soft_meta[2];
-        result.push(func);
-        let desc: String = String::from("");
-        if status == String::from("timeout") {
-            desc.push_str(String::from("verification timed out"));
-        } else if status == String::from("unknown") {
-            desc.push_str(String::from("verification result unknown: "));
-            desc.push_str(message);
-        } else if status == String::from("error") {
-            desc.push_str(String::from("esbmc error: "));
-            desc.push_str(message);
-        } else if status == String::from("tool_not_found") {
-            desc.push_str(String::from("ESBMC not found"));
-        } else {
-            desc.push_str(message);
-        }
-        result.push(desc);
-        return result;
+    let status: String = soft_meta[0];
+    let message: String = soft_meta[1];
+    let func: String = soft_meta[2];
+    result.push(func);
+    let desc: String = String::from("");
+    if status == String::from("timeout") {
+        desc.push_str(String::from("verification timed out"));
+    } else if status == String::from("unknown") {
+        desc.push_str(String::from("verification result unknown: "));
+        desc.push_str(message);
+    } else if status == String::from("error") {
+        desc.push_str(String::from("esbmc error: "));
+        desc.push_str(message);
+    } else if status == String::from("tool_not_found") {
+        desc.push_str(String::from("ESBMC not found"));
+    } else {
+        desc.push_str(message);
     }
-    result.push(String::from(""));
-    result.push(String::from(""));
+    result.push(desc);
     result
 }
 
@@ -553,8 +547,14 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     };
     let vstatus: String = { if soft_meta.len() >= 1 { soft_meta[0] } else { String::from("") } };
     let vmsg: String = { if soft_meta.len() >= 2 { soft_meta[1] } else { String::from("") } };
-    let legacy: Vec<String> = vf_legacy_fields(ces, soft_meta);
-    diag_emit_verify_json_full(status_str, dctx, ces, vstatus, vmsg, legacy[0], legacy[1]);
+    let mut vf_func: String = String::from("");
+    let mut vf_ce: String = String::from("");
+    if status_str == String::from("VerifyFailed") {
+        let legacy: Vec<String> = vf_legacy_fields(ces, soft_meta);
+        vf_func = legacy[0];
+        vf_ce = legacy[1];
+    }
+    diag_emit_verify_json_full(status_str, dctx, ces, vstatus, vmsg, vf_func, vf_ce);
     if all_proven == 0 {
         return 1;
     }
@@ -713,8 +713,14 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     };
     let vstatus: String = { if soft_meta.len() >= 1 { soft_meta[0] } else { String::from("") } };
     let vmsg: String = { if soft_meta.len() >= 2 { soft_meta[1] } else { String::from("") } };
-    let legacy: Vec<String> = vf_legacy_fields(ces, soft_meta);
-    diag_emit_build_verify_json_full(status_str, out, dctx, ces, vstatus, vmsg, legacy[0], legacy[1]);
+    let mut vf_func: String = String::from("");
+    let mut vf_ce: String = String::from("");
+    if status_str == String::from("VerifyFailed") {
+        let legacy: Vec<String> = vf_legacy_fields(ces, soft_meta);
+        vf_func = legacy[0];
+        vf_ce = legacy[1];
+    }
+    diag_emit_build_verify_json_full(status_str, out, dctx, ces, vstatus, vmsg, vf_func, vf_ce);
     if all_proven == 0 {
         return 1;
     }
@@ -1119,8 +1125,14 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             };
             let vstatus_leg: String = { if soft_meta_leg.len() >= 1 { soft_meta_leg[0] } else { String::from("") } };
             let vmsg_leg: String = { if soft_meta_leg.len() >= 2 { soft_meta_leg[1] } else { String::from("") } };
-            let legacy_leg: Vec<String> = vf_legacy_fields(ces, soft_meta_leg);
-            diag_emit_verify_json_full(status_str, dctx, ces, vstatus_leg, vmsg_leg, legacy_leg[0], legacy_leg[1]);
+            let mut vf_func_leg: String = String::from("");
+            let mut vf_ce_leg: String = String::from("");
+            if status_str == String::from("VerifyFailed") {
+                let legacy_leg: Vec<String> = vf_legacy_fields(ces, soft_meta_leg);
+                vf_func_leg = legacy_leg[0];
+                vf_ce_leg = legacy_leg[1];
+            }
+            diag_emit_verify_json_full(status_str, dctx, ces, vstatus_leg, vmsg_leg, vf_func_leg, vf_ce_leg);
             if all_proven == 0 {
                 return 1;
             }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -242,7 +242,7 @@ fn skip_if_non_modelable(f: IrFunction, ir_mod: IrModule, const_fn_indices: Vec<
     true
 }
 
-fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec<i64>, dctx: DiagCtx, path: String, ces: Vec<VerifyCE>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
+fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec<i64>, dctx: DiagCtx, path: String, ces: Vec<VerifyCE>, soft_meta: Vec<String>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
                    vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, jobs: i64) -> i64 [io] {
     let mut all_proven: i64 = 1;
     // Bounded pool: ≤ jobs ESBMC processes in flight, FIFO drain. See #175.
@@ -260,7 +260,7 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec
                 let oldest_f: IrFunction = fns[oldest_fi];
                 vec_i64_remove_front(in_flight_h);
                 vec_i64_remove_front(in_flight_fi);
-                let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+                let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
                 if proven == 0 {
                     all_proven = 0;
                 }
@@ -284,7 +284,7 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec
         let oldest_f: IrFunction = fns[oldest_fi];
         vec_i64_remove_front(in_flight_h);
         vec_i64_remove_front(in_flight_fi);
-        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
         if proven == 0 {
             all_proven = 0;
         }
@@ -340,8 +340,18 @@ fn vec_i64_remove_front(v: Vec<i64>) {
     v.pop();
 }
 
+// Record the first soft-fail ESBMC outcome (status/message) into `meta`.
+// Convention: meta is `[]` until the first soft-fail, then `[status, message]`.
+// Subsequent calls are no-ops to preserve the first-observed signal.
+fn record_soft_fail(meta: Vec<String>, status: String, message: String) {
+    if meta.len() == 0 {
+        meta.push(status);
+        meta.push(message);
+    }
+}
+
 fn verify_collect_and_report(
-    h: i64, f: IrFunction, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>,
+    h: i64, f: IrFunction, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, soft_meta: Vec<String>,
     max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
     vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64,
 ) -> i64 [io] {
@@ -350,6 +360,7 @@ fn verify_collect_and_report(
         // is distinct from "no vows", which the caller already filters.
         // Silently skipping would mis-report an un-verified function as proven.
         eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR (failed to start ESBMC)")));
+        record_soft_fail(soft_meta, String::from("error"), String::from("failed to start ESBMC"));
         return 0;
     }
     let effective_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
@@ -371,12 +382,21 @@ fn verify_collect_and_report(
         ces.push(build_ce_from_result(f, vr, path));
         return 0;
     }
-    if st == VERIFY_TIMEOUT() {
-        // BV timed out; retry with IR before failing (Phase D fallback).
+    if st == VERIFY_TIMEOUT() || st == VERIFY_UNKNOWN() {
+        // BV could neither prove nor falsify (Timeout or Unknown); retry
+        // with IR before failing (Phase D fallback). Mirrors the
+        // run_with_fallback logic in vow-verify/src/solver_strategy.rs.
+        let bv_is_unknown: bool = st == VERIFY_UNKNOWN();
+        let bv_label: String = { if bv_is_unknown { String::from("unknown") } else { String::from("timeout") } };
+        let bv_label_upper: String = { if bv_is_unknown { String::from("UNKNOWN") } else { String::from("TIMEOUT") } };
+        let bv_msg_initial: String = {
+            if bv_is_unknown { parse_unknown_reason(vr.raw_output) }
+            else { String::from("verification timed out") }
+        };
         let bv_solver: String = resolve_auto_bv_solver(solver);
         let auto_enc: bool = is_auto_encoding(encoding);
         if auto_enc && bv_solver != String::from("bitwuzla") {
-            eprintln_str(str3(String::from("  "), f.name, String::from(": BV timeout, retrying with --z3 --ir...")));
+            eprintln_str(str3(String::from("  "), f.name, String::from(": BV inconclusive, retrying with --z3 --ir...")));
             let vr2: VerifyResult = verify_function_ir_fallback(f, ir_mod, max_k_step, use_cache, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
             let st2: i64 = vr2.status;
             if st2 == VERIFY_PROVEN_IR() {
@@ -384,30 +404,45 @@ fn verify_collect_and_report(
                 return 1;
             }
             if st2 == VERIFY_FAILED() {
-                eprintln_str(str3(String::from("  "), f.name, String::from(": FAILED")));
-                emit_ce_vars(vr2);
-                ces.push(build_ce_from_result(f, vr2, path));
+                // IR-only counterexamples can be infeasible under BV (no
+                // overflow modeling), so a FAILED here is unsound — surface
+                // the original BV outcome instead. Mirrors solver_strategy's
+                // demote-IR-FAILED rule.
+                eprintln_str(str4(String::from("  "), f.name, String::from(": "), bv_label_upper));
+                record_soft_fail(soft_meta, bv_label, bv_msg_initial);
                 return 0;
             }
             if st2 == VERIFY_TIMEOUT() {
                 eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT (BV and IR)")));
+                record_soft_fail(soft_meta, String::from("timeout"), String::from("verification timed out (BV and IR)"));
+                return 0;
+            }
+            if st2 == VERIFY_UNKNOWN() {
+                let reason2: String = parse_unknown_reason(vr2.raw_output);
+                eprintln_str(str3(String::from("  "), f.name, String::from(": UNKNOWN (BV and IR)")));
+                record_soft_fail(soft_meta, String::from("unknown"), reason2);
                 return 0;
             }
             if st2 == VERIFY_NOT_FOUND() {
                 eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
+                record_soft_fail(soft_meta, String::from("tool_not_found"), String::from("ESBMC not found"));
                 return 0;
             }
             eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
+            record_soft_fail(soft_meta, String::from("error"), String::from("ESBMC error during IR fallback"));
             return 0;
         }
-        eprintln_str(str3(String::from("  "), f.name, String::from(": TIMEOUT")));
+        eprintln_str(str4(String::from("  "), f.name, String::from(": "), bv_label_upper));
+        record_soft_fail(soft_meta, bv_label, bv_msg_initial);
         return 0;
     }
     if st == VERIFY_NOT_FOUND() {
         eprintln_str(String::from("error: ESBMC not found; install ESBMC or use --no-verify"));
+        record_soft_fail(soft_meta, String::from("tool_not_found"), String::from("ESBMC not found"));
         return 0;
     }
     eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
+    record_soft_fail(soft_meta, String::from("error"), String::from("unrecognized ESBMC outcome"));
     0
 }
 
@@ -461,8 +496,9 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     emit_ir_warnings(ir_mod, dctx);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
+    let soft_meta: Vec<String> = Vec::new();
     let const_fn_indices: Vec<i64> = detect_const_fns(ir_mod);
-    let all_proven: i64 = run_verify_loop(fns, ir_mod, const_fn_indices, dctx, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max, jobs);
+    let all_proven: i64 = run_verify_loop(fns, ir_mod, const_fn_indices, dctx, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max, jobs);
     let status_str: String = {
         if all_proven == 1 {
             String::from("Verified")
@@ -470,7 +506,9 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
             String::from("VerifyFailed")
         }
     };
-    diag_emit_verify_json(status_str, dctx, ces);
+    let vstatus: String = { if soft_meta.len() >= 1 { soft_meta[0] } else { String::from("") } };
+    let vmsg: String = { if soft_meta.len() >= 2 { soft_meta[1] } else { String::from("") } };
+    diag_emit_verify_json_full(status_str, dctx, ces, vstatus, vmsg);
     if all_proven == 0 {
         return 1;
     }
@@ -556,6 +594,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     let jobs: i64 = resolve_verify_jobs(argv);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
+    let soft_meta: Vec<String> = Vec::new();
     let mut all_proven: i64 = 1;
     // Bounded pool: ≤ jobs ESBMC processes in flight, FIFO drain. See #175.
     let in_flight_h: Vec<i64> = Vec::new();
@@ -574,7 +613,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
                     let oldest_f: IrFunction = fns[oldest_fi];
                     vec_i64_remove_front(in_flight_h);
                     vec_i64_remove_front(in_flight_fi);
-                    let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+                    let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
                     if proven == 0 {
                         all_proven = 0;
                     }
@@ -614,7 +653,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         let oldest_f: IrFunction = fns[oldest_fi];
         vec_i64_remove_front(in_flight_h);
         vec_i64_remove_front(in_flight_fi);
-        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
         if proven == 0 {
             all_proven = 0;
         }
@@ -626,7 +665,9 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
             String::from("VerifyFailed")
         }
     };
-    diag_emit_build_verify_json(status_str, out, dctx, ces);
+    let vstatus: String = { if soft_meta.len() >= 1 { soft_meta[0] } else { String::from("") } };
+    let vmsg: String = { if soft_meta.len() >= 2 { soft_meta[1] } else { String::from("") } };
+    diag_emit_build_verify_json_full(status_str, out, dctx, ces, vstatus, vmsg);
     if all_proven == 0 {
         return 1;
     }
@@ -817,8 +858,8 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                                 let ovr: VerifyResult = verify_collect(oh, ovf, t_eff);
                                 if ovr.status == VERIFY_FAILED() {
                                     verify_failed = true;
-                                } else if ovr.status == VERIFY_TIMEOUT() {
-                                    // BV timed out; retry with IR before failing.
+                                } else if ovr.status == VERIFY_TIMEOUT() || ovr.status == VERIFY_UNKNOWN() {
+                                    // BV could neither prove nor falsify; retry with IR before failing.
                                     let ovr2: VerifyResult = verify_function_ir_fallback(ovf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
                                     if ovr2.status != VERIFY_PROVEN() && ovr2.status != VERIFY_PROVEN_IR() {
                                         verify_failed = true;
@@ -1010,10 +1051,11 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
             emit_ir_warnings(ir_mod, dctx);
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
+            let soft_meta_leg: Vec<String> = Vec::new();
             let use_cache_leg: bool = !has_flag(argv, "--no-cache");
             let jobs_leg: i64 = resolve_verify_jobs(argv);
             let const_fn_indices_leg: Vec<i64> = detect_const_fns(ir_mod);
-            let all_proven: i64 = run_verify_loop(fns, ir_mod, const_fn_indices_leg, dctx, path, ces, max_k_step, use_cache_leg, String::from(""), String::from(""), String::from(""), vec_max_leg, string_max_leg, hashmap_max_leg, btreemap_max_leg, jobs_leg);
+            let all_proven: i64 = run_verify_loop(fns, ir_mod, const_fn_indices_leg, dctx, path, ces, soft_meta_leg, max_k_step, use_cache_leg, String::from(""), String::from(""), String::from(""), vec_max_leg, string_max_leg, hashmap_max_leg, btreemap_max_leg, jobs_leg);
             let status_str: String = {
                 if all_proven == 1 {
                     String::from("Verified")
@@ -1021,7 +1063,9 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
                     String::from("VerifyFailed")
                 }
             };
-            diag_emit_verify_json(status_str, dctx, ces);
+            let vstatus_leg: String = { if soft_meta_leg.len() >= 1 { soft_meta_leg[0] } else { String::from("") } };
+            let vmsg_leg: String = { if soft_meta_leg.len() >= 2 { soft_meta_leg[1] } else { String::from("") } };
+            diag_emit_verify_json_full(status_str, dctx, ces, vstatus_leg, vmsg_leg);
             if all_proven == 0 {
                 return 1;
             }
@@ -3391,7 +3435,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `Verified`      | Compiled + all contracts proved by ESBMC. Functions whose bodies the verifier cannot model (`RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, effectful) are reported as a `VerificationSkipped` *Warning* in `diagnostics[]` and the build still succeeds -- their contracts are documentary, runtime-checked under `--mode debug`. |\n"));
     r.push_str(String::from("| `Unverified`    | Compiled with `--no-verify` (ESBMC skipped)  |\n"));
     r.push_str(String::from("| `CompileFailed` | Parse error, type error, module load error, or link failure |\n"));
-    r.push_str(String::from("| `VerifyFailed`  | ESBMC found a counterexample, timed out, errored, or was not found |\n"));
+    r.push_str(String::from("| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: \"unknown\"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Verified Example\n"));
     r.push_str(String::from("\n"));
@@ -3463,7 +3507,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `function`         | string              | VerifyFailed      | Function where verification failed        |\n"));
     r.push_str(String::from("| `counterexample`   | string              | VerifyFailed      | Legacy description string                 |\n"));
     r.push_str(String::from("| `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |\n"));
-    r.push_str(String::from("| `verify_status`    | string              | On backend failure | `\"timeout\"`, `\"error\"`, or `\"tool_not_found\"` |\n"));
+    r.push_str(String::from("| `verify_status`    | string              | On backend failure | `\"timeout\"`, `\"unknown\"`, `\"error\"`, or `\"tool_not_found\"` |\n"));
     r.push_str(String::from("| `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Contracts Output JSON\n"));
@@ -3528,7 +3572,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `proven`        | ESBMC proved this contract holds for all inputs (bit-vector encoding, overflow modeled) |\n"));
     r.push_str(String::from("| `proven-ir`     | ESBMC proved this contract under integer-arithmetic encoding after BV timed out; overflow is not modeled by IR, but the BV caller preconditions still guard against it |\n"));
     r.push_str(String::from("| `failed`        | ESBMC found a counterexample violating this contract |\n"));
-    r.push_str(String::from("| `unknown`       | Another contract in the same function failed; this one was not individually checked |\n"));
+    r.push_str(String::from("| `unknown`       | ESBMC could not conclude for this contract -- either `VERIFICATION UNKNOWN` was reported for the containing function (k-induction's forward condition unable to prove or falsify), or another contract in the same function failed and this one was not individually checked |\n"));
     r.push_str(String::from("| `timeout`       | ESBMC timed out on the containing function (BV and -- when applicable -- IR fallback both timed out) |\n"));
     r.push_str(String::from("| `error`         | ESBMC error or tool not found                        |\n"));
     r.push_str(String::from("| `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]`. |\n"));
@@ -4942,7 +4986,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"verify_status\": {\n"));
     r.push_str(String::from("      \"type\": \"string\",\n"));
-    r.push_str(String::from("      \"enum\": [\"timeout\", \"error\", \"tool_not_found\"],\n"));
+    r.push_str(String::from("      \"enum\": [\"timeout\", \"unknown\", \"error\", \"tool_not_found\"],\n"));
     r.push_str(String::from("      \"description\": \"Verification sub-status (present only when the verification backend did not produce a proof or counterexample)\"\n"));
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"verify_message\": {\n"));
@@ -6501,7 +6545,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `Verified`      | Compiled + all contracts proved by ESBMC. Functions whose bodies the verifier cannot model (`RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, effectful) are reported as a `VerificationSkipped` *Warning* in `diagnostics[]` and the build still succeeds -- their contracts are documentary, runtime-checked under `--mode debug`. |\n"));
     r.push_str(String::from("| `Unverified`    | Compiled with `--no-verify` (ESBMC skipped)  |\n"));
     r.push_str(String::from("| `CompileFailed` | Parse error, type error, module load error, or link failure |\n"));
-    r.push_str(String::from("| `VerifyFailed`  | ESBMC found a counterexample, timed out, errored, or was not found |\n"));
+    r.push_str(String::from("| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: \"unknown\"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Verified Example\n"));
     r.push_str(String::from("\n"));
@@ -6573,7 +6617,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `function`         | string              | VerifyFailed      | Function where verification failed        |\n"));
     r.push_str(String::from("| `counterexample`   | string              | VerifyFailed      | Legacy description string                 |\n"));
     r.push_str(String::from("| `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |\n"));
-    r.push_str(String::from("| `verify_status`    | string              | On backend failure | `\"timeout\"`, `\"error\"`, or `\"tool_not_found\"` |\n"));
+    r.push_str(String::from("| `verify_status`    | string              | On backend failure | `\"timeout\"`, `\"unknown\"`, `\"error\"`, or `\"tool_not_found\"` |\n"));
     r.push_str(String::from("| `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Contracts Output JSON\n"));
@@ -6638,7 +6682,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `proven`        | ESBMC proved this contract holds for all inputs (bit-vector encoding, overflow modeled) |\n"));
     r.push_str(String::from("| `proven-ir`     | ESBMC proved this contract under integer-arithmetic encoding after BV timed out; overflow is not modeled by IR, but the BV caller preconditions still guard against it |\n"));
     r.push_str(String::from("| `failed`        | ESBMC found a counterexample violating this contract |\n"));
-    r.push_str(String::from("| `unknown`       | Another contract in the same function failed; this one was not individually checked |\n"));
+    r.push_str(String::from("| `unknown`       | ESBMC could not conclude for this contract -- either `VERIFICATION UNKNOWN` was reported for the containing function (k-induction's forward condition unable to prove or falsify), or another contract in the same function failed and this one was not individually checked |\n"));
     r.push_str(String::from("| `timeout`       | ESBMC timed out on the containing function (BV and -- when applicable -- IR fallback both timed out) |\n"));
     r.push_str(String::from("| `error`         | ESBMC error or tool not found                        |\n"));
     r.push_str(String::from("| `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]`. |\n"));
@@ -8055,7 +8099,7 @@ fn skill_support_content_5() -> String {
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"verify_status\": {\n"));
     r.push_str(String::from("      \"type\": \"string\",\n"));
-    r.push_str(String::from("      \"enum\": [\"timeout\", \"error\", \"tool_not_found\"],\n"));
+    r.push_str(String::from("      \"enum\": [\"timeout\", \"unknown\", \"error\", \"tool_not_found\"],\n"));
     r.push_str(String::from("      \"description\": \"Verification sub-status (present only when the verification backend did not produce a proof or counterexample)\"\n"));
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"verify_message\": {\n"));
@@ -8818,6 +8862,8 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
                                 }
                             } else if st == VERIFY_TIMEOUT() {
                                 e_statuses[ei] = String::from("timeout");
+                            } else if st == VERIFY_UNKNOWN() {
+                                e_statuses[ei] = String::from("unknown");
                             } else {
                                 e_statuses[ei] = String::from("error");
                             }

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -771,15 +771,7 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
         if r.exit_code == -2 { VERIFY_TIMEOUT() } else { parse_verify_status(combined) }
     };
     let status: i64 = {
-        // IR-only counterexamples can be infeasible under BV (no overflow
-        // modeling). Callers that distinguish FAILED vs the original BV
-        // status (e.g. `verify_collect_and_report` in compiler/main.vow)
-        // are responsible for surfacing the original BV outcome instead
-        // of the IR FAILED; this helper just passes the raw IR result
-        // through. Callers that don't distinguish (cmd_test/run_test
-        // bounded-pool drains) treat any non-PROVEN/PROVEN_IR as failure
-        // and are unaffected. Demoting FAILED here would clobber the
-        // original BV-Unknown signal in the parallel path.
+        // Pass raw IR status through: distinguishing callers (verify_collect_and_report) surface the original BV outcome for IR FAILED; non-distinguishing callers (run_test) treat any non-PROVEN as failure.
         if raw_status == VERIFY_PROVEN() { VERIFY_PROVEN_IR() }
         else { raw_status }
     };

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -11,6 +11,7 @@ fn VERIFY_TIMEOUT() -> i64 vow { ensures: result >= 0 } { 2 }
 fn VERIFY_ERROR() -> i64 vow { ensures: result >= 0 } { 3 }
 fn VERIFY_NOT_FOUND() -> i64 vow { ensures: result >= 0 } { 4 }
 fn VERIFY_PROVEN_IR() -> i64 vow { ensures: result >= 0 } { 5 }
+fn VERIFY_UNKNOWN() -> i64 vow { ensures: result >= 0 } { 6 }
 
 struct VerifyResult {
     status: i64,
@@ -354,6 +355,12 @@ fn parse_verify_status(combined: String) -> i64 {
     if str_find_str(combined, String::from("VERIFICATION FAILED")) >= 0 {
         return VERIFY_FAILED();
     }
+    // ESBMC's third legitimate outcome: it finished without proving or
+    // falsifying (e.g. k-induction's forward condition couldn't establish
+    // the property). Must be checked before the generic ERROR fallback.
+    if str_find_str(combined, String::from("VERIFICATION UNKNOWN")) >= 0 {
+        return VERIFY_UNKNOWN();
+    }
     if str_find_str(combined, String::from("timeout")) >= 0 {
         return VERIFY_TIMEOUT();
     }
@@ -364,6 +371,38 @@ fn parse_verify_status(combined: String) -> i64 {
         return VERIFY_TIMEOUT();
     }
     VERIFY_ERROR()
+}
+
+// Extract a short explanation from an ESBMC `VERIFICATION UNKNOWN` log.
+// Mirrors `parse_unknown_reason` in vow-verify/src/esbmc.rs.
+fn parse_unknown_reason(combined: String) -> String {
+    let lines: Vec<String> = Vec::new();
+    split_lines(combined, lines);
+    let n: i64 = lines.len();
+    let mut reason: String = String::from("");
+    let mut i: i64 = 0;
+    while i < n {
+        let line: String = str_trim(lines[i]);
+        if line == String::from("VERIFICATION UNKNOWN") {
+            break;
+        }
+        if line.len() > 0 {
+            let has_unable: bool =
+                str_find_str(line, String::from("unable to prove")) >= 0
+                || str_find_str(line, String::from("Unable to prove")) >= 0
+                || str_find_str(line, String::from("giving up")) >= 0
+                || str_find_str(line, String::from("inductive step")) >= 0;
+            if has_unable {
+                reason = line;
+            }
+        }
+        i = i + 1;
+    }
+    if reason.len() == 0 {
+        String::from("ESBMC returned VERIFICATION UNKNOWN")
+    } else {
+        reason
+    }
 }
 
 fn parse_vow_id(output: String) -> i64 {
@@ -649,9 +688,11 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
     };
     let mut used_combined: String = combined;
 
-    // Phase D: if BV timed out under Auto encoding and the BV solver is not
-    // Bitwuzla, retry once with --z3 --ir (integer encoding).
-    if status == VERIFY_TIMEOUT() && auto_enc && bv_solver != String::from("bitwuzla") {
+    // Phase D: if BV could neither prove nor falsify (Timeout or Unknown)
+    // under Auto encoding and the BV solver is not Bitwuzla, retry once
+    // with --z3 --ir (integer encoding).
+    let bv_inconclusive: bool = status == VERIFY_TIMEOUT() || status == VERIFY_UNKNOWN();
+    if bv_inconclusive && auto_enc && bv_solver != String::from("bitwuzla") {
         let ir_solver: String = String::from("z3");
         let ir_encoding: String = String::from("ir");
         let ir_timeout: String = {
@@ -674,10 +715,13 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
         let s2: i64 = {
             if r2.exit_code == -2 { VERIFY_TIMEOUT() } else { parse_verify_status(combined2) }
         };
+        let bv_status: i64 = status;
         status = {
-            // IR-only counterexamples can be infeasible under BV (no overflow modeling), so a FAILED here is inconclusive — report the original Timeout instead.
+            // IR-only counterexamples can be infeasible under BV (no overflow modeling),
+            // so a FAILED here is inconclusive — report the original BV outcome
+            // (Timeout or Unknown) instead.
             if s2 == VERIFY_PROVEN() { VERIFY_PROVEN_IR() }
-            else if s2 == VERIFY_FAILED() { VERIFY_TIMEOUT() }
+            else if s2 == VERIFY_FAILED() { bv_status }
             else { s2 }
         };
         used_combined = combined2;

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -771,9 +771,16 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
         if r.exit_code == -2 { VERIFY_TIMEOUT() } else { parse_verify_status(combined) }
     };
     let status: i64 = {
-        // IR-only CEs can be infeasible under BV — demote FAILED to TIMEOUT (the caller only reaches us because BV already timed out).
+        // IR-only counterexamples can be infeasible under BV (no overflow
+        // modeling). Callers that distinguish FAILED vs the original BV
+        // status (e.g. `verify_collect_and_report` in compiler/main.vow)
+        // are responsible for surfacing the original BV outcome instead
+        // of the IR FAILED; this helper just passes the raw IR result
+        // through. Callers that don't distinguish (cmd_test/run_test
+        // bounded-pool drains) treat any non-PROVEN/PROVEN_IR as failure
+        // and are unaffected. Demoting FAILED here would clobber the
+        // original BV-Unknown signal in the parallel path.
         if raw_status == VERIFY_PROVEN() { VERIFY_PROVEN_IR() }
-        else if raw_status == VERIFY_FAILED() { VERIFY_TIMEOUT() }
         else { raw_status }
     };
     // No on-disk caching on self-hosted: see the note above resolve_auto_bv_solver.

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -240,7 +240,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `Verified`      | Compiled + all contracts proved by ESBMC. Functions whose bodies the verifier cannot model (`RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, effectful) are reported as a `VerificationSkipped` *Warning* in `diagnostics[]` and the build still succeeds — their contracts are documentary, runtime-checked under `--mode debug`. |
 | `Unverified`    | Compiled with `--no-verify` (ESBMC skipped)  |
 | `CompileFailed` | Parse error, type error, module load error, or link failure |
-| `VerifyFailed`  | ESBMC found a counterexample, timed out, errored, or was not found |
+| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
 
 ### Verified Example
 
@@ -312,7 +312,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `function`         | string              | VerifyFailed      | Function where verification failed        |
 | `counterexample`   | string              | VerifyFailed      | Legacy description string                 |
 | `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |
-| `verify_status`    | string              | On backend failure | `"timeout"`, `"error"`, or `"tool_not_found"` |
+| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, or `"tool_not_found"` |
 | `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |
 
 ## Contracts Output JSON
@@ -377,7 +377,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `proven`        | ESBMC proved this contract holds for all inputs (bit-vector encoding, overflow modeled) |
 | `proven-ir`     | ESBMC proved this contract under integer-arithmetic encoding after BV timed out; overflow is not modeled by IR, but the BV caller preconditions still guard against it |
 | `failed`        | ESBMC found a counterexample violating this contract |
-| `unknown`       | Another contract in the same function failed; this one was not individually checked |
+| `unknown`       | ESBMC could not conclude for this contract — either `VERIFICATION UNKNOWN` was reported for the containing function (k-induction's forward condition unable to prove or falsify), or another contract in the same function failed and this one was not individually checked |
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]`. |

--- a/docs/spec/schemas/build-result.schema.json
+++ b/docs/spec/schemas/build-result.schema.json
@@ -39,7 +39,7 @@
     },
     "verify_status": {
       "type": "string",
-      "enum": ["timeout", "error", "tool_not_found"],
+      "enum": ["timeout", "unknown", "error", "tool_not_found"],
       "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample)"
     },
     "verify_message": {

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -124,6 +124,7 @@ soft_fail = rs == 'VerifyFailed' and ss == 'VerifyFailed' and rvs and svs
 if soft_fail:
     if rvs != svs:
         errors.append(f'verify_status: {rvs} vs {svs}')
+    # verify_message is not compared — ESBMC-output text varies across runs and would cause brittle parity failures.
 elif rs == 'VerifyFailed' and ss == 'VerifyFailed':
     if len(rc) == 0:
         errors.append('rust has no counterexamples for VerifyFailed')

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -115,7 +115,16 @@ if rs != 'VerifyFailed':
 
 rc = r.get('counterexamples', [])
 sc = s.get('counterexamples', [])
-if rs == 'VerifyFailed' and ss == 'VerifyFailed':
+# A VerifyFailed with a non-empty verify_status is a 'soft' ESBMC outcome
+# (timeout / unknown / error / tool_not_found) — ESBMC produced no
+# counterexample by design, so the parity check must not require one.
+rvs = r.get('verify_status') or ''
+svs = s.get('verify_status') or ''
+soft_fail = rs == 'VerifyFailed' and ss == 'VerifyFailed' and rvs and svs
+if soft_fail:
+    if rvs != svs:
+        errors.append(f'verify_status: {rvs} vs {svs}')
+elif rs == 'VerifyFailed' and ss == 'VerifyFailed':
     if len(rc) == 0:
         errors.append('rust has no counterexamples for VerifyFailed')
     if len(sc) == 0:

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -36,6 +36,14 @@ pub enum VerificationResult {
     Timeout,
     ToolNotFound,
     ToolError(String),
+    /// ESBMC returned `VERIFICATION UNKNOWN` — finished cleanly but could
+    /// neither prove nor falsify the property within its bound (e.g.
+    /// k-induction's forward condition could not establish the property).
+    /// Distinct from `Failed` (no real counterexample) and from `Timeout`
+    /// (no wall-clock cutoff). `reason` carries the short ESBMC explanation.
+    Unknown {
+        reason: String,
+    },
     /// Function's body contains non-modelable opcodes or effects; ESBMC not invoked. Treat as warning, not failure.
     Skipped {
         reason: String,
@@ -490,10 +498,43 @@ pub fn run_esbmc_with_max_k_step(
         VerificationResult::Proven
     } else if combined.contains("VERIFICATION FAILED") {
         VerificationResult::Failed(parse_esbmc_output(&combined))
+    } else if combined.contains("VERIFICATION UNKNOWN") {
+        VerificationResult::Unknown {
+            reason: parse_unknown_reason(&combined),
+        }
     } else if combined.to_lowercase().contains("timeout") {
         VerificationResult::Timeout
     } else {
         VerificationResult::ToolError(format!("unexpected esbmc output:\n{combined}"))
+    }
+}
+
+/// Extract the short explanation that precedes `VERIFICATION UNKNOWN` from an
+/// ESBMC log. Typical lines: `The forward condition is unable to prove the
+/// property` or `Unable to prove or falsify the program, giving up.` — we
+/// keep the most informative of these and fall back to a generic message.
+fn parse_unknown_reason(combined: &str) -> String {
+    let mut reason = String::new();
+    for line in combined.lines() {
+        let t = line.trim();
+        if t.is_empty() {
+            continue;
+        }
+        if t == "VERIFICATION UNKNOWN" {
+            break;
+        }
+        if t.contains("unable to prove")
+            || t.contains("Unable to prove")
+            || t.contains("giving up")
+            || t.contains("inductive step")
+        {
+            reason = t.to_string();
+        }
+    }
+    if reason.is_empty() {
+        "ESBMC returned VERIFICATION UNKNOWN".to_string()
+    } else {
+        reason
     }
 }
 
@@ -848,6 +889,30 @@ VERIFICATION FAILED";
         let ce = parse_esbmc_output(output);
         assert_eq!(ce.vow_id, None);
         assert!(ce.values.is_empty());
+    }
+
+    #[test]
+    fn parse_unknown_reason_picks_forward_condition_line() {
+        let combined = "ESBMC version 8.2.0\n\
+                        Checking forward condition, k = 1\n\
+                        The forward condition is unable to prove the property\n\
+                        Unable to prove or falsify the program, giving up.\n\
+                        VERIFICATION UNKNOWN\n";
+        let reason = parse_unknown_reason(combined);
+        // Prefers the most specific 'unable to prove'/'giving up' line. Both
+        // contain trigger keywords; the last one observed before
+        // VERIFICATION UNKNOWN is kept.
+        assert!(
+            reason.contains("Unable to prove or falsify") || reason.contains("unable to prove"),
+            "reason was: {reason}"
+        );
+    }
+
+    #[test]
+    fn parse_unknown_reason_falls_back_to_generic_when_no_marker() {
+        let combined = "ESBMC version 8.2.0\nSome unrelated output\nVERIFICATION UNKNOWN\n";
+        let reason = parse_unknown_reason(combined);
+        assert_eq!(reason, "ESBMC returned VERIFICATION UNKNOWN");
     }
 
     #[test]

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -239,12 +239,16 @@ pub fn run_with_fallback(
     let result = run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, &bv_config);
 
     match result {
-        VerificationResult::Timeout => {
+        // Both Timeout and Unknown mean "BV could neither prove nor disprove"
+        // — retry with Z3+IR. Same soundness rules apply to either fallback:
+        // an IR-only CE can be infeasible under BV, so we never return Failed
+        // from IR; we report the original BV outcome instead.
+        VerificationResult::Timeout | VerificationResult::Unknown { .. } => {
             // IR encoding only works with Z3. If the resolved BV solver was
             // Boolector or Z3, we can switch to Z3+IR. Bitwuzla cannot do IR.
             let can_ir = !matches!(bv_config.solver, Solver::Bitwuzla);
             if !can_ir {
-                return (VerificationResult::Timeout, bv_config);
+                return (result, bv_config);
             }
 
             // Reuse the same timeout policy for the IR retry: user override
@@ -261,9 +265,9 @@ pub fn run_with_fallback(
                 VerificationResult::Proven => (VerificationResult::ProvenIr, ir_config),
                 // IR returned a counterexample, but IR does not model
                 // overflow — a CE found only under IR can be infeasible
-                // under BV. Report Timeout (which is what BV actually
-                // produced) rather than an unsound definitive Failed.
-                VerificationResult::Failed(_) => (VerificationResult::Timeout, ir_config),
+                // under BV. Report the BV outcome (Timeout or Unknown)
+                // rather than an unsound definitive Failed.
+                VerificationResult::Failed(_) => (result, ir_config),
                 other => (other, ir_config),
             }
         }

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2683,7 +2683,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `Verified`      | Compiled + all contracts proved by ESBMC. Functions whose bodies the verifier cannot model (`RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, effectful) are reported as a `VerificationSkipped` *Warning* in `diagnostics[]` and the build still succeeds — their contracts are documentary, runtime-checked under `--mode debug`. |
 | `Unverified`    | Compiled with `--no-verify` (ESBMC skipped)  |
 | `CompileFailed` | Parse error, type error, module load error, or link failure |
-| `VerifyFailed`  | ESBMC found a counterexample, timed out, errored, or was not found |
+| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
 
 ### Verified Example
 
@@ -2755,7 +2755,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `function`         | string              | VerifyFailed      | Function where verification failed        |
 | `counterexample`   | string              | VerifyFailed      | Legacy description string                 |
 | `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |
-| `verify_status`    | string              | On backend failure | `"timeout"`, `"error"`, or `"tool_not_found"` |
+| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, or `"tool_not_found"` |
 | `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |
 
 ## Contracts Output JSON
@@ -2820,7 +2820,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `proven`        | ESBMC proved this contract holds for all inputs (bit-vector encoding, overflow modeled) |
 | `proven-ir`     | ESBMC proved this contract under integer-arithmetic encoding after BV timed out; overflow is not modeled by IR, but the BV caller preconditions still guard against it |
 | `failed`        | ESBMC found a counterexample violating this contract |
-| `unknown`       | Another contract in the same function failed; this one was not individually checked |
+| `unknown`       | ESBMC could not conclude for this contract — either `VERIFICATION UNKNOWN` was reported for the containing function (k-induction's forward condition unable to prove or falsify), or another contract in the same function failed and this one was not individually checked |
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]`. |
@@ -4234,7 +4234,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
     },
     "verify_status": {
       "type": "string",
-      "enum": ["timeout", "error", "tool_not_found"],
+      "enum": ["timeout", "unknown", "error", "tool_not_found"],
       "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample)"
     },
     "verify_message": {
@@ -5779,7 +5779,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `Verified`      | Compiled + all contracts proved by ESBMC. Functions whose bodies the verifier cannot model (`RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, effectful) are reported as a `VerificationSkipped` *Warning* in `diagnostics[]` and the build still succeeds — their contracts are documentary, runtime-checked under `--mode debug`. |
 | `Unverified`    | Compiled with `--no-verify` (ESBMC skipped)  |
 | `CompileFailed` | Parse error, type error, module load error, or link failure |
-| `VerifyFailed`  | ESBMC found a counterexample, timed out, errored, or was not found |
+| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
 
 ### Verified Example
 
@@ -5851,7 +5851,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `function`         | string              | VerifyFailed      | Function where verification failed        |
 | `counterexample`   | string              | VerifyFailed      | Legacy description string                 |
 | `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |
-| `verify_status`    | string              | On backend failure | `"timeout"`, `"error"`, or `"tool_not_found"` |
+| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, or `"tool_not_found"` |
 | `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |
 
 ## Contracts Output JSON
@@ -5916,7 +5916,7 @@ vow verify --help --human  # same legacy text (works on all subcommands)
 | `proven`        | ESBMC proved this contract holds for all inputs (bit-vector encoding, overflow modeled) |
 | `proven-ir`     | ESBMC proved this contract under integer-arithmetic encoding after BV timed out; overflow is not modeled by IR, but the BV caller preconditions still guard against it |
 | `failed`        | ESBMC found a counterexample violating this contract |
-| `unknown`       | Another contract in the same function failed; this one was not individually checked |
+| `unknown`       | ESBMC could not conclude for this contract — either `VERIFICATION UNKNOWN` was reported for the containing function (k-induction's forward condition unable to prove or falsify), or another contract in the same function failed and this one was not individually checked |
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]`. |
@@ -7329,7 +7329,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
     },
     "verify_status": {
       "type": "string",
-      "enum": ["timeout", "error", "tool_not_found"],
+      "enum": ["timeout", "unknown", "error", "tool_not_found"],
       "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample)"
     },
     "verify_message": {
@@ -7970,6 +7970,13 @@ enum VerifyOutcome {
     },
     Timeout {
         function: String,
+    },
+    /// ESBMC finished but returned `VERIFICATION UNKNOWN` — neither proof
+    /// nor counterexample. Distinct from Timeout (no wall-clock cutoff) and
+    /// from Error (no parser failure / process crash).
+    Unknown {
+        function: String,
+        reason: String,
     },
     Error {
         function: String,
@@ -8755,6 +8762,10 @@ fn verify_one_function(
         VerificationResult::Timeout => PerFuncResult::Halt(VerifyOutcome::Timeout {
             function: func.name.clone(),
         }),
+        VerificationResult::Unknown { reason } => PerFuncResult::Halt(VerifyOutcome::Unknown {
+            function: func.name.clone(),
+            reason,
+        }),
         VerificationResult::Proven | VerificationResult::ProvenIr => PerFuncResult::Ok,
         VerificationResult::ToolNotFound => PerFuncResult::Halt(VerifyOutcome::ToolNotFound),
         // The verifier-side gate already short-circuits this path; the
@@ -9015,6 +9026,15 @@ fn verify_outcome_to_output_with_skipped(
             vec![],
             Some("timeout".to_string()),
             None,
+        ),
+        VerifyOutcome::Unknown { function, reason } => (
+            BuildStatus::VerifyFailed {
+                function,
+                description: format!("verification result unknown: {reason}"),
+            },
+            vec![],
+            Some("unknown".to_string()),
+            Some(reason),
         ),
         VerifyOutcome::Error { function, message } => (
             BuildStatus::VerifyFailed {
@@ -9958,6 +9978,9 @@ fn update_contract_statuses(
                     }
                     VerificationResult::Timeout => {
                         entry.status = "timeout".to_string();
+                    }
+                    VerificationResult::Unknown { .. } => {
+                        entry.status = "unknown".to_string();
                     }
                     VerificationResult::ToolError(_) | VerificationResult::ToolNotFound => {
                         entry.status = "error".to_string();


### PR DESCRIPTION
## Summary
- Recognize `VERIFICATION UNKNOWN` as a third legitimate ESBMC outcome (alongside `SUCCESSFUL`/`FAILED`) in both compilers
- Surface as `VerifyFailed` with `verify_status: "unknown"` + `verify_message: <reason>`, mirroring the existing Timeout shape (exit code 1)
- Unify the BV→IR auto-fallback for Timeout and Unknown, with the established demote-IR-FAILED soundness rule applied to both
- `compare_verify` in `scripts/full_test.sh` now tolerates an empty counterexamples array when both compilers set a non-empty `verify_status` — closes the symmetric latent gap for Timeout too

Fixes #370.

## Test plan
- [x] `cargo test --all` green
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `scripts/full_test.sh` — **375 passed, 0 failed, 1 skipped** (the five reported examples `search`/`sum_range`/`vec_fill`/`gc`/`math` all pass; bootstrap triple test still produces a binary fixed point)
- [x] Codex review (`/codex:rescue`) addressed: self-hosted parallel-path IR retry on Unknown, schema enum, self-hosted contracts mapping

## Notes
- Spec updates in `docs/spec/cli.md` and `docs/spec/schemas/build-result.schema.json`
- `--help` / skill text regenerated via `scripts/generate_help.py`
- Per CLAUDE.md, merge via `gh pr merge --merge` (no squash/rebase) so the single commit lands as-is