### PR TITLE
fix: keep ESBMC UNKNOWN from IR-proof fallback

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -420,9 +420,9 @@ fn verify_collect_and_report(
         return 0;
     }
     if st == VERIFY_TIMEOUT() || st == VERIFY_UNKNOWN() {
-        // BV could neither prove nor falsify (Timeout or Unknown); retry
-        // with IR before failing (Phase D fallback). Mirrors the
-        // run_with_fallback logic in vow-verify/src/solver_strategy.rs.
+        // BV timeout may retry with IR before failing (Phase D fallback).
+        // UNKNOWN is an explicit inconclusive ESBMC result; do not let an IR
+        // proof hide it. Mirrors run_with_fallback in vow-verify.
         let bv_is_unknown: bool = st == VERIFY_UNKNOWN();
         let bv_label: String = { if bv_is_unknown { String::from("unknown") } else { String::from("timeout") } };
         let bv_label_upper: String = { if bv_is_unknown { String::from("UNKNOWN") } else { String::from("TIMEOUT") } };
@@ -433,7 +433,7 @@ fn verify_collect_and_report(
         };
         let bv_solver: String = resolve_auto_bv_solver(solver);
         let auto_enc: bool = is_auto_encoding(encoding);
-        if auto_enc && bv_solver != String::from("bitwuzla") {
+        if !bv_is_unknown && auto_enc && bv_solver != String::from("bitwuzla") {
             eprintln_str(str3(String::from("  "), f.name, String::from(": BV inconclusive, retrying with --z3 --ir...")));
             let vr2: VerifyResult = verify_function_ir_fallback(f, ir_mod, max_k_step, use_cache, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
             let st2: i64 = vr2.status;
@@ -444,7 +444,7 @@ fn verify_collect_and_report(
             if st2 == VERIFY_FAILED() {
                 // IR-only counterexamples can be infeasible under BV (no
                 // overflow modeling), so a FAILED here is unsound — surface
-                // the original BV outcome instead. Mirrors solver_strategy's
+                // the original timeout instead. Mirrors solver_strategy's
                 // demote-IR-FAILED rule.
                 eprintln_str(str4(String::from("  "), f.name, String::from(": "), bv_label_upper));
                 record_soft_fail(soft_meta, bv_label, bv_msg_initial, f.name);
@@ -911,12 +911,16 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                                 let ovr: VerifyResult = verify_collect(oh, ovf, t_eff);
                                 if ovr.status == VERIFY_FAILED() {
                                     verify_failed = true;
-                                } else if ovr.status == VERIFY_TIMEOUT() || ovr.status == VERIFY_UNKNOWN() {
-                                    // BV could neither prove nor falsify; retry with IR before failing.
+                                } else if ovr.status == VERIFY_TIMEOUT() {
+                                    // BV timed out; retry with IR before failing.
                                     let ovr2: VerifyResult = verify_function_ir_fallback(ovf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
                                     if ovr2.status != VERIFY_PROVEN() && ovr2.status != VERIFY_PROVEN_IR() {
                                         verify_failed = true;
                                     }
+                                } else if ovr.status == VERIFY_UNKNOWN() {
+                                    // UNKNOWN is an explicit inconclusive BV outcome; do not let
+                                    // a weaker IR proof turn it into a passing test.
+                                    verify_failed = true;
                                 }
                             }
                         }
@@ -942,13 +946,17 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                         let ovr: VerifyResult = verify_collect(oh, ovf, t_eff);
                         if ovr.status == VERIFY_FAILED() {
                             verify_failed = true;
-                        } else if ovr.status == VERIFY_TIMEOUT() || ovr.status == VERIFY_UNKNOWN() {
-                            // Mirror the bounded-pool drain: retry IR before treating Timeout/Unknown as passing.
+                        } else if ovr.status == VERIFY_TIMEOUT() {
+                            // Mirror the bounded-pool drain: retry IR before treating Timeout as passing.
                             // Without this, the common nfns <= t_jobs case silently accepts unverified functions.
                             let ovr2: VerifyResult = verify_function_ir_fallback(ovf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
                             if ovr2.status != VERIFY_PROVEN() && ovr2.status != VERIFY_PROVEN_IR() {
                                 verify_failed = true;
                             }
+                        } else if ovr.status == VERIFY_UNKNOWN() {
+                            // UNKNOWN is an explicit inconclusive BV outcome; do not let
+                            // a weaker IR proof turn it into a passing test.
+                            verify_failed = true;
                         }
                     }
                 }

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -688,11 +688,10 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
     };
     let mut used_combined: String = combined;
 
-    // Phase D: if BV could neither prove nor falsify (Timeout or Unknown)
-    // under Auto encoding and the BV solver is not Bitwuzla, retry once
-    // with --z3 --ir (integer encoding).
-    let bv_inconclusive: bool = status == VERIFY_TIMEOUT() || status == VERIFY_UNKNOWN();
-    if bv_inconclusive && auto_enc && bv_solver != String::from("bitwuzla") {
+    // Phase D: if BV times out under Auto encoding and the BV solver is not
+    // Bitwuzla, retry once with --z3 --ir (integer encoding). UNKNOWN is an
+    // explicit inconclusive ESBMC result; do not let an IR proof hide it.
+    if status == VERIFY_TIMEOUT() && auto_enc && bv_solver != String::from("bitwuzla") {
         let ir_solver: String = String::from("z3");
         let ir_encoding: String = String::from("ir");
         let ir_timeout: String = {
@@ -718,8 +717,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
         let bv_status: i64 = status;
         status = {
             // IR-only counterexamples can be infeasible under BV (no overflow modeling),
-            // so a FAILED here is inconclusive — report the original BV outcome
-            // (Timeout or Unknown) instead.
+            // so a FAILED here is inconclusive — report the original timeout instead.
             if s2 == VERIFY_PROVEN() { VERIFY_PROVEN_IR() }
             else if s2 == VERIFY_FAILED() { bv_status }
             else { s2 }

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -721,8 +721,14 @@ mod tests {
 
     /// UNKNOWN is an explicit ESBMC outcome, not a wall-clock timeout.
     /// Auto fallback must not let a weaker IR proof upgrade it to ProvenIr.
+    ///
+    /// Unix-only: the fake-esbmc is a `#!/bin/sh` script that cannot be
+    /// launched directly on Windows even with the chmod skipped.
+    #[cfg(unix)]
     #[test]
     fn fallback_auto_bv_unknown_does_not_retry_ir() {
+        use std::os::unix::fs::PermissionsExt;
+
         let dir = tempfile::tempdir().expect("tempdir");
         let esbmc = dir.path().join("fake-esbmc");
         std::fs::write(
@@ -739,13 +745,9 @@ echo "VERIFICATION UNKNOWN"
 "#,
         )
         .expect("write fake esbmc");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(&esbmc).expect("metadata").permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&esbmc, perms).expect("chmod fake esbmc");
-        }
+        let mut perms = std::fs::metadata(&esbmc).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&esbmc, perms).expect("chmod fake esbmc");
 
         let cfg = SolverConfig {
             solver: Solver::Auto,

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -239,11 +239,11 @@ pub fn run_with_fallback(
     let result = run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, &bv_config);
 
     match result {
-        // Both Timeout and Unknown mean "BV could neither prove nor disprove"
-        // — retry with Z3+IR. Same soundness rules apply to either fallback:
-        // an IR-only CE can be infeasible under BV, so we never return Failed
-        // from IR; we report the original BV outcome instead.
-        VerificationResult::Timeout | VerificationResult::Unknown { .. } => {
+        // Timeout means BV could neither prove nor disprove within the time
+        // budget, so auto mode may retry with Z3+IR. UNKNOWN is different:
+        // ESBMC reached an inconclusive verification result, and proving the
+        // weaker IR abstraction must not hide that BV outcome.
+        VerificationResult::Timeout => {
             // IR encoding only works with Z3. If the resolved BV solver was
             // Boolector or Z3, we can switch to Z3+IR. Bitwuzla cannot do IR.
             let can_ir = !matches!(bv_config.solver, Solver::Bitwuzla);
@@ -265,8 +265,8 @@ pub fn run_with_fallback(
                 VerificationResult::Proven => (VerificationResult::ProvenIr, ir_config),
                 // IR returned a counterexample, but IR does not model
                 // overflow — a CE found only under IR can be infeasible
-                // under BV. Report the BV outcome (Timeout or Unknown)
-                // rather than an unsound definitive Failed.
+                // under BV. Report the original timeout rather than an
+                // unsound definitive Failed.
                 VerificationResult::Failed(_) => (result, ir_config),
                 other => (other, ir_config),
             }
@@ -717,6 +717,52 @@ mod tests {
             }
             other => panic!("unexpected result: {other:?}"),
         }
+    }
+
+    /// UNKNOWN is an explicit ESBMC outcome, not a wall-clock timeout.
+    /// Auto fallback must not let a weaker IR proof upgrade it to ProvenIr.
+    #[test]
+    fn fallback_auto_bv_unknown_does_not_retry_ir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let esbmc = dir.path().join("fake-esbmc");
+        std::fs::write(
+            &esbmc,
+            r#"#!/bin/sh
+for arg in "$@"; do
+    if [ "$arg" = "--ir" ]; then
+        echo "VERIFICATION SUCCESSFUL"
+        exit 0
+    fi
+done
+echo "Unable to prove or falsify the program, giving up."
+echo "VERIFICATION UNKNOWN"
+"#,
+        )
+        .expect("write fake esbmc");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&esbmc).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&esbmc, perms).expect("chmod fake esbmc");
+        }
+
+        let cfg = SolverConfig {
+            solver: Solver::Auto,
+            encoding: Encoding::Auto,
+            timeout_secs: Some(5),
+        };
+        let (result, resolved) =
+            run_with_fallback(&esbmc, "int main(void) { return 0; }", 5, "main", &cfg);
+
+        match result {
+            VerificationResult::Unknown { reason } => {
+                assert!(reason.contains("Unable to prove or falsify"));
+            }
+            other => panic!("UNKNOWN must not be upgraded by IR fallback: {other:?}"),
+        }
+        assert_eq!(resolved.solver, Solver::Boolector);
+        assert_eq!(resolved.encoding, Encoding::Bv);
     }
 
     /// Phase D: when BV times out under Auto encoding (non-Bitwuzla solver),


### PR DESCRIPTION
### Motivation
- The auto fallback path could upgrade ESBMC `VERIFICATION UNKNOWN` to a successful `ProvenIr` when the weaker IR encoding proved the property, which undermines verification integrity by hiding an inconclusive BV outcome.
- UNKNOWN is an explicit inconclusive verifier outcome and must be surfaced to callers/CI rather than consumed by a weaker abstraction.

### Description
- Change Rust fallback logic so only BV `Timeout` triggers the Z3+IR retry; `VerificationResult::Unknown` is no longer grouped with `Timeout` in `run_with_fallback` (`vow-verify/src/solver_strategy.rs`).
- Add a unit regression test that uses a fake ESBMC which returns `VERIFICATION UNKNOWN` for BV and `VERIFICATION SUCCESSFUL` for `--ir`, asserting UNKNOWN is not upgraded (new test in `vow-verify/src/solver_strategy.rs`).
- Mirror the same timeout-only fallback policy in the self-hosted verifier and test-run paths by updating `compiler/verifier.vow` and `compiler/main.vow` so `VERIFY_UNKNOWN()` does not trigger the IR fallback and remains an inconclusive outcome.
- Update wording/comments to document that UNKNOWN is an explicit ESBMC outcome and must not be hidden by the weaker IR abstraction.

### Testing
- Ran `cargo test -p vow-verify fallback_auto_bv_unknown_does_not_retry_ir` which passed.
- Ran the full `cargo test -p vow-verify` suite which completed with all tests passing in that crate.
- Built the workspace with `cargo build --all` which completed successfully in this environment.
- Verified the self-hosted compiler path with `target/debug/vow build --no-verify compiler/main.vow -o /tmp/vow_main_check` which produced expected output.
- Attempted `cargo test --all` but it failed in this environment due to missing external dependencies (`esbmc` and `libvow_runtime.a`); those failures are environment-related and unrelated to the change (tests that exercise ESBMC/toolchain reported `ESBMC not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0420e54e108332943471a6f11ab317)