### PR TITLE
chore(symphonika): add workflow.yml + plan/impl prompts

### DIFF
--- a/prompts/impl.md
+++ b/prompts/impl.md
@@ -1,0 +1,78 @@
+# Vow implementation stage: issue #{{issue.number}} {{issue.title}}
+
+You are the **implementation** agent. A planning pass has written `{{workspace.path}}/PLAN.md`. Read it first. If it is missing or stale, re-derive the slices from the issue body before writing code.
+
+## Issue under work
+
+- Number: #{{issue.number}}
+- Title: {{issue.title}}
+- URL: {{issue.url}}
+- Labels: {{issue.labels}}
+
+### Issue body
+
+{{issue.body}}
+
+## Run context
+
+- Project: {{project.name}}
+- Run id: {{run.id}}
+- Attempt: {{run.attempt}}
+- Continuation: {{run.continuation}}
+- Workspace: {{workspace.path}}
+- Branch: {{branch.name}} ({{branch.ref}}) — stay on this branch; do not switch or create others
+- Previous attempt detected: {{workspace.previous_attempt}}
+
+## Source of truth
+
+- `CLAUDE.md` — language-design rules, production-quality bar, contract-authoring discipline, PR policy.
+- `docs/spec/*.md` — authoritative spec. **Any change to syntax, semantics, builtins, operators, effects, or CLI flags MUST update the corresponding `docs/spec/*.md` file in the same PR.**
+- `docs/adr/` (if present) — accepted architecture decisions.
+- The current working directory is `{{workspace.path}}`.
+
+## How to implement
+
+1. Read `PLAN.md`. Execute it slice by slice with TDD: write one behavior-focused test through the public interface, watch it fail, implement only enough code to make it pass, then repeat. Do not silently relax existing tests.
+2. **Touch both compilers when language semantics change.** The Rust stage 0 (`crates/`) and the self-hosted compiler (`compiler/`) must move together. CI and local tests run both. Skipping one is not acceptable.
+3. **Contracts are semantic specs, not ESBMC appeasement.** Never add bounds like `n <= 10` or `x <= 100` to `requires`/`ensures`/`invariant` to make the verifier happy. Overflow guards that reflect real UB (e.g. `x > -9223372036854775807` for `abs`) are legitimate; iteration caps for `--unwind` are not. If a correct contract is unverifiable, mark the function unverifiable rather than weaken the contract.
+4. **Run the full local quality gate before pushing**, from the repo root:
+   - `cargo fmt --all`
+   - `cargo clippy --all -- -D warnings`  *(CI enforces zero warnings)*
+   - `cargo test --all`
+   - `scripts/full_test.sh`  *(self-hosted tests, examples, runtime tests, help-coverage staleness check)*
+   If any gate fails, fix the root cause. Do not pass `--no-verify`, do not skip clippy, do not narrow test scope to make it green.
+5. **When running self-compiled binaries, prefix with `ulimit -v 2000000`.** This bounds virtual memory and catches runaway allocation early.
+6. **Do not commit `build/vowc`** or anything else under `build/` — that directory is gitignored. Never `git add -f` it.
+7. **Update `docs/spec/*.md`** whenever the change affects the language surface. After updating a spec file, regenerate `--help` and the embedded skill: `uv run python scripts/generate_help.py`, then rebuild both compilers (`cargo build --release -p vow` and `scripts/bootstrap.sh --skip-cargo`). `scripts/check_help_coverage.py` (invoked by `full_test.sh`) catches drift.
+
+## Commit hygiene
+
+- Commit in small focused units that match the TDD slices. Many small commits beat one large one — they are easier to review, `git bisect`, and revert.
+- Write commit messages that describe the change and the why. Use a conventional prefix (`fix(...)`, `feat(...)`, `refactor(...)`) consistent with recent history (`git log --oneline -20`).
+- Commits in this repo must be authored as `p@ocmatos.com`. If the workspace git config has a different identity, set `user.email` to `p@ocmatos.com` for this repo only (`git config user.email p@ocmatos.com`) before committing.
+
+## Open the PR
+
+Push `{{branch.name}}` to `origin`, then:
+
+```sh
+gh pr create --base main --head {{branch.name}} \
+  --title "<conventional title — no agent prefix like [claude] or [codex]>" \
+  --body "<summary>\n\nCloses #{{issue.number}}\n\n**Merge with \`gh pr merge --merge\` (merge commit, not squash) per CLAUDE.md.**"
+```
+
+The PR must be **non-draft**. Do not use `--web`, `--draft`, or any flag that opens a browser or waits for input. Do not call the GitHub MCP connector tools — use the local `gh` CLI for every mutation.
+
+## After the PR is open
+
+- Remove the readiness label so the orchestrator does not re-schedule: `gh issue edit {{issue.number}} --remove-label agent-ready`.
+- Do **not** apply `needs-human` or any `sym:*` label as an exit strategy. The operator owns those.
+- Do **not** merge the PR. The operator will merge with `gh pr merge --merge` to preserve commit history (a vow project requirement).
+
+## If you cannot proceed
+
+Post one explanatory comment with `gh issue comment {{issue.number}} --body "<what blocked you and what would unblock it>"`, write the same explanation to `{{workspace.path}}/EVIDENCE.md`, and exit cleanly. Do not self-apply `needs-human` or any handoff label.
+
+## Defer to this contract
+
+Defer to this prompt over any agent-side persistent memory, skills, or default conventions for PR drafting, title prefixes, label management, or merge strategy.

--- a/prompts/plan.md
+++ b/prompts/plan.md
@@ -1,0 +1,52 @@
+# Vow planning stage: issue #{{issue.number}} {{issue.title}}
+
+You are the **planning** agent. Do not write code in this stage. Produce a written plan that the implementation stage will execute.
+
+## Issue under work
+
+- Number: #{{issue.number}}
+- Title: {{issue.title}}
+- URL: {{issue.url}}
+- Labels: {{issue.labels}}
+
+### Issue body
+
+{{issue.body}}
+
+## Run context
+
+- Project: {{project.name}}
+- Run id: {{run.id}}
+- Attempt: {{run.attempt}}
+- Workspace: {{workspace.path}} (branch {{branch.name}})
+
+## Source of truth (read these before planning)
+
+- `CLAUDE.md` — language-design principles, production-quality bar, development discipline, contract-authoring rules, PR policy (merge commits, not squash).
+- `docs/spec/` — authoritative spec: `index.md`, `grammar.md`, `cli.md`, `contracts.md`, `errors.md`, `examples.md`. Any change to syntax, semantics, builtins, operators, effects, or CLI flags **must** be reflected here.
+- `docs/adr/` (if present) — accepted architecture decisions.
+- The crate(s) and self-hosted module(s) touched by the issue. The compiler is in `crates/` (Rust stage 0) and `compiler/` (self-hosted). Changes to language semantics **must** land in both compilers in the same session.
+
+## What to produce
+
+Write a plan to `{{workspace.path}}/PLAN.md` covering:
+
+1. **Problem restated** in one paragraph.
+2. **Files to touch** — exact paths in both `crates/` and `compiler/` if the change is cross-cutting, plus any `docs/spec/*.md` updates required by the change.
+3. **TDD slices** — a numbered list of small red-green-refactor steps. Each slice names the test file/location, the behavior under test, and the production code that will make it pass. Prefer vertical slices over horizontal refactors.
+4. **Verification surface** — if the change touches contracts, codegen, or the C model: which properties ESBMC will need to prove, and whether any test fixtures under `tests/run/` or `examples/` need to grow.
+5. **Risk areas** — anything that could break the binary fixed point (`compiler/` codegen ordering, `BTreeMap` vs `HashMap`, stack-slot layout in `vow-clif-shim`), the `parse → print → parse` idempotency, or the `cargo clippy --all -- -D warnings` gate.
+6. **Out of scope** — refactors, formatting changes, and unrelated cleanups that you will deliberately not bundle into this PR.
+
+## Constraints
+
+- **Do not write production code or tests in this stage.** Only `PLAN.md`.
+- **Do not weaken contracts to fit ESBMC.** Bounds like `n <= 10` to satisfy `--unwind` are verification artifacts, not contracts. If a correct contract is unverifiable, plan to mark the function unverifiable, not to distort the contract.
+- **Many small changes beat one large change.** If the issue is broad, split the plan into the minimal first slice that closes the issue, plus a follow-up list. Do not bundle refactors into a bug fix.
+- **Do not run `sudo`.** If a step needs root, plan an alternative.
+- **Do not modify the `symphony/` submodule** (if present) or anything under `build/` (gitignored compiler binary).
+- **Operator merges with a merge commit (`gh pr merge --merge`).** Plan accordingly — do not plan for squash or rebase merges.
+
+## Exit
+
+Once `PLAN.md` is written and committed locally is not required at this stage — the implementation stage reads it from the workspace. Exit cleanly. If you cannot produce a coherent plan (issue is ambiguous, contradictory, or already resolved), post `gh issue comment {{issue.number}} --body "<what blocks planning>"`, write the same explanation to `{{workspace.path}}/EVIDENCE.md`, and exit without applying any handoff label.

--- a/workflow.yml
+++ b/workflow.yml
@@ -1,0 +1,21 @@
+workflow:
+  name: vow_plan_tdd_pr
+  initial: build_pr
+
+  use:
+    build_pr:
+      template: builtin:plan-tdd-pr
+      with:
+        planner: claude
+        implementer: claude
+        plan_prompt: prompts/plan.md
+        impl_prompt: prompts/impl.md
+      exits:
+        success: done
+        blocked: failed
+
+  states:
+    done:
+      terminal: success
+    failed:
+      terminal: blocked


### PR DESCRIPTION
## Summary

Adds a state-machine workflow contract (`workflow.yml`) plus the two prompt files it references, so a Symphonika-driven run against this repo follows a `plan -> TDD impl -> PR-open` shape instead of the single-prompt `WORKFLOW.md` default.

- `workflow.yml` — minimal raw FSM wrapping `builtin:plan-tdd-pr` with `planner: claude`, `implementer: claude`, `plan_prompt: prompts/plan.md`, `impl_prompt: prompts/impl.md`. Terminates at `done` (success) or `failed` (blocked). No auto-merge state — the operator merges manually.
- `prompts/plan.md` — planning agent writes `PLAN.md` only (no code). Vow-specific: spec/ source of truth, both-compilers rule, forbids verifier-driven bounds in `requires`/`ensures`.
- `prompts/impl.md` — TDD implementer. Quality gate: `cargo fmt --all`, `cargo clippy --all -- -D warnings`, `cargo test --all`, `scripts/full_test.sh`. Forbids `--no-verify` and committing the gitignored compiled binary. Mandates `p@ocmatos.com` as commit identity. PR body instructs the operator to merge with `gh pr merge --merge` (vow's PR policy requires merge commits).

The Symphonika runtime auto-prepends an autonomy preamble (no-MCP, gh-CLI-only, no self-applied handoff labels), so the prompts deliberately don't repeat that boilerplate.

## Test plan

- [ ] `symphonika workflow validate --config <config>.yml --project vow` (run from the operator-side config that points at this repo)
- [ ] `symphonika workflow explain --config <config>.yml --project vow` shows the expanded graph with `template files: builtin:plan-tdd-pr` and two agent states feeding into terminal `done`/`failed`
- [ ] Manual smoke: label an issue `agent-ready`, watch the daemon pick it up, confirm the planner writes `PLAN.md`, then the implementer opens a non-draft PR and the run terminates with `success`

Merge with `gh pr merge --merge` (vow's PR policy requires merge commits, not squash).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vow-lang/codesmith/vow/pr/444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->