### PR TITLE
fix(verifier): clean self-hosted ESBMC scratch dirs

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -250,6 +250,7 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec
     // Bounded pool: ≤ jobs ESBMC processes in flight, FIFO drain. See #175.
     let in_flight_h: Vec<i64> = Vec::new();
     let in_flight_fi: Vec<i64> = Vec::new();
+    let in_flight_tmp: Vec<String> = Vec::new();
     let mut fi: i64 = 0;
     while fi < fns.len() {
         let f: IrFunction = fns[fi];
@@ -259,10 +260,12 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec
             while in_flight_h.len() >= jobs {
                 let oldest_h: i64 = in_flight_h[0];
                 let oldest_fi: i64 = in_flight_fi[0];
+                let oldest_tmp: String = in_flight_tmp[0];
                 let oldest_f: IrFunction = fns[oldest_fi];
                 vec_i64_remove_front(in_flight_h);
                 vec_i64_remove_front(in_flight_fi);
-                let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+                vec_string_remove_front(in_flight_tmp);
+                let proven: i64 = verify_collect_and_report(oldest_h, oldest_tmp, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
                 if proven == 0 {
                     all_proven = 0;
                 }
@@ -273,9 +276,10 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec
                     any_skipped = 1;
                 } else {
                     eprintln_str(str3(String::from("Verifying "), f.name, String::from("...")));
-                    let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
-                    in_flight_h.push(h);
+                    let started: EsbmcStart = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+                    in_flight_h.push(started.handle);
                     in_flight_fi.push(fi);
+                    in_flight_tmp.push(started.tmp_path);
                 }
             }
         }
@@ -284,10 +288,12 @@ fn run_verify_loop(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec
     while in_flight_h.len() > 0 {
         let oldest_h: i64 = in_flight_h[0];
         let oldest_fi: i64 = in_flight_fi[0];
+        let oldest_tmp: String = in_flight_tmp[0];
         let oldest_f: IrFunction = fns[oldest_fi];
         vec_i64_remove_front(in_flight_h);
         vec_i64_remove_front(in_flight_fi);
-        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+        vec_string_remove_front(in_flight_tmp);
+        let proven: i64 = verify_collect_and_report(oldest_h, oldest_tmp, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
         if proven == 0 {
             all_proven = 0;
         }
@@ -335,6 +341,17 @@ fn resolve_verify_jobs(argv: Vec<String>) -> i64 [io] {
 fn vec_i64_remove_front(v: Vec<i64>) {
     // Caller-enforced invariant: v.len() > 0 (drain loops guard this).
     // Guard defensively so an empty Vec becomes a no-op rather than popping below zero.
+    let n: i64 = v.len();
+    if n == 0 { return; }
+    let mut i: i64 = 0;
+    while i < n - 1 {
+        v[i] = v[i + 1];
+        i = i + 1;
+    }
+    v.pop();
+}
+
+fn vec_string_remove_front(v: Vec<String>) {
     let n: i64 = v.len();
     if n == 0 { return; }
     let mut i: i64 = 0;
@@ -393,7 +410,7 @@ fn vf_legacy_fields(ces: Vec<VerifyCE>, soft_meta: Vec<String>) -> Vec<String> {
 }
 
 fn verify_collect_and_report(
-    h: i64, f: IrFunction, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, soft_meta: Vec<String>,
+    h: i64, tmp_path: String, f: IrFunction, ir_mod: IrModule, path: String, ces: Vec<VerifyCE>, soft_meta: Vec<String>,
     max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
     vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64,
 ) -> i64 [io] {
@@ -401,12 +418,13 @@ fn verify_collect_and_report(
         // process_start failed (fork/exec error, OOM, rlimit, etc.) — this
         // is distinct from "no vows", which the caller already filters.
         // Silently skipping would mis-report an un-verified function as proven.
+        cleanup_verify_tmp_path(tmp_path);
         eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR (failed to start ESBMC)")));
         record_soft_fail(soft_meta, String::from("error"), String::from("failed to start ESBMC"), f.name);
         return 0;
     }
     let effective_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
-    let vr: VerifyResult = verify_collect(h, f, effective_timeout);
+    let vr: VerifyResult = verify_collect(h, f, effective_timeout, tmp_path);
     let st: i64 = vr.status;
     if st == VERIFY_PROVEN() {
         eprintln_str(str3(String::from("  "), f.name, String::from(": PROVEN")));
@@ -570,13 +588,13 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
 //
 // State threading (Vow Vecs share heap backing across by-value copies, so
 // pushes/removes visible to the caller — see compiler/frontend.vow:202-204):
-//   - `in_flight_h`, `in_flight_fi`: caller-allocated FIFO queues. This phase
-//     pushes new handles and pre-drains when the pool is full. Remaining
-//     entries are drained by `build_drain_verify_phase` after codegen.
+//   - `in_flight_h`, `in_flight_fi`, `in_flight_tmp`: caller-allocated FIFO
+//     queues. This phase pushes new handles and pre-drains when the pool is
+//     full. Remaining entries are drained by `build_drain_verify_phase` after codegen.
 //   - `ces`, `soft_meta`: counterexample + soft-fail accumulators threaded
 //     through to `verify_collect_and_report`.
 // Returns `[all_proven, any_skipped]`.
-fn build_verify_phase(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec<i64>, dctx: DiagCtx, path: String, ces: Vec<VerifyCE>, soft_meta: Vec<String>, in_flight_h: Vec<i64>, in_flight_fi: Vec<i64>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
+fn build_verify_phase(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: Vec<i64>, dctx: DiagCtx, path: String, ces: Vec<VerifyCE>, soft_meta: Vec<String>, in_flight_h: Vec<i64>, in_flight_fi: Vec<i64>, in_flight_tmp: Vec<String>, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
                      vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, jobs: i64) -> Vec<i64> [io] {
     let mut all_proven: i64 = 1;
     let mut any_skipped: i64 = 0;
@@ -589,10 +607,12 @@ fn build_verify_phase(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: 
             while in_flight_h.len() >= jobs {
                 let oldest_h: i64 = in_flight_h[0];
                 let oldest_fi: i64 = in_flight_fi[0];
+                let oldest_tmp: String = in_flight_tmp[0];
                 let oldest_f: IrFunction = fns[oldest_fi];
                 vec_i64_remove_front(in_flight_h);
                 vec_i64_remove_front(in_flight_fi);
-                let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+                vec_string_remove_front(in_flight_tmp);
+                let proven: i64 = verify_collect_and_report(oldest_h, oldest_tmp, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
                 if proven == 0 {
                     all_proven = 0;
                 }
@@ -603,9 +623,10 @@ fn build_verify_phase(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: 
                     any_skipped = 1;
                 } else {
                     eprintln_str(str3(String::from("Starting verification of "), f.name, String::from("...")));
-                    let h: i64 = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
-                    in_flight_h.push(h);
+                    let started: EsbmcStart = verify_start(f, ir_mod, max_k_step, fi, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+                    in_flight_h.push(started.handle);
                     in_flight_fi.push(fi);
+                    in_flight_tmp.push(started.tmp_path);
                 }
             }
         }
@@ -625,15 +646,17 @@ fn build_verify_phase(fns: Vec<IrFunction>, ir_mod: IrModule, const_fn_indices: 
 //
 // A no-op when `in_flight_h` is empty; callers may invoke it unconditionally
 // without a do_verify guard if desired.
-fn build_drain_verify_phase(in_flight_h: Vec<i64>, in_flight_fi: Vec<i64>, fns: Vec<IrFunction>, ir_mod: IrModule, ces: Vec<VerifyCE>, soft_meta: Vec<String>, path: String, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String, vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, all_proven_in: i64) -> i64 [io] {
+fn build_drain_verify_phase(in_flight_h: Vec<i64>, in_flight_fi: Vec<i64>, in_flight_tmp: Vec<String>, fns: Vec<IrFunction>, ir_mod: IrModule, ces: Vec<VerifyCE>, soft_meta: Vec<String>, path: String, max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String, vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, all_proven_in: i64) -> i64 [io] {
     let mut all_proven: i64 = all_proven_in;
     while in_flight_h.len() > 0 {
         let oldest_h: i64 = in_flight_h[0];
         let oldest_fi: i64 = in_flight_fi[0];
+        let oldest_tmp: String = in_flight_tmp[0];
         let oldest_f: IrFunction = fns[oldest_fi];
         vec_i64_remove_front(in_flight_h);
         vec_i64_remove_front(in_flight_fi);
-        let proven: i64 = verify_collect_and_report(oldest_h, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
+        vec_string_remove_front(in_flight_tmp);
+        let proven: i64 = verify_collect_and_report(oldest_h, oldest_tmp, oldest_f, ir_mod, path, ces, soft_meta, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
         if proven == 0 {
             all_proven = 0;
         }
@@ -746,9 +769,10 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
     // Bounded pool: ≤ jobs ESBMC processes in flight, FIFO drain. See #175.
     let in_flight_h: Vec<i64> = Vec::new();
     let in_flight_fi: Vec<i64> = Vec::new();
+    let in_flight_tmp: Vec<String> = Vec::new();
     let const_fn_indices: Vec<i64> = detect_const_fns(ir_mod);
     if do_verify {
-        let phase_result: Vec<i64> = build_verify_phase(fns, ir_mod, const_fn_indices, dctx, path, ces, soft_meta, in_flight_h, in_flight_fi, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max, jobs);
+        let phase_result: Vec<i64> = build_verify_phase(fns, ir_mod, const_fn_indices, dctx, path, ces, soft_meta, in_flight_h, in_flight_fi, in_flight_tmp, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max, jobs);
         if phase_result[0] == 0 { all_proven = 0; }
         if phase_result[1] == 1 { any_skipped = 1; }
     }
@@ -758,7 +782,7 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
         diag_emit_build_verify_json(String::from("Unverified"), out, dctx, Vec::new());
         return 0;
     }
-    all_proven = build_drain_verify_phase(in_flight_h, in_flight_fi, fns, ir_mod, ces, soft_meta, path, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max, all_proven);
+    all_proven = build_drain_verify_phase(in_flight_h, in_flight_fi, in_flight_tmp, fns, ir_mod, ces, soft_meta, path, max_k_step, use_cache, solver, encoding, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max, all_proven);
     let status_str: String = {
         if all_proven == 0 { String::from("VerifyFailed") }
         else if any_skipped == 1 { String::from("Skipped") }
@@ -1054,6 +1078,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                 let vfns: Vec<IrFunction> = ir_mod.functions;
                 let vin_flight_h: Vec<i64> = Vec::new();
                 let vin_flight_fi: Vec<i64> = Vec::new();
+                let vin_flight_tmp: Vec<String> = Vec::new();
                 let mut verify_failed: bool = false;
                 let t_dctx: DiagCtx = checked.dctx;
                 let t_const_fns: Vec<i64> = detect_const_fns(ir_mod);
@@ -1066,17 +1091,20 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                         while vin_flight_h.len() >= t_jobs {
                             let oh: i64 = vin_flight_h[0];
                             let ofi: i64 = vin_flight_fi[0];
+                            let otmp: String = vin_flight_tmp[0];
                             let ovf: IrFunction = vfns[ofi];
                             vec_i64_remove_front(vin_flight_h);
                             vec_i64_remove_front(vin_flight_fi);
+                            vec_string_remove_front(vin_flight_tmp);
                             if oh == -1 {
                                 // process_start failed — treat as verification failure, not silent success.
+                                cleanup_verify_tmp_path(otmp);
                                 verify_failed = true;
                             } else if oh != -2 {
                                 // cmd_test launches verify_start with empty solver/encoding/timeout,
                                 // so effective_timeout matches what start_esbmc passed: 30s under auto.
                                 let t_eff: String = effective_timeout_for(String::from(""), String::from(""), String::from(""));
-                                let ovr: VerifyResult = verify_collect(oh, ovf, t_eff);
+                                let ovr: VerifyResult = verify_collect(oh, ovf, t_eff, otmp);
                                 if ovr.status == VERIFY_FAILED() {
                                     verify_failed = true;
                                 } else if ovr.status == VERIFY_TIMEOUT() {
@@ -1097,9 +1125,10 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                             if skip_if_non_modelable(vf, ir_mod, t_const_fns, t_dctx) {
                                 verify_failed = true;
                             } else {
-                                let vh: i64 = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
-                                vin_flight_h.push(vh);
+                                let vstarted: EsbmcStart = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
+                                vin_flight_h.push(vstarted.handle);
                                 vin_flight_fi.push(vfi);
+                                vin_flight_tmp.push(vstarted.tmp_path);
                             }
                         }
                     }
@@ -1108,15 +1137,18 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                 while vin_flight_h.len() > 0 {
                     let oh: i64 = vin_flight_h[0];
                     let ofi: i64 = vin_flight_fi[0];
+                    let otmp: String = vin_flight_tmp[0];
                     let ovf: IrFunction = vfns[ofi];
                     vec_i64_remove_front(vin_flight_h);
                     vec_i64_remove_front(vin_flight_fi);
+                    vec_string_remove_front(vin_flight_tmp);
                     if oh == -1 {
                         // Spawn failure — critical when t_jobs >= nfns and every handle lands here.
+                        cleanup_verify_tmp_path(otmp);
                         verify_failed = true;
                     } else if oh != -2 {
                         let t_eff: String = effective_timeout_for(String::from(""), String::from(""), String::from(""));
-                        let ovr: VerifyResult = verify_collect(oh, ovf, t_eff);
+                        let ovr: VerifyResult = verify_collect(oh, ovf, t_eff, otmp);
                         if ovr.status == VERIFY_FAILED() {
                             verify_failed = true;
                         } else if ovr.status == VERIFY_TIMEOUT() {

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -28,6 +28,11 @@ struct EsbmcRun {
     combined: String,
 }
 
+struct EsbmcStart {
+    handle: i64,
+    tmp_path: String,
+}
+
 fn str_contains_byte(s: String, b: i64) -> bool {
     let n: i64 = s.len();
     let mut i: i64 = 0;
@@ -251,6 +256,34 @@ fn verify_tmp_path() -> String [io] {
     path
 }
 
+fn verify_tmp_dir_for_path(tmp_path: String) -> String {
+    let suffix: String = String::from("/esbmc.c");
+    let n: i64 = tmp_path.len();
+    let sn: i64 = suffix.len();
+    if n <= sn {
+        return String::from("");
+    }
+    let mut i: i64 = 0;
+    while i < sn {
+        if tmp_path.byte_at(n - sn + i) != suffix.byte_at(i) {
+            return String::from("");
+        }
+        i = i + 1;
+    }
+    str_substring(tmp_path, 0, n - sn)
+}
+
+fn cleanup_verify_tmp_path(tmp_path: String) [io] {
+    if tmp_path.len() == 0 {
+        return;
+    }
+    fs_remove(tmp_path);
+    let tmp_dir: String = verify_tmp_dir_for_path(tmp_path);
+    if tmp_dir.len() > 0 {
+        fs_remove_dir(tmp_dir);
+    }
+}
+
 fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func_name: String, debug: bool) [io] {
     if !debug {
         return;
@@ -324,12 +357,14 @@ fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: 
     // Kernel watchdog kills the child if ESBMC's own --timeout doesn't fire.
     let handle: i64 = process_start(esbmc_path(), esbmc_args);
     if handle == -1 {
+        cleanup_verify_tmp_path(tmp_path);
         return EsbmcRun { exit_code: -1, combined: String::from("") };
     }
     let watchdog_ms: i64 = watchdog_ms_for(timeout_secs);
     let exit_code: i64 = process_wait_timeout(handle, watchdog_ms);
     if exit_code == -2 {
         process_kill(handle);
+        cleanup_verify_tmp_path(tmp_path);
         return EsbmcRun { exit_code: -2, combined: String::from("(watchdog timeout)") };
     }
     let stdout: String = process_stdout_for(handle);
@@ -340,6 +375,7 @@ fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: 
     // Evict the Completed entry from PROCESS_MAP so its captured buffers don't
     // accumulate across runs. process_kill is a no-op on already-completed handles.
     process_kill(handle);
+    cleanup_verify_tmp_path(tmp_path);
     EsbmcRun { exit_code: exit_code, combined: combined }
 }
 
@@ -805,10 +841,10 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
 }
 
 fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
-                vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64) -> i64 [io] {
+                vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64) -> EsbmcStart [io] {
     let vows: Vec<IrVowEntry> = f.vows;
     if vows.len() == 0 {
-        return -1;
+        return EsbmcStart { handle: -1, tmp_path: String::from("") };
     }
     let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max);
     // No cache lookup or write — see the note above resolve_auto_bv_solver.
@@ -821,14 +857,15 @@ fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_ca
     let fn_name: String = f.name;
     let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
     let handle: i64 = start_esbmc(c_source, max_k_step, tmp_path, fn_name, solver, encoding, bv_timeout);
-    handle
+    EsbmcStart { handle: handle, tmp_path: tmp_path }
 }
 
-fn verify_collect(handle: i64, f: IrFunction, effective_timeout: String) -> VerifyResult [io] {
+fn verify_collect(handle: i64, f: IrFunction, effective_timeout: String, tmp_path: String) -> VerifyResult [io] {
     // Kernel watchdog sized to match ESBMC's --timeout so a runaway process can't block indefinitely.
     let exit_code: i64 = process_wait_timeout(handle, watchdog_ms_for(effective_timeout));
     if exit_code == -2 {
         process_kill(handle);
+        cleanup_verify_tmp_path(tmp_path);
         return VerifyResult {
             status: VERIFY_TIMEOUT(),
             vow_id: -1,
@@ -843,6 +880,7 @@ fn verify_collect(handle: i64, f: IrFunction, effective_timeout: String) -> Veri
         // before returning -1, so we still need to evict the PROCESS_MAP entry.
         // For the handle-not-found case, process_kill is a no-op.
         process_kill(handle);
+        cleanup_verify_tmp_path(tmp_path);
         return VerifyResult {
             status: VERIFY_NOT_FOUND(),
             vow_id: -1,
@@ -860,6 +898,7 @@ fn verify_collect(handle: i64, f: IrFunction, effective_timeout: String) -> Veri
     // Evict the Completed entry from PROCESS_MAP so its captured buffers don't
     // accumulate across runs. process_kill is a no-op on already-completed handles.
     process_kill(handle);
+    cleanup_verify_tmp_path(tmp_path);
     let status: i64 = parse_verify_status(combined);
     let vow_id: i64 = {
         if status == VERIFY_FAILED() {

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -252,11 +252,16 @@ fn verify_tmp_path() -> String [io] {
     let dir: String = string_trim(process_get_stdout());
     let path: String = String::from("");
     path.push_str(dir);
+    // verify_tmp_dir_for_path hardcodes this suffix to recover the mktemp
+    // directory for fs_remove_dir; changing the filename here without updating
+    // it there silently makes cleanup_verify_tmp_path skip the directory and
+    // leak the mktemp dir on disk.
     path.push_str(String::from("/esbmc.c"));
     path
 }
 
 fn verify_tmp_dir_for_path(tmp_path: String) -> String {
+    // Suffix must match the filename appended by verify_tmp_path.
     let suffix: String = String::from("/esbmc.c");
     let n: i64 = tmp_path.len();
     let sn: i64 = suffix.len();

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -44,6 +44,12 @@ run_vowc() {
   ( ulimit -v 2000000; "$VOWC" "$@" )
 }
 
+run_vowc_with_tmpdir() {
+  local tmp_root="$1"
+  shift
+  ( export TMPDIR="$tmp_root"; ulimit -v 2000000; "$VOWC" "$@" )
+}
+
 run_bin() {
   ( ulimit -v 2000000; "$@" )
 }
@@ -115,6 +121,11 @@ cx=d.get('counterexamples',[])
 if cx: print(cx[0].get('$field',''))
 else: print('')
 " <<< "$json"
+}
+
+count_verify_scratch_dirs() {
+  local tmp_root="$1"
+  find "$tmp_root" -maxdepth 1 -type d -name 'vow-verify.*' | wc -l | tr -d '[:space:]'
 }
 
 parse_annotations() {
@@ -312,6 +323,47 @@ else
 
     pass "$name"
   done
+
+  name="verify_tmp_cleanup"
+  if matches_filter "$name"; then
+    scratch_tmp="$TMPDIR/${name}"
+    mkdir -p "$scratch_tmp"
+    before_count="$(count_verify_scratch_dirs "$scratch_tmp")"
+    set +e
+    verify_json="$(run_vowc_with_tmpdir "$scratch_tmp" verify --verify-jobs 2 "$SCRIPT_DIR/verify/verify_jobs_pool.vow" 2>/dev/null)"
+    verify_exit=$?
+    set -e
+    after_count="$(count_verify_scratch_dirs "$scratch_tmp")"
+    actual_status="$(json_field "$verify_json" "status")"
+    if [[ "$verify_exit" -ne 0 ]]; then
+      fail "$name" "exit $verify_exit"
+    elif [[ "$actual_status" != "Verified" ]]; then
+      fail "$name" "status=$actual_status (expected Verified)"
+    elif [[ "$after_count" != "$before_count" ]]; then
+      fail "$name" "scratch dirs grew from $before_count to $after_count"
+    else
+      pass "$name"
+    fi
+  fi
+
+  name="contracts_tmp_cleanup"
+  if matches_filter "$name"; then
+    scratch_tmp="$TMPDIR/${name}"
+    mkdir -p "$scratch_tmp"
+    before_count="$(count_verify_scratch_dirs "$scratch_tmp")"
+    set +e
+    contracts_json="$(run_vowc_with_tmpdir "$scratch_tmp" contracts --verify "$SCRIPT_DIR/verify/verify_jobs_pool.vow" 2>/dev/null)"
+    contracts_exit=$?
+    set -e
+    after_count="$(count_verify_scratch_dirs "$scratch_tmp")"
+    if [[ "$contracts_exit" -ne 0 ]]; then
+      fail "$name" "exit $contracts_exit"
+    elif [[ "$after_count" != "$before_count" ]]; then
+      fail "$name" "scratch dirs grew from $before_count to $after_count"
+    else
+      pass "$name"
+    fi
+  fi
 fi
 
 # --- Phase 3: verify-fail/ tests ---

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -356,8 +356,19 @@ else
     contracts_exit=$?
     set -e
     after_count="$(count_verify_scratch_dirs "$scratch_tmp")"
+    contracts_proven="$(python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    print('parse_error'); sys.exit(0)
+ss = [e.get('status', '') for e in d.get('contracts', [])]
+print('ok' if any(s in ('proven', 'proven-ir') for s in ss) else 'no_proven')
+" <<< "$contracts_json")"
     if [[ "$contracts_exit" -ne 0 ]]; then
       fail "$name" "exit $contracts_exit"
+    elif [[ "$contracts_proven" != "ok" ]]; then
+      fail "$name" "no proven contracts (got $contracts_proven)"
     elif [[ "$after_count" != "$before_count" ]]; then
       fail "$name" "scratch dirs grew from $before_count to $after_count"
     else


### PR DESCRIPTION
## Summary
- clean self-hosted ESBMC scratch files and their mktemp parent directories on spawn failure, watchdog timeout, and normal completion
- thread tmp paths beside parallel verifier handles in verify/build/test drain loops
- add regression checks that isolated TMPDIR scratch-dir counts do not grow for `verify` and `contracts --verify`

Closes #443.

## Validation
- `CARGO_TARGET_DIR=/tmp/cargo-target-vow-443 cargo build --release --all`
- `VOW_RUNTIME_PATH=/tmp/cargo-target-vow-443/release/libvow_runtime.a /tmp/cargo-target-vow-443/release/vow build --no-verify compiler/main.vow -o /tmp/vowc-443`
- `tests/run_tests.sh --no-bootstrap --filter verify_tmp_cleanup`
- `tests/run_tests.sh --no-bootstrap --filter contracts_tmp_cleanup`
- direct acceptance: `build/vowc verify --verify-jobs 2 tests/verify/verify_jobs_pool.vow` returned `Verified`; `/tmp/vow-verify.*` count stayed `3454 -> 3454`
- `CARGO_TARGET_DIR=/tmp/cargo-target-vow-443 VOW_RUNTIME_PATH=/tmp/cargo-target-vow-443/release/libvow_runtime.a cargo test --all`

## Caveat
- `scripts/full_test.sh` was attempted with `/tmp` target/runtime env. It did not complete: it reported an existing-looking `issue400_internal_call_root_escape/test-expected` runtime memory-delta failure, then later aborted with `Disk quota exceeded` while writing comparison JSON during the bignum section.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vow-lang/codesmith/vow/pr/450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->