### PR TITLE
Fix arena verify address cap assumption

### DIFF
--- a/vow-runtime/verify/arena.c
+++ b/vow-runtime/verify/arena.c
@@ -43,6 +43,10 @@ struct VowArena {
 #define CHUNK_LINK_BYTES        16
 #define CHUNK_TOTAL_OFFSET      8
 #define CHUNK_OVERSIZED_FLAG    ((uintptr_t)1 << 62)
+/* Intentionally aliased to CHUNK_OVERSIZED_FLAG: addresses must stay strictly
+ * below the flag bit so chunk-base arithmetic never collides with the
+ * oversized marker stored in the size word. Moving the flag bit moves the
+ * cap with it — that coupling is the point of the alias, not a coincidence. */
 #define ARENA_VERIFY_ADDR_CAP   CHUNK_OVERSIZED_FLAG
 #define CHUNK_PAYLOAD           4096
 #define OVERSIZED_THRESHOLD     2048

--- a/vow-runtime/verify/arena.c
+++ b/vow-runtime/verify/arena.c
@@ -76,7 +76,10 @@ static void* alloc_chunk(uintptr_t total, int oversized) {
          * top of the address space. */
         __ESBMC_assume(total <= ARENA_VERIFY_ADDR_CAP);
         __ESBMC_assume(base_addr <= ARENA_VERIFY_ADDR_CAP - total);
-        assert(base_addr <= ARENA_VERIFY_ADDR_CAP - total);
+        /* Regression assert in derived form: implied by the two assumes above
+         * but as a distinct expression, so ESBMC actually exercises it. A
+         * tautological repeat of the assume would be a verification no-op. */
+        assert(base_addr + total <= ARENA_VERIFY_ADDR_CAP);
         *(void**)base = NULL;  /* next-chunk link */
         uintptr_t word = total | (oversized ? CHUNK_OVERSIZED_FLAG : 0);
         *(uintptr_t*)((char*)base + CHUNK_TOTAL_OFFSET) = word;

--- a/vow-runtime/verify/arena.c
+++ b/vow-runtime/verify/arena.c
@@ -43,7 +43,7 @@ struct VowArena {
 #define CHUNK_LINK_BYTES        16
 #define CHUNK_TOTAL_OFFSET      8
 #define CHUNK_OVERSIZED_FLAG    ((uintptr_t)1 << 62)
-#define ARENA_VERIFY_ADDR_CAP   ((uintptr_t)1 << 62)
+#define ARENA_VERIFY_ADDR_CAP   CHUNK_OVERSIZED_FLAG
 #define CHUNK_PAYLOAD           4096
 #define OVERSIZED_THRESHOLD     2048
 

--- a/vow-runtime/verify/arena.c
+++ b/vow-runtime/verify/arena.c
@@ -43,15 +43,17 @@ struct VowArena {
 #define CHUNK_LINK_BYTES        16
 #define CHUNK_TOTAL_OFFSET      8
 #define CHUNK_OVERSIZED_FLAG    ((uintptr_t)1 << 62)
+#define ARENA_VERIFY_ADDR_CAP   ((uintptr_t)1 << 62)
 #define CHUNK_PAYLOAD           4096
 #define OVERSIZED_THRESHOLD     2048
 
 /* `addr + align - 1` could wrap uintptr_t for adversarial inputs. Safe here
- * because the harness constrains `align` to {1, 8, 16, 4096} and bounds
- * every chunk address via alloc_chunk's `(uintptr_t)base + total <= 1<<62`
- * assumption. Widening either bound (larger symbolic alignments, or removing
- * the chunk-base bound) requires a checked-add guard or explicit
- * __ESBMC_assume on the sum. */
+ * because the harness constrains `align` to {1, 8, 16, 4096} and bounds every
+ * chunk to alloc_chunk's non-wrapping low-address model:
+ * `total <= ARENA_VERIFY_ADDR_CAP` and
+ * `(uintptr_t)base <= ARENA_VERIFY_ADDR_CAP - total`. Widening either bound
+ * (larger symbolic alignments, or removing the chunk-base bound) requires a
+ * checked-add guard or explicit __ESBMC_assume on the sum. */
 static uintptr_t align_up(uintptr_t addr, uintptr_t align) {
     return (addr + align - 1) & ~(align - 1);
 }
@@ -67,11 +69,14 @@ static uintptr_t oversized_total(uintptr_t bytes, uintptr_t align) {
 static void* alloc_chunk(uintptr_t total, int oversized) {
     void* base = malloc(total);
     if (base != NULL) {
-        /* Real-world malloc returns addresses far below UINTPTR_MAX; no OS
-         * maps the top of the address space. Constrain the abstract pointer
-         * so ESBMC does not consider overflow scenarios that cannot occur
-         * on any real host. */
-        __ESBMC_assume((uintptr_t)base + total <= ((uintptr_t)1 << 62));
+        uintptr_t base_addr = (uintptr_t)base;
+        /* ESBMC models malloc addresses symbolically. Constrain the abstract
+         * pointer to the intended non-wrapping low-address model before any
+         * base + total arithmetic, matching real hosts that do not map the
+         * top of the address space. */
+        __ESBMC_assume(total <= ARENA_VERIFY_ADDR_CAP);
+        __ESBMC_assume(base_addr <= ARENA_VERIFY_ADDR_CAP - total);
+        assert(base_addr <= ARENA_VERIFY_ADDR_CAP - total);
         *(void**)base = NULL;  /* next-chunk link */
         uintptr_t word = total | (oversized ? CHUNK_OVERSIZED_FLAG : 0);
         *(uintptr_t*)((char*)base + CHUNK_TOTAL_OFFSET) = word;


### PR DESCRIPTION
Fixes #416.

## Summary
- replace the wrapped `base + total <= cap` ESBMC assumption with pre-add bounds on `total` and `base <= cap - total`
- add the requested regression assertion proving the non-wrapping base range immediately after the allocation assumptions
- update the `align_up` safety comment to name the non-wrapping low-address model

## Validation
- `cc -Wall -Wextra -Werror -fsyntax-only arena.c` passed from `vow-runtime/verify`
- `git diff --check` passed
- `cargo test -p vow-runtime` passed: 86 tests
- `timeout 300s make verify` from `vow-runtime/verify` reached ESBMC solving with default Bitwuzla and timed out
- `timeout 180s make verify ESBMC='esbmc --z3'` proved the base case, then timed out in the forward condition
- `timeout 180s make verify ESBMC='esbmc --boolector'` could not run because this ESBMC build has no Boolector support
- `timeout 900s scripts/full_test.sh` did not complete: it recorded an unrelated `issue400_internal_call_root_escape/test-expected` mismatch, then exited in Section 6 with `scripts/full_test.sh: line 84: /tmp/tmp.GoVXekMLNb/cmp_rust_2590971.json: No such file or directory` before reaching the arena ESBMC section

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vow-lang/codesmith/vow/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->