### PR TITLE
fix(verify): write ESBMC scratch under $TMPDIR, not CWD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ compiler/main
 build/
 compiler/*.o
 compiler/*.vow.c
+/.vow-verify-tmp/
 /.claude/*.local.json
 /.claude/worktrees/
 /.chief/

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ compiler/main
 build/
 compiler/*.o
 compiler/*.vow.c
-/.vow-verify-tmp/
 /.claude/*.local.json
 /.claude/worktrees/
 /.chief/

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -223,18 +223,31 @@ fn esbmc_exists() -> bool [io] {
     esbmc_path().len() > 0
 }
 
-fn verify_tmp_dir() -> String {
-    String::from(".vow-verify-tmp")
-}
-
-fn verify_tmp_path(idx: i64) -> String [io] {
-    fs_mkdir(verify_tmp_dir());
-    let path: String = verify_tmp_dir();
-    path.push_str(String::from("/esbmc_"));
-    path.push_str(i64_to_str(time_unix_ms()));
-    path.push_str(String::from("_"));
-    path.push_str(i64_to_str(idx));
-    path.push_str(String::from(".c"));
+// Allocate a fresh secure scratch path for an ESBMC invocation. mktemp -d
+// atomically creates an unpredictable directory under $TMPDIR (or /tmp) with
+// mode 0700; we drop a fixed-name `esbmc.c` inside it. This mirrors the Rust
+// toolchain's `tempfile::Builder::new().suffix(".c").tempfile()` in
+// vow-verify/src/esbmc.rs — scratch lives under $TMPDIR rather than CWD, so
+// running `vow verify` from anywhere does not leak a directory next to the
+// user's source tree.
+fn verify_tmp_path() -> String [io] {
+    let pargs: Vec<String> = Vec::new();
+    pargs.push(String::from("-c"));
+    pargs.push(String::from("mktemp -d \"${TMPDIR:-/tmp}/vow-verify.XXXXXXXXXX\""));
+    let rc: i64 = process_run(String::from("sh"), pargs);
+    if rc != 0 {
+        // mktemp is POSIX-mandated. If it failed, the environment is broken
+        // (no /tmp, no $TMPDIR writable, no mktemp) and falling back to a
+        // predictable path would re-introduce the symlink-attack vector this
+        // function exists to avoid. Surface the failure via an empty path:
+        // the downstream fs_write will fail and the verifier will report a
+        // tool error instead of silently writing to an attacker-chosen path.
+        return String::from("");
+    }
+    let dir: String = string_trim(process_get_stdout());
+    let path: String = String::from("");
+    path.push_str(dir);
+    path.push_str(String::from("/esbmc.c"));
     path
 }
 
@@ -684,7 +697,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
     let auto_enc: bool = is_auto_encoding(encoding);
     let bv_solver: String = resolve_auto_bv_solver(solver);
     let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
-    let tmp_path: String = verify_tmp_path(0);
+    let tmp_path: String = verify_tmp_path();
     let r: EsbmcRun = run_esbmc(c_source, max_k_step, tmp_path, fn_name, solver, encoding, bv_timeout);
     if r.exit_code == -1 {
         return VerifyResult {
@@ -711,7 +724,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
         let ir_timeout: String = {
             if timeout_secs.len() > 0 { timeout_secs } else { DEFAULT_AUTO_TIMEOUT_STR() }
         };
-        let tmp_path2: String = verify_tmp_path(1);
+        let tmp_path2: String = verify_tmp_path();
         let r2: EsbmcRun = run_esbmc(c_source, max_k_step, tmp_path2, fn_name, ir_solver, ir_encoding, ir_timeout);
         if r2.exit_code == -1 {
             // ESBMC disappeared between BV and IR runs; surface consistently with verify_function_ir_fallback.
@@ -766,7 +779,7 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
     // No cache lookup or write — see the note above resolve_auto_bv_solver.
     // `use_cache` stays on the signature for caller-side symmetry with the
     // Rust toolchain but has no effect.
-    let tmp_path: String = verify_tmp_path(0);
+    let tmp_path: String = verify_tmp_path();
     let r: EsbmcRun = run_esbmc(c_source, max_k_step, tmp_path, fn_name, ir_solver, ir_encoding, ir_timeout);
     if r.exit_code == -1 {
         return VerifyResult {
@@ -801,7 +814,10 @@ fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_ca
     // No cache lookup or write — see the note above resolve_auto_bv_solver.
     // `use_cache` stays on the signature for caller-side symmetry with the
     // Rust toolchain but has no effect.
-    let tmp_path: String = verify_tmp_path(idx);
+    // `idx` (the function index, threaded through for symmetry with the
+    // Rust toolchain) is not needed here: verify_tmp_path's mktemp guarantees
+    // a unique path even when several jobs run concurrently.
+    let tmp_path: String = verify_tmp_path();
     let fn_name: String = f.name;
     let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
     let handle: i64 = start_esbmc(c_source, max_k_step, tmp_path, fn_name, solver, encoding, bv_timeout);


### PR DESCRIPTION
## Summary
- `compiler/verifier.vow:226-228` returned the relative path `.vow-verify-tmp`, so `vowc verify` (and `vowc build` without `--no-verify`) dropped a scratch dir in whatever the shell's CWD happened to be.
- Switch `verify_tmp_path` to `mktemp -d "${TMPDIR:-/tmp}/vow-verify.XXXXXXXXXX"`. Scratch now lives under `$TMPDIR` with mode 0700 and an unpredictable name, matching the Rust toolchain's `tempfile::Builder::new().suffix(".c").tempfile()` in `vow-verify/src/esbmc.rs`.
- Removes the no-longer-needed `idx` arg at the four call sites inside `verifier.vow` (mktemp guarantees per-call uniqueness).
- Drops the now-dead `/.vow-verify-tmp/` entry from `.gitignore`.

The earlier commit on this branch (f40d760) just gitignored the scratch directory; this commit removes that line and fixes the root cause instead.

## Test plan
- [x] `scripts/bootstrap.sh --skip-cargo` reaches the binary fixed point with the new helper.
- [x] `vowc verify examples/divide.vow` run from `/tmp/vowtest` leaves the dir empty; scratch lands under `/tmp/vow-verify.*/esbmc.c`.
- [x] `git status` is clean after running verify from anywhere.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vow-lang/codesmith/vow/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->