### PR TITLE
fix: keep contracts schema when ESBMC is missing

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3534,6 +3534,8 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |\n"));
     r.push_str(String::from("\n"));
+    r.push_str(String::from("When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.\n"));
+    r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow skill`\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("Generate or install the Claude Code skill document for the current compiler version. The skill is embedded in the compiler binary, ensuring the documentation always matches the installed toolchain.\n"));
@@ -6657,6 +6659,8 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
     r.push_str(String::from("| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow skill`\n"));
     r.push_str(String::from("\n"));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -9112,7 +9112,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     }
 
     // If --verify, run verification per function and update statuses
-    let exit_code: i32 = 0;
+    let mut exit_code: i32 = 0;
     if do_verify {
         if !esbmc_exists() {
             let mut ei_missing: i64 = 0;

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -9112,54 +9112,60 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     }
 
     // If --verify, run verification per function and update statuses
+    let exit_code: i32 = 0;
     if do_verify {
         if !esbmc_exists() {
-            eprintln_str(String::from("error: ESBMC not found; install ESBMC to run verification"));
-            return 1;
-        }
-        let const_fn_indices_c: Vec<i64> = detect_const_fns(ir_mod);
-        fi = 0;
-        while fi < nf {
-            let func: IrFunction = ir_mod.functions[fi];
-            if func.vows.len() > 0 {
-                let skip_reason: String = non_modelable_reason(func, ir_mod, const_fn_indices_c);
-                if skip_reason.len() > 0 {
-                    let mut ei: i64 = 0;
-                    while ei < e_func_ids.len() {
-                        if e_func_ids[ei] == func.id {
-                            e_statuses[ei] = String::from("skipped");
-                        }
-                        ei = ei + 1;
-                    }
-                } else {
-                    let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max_c, string_max_c, hashmap_max_c, btreemap_max_c);
-                    let st: i64 = vr.status;
-                    let mut ei: i64 = 0;
-                    while ei < e_func_ids.len() {
-                        if e_func_ids[ei] == func.id {
-                            if st == VERIFY_PROVEN() {
-                                e_statuses[ei] = String::from("proven");
-                            } else if st == VERIFY_PROVEN_IR() {
-                                e_statuses[ei] = String::from("proven-ir");
-                            } else if st == VERIFY_FAILED() {
-                                if vr.vow_id == e_vow_ids[ei] {
-                                    e_statuses[ei] = String::from("failed");
-                                } else {
-                                    e_statuses[ei] = String::from("unknown");
-                                }
-                            } else if st == VERIFY_TIMEOUT() {
-                                e_statuses[ei] = String::from("timeout");
-                            } else if st == VERIFY_UNKNOWN() {
-                                e_statuses[ei] = String::from("unknown");
-                            } else {
-                                e_statuses[ei] = String::from("error");
+            let mut ei_missing: i64 = 0;
+            while ei_missing < e_statuses.len() {
+                e_statuses[ei_missing] = String::from("error");
+                ei_missing = ei_missing + 1;
+            }
+            exit_code = 1;
+        } else {
+            let const_fn_indices_c: Vec<i64> = detect_const_fns(ir_mod);
+            fi = 0;
+            while fi < nf {
+                let func: IrFunction = ir_mod.functions[fi];
+                if func.vows.len() > 0 {
+                    let skip_reason: String = non_modelable_reason(func, ir_mod, const_fn_indices_c);
+                    if skip_reason.len() > 0 {
+                        let mut ei: i64 = 0;
+                        while ei < e_func_ids.len() {
+                            if e_func_ids[ei] == func.id {
+                                e_statuses[ei] = String::from("skipped");
                             }
+                            ei = ei + 1;
                         }
-                        ei = ei + 1;
+                    } else {
+                        let vr: VerifyResult = verify_function_full(func, ir_mod, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max_c, string_max_c, hashmap_max_c, btreemap_max_c);
+                        let st: i64 = vr.status;
+                        let mut ei: i64 = 0;
+                        while ei < e_func_ids.len() {
+                            if e_func_ids[ei] == func.id {
+                                if st == VERIFY_PROVEN() {
+                                    e_statuses[ei] = String::from("proven");
+                                } else if st == VERIFY_PROVEN_IR() {
+                                    e_statuses[ei] = String::from("proven-ir");
+                                } else if st == VERIFY_FAILED() {
+                                    if vr.vow_id == e_vow_ids[ei] {
+                                        e_statuses[ei] = String::from("failed");
+                                    } else {
+                                        e_statuses[ei] = String::from("unknown");
+                                    }
+                                } else if st == VERIFY_TIMEOUT() {
+                                    e_statuses[ei] = String::from("timeout");
+                                } else if st == VERIFY_UNKNOWN() {
+                                    e_statuses[ei] = String::from("unknown");
+                                } else {
+                                    e_statuses[ei] = String::from("error");
+                                }
+                            }
+                            ei = ei + 1;
+                        }
                     }
                 }
+                fi = fi + 1;
             }
-            fi = fi + 1;
         }
     }
 
@@ -9238,7 +9244,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     json.push_str(i64_to_str(n_skipped));
     json.push_str(String::from("}}"));
     print_str(json);
-    0
+    exit_code
 }
 
 fn main() -> i32 [io, read, write] {

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -79,6 +79,8 @@ vow contracts [OPTIONS] <source.vow>
 | `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
+When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
+
 ### `vow skill`
 
 Generate or install the Claude Code skill document for the current compiler version. The skill is embedded in the compiler binary, ensuring the documentation always matches the installed toolchain.

--- a/skills/vow/reference/cli.md
+++ b/skills/vow/reference/cli.md
@@ -79,6 +79,8 @@ vow contracts [OPTIONS] <source.vow>
 | `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
+When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
+
 ### `vow skill`
 
 Generate or install the Claude Code skill document for the current compiler version. The skill is embedded in the compiler binary, ensuring the documentation always matches the installed toolchain.

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -10109,7 +10109,6 @@ fn run_contracts_command(
             std::process::exit(1);
         }
     };
-    let all_diagnostics = frontend.diagnostics().to_vec();
     let ir_module = frontend
         .ir()
         .expect("LoweredIr goal must produce IR for contracts");
@@ -10139,21 +10138,23 @@ fn run_contracts_command(
         }
     }
 
+    let mut exit_code = 0;
     if verify {
         if find_esbmc().is_none() {
-            let output =
-                verify_outcome_to_output(VerifyOutcome::ToolNotFound, all_diagnostics, None);
-            output.emit_json();
-            std::process::exit(1);
+            for entry in &mut entries {
+                entry.status = "error".to_string();
+            }
+            exit_code = 1;
+        } else {
+            let verify_cache = if no_cache { None } else { VerifyCache::new() };
+            update_contract_statuses(
+                &mut entries,
+                ir_module,
+                verify_cache.as_ref(),
+                limits,
+                config,
+            );
         }
-        let verify_cache = if no_cache { None } else { VerifyCache::new() };
-        update_contract_statuses(
-            &mut entries,
-            ir_module,
-            verify_cache.as_ref(),
-            limits,
-            config,
-        );
     }
 
     let summary = build_contracts_summary(&entries);
@@ -10163,6 +10164,9 @@ fn run_contracts_command(
     };
     let json = serde_json::to_string(&result).expect("ContractsResult must be serializable");
     println!("{json}");
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
 }
 
 fn main() {

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2543,6 +2543,8 @@ vow contracts [OPTIONS] <source.vow>
 | `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
+When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
+
 ### `vow skill`
 
 Generate or install the Claude Code skill document for the current compiler version. The skill is embedded in the compiler binary, ensuring the documentation always matches the installed toolchain.
@@ -5652,6 +5654,8 @@ vow contracts [OPTIONS] <source.vow>
 | `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
 | `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
+
+When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
 
 ### `vow skill`
 

--- a/vow/tests/contracts.rs
+++ b/vow/tests/contracts.rs
@@ -62,6 +62,32 @@ fn contracts_divide_requires() {
 }
 
 #[test]
+fn contracts_verify_missing_esbmc_keeps_contracts_schema() {
+    let empty_path = tempfile::TempDir::new().unwrap();
+    let out = Command::new(vow_bin())
+        .args([
+            "contracts",
+            "--verify",
+            examples_dir().join("divide.vow").to_str().unwrap(),
+        ])
+        .env("PATH", empty_path.path())
+        .output()
+        .expect("failed to run vow");
+    assert_eq!(out.status.code(), Some(1), "exit code should be 1");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("invalid JSON from contracts --verify without ESBMC: {e}\nstdout: {stdout}")
+    });
+    let contracts = json["contracts"].as_array().unwrap();
+    assert_eq!(contracts.len(), 1);
+    assert_eq!(contracts[0]["status"], "error");
+    assert!(json["summary"].is_object());
+    assert_eq!(json["summary"]["total"], 1);
+    assert_eq!(json["summary"]["error"], 1);
+    assert_eq!(json["summary"]["not_verified"], 0);
+}
+
+#[test]
 fn contracts_bisect_requires_and_invariant() {
     let json = run_contracts("bisect.vow");
     let contracts = json["contracts"].as_array().unwrap();


### PR DESCRIPTION
## Summary
- keep `vow contracts --verify` on the contracts-result JSON schema when ESBMC is absent
- mark collected contract entries as `error` and keep the command failing closed with exit 1
- mirror the behavior in the self-hosted compiler and add a Rust regression test

Closes #414

## Validation
- `cargo test -p vow --test contracts contracts_verify_missing_esbmc_keeps_contracts_schema`
- `cargo test -p vow --test contracts`
- `CARGO_TARGET_DIR=/tmp/vow-target-414 VOW_RUNTIME_PATH=/tmp/vow-target-414/release/libvow_runtime.a cargo test --all`
- `PATH=<empty> ./target/release/vow contracts --verify examples/divide.vow` -> exit 1, contracts-result JSON with `summary.error == 1`
- `PATH=<empty> /tmp/vowc_self_debug contracts --verify examples/divide.vow` -> exit 1, contracts-result JSON with `summary.error == 1`

## Gate note
- `scripts/full_test.sh` was run. It progressed through setup, concrete block-region parity, build/no-verify, verify, runtime execution, and part of run tests, then failed on the existing `issue400_internal_call_root_escape/test-expected` memory-threshold case: expected `ok`, got `total=2500000000 delta=4465632`. A direct rerun of `./target/release/vow build --no-verify tests/run/issue400_internal_call_root_escape.vow -o /tmp/issue400_rust && /tmp/issue400_rust` reproduced the same output. This path is unrelated to `contracts` schema handling. The script then also hit `printf: write error: Disk quota exceeded` while continuing after the failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vow-lang/codesmith/vow/pr/448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->