### PR TITLE
ci: cache cargo deps in build-and-test + bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Cache ESBMC
         id: cache-esbmc
@@ -88,6 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Cache ESBMC
         id: cache-esbmc
         uses: actions/cache@v5


### PR DESCRIPTION
Closes #395.

Adds `Swatinem/rust-cache@v2` after the `dtolnay/rust-toolchain@stable`
step in both the `build-and-test` and `bootstrap` jobs of
`.github/workflows/ci.yml`.

## Why

Per the deferred feedback on PR #393, Stage 0 of `bootstrap` is
`cargo build --all --release` on a cold toolchain — 10–20 min on a
fresh runner before Stage 1 starts. The 90-minute ceiling is currently
generous, but caching now removes the headroom risk before it flakes.
`build-and-test` does the same cold build (debug + llvm-cov) so it
gets the same treatment for consistency.

## Why no `with:` block

Swatinem v2's defaults (key from `Cargo.lock` SHA + rustc version + job
ID, save only on default branch, prune `target/` cruft before save)
are exactly what we want. The two jobs get separate caches because the
default key includes `${{ github.job }}`, so debug vs release
artifacts do not collide.

## Out of scope

`release.yml` (manual `workflow_dispatch` only) and `cargo-mutants.yml`
(nightly cron with 8-shard fan-out) also have cold cargo builds. The
issue explicitly scopes to `build-and-test` + `bootstrap`; extending
to the others is a separate follow-up.

## Test plan

- [ ] First post-merge run: cache miss expected, no speedup, cache populated.
- [ ] Second post-merge run on `main`: cache hit expected — `cargo build` step drops from full compile to a near-instant link.
- [ ] Bootstrap fixed-point check (`sha256(vowc2) == sha256(vowc3)`) still passes — caching `target/` only restores deps, not workspace binaries, so Stage 0 always relinks fresh.