### PR TITLE
Standardize pure verify test mains

### DIFF
--- a/tests/verify/lexer_is_whitespace.vow
+++ b/tests/verify/lexer_is_whitespace.vow
@@ -8,6 +8,6 @@ fn is_whitespace(b: i64) -> bool vow {
     b == 32 || b == 9 || b == 10 || b == 13
 }
 
-fn main() -> i32 [io] {
+fn main() -> i32 {
     if is_whitespace(32) { 0 } else { 1 }
 }

--- a/tests/verify/string_eq_idempotent.vow
+++ b/tests/verify/string_eq_idempotent.vow
@@ -20,6 +20,6 @@ fn eq_is_idempotent() -> bool vow {
   first == second
 }
 
-fn main() -> i32 [io] {
+fn main() -> i32 {
   if eq_is_idempotent() { 0 } else { 1 }
 }

--- a/tests/verify/string_literal_byte_at.vow
+++ b/tests/verify/string_literal_byte_at.vow
@@ -14,6 +14,6 @@ fn literal_first_byte_direct() -> i64 vow {
     s.byte_at(0)
 }
 
-fn main() -> i32 [io] {
+fn main() -> i32 {
     0
 }

--- a/tests/verify/string_matches_literal_at.vow
+++ b/tests/verify/string_matches_literal_at.vow
@@ -10,6 +10,6 @@ fn matched_literal_implies_bytes(s: String, pos: i64) -> bool vow {
     s.byte_at(pos) == 97 && s.byte_at(pos + 1) == 98
 }
 
-fn main() -> i32 [io] {
+fn main() -> i32 {
     0
 }


### PR DESCRIPTION
## Summary

- Drop `[io]` from the four `tests/verify` `main` functions that do not perform IO.
- Leave verify tests that actually call IO builtins annotated with `[io]`.

## Decision

Chose issue option 1. Pure functions need no effect annotation, and these four files are verification-only tests, so removing the unused effect is narrower than adding `print_i64(...)` calls just to justify `[io]`.

## Validation

- Focused verify with freshly built Rust compiler in `/tmp/vow441-target/release/vow`: all four edited files returned `{"status":"Verified"}`.
- Convention scan after edit: no `tests/verify/*.vow` file declares `fn main() -> i32 [io]` without an observed IO-style call.
- `git diff --check`: passed.
- `CARGO_TARGET_DIR=/tmp/vow441-target cargo test -p vow-syntax`: passed (163 unit + 8 integration + 7 proptest tests).
- `scripts/full_test.sh`: partially passed, but overall nonzero. The relevant `Section 4b: Verify Tests` passed, including all four edited files. Unrelated failures observed outside this patch: `issue400_internal_call_root_escape/test-expected` printed `total=2500000000 delta=4465632`, `math/build-no-verify` reported a Rust/self-hosted status mismatch, and the script later exited during `Section 9: Bootstrap Triple Test` without a final summary.

Fixes #441

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vow-lang/codesmith/vow/pr/451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->