### PR TITLE
fix(lexer): add ensures postcondition to is_whitespace

### DIFF
--- a/compiler/lexer.vow
+++ b/compiler/lexer.vow
@@ -4,7 +4,8 @@ use token
 
 fn is_whitespace(b: i64) -> bool vow {
     requires: b >= 0,
-    requires: b <= 255
+    requires: b <= 255,
+    ensures: result == (b == 32 || b == 9 || b == 10 || b == 13)
 } {
     b == 32 || b == 9 || b == 10 || b == 13
 }

--- a/tests/verify/lexer_is_whitespace.vow
+++ b/tests/verify/lexer_is_whitespace.vow
@@ -1,0 +1,13 @@
+module LexerIsWhitespaceVerify
+
+fn is_whitespace(b: i64) -> bool vow {
+    requires: b >= 0,
+    requires: b <= 255,
+    ensures: result == (b == 32 || b == 9 || b == 10 || b == 13)
+} {
+    b == 32 || b == 9 || b == 10 || b == 13
+}
+
+fn main() -> i32 [io] {
+    if is_whitespace(32) { 0 } else { 1 }
+}


### PR DESCRIPTION
## Summary
- Tighten the contract on is_whitespace in compiler/lexer.vow with an ensures clause matching the predicate body: result == (b == 32 || b == 9 || b == 10 || b == 13).
- Previously the contract only constrained inputs (0 <= b <= 255), so the generated ESBMC harness called the function but discarded the returned boolean — a mutant returning the wrong value would still verify (vacuous harness).
- Add a standalone verification regression at tests/verify/lexer_is_whitespace.vow matching the existing convention.

Addresses clawpatch finding fnd_sig-feat-cli-command-0334d8e5f3-_e22cb63895 (revalidated: fixed).

## Test plan
- [ ] cargo fmt --all --check
- [ ] cargo check --workspace --all-targets
- [ ] cargo test --workspace
- [ ] verify tests/verify/lexer_is_whitespace.vow with the self-hosted compiler

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vow-lang/codesmith/vow/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->