### PR TITLE
driver: shorten run_build phases (#178)

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -623,8 +623,8 @@ fn build_verify_phase(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: 
 // Returns the post-drain `all_proven` flag (0 if any in-flight job failed,
 // otherwise the input value).
 //
-// A no-op when `in_flight_h` is empty (e.g. `--no-verify` path that never
-// reached `build_verify_phase`); callers may invoke it unconditionally.
+// A no-op when `in_flight_h` is empty; callers may invoke it unconditionally
+// without a do_verify guard if desired.
 fn build_drain_verify_phase(in_flight_h: Vec<i64>, in_flight_fi: Vec<i64>, fns: Vec<IrFunction>, ir_mod: IrModule, ces: Vec<VerifyCE>, soft_meta: Vec<String>, path: String, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String, vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, all_proven_in: i64) -> i64 [io] {
     let mut all_proven: i64 = all_proven_in;
     while in_flight_h.len() > 0 {

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -564,6 +564,103 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
     0
 }
 
+// Spawn-with-FIFO-drain phase of `run_build`. Mirrors `run_verify_loop` but
+// leaves the final drain to `build_drain_verify_phase` so the orchestrator can
+// run codegen in parallel with in-flight ESBMC processes.
+//
+// State threading (Vow Vecs share heap backing across by-value copies, so
+// pushes/removes visible to the caller — see compiler/frontend.vow:202-204):
+//   - `in_flight_h`, `in_flight_fi`: caller-allocated FIFO queues. This phase
+//     pushes new handles and pre-drains when the pool is full. Remaining
+//     entries are drained by `build_drain_verify_phase` after codegen.
+//   - `ces`, `soft_meta`: counterexample + soft-fail accumulators threaded
+//     through to `verify_collect_and_report`.
+// Returns `[all_proven, any_skipped]`.
+fn build_verify_phase(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec<i64>, dctx: DiagCtx, path: String, ces: Vec<VerifyCE>, soft_meta: Vec<String>, in_flight_h: Vec<i64>, in_flight_fi: Vec<i64>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
+                     vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, jobs: i64) -> Vec<i64> [io] {
+    let mut all_proven: i64 = 1;
+    let mut any_skipped: i64 = 0;
+    let mut fi: i64 = 0;
+    while fi < fns.len() {
+        let f: IrFunction = fns[fi];
+        let vows: Vec<IrVowEntry> = f.vows;
+        // Stop launching new ESBMC jobs once any in-flight verification has failed.
+        if vows.len() > 0 && all_proven == 1 {
+            while in_flight_h.len() >= jobs {
+                let oldest_h: i64 = in_flight_h[0];
+                let oldest_fi: i64 = in_flight_fi[0];
+                let oldest_f: IrFunction = fns[oldest_fi];
+                vec_i64_remove_front(in_flight_h);
+                vec_i64_remove_front(in_flight_fi);
+                let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+                if proven == 0 {
+                    all_proven = 0;
+                }
+            }
+            if all_proven == 1 {
+                if skip_if_non_modelable(f, ir_mod, const_fn_indices, dctx) {
+                    // Fail closed: a non-modelable function is not statically proved.
+                    any_skipped = 1;
+                } else {
+                    eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
+                    let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+                    in_flight_h.push(h);
+                    in_flight_fi.push(fi);
+                }
+            }
+        }
+        fi = fi + 1;
+    }
+    let result: Vec<i64> = Vec::new();
+    result.push(all_proven);
+    result.push(any_skipped);
+    result
+}
+
+// Post-codegen FIFO drain phase of `run_build`. Collects results from
+// every ESBMC process still in flight after `build_verify_phase` returned
+// and codegen completed. Mutates `ces` / `soft_meta` via shared Vec backings.
+// Returns the post-drain `all_proven` flag (0 if any in-flight job failed,
+// otherwise the input value).
+//
+// A no-op when `in_flight_h` is empty (e.g. `--no-verify` path that never
+// reached `build_verify_phase`); callers may invoke it unconditionally.
+fn build_drain_verify_phase(in_flight_h: Vec<i64>, in_flight_fi: Vec<i64>, fns: Vec<IrFunction>, ir_mod: IrModule, ces: Vec<VerifyCE>, soft_meta: Vec<String>, path: String, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String, vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, all_proven_in: i64) -> i64 [io] {
+    let mut all_proven: i64 = all_proven_in;
+    while in_flight_h.len() > 0 {
+        let oldest_h: i64 = in_flight_h[0];
+        let oldest_fi: i64 = in_flight_fi[0];
+        let oldest_f: IrFunction = fns[oldest_fi];
+        vec_i64_remove_front(in_flight_h);
+        vec_i64_remove_front(in_flight_fi);
+        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+        if proven == 0 {
+            all_proven = 0;
+        }
+    }
+    all_proven
+}
+
+// Codegen phase: emits the native object via Cranelift FFI and links it.
+// Returns 0 on success. On failure (`clif_emit_module` returns -1 = compile,
+// -2 = link), the helper emits the `CompileFailed` JSON itself and returns 1;
+// the orchestrator propagates that as the process exit code. Behavior matches
+// the inline branches the original `run_build` carried.
+fn build_codegen_phase(ir_mod: IrModule, out: String, mode: i64, trace: i64, dctx: DiagCtx) -> i64 [io] {
+    let result: i64 = clif_emit_module(ir_mod, out, mode, trace);
+    if result == -1 {
+        eprintln_str(String::from("compilation failed"));
+        diag_emit_build_verify_json(String::from("CompileFailed"), String::from(""), dctx, Vec::new());
+        return 1;
+    }
+    if result == -2 {
+        eprintln_str(String::from("link failed"));
+        diag_emit_build_verify_json(String::from("CompileFailed"), String::from(""), dctx, Vec::new());
+        return 1;
+    }
+    0
+}
+
 fn run_build(argv: Vec<String>) -> i32 [io] {
     let path: String = frontend_path_from_argv(argv, true);
     let fr: LoweredFrontend = frontend_lower_path(path);
@@ -651,64 +748,17 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     let in_flight_fi: Vec<i64> = Vec::new();
     let const_fn_indices: Vec<i64> = detect_const_fns(ir_mod);
     if do_verify {
-        let mut fi: i64 = 0;
-        while fi < fns.len() {
-            let f: IrFunction = fns[fi];
-            let vows: Vec<IrVowEntry> = f.vows;
-            // Stop launching new ESBMC jobs once any in-flight verification has failed.
-            if vows.len() > 0 && all_proven == 1 {
-                while in_flight_h.len() >= jobs {
-                    let oldest_h: i64 = in_flight_h[0];
-                    let oldest_fi: i64 = in_flight_fi[0];
-                    let oldest_f: IrFunction = fns[oldest_fi];
-                    vec_i64_remove_front(in_flight_h);
-                    vec_i64_remove_front(in_flight_fi);
-                    let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
-                    if proven == 0 {
-                        all_proven = 0;
-                    }
-                }
-                if all_proven == 1 {
-                    if skip_if_non_modelable(f, ir_mod, const_fn_indices, dctx) {
-                        // Fail closed: a non-modelable function is not statically proved.
-                        any_skipped = 1;
-                    } else {
-                        eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
-                        let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
-                        in_flight_h.push(h);
-                        in_flight_fi.push(fi);
-                    }
-                }
-            }
-            fi = fi + 1;
-        }
+        let phase_result: Vec<i64> = build_verify_phase(fns, ir_mod, const_fn_indices, dctx, path, ces, soft_meta, in_flight_h, in_flight_fi, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max, jobs);
+        if phase_result[0] == 0 { all_proven = 0; }
+        if phase_result[1] == 1 { any_skipped = 1; }
     }
-    let result: i64 = clif_emit_module(ir_mod, out, mode, trace);
-    if result == -1 {
-        eprintln_str(String::from("compilation failed"));
-        diag_emit_build_verify_json(String::from("CompileFailed"), String::from(""), dctx, Vec::new());
-        return 1;
-    }
-    if result == -2 {
-        eprintln_str(String::from("link failed"));
-        diag_emit_build_verify_json(String::from("CompileFailed"), String::from(""), dctx, Vec::new());
-        return 1;
-    }
+    let codegen_status: i64 = build_codegen_phase(ir_mod, out, mode, trace, dctx);
+    if codegen_status != 0 { return 1; }
     if !do_verify {
         diag_emit_build_verify_json(String::from("Unverified"), out, dctx, Vec::new());
         return 0;
     }
-    while in_flight_h.len() > 0 {
-        let oldest_h: i64 = in_flight_h[0];
-        let oldest_fi: i64 = in_flight_fi[0];
-        let oldest_f: IrFunction = fns[oldest_fi];
-        vec_i64_remove_front(in_flight_h);
-        vec_i64_remove_front(in_flight_fi);
-        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
-        if proven == 0 {
-            all_proven = 0;
-        }
-    }
+    all_proven = build_drain_verify_phase(in_flight_h, in_flight_fi, fns, ir_mod, ces, soft_meta, path, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max, all_proven);
     let status_str: String = {
         if all_proven == 0 { String::from("VerifyFailed") }
         else if any_skipped == 1 { String::from("Skipped") }

--- a/scripts/measure_bootstrap_rss.sh
+++ b/scripts/measure_bootstrap_rss.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Measure peak RSS of build/vowc compiling compiler/main.vow.
+# Used as baseline + post-refactor gate for issue #178 (driver lifetimes).
+#
+# Default: 3 samples of `--no-verify` compilation (the cleanest signal for
+# driver-side memory; ESBMC subprocesses dominate verify-mode RSS and are a
+# separate concern tracked in #175 / #179).
+#
+# Env:
+#   VOW_RSS_SAMPLES         (default 3)  samples per configuration
+#   VOW_RSS_INCLUDE_VERIFY  (default 0)  also measure --verify-jobs 1 (slow)
+#   VOW_RSS_OUT             (default build/bootstrap_rss.json)
+#
+# Output: writes JSON to $VOW_RSS_OUT and a one-line summary to stdout.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SAMPLES="${VOW_RSS_SAMPLES:-3}"
+INCLUDE_VERIFY="${VOW_RSS_INCLUDE_VERIFY:-0}"
+OUT="${VOW_RSS_OUT:-build/bootstrap_rss.json}"
+
+if ! [[ "$SAMPLES" =~ ^[0-9]+$ ]] || [ "$SAMPLES" -lt 1 ]; then
+    echo "error: VOW_RSS_SAMPLES must be a positive integer (got: '$SAMPLES')" >&2
+    exit 1
+fi
+
+# Capability probe: /usr/bin/time must support -v and produce a "Maximum
+# resident set size" line. Mirrors bench/memory/run.sh:225-233.
+probe=$(mktemp)
+trap 'rm -f "$probe"' EXIT
+if ! /usr/bin/time -v -o "$probe" true >/dev/null 2>&1; then
+    echo "error: /usr/bin/time must support -v" >&2
+    exit 1
+fi
+if ! grep -q "Maximum resident set size" "$probe"; then
+    echo "error: /usr/bin/time -v output did not include 'Maximum resident set size'" >&2
+    exit 1
+fi
+
+if [ ! -x build/vowc ]; then
+    echo "error: build/vowc not found; run scripts/bootstrap.sh first" >&2
+    exit 1
+fi
+
+# Mirrors bench/memory/run.sh:131-134.
+parse_max_rss() {
+    awk -F': ' '/Maximum resident set size/ { print $2; exit }' "$1"
+}
+
+# Integer median over positional args.
+median() {
+    printf '%s\n' "$@" | sort -n | awk '
+        { a[NR]=$1 }
+        END {
+            n=NR
+            if (n%2==1) print a[(n+1)/2]
+            else print int((a[n/2] + a[n/2+1])/2)
+        }
+    '
+}
+
+# Run one configuration N times and echo the median peak RSS (kbytes).
+# Args: label, then the full vowc command (with placeholder output handled here).
+measure_one() {
+    local label="$1"; shift
+    local samples=() i tmplog tmpout rss
+    for ((i=1; i<=SAMPLES; i++)); do
+        tmplog=$(mktemp)
+        tmpout=$(mktemp "/tmp/vowc_rss_${label}_XXXX")
+        if ! /usr/bin/time -v -o "$tmplog" "$@" -o "$tmpout" >/dev/null 2>&1; then
+            echo "--- /usr/bin/time output ($label sample $i) ---" >&2
+            cat "$tmplog" >&2
+            echo "error: measurement failed for $label" >&2
+            rm -f "$tmplog" "$tmpout"
+            return 1
+        fi
+        rss=$(parse_max_rss "$tmplog")
+        if [ -z "$rss" ]; then
+            cat "$tmplog" >&2
+            echo "error: could not extract max RSS for $label" >&2
+            rm -f "$tmplog" "$tmpout"
+            return 1
+        fi
+        samples+=("$rss")
+        rm -f "$tmplog" "$tmpout"
+    done
+    echo "  samples ($label): ${samples[*]}" >&2
+    median "${samples[@]}"
+}
+
+mkdir -p build
+
+echo "Measuring build/vowc build --no-verify compiler/main.vow ($SAMPLES samples)..." >&2
+nv_rss=$(measure_one no_verify build/vowc build --no-verify compiler/main.vow)
+echo "  median peak RSS (kbytes): $nv_rss" >&2
+
+verify_block='"stage2_default_kb": null'
+if [ "$INCLUDE_VERIFY" = "1" ]; then
+    echo "Measuring build/vowc build --verify-jobs 1 compiler/main.vow ($SAMPLES samples)..." >&2
+    v_rss=$(measure_one verify_j1 build/vowc build --verify-jobs 1 compiler/main.vow)
+    echo "  median peak RSS (kbytes): $v_rss" >&2
+    verify_block="\"stage2_default_kb\": $v_rss"
+fi
+
+cat > "$OUT" <<EOF
+{
+    "stage2_no_verify_kb": $nv_rss,
+    $verify_block,
+    "samples": $SAMPLES
+}
+EOF
+
+echo "Wrote $OUT"
+echo "  stage2_no_verify_kb = $nv_rss"
+if [ "$INCLUDE_VERIFY" = "1" ]; then
+    echo "  stage2_default_kb   = $v_rss"
+fi

--- a/vow/src/frontend.rs
+++ b/vow/src/frontend.rs
@@ -268,11 +268,13 @@ mod tests {
         assert_eq!(bundle.module().items.len(), 2);
         assert!(bundle.ir().is_none());
         assert_eq!(bundle.dependencies().paths().len(), 2);
-        assert!(bundle
-            .dependencies()
-            .paths()
-            .iter()
-            .any(|path| path.ends_with("lib.vow")));
+        assert!(
+            bundle
+                .dependencies()
+                .paths()
+                .iter()
+                .any(|path| path.ends_with("lib.vow"))
+        );
     }
 
     #[test]
@@ -290,11 +292,13 @@ mod tests {
         assert!(bundle.diagnostics().is_empty());
         assert!(bundle.ir().is_some());
         assert_eq!(bundle.dependencies().paths().len(), 2);
-        assert!(bundle
-            .dependencies()
-            .paths()
-            .iter()
-            .any(|path| path.ends_with("main.vow")));
+        assert!(
+            bundle
+                .dependencies()
+                .paths()
+                .iter()
+                .any(|path| path.ends_with("main.vow"))
+        );
     }
 
     #[test]
@@ -324,11 +328,13 @@ mod tests {
                 .unwrap();
         assert_eq!(bundle.module().name, "TestLib");
         assert_eq!(bundle.dependencies().paths().len(), 2);
-        assert!(bundle
-            .dependencies()
-            .paths()
-            .iter()
-            .any(|p| p.ends_with("lib.vow")));
+        assert!(
+            bundle
+                .dependencies()
+                .paths()
+                .iter()
+                .any(|p| p.ends_with("lib.vow"))
+        );
     }
 
     #[test]
@@ -343,10 +349,12 @@ mod tests {
         let error = prepare_frontend(&root, FrontendGoal::MergedAst).unwrap_err();
 
         assert_eq!(error.failure_message(), "module load error");
-        assert!(error
-            .diagnostics()
-            .iter()
-            .any(|diag| diag.message.contains("cannot load module `missing`")));
+        assert!(
+            error
+                .diagnostics()
+                .iter()
+                .any(|diag| diag.message.contains("cannot load module `missing`"))
+        );
     }
 
     #[test]

--- a/vow/src/frontend.rs
+++ b/vow/src/frontend.rs
@@ -44,12 +44,27 @@ impl FrontendBundle {
         &self.module
     }
 
+    #[cfg(test)]
     pub(crate) fn dependencies(&self) -> &DependencyManifest {
         &self.deps
     }
 
     pub(crate) fn ir(&self) -> Option<&Arc<vow_ir::Module>> {
         self.ir.as_ref()
+    }
+
+    // Consume the bundle, dropping the AST `Module` field, and return only
+    // the parts the build pipeline still needs after lowering. Lets callers
+    // free the largest leftover frontend allocation right after IR
+    // extraction instead of carrying it through codegen + verify. See #178.
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        Vec<Diagnostic>,
+        Option<Arc<vow_ir::Module>>,
+        DependencyManifest,
+    ) {
+        (self.diagnostics, self.ir, self.deps)
     }
 }
 
@@ -253,13 +268,11 @@ mod tests {
         assert_eq!(bundle.module().items.len(), 2);
         assert!(bundle.ir().is_none());
         assert_eq!(bundle.dependencies().paths().len(), 2);
-        assert!(
-            bundle
-                .dependencies()
-                .paths()
-                .iter()
-                .any(|path| path.ends_with("lib.vow"))
-        );
+        assert!(bundle
+            .dependencies()
+            .paths()
+            .iter()
+            .any(|path| path.ends_with("lib.vow")));
     }
 
     #[test]
@@ -277,13 +290,11 @@ mod tests {
         assert!(bundle.diagnostics().is_empty());
         assert!(bundle.ir().is_some());
         assert_eq!(bundle.dependencies().paths().len(), 2);
-        assert!(
-            bundle
-                .dependencies()
-                .paths()
-                .iter()
-                .any(|path| path.ends_with("main.vow"))
-        );
+        assert!(bundle
+            .dependencies()
+            .paths()
+            .iter()
+            .any(|path| path.ends_with("main.vow")));
     }
 
     #[test]
@@ -313,13 +324,11 @@ mod tests {
                 .unwrap();
         assert_eq!(bundle.module().name, "TestLib");
         assert_eq!(bundle.dependencies().paths().len(), 2);
-        assert!(
-            bundle
-                .dependencies()
-                .paths()
-                .iter()
-                .any(|p| p.ends_with("lib.vow"))
-        );
+        assert!(bundle
+            .dependencies()
+            .paths()
+            .iter()
+            .any(|p| p.ends_with("lib.vow")));
     }
 
     #[test]
@@ -334,12 +343,10 @@ mod tests {
         let error = prepare_frontend(&root, FrontendGoal::MergedAst).unwrap_err();
 
         assert_eq!(error.failure_message(), "module load error");
-        assert!(
-            error
-                .diagnostics()
-                .iter()
-                .any(|diag| diag.message.contains("cannot load module `missing`"))
-        );
+        assert!(error
+            .diagnostics()
+            .iter()
+            .any(|diag| diag.message.contains("cannot load module `missing`")));
     }
 
     #[test]

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -9297,8 +9297,7 @@ fn run_pipeline_from_frontend(
     // final BuildOutput; `ir_module` is the only large allocation we keep
     // alive past this point (shared via Arc with the verify thread). See #178.
     let (all_diagnostics, ir_opt, deps) = frontend.into_parts();
-    let ir_module =
-        ir_opt.expect("LoweredIr goal must produce IR for build pipeline");
+    let ir_module = ir_opt.expect("LoweredIr goal must produce IR for build pipeline");
 
     if dump_ir {
         print!("{}", vow_ir::print_module(&ir_module));
@@ -9359,9 +9358,9 @@ fn run_pipeline_from_frontend(
         None
     };
     // Skip the dependency-content hash when the cache is disabled — no point reading every dep file with no possible hit/store. `and_then` propagates a None from `cache_key` (fail-closed on per-dep canonicalize/open/read errors) so neither lookup nor store fires with an incomplete dep set.
-    let cache_key = compile_cache.as_ref().and_then(|_| {
-        cache::CompileCache::cache_key(&deps, &mode_str, &trace_str)
-    });
+    let cache_key = compile_cache
+        .as_ref()
+        .and_then(|_| cache::CompileCache::cache_key(&deps, &mode_str, &trace_str));
     if compile_cache.is_some() && cache_key.is_none() {
         eprintln!("warning: compile cache bypassed — one or more dependencies could not be hashed");
     }

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -9291,11 +9291,14 @@ fn run_pipeline_from_frontend(
     jobs: usize,
     config: &SolverConfig,
 ) -> BuildOutput {
-    let all_diagnostics = frontend.diagnostics().to_vec();
-    let ir_module = frontend
-        .ir()
-        .cloned()
-        .expect("LoweredIr goal must produce IR for build pipeline");
+    // Consume the frontend bundle immediately so the AST `Module` field can
+    // be dropped before codegen + verify start. The `deps` manifest survives
+    // for the cache-key computation below; `all_diagnostics` flows into the
+    // final BuildOutput; `ir_module` is the only large allocation we keep
+    // alive past this point (shared via Arc with the verify thread). See #178.
+    let (all_diagnostics, ir_opt, deps) = frontend.into_parts();
+    let ir_module =
+        ir_opt.expect("LoweredIr goal must produce IR for build pipeline");
 
     if dump_ir {
         print!("{}", vow_ir::print_module(&ir_module));
@@ -9357,7 +9360,7 @@ fn run_pipeline_from_frontend(
     };
     // Skip the dependency-content hash when the cache is disabled — no point reading every dep file with no possible hit/store. `and_then` propagates a None from `cache_key` (fail-closed on per-dep canonicalize/open/read errors) so neither lookup nor store fires with an incomplete dep set.
     let cache_key = compile_cache.as_ref().and_then(|_| {
-        cache::CompileCache::cache_key(frontend.dependencies(), &mode_str, &trace_str)
+        cache::CompileCache::cache_key(&deps, &mode_str, &trace_str)
     });
     if compile_cache.is_some() && cache_key.is_none() {
         eprintln!("warning: compile cache bypassed — one or more dependencies could not be hashed");


### PR DESCRIPTION
## Summary

Refactors `run_build` in both compilers to split the build pipeline into phase helpers with clearer ownership boundaries, per issue #178.

- **Self-hosted (`compiler/main.vow`)**: `run_build` shrinks from 165 to ~110 lines by extracting `build_verify_phase`, `build_drain_verify_phase`, and `build_codegen_phase`. The orchestrator now reads top-to-bottom as frontend → flag-parse → verify-spawn → codegen → verify-drain → emit.
- **Rust (`vow/src/main.rs`, `vow/src/frontend.rs`)**: adds `FrontendBundle::into_parts(self)` and switches `run_pipeline_from_frontend` to consume the bundle immediately after IR extraction. Drops the merged AST (`module: Module`) right after lowering instead of holding it across codegen + verify.
- **Infra (`scripts/measure_bootstrap_rss.sh`)**: new helper that runs `/usr/bin/time -v` over Stage-2-shaped compiles, parses peak RSS, and writes JSON. Default is median of 3 `--no-verify` samples. Available for any future #178 work to validate against.

## Empirical RSS — flat, #178 stays open

Apples-to-apples measurement on the same bootstrap-run conditions:

| | Stage 2 `--no-verify` peak RSS | Samples |
|--|--|--|
| Baseline (no refactor) | 249,876 KB | 5 |
| With this PR | 250,208 KB | 5 |

Delta: +332 KB / +0.13%, well within the ~700 KB sample spread. **The refactor does not deliver the "peak RSS improves measurably" criterion from #178.**

Root cause (called out as Risk #1 in the implementation plan): Vow `Vec` field extraction creates a *shared* heap backing rather than transferring ownership (see the explanatory comment at `compiler/frontend.vow:202-204`). Function-return boundaries on the new phase helpers therefore don't actually release heap. The structural change is clean — the runtime semantics it's stacked on top of are what need to change for memory to drop.

**Issue #178 should stay open** after this merges. A follow-up needs to either teach the runtime to release heap on function-return / scope exit, or restructure data flow so the big aggregates (`IrModule`, `DiagCtx`, the in-flight queues) are owned linearly rather than copy-with-shared-backing.

## What the refactor still buys

- Bootstrap fixed point preserved: `sha256(vowc2) == sha256(vowc3)` at `06583951b390e1661a6b7533aea68bb2d275ad9dec54e874abb6466ed32e406e`.
- `cargo test --all --release` passes; `cargo clippy --all -- -D warnings` clean.
- `scripts/full_test.sh`: 380 PASS / 1 pre-existing `geometry/verify` failure (reproduces on `main` — unrelated to this PR; about an intermittent ESBMC-path lookup in the self-hosted verifier on `rect_area`).
- Drops the Rust AST `Module` field ~60 lines earlier in `run_pipeline_from_frontend` (the `frontend.dependencies()` chokepoint at the original `vow/src/main.rs:9360`).
- Phase boundaries are now ready for whatever the follow-up's deeper memory work needs to touch.

## Test plan

- [x] `cargo build --all --release` clean
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo test --all --release` — all crates pass
- [x] `scripts/bootstrap.sh --skip-cargo --stage3-no-verify` — sha256 fixed point matches
- [x] `scripts/full_test.sh` — 380 PASS (1 pre-existing FAIL, not introduced here)
- [x] `scripts/measure_bootstrap_rss.sh` — captured before/after baselines (see table above)
