### PR TITLE
fix(diag): surface emitter write failures

### DIFF
--- a/vow-codegen/tests/proptest_pipeline.rs
+++ b/vow-codegen/tests/proptest_pipeline.rs
@@ -16,10 +16,14 @@ impl CollectingEmitter {
 }
 
 impl DiagnosticEmitter for CollectingEmitter {
-    fn emit(&mut self, diag: &Diagnostic) {
+    fn try_emit(&mut self, diag: &Diagnostic) -> std::io::Result<()> {
         self.diagnostics.push(diag.clone());
+        Ok(())
     }
-    fn finish(&mut self) {}
+
+    fn try_finish(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 fn parse_typecheck_and_lower(src: &str) -> bool {

--- a/vow-diag/src/lib.rs
+++ b/vow-diag/src/lib.rs
@@ -80,8 +80,18 @@ pub enum ErrorCode {
 }
 
 pub trait DiagnosticEmitter {
-    fn emit(&mut self, diagnostic: &Diagnostic);
-    fn finish(&mut self);
+    fn try_emit(&mut self, diagnostic: &Diagnostic) -> std::io::Result<()>;
+    fn try_finish(&mut self) -> std::io::Result<()>;
+
+    fn emit(&mut self, diagnostic: &Diagnostic) {
+        self.try_emit(diagnostic)
+            .expect("failed to emit diagnostic");
+    }
+
+    fn finish(&mut self) {
+        self.try_finish()
+            .expect("failed to finish diagnostic emission");
+    }
 }
 
 pub struct JsonEmitter {
@@ -99,14 +109,15 @@ impl JsonEmitter {
 }
 
 impl DiagnosticEmitter for JsonEmitter {
-    fn emit(&mut self, diagnostic: &Diagnostic) {
+    fn try_emit(&mut self, diagnostic: &Diagnostic) -> std::io::Result<()> {
         self.diagnostics.push(diagnostic.clone());
+        Ok(())
     }
 
-    fn finish(&mut self) {
+    fn try_finish(&mut self) -> std::io::Result<()> {
         let json = serde_json::to_string_pretty(&self.diagnostics)
             .expect("diagnostics must be serializable");
-        writeln!(self.output, "{}", json).ok();
+        writeln!(self.output, "{}", json)
     }
 }
 
@@ -129,13 +140,14 @@ impl<'a> CollectingEmitter<'a> {
 }
 
 impl DiagnosticEmitter for CollectingEmitter<'_> {
-    fn emit(&mut self, diagnostic: &Diagnostic) {
-        self.inner.emit(diagnostic);
+    fn try_emit(&mut self, diagnostic: &Diagnostic) -> std::io::Result<()> {
+        self.inner.try_emit(diagnostic)?;
         self.collected.push(diagnostic.clone());
+        Ok(())
     }
 
-    fn finish(&mut self) {
-        self.inner.finish();
+    fn try_finish(&mut self) -> std::io::Result<()> {
+        self.inner.try_finish()
     }
 }
 
@@ -150,7 +162,7 @@ impl HumanEmitter {
 }
 
 impl DiagnosticEmitter for HumanEmitter {
-    fn emit(&mut self, diagnostic: &Diagnostic) {
+    fn try_emit(&mut self, diagnostic: &Diagnostic) -> std::io::Result<()> {
         let severity = match diagnostic.severity {
             Severity::Error => "error",
             Severity::Warning => "warning",
@@ -164,22 +176,25 @@ impl DiagnosticEmitter for HumanEmitter {
             diagnostic.message,
             diagnostic.primary.file,
             diagnostic.primary.byte_offset,
-        )
-        .ok();
+        )?;
         if diagnostic.blame != Blame::None {
-            writeln!(self.output, "  blame: {:?}", diagnostic.blame).ok();
+            writeln!(self.output, "  blame: {:?}", diagnostic.blame)?;
         }
         for hint in &diagnostic.hints {
-            writeln!(self.output, "  hint: {hint}").ok();
+            writeln!(self.output, "  hint: {hint}")?;
         }
+        Ok(())
     }
 
-    fn finish(&mut self) {}
+    fn try_finish(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
     use std::sync::{Arc, Mutex};
 
     struct SharedBuf(Arc<Mutex<Vec<u8>>>);
@@ -188,6 +203,18 @@ mod tests {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
             self.0.lock().unwrap().write(buf)
         }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FailingWrite;
+
+    impl std::io::Write for FailingWrite {
+        fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe"))
+        }
+
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
         }
@@ -233,6 +260,21 @@ mod tests {
         let output = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
         assert!(output.contains("error"));
         assert!(output.contains("precondition violated"));
+    }
+
+    #[test]
+    fn json_emitter_finish_reports_writer_failure() {
+        let mut emitter = JsonEmitter::new(Box::new(FailingWrite));
+        emitter.emit(&make_diagnostic());
+        let err = emitter.try_finish().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    }
+
+    #[test]
+    fn human_emitter_emit_reports_writer_failure() {
+        let mut emitter = HumanEmitter::new(Box::new(FailingWrite));
+        let err = emitter.try_emit(&make_diagnostic()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
     }
 
     #[test]

--- a/vow-types/src/check.rs
+++ b/vow-types/src/check.rs
@@ -1976,10 +1976,14 @@ mod tests {
     struct TestEmitter(Vec<Diagnostic>);
 
     impl DiagnosticEmitter for TestEmitter {
-        fn emit(&mut self, d: &Diagnostic) {
+        fn try_emit(&mut self, d: &Diagnostic) -> std::io::Result<()> {
             self.0.push(d.clone());
+            Ok(())
         }
-        fn finish(&mut self) {}
+
+        fn try_finish(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
     }
 
     fn dummy_span() -> Span {

--- a/vow-types/src/effects.rs
+++ b/vow-types/src/effects.rs
@@ -287,10 +287,14 @@ mod tests {
     struct TestEmitter(Vec<Diagnostic>);
 
     impl DiagnosticEmitter for TestEmitter {
-        fn emit(&mut self, d: &Diagnostic) {
+        fn try_emit(&mut self, d: &Diagnostic) -> std::io::Result<()> {
             self.0.push(d.clone());
+            Ok(())
         }
-        fn finish(&mut self) {}
+
+        fn try_finish(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
     }
 
     fn dummy_span() -> Span {

--- a/vow-types/src/exhaustiveness.rs
+++ b/vow-types/src/exhaustiveness.rs
@@ -165,10 +165,14 @@ mod tests {
     struct TestEmitter(Vec<Diagnostic>);
 
     impl DiagnosticEmitter for TestEmitter {
-        fn emit(&mut self, d: &Diagnostic) {
+        fn try_emit(&mut self, d: &Diagnostic) -> std::io::Result<()> {
             self.0.push(d.clone());
+            Ok(())
         }
-        fn finish(&mut self) {}
+
+        fn try_finish(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
     }
 
     fn dummy_span() -> Span {

--- a/vow-types/src/linear.rs
+++ b/vow-types/src/linear.rs
@@ -464,10 +464,14 @@ mod tests {
     struct TestEmitter(Vec<Diagnostic>);
 
     impl DiagnosticEmitter for TestEmitter {
-        fn emit(&mut self, d: &Diagnostic) {
+        fn try_emit(&mut self, d: &Diagnostic) -> std::io::Result<()> {
             self.0.push(d.clone());
+            Ok(())
         }
-        fn finish(&mut self) {}
+
+        fn try_finish(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
     }
 
     fn dummy_span() -> Span {

--- a/vow-types/tests/proptest_typecheck.rs
+++ b/vow-types/tests/proptest_typecheck.rs
@@ -17,10 +17,14 @@ impl CollectingEmitter {
 }
 
 impl DiagnosticEmitter for CollectingEmitter {
-    fn emit(&mut self, diag: &Diagnostic) {
+    fn try_emit(&mut self, diag: &Diagnostic) -> std::io::Result<()> {
         self.diagnostics.push(diag.clone());
+        Ok(())
     }
-    fn finish(&mut self) {}
+
+    fn try_finish(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 fn typecheck_source(src: &str) -> Vec<Diagnostic> {

--- a/vow/src/frontend.rs
+++ b/vow/src/frontend.rs
@@ -122,9 +122,13 @@ impl FrontendStage {
 struct NullEmitter;
 
 impl DiagnosticEmitter for NullEmitter {
-    fn emit(&mut self, _: &Diagnostic) {}
+    fn try_emit(&mut self, _: &Diagnostic) -> std::io::Result<()> {
+        Ok(())
+    }
 
-    fn finish(&mut self) {}
+    fn try_finish(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 pub(crate) fn prepare_frontend(


### PR DESCRIPTION
## Summary
- add fallible `try_emit` / `try_finish` methods to `DiagnosticEmitter`
- propagate `std::io::Write` errors from JSON and human emitters instead of dropping them with `.ok()`
- add failing-writer regression tests for JSON finish and human emit paths

Closes #418.

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p vow-diag`
- `cargo build --release --all`
- `cargo test --all`

## Full-gate note
- `scripts/full_test.sh` was attempted after moving `target/` to `/tmp` to work around local root-disk exhaustion. It did not complete reliably in this workspace: one run was interrupted by disk exhaustion, and the retry reached `compiler/concrete-block-region-parity` PASS before becoming invalid when the temporary target directory disappeared and `./target/release/vow` returned exit 127.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vow-lang/codesmith/vow/pr/452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->