### PR TITLE
docs: add agent-language comparison reports (closes #267, #268)

### DIFF
--- a/docs/comparisons/README.md
+++ b/docs/comparisons/README.md
@@ -1,0 +1,13 @@
+# Agent-oriented language comparisons
+
+Comparative reports situating Vow against other languages pitched at AI-agent code generation. Open the HTML files in a browser.
+
+| File | Scope |
+| ---- | ----- |
+| [`index.html`](index.html) | **Unified synthesis** across MoonBit, Vera, and Zero — convergent diagnosis, divergent bets, what Vow can borrow, what to reject, prioritised action list. Start here. |
+| [`vs-moonbit.html`](vs-moonbit.html) | MoonBit (0.9, April 2026) — Why3 + SMT deductive verification, MoonBit Pilot agent, constrained decoding, ASP protocol. |
+| [`vs-vera.html`](vs-vera.html) | Vera (v0.0.155, May 2026) — De Bruijn slot references, mandatory contracts, Z3 with runtime-fallback tier, `Inference` as a tracked effect. |
+| [`vera-skill-analysis.html`](vera-skill-analysis.html) | Structural deep-dive on Vera's 99 KB monolithic `SKILL.md` versus Vow's progressive-disclosure entrypoint. |
+| [`vs-zero.html`](vs-zero.html) | Zero (Vercel Labs, v0.1.2, May 2026) — `fixSafety` ladder, typed `repair` handles, binary-pinned skills, capability passing. |
+
+The unified report is the canonical artefact; the per-language reports are the underlying evidence with primary citations. All four were compiled 2026-05-18; the unified synthesis was added 2026-05-19.

--- a/docs/comparisons/index.html
+++ b/docs/comparisons/index.html
@@ -1,0 +1,829 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Agent-oriented languages — unified report (MoonBit, Vera, Zero, Vow)</title>
+<style>
+  :root {
+    --bg: #0e1116;
+    --panel: #161b22;
+    --panel-2: #1c2330;
+    --fg: #e6edf3;
+    --muted: #8b949e;
+    --dim: #6e7681;
+    --line: #30363d;
+    --accent: #58a6ff;
+    --vow:  #7ee787;
+    --moonbit: #b388ff;
+    --vera: #e87a5d;
+    --zero: #f0b429;
+    --warn: #f97583;
+    --good: #56d364;
+    --code-bg: #0b0f14;
+    --code-fg: #d1d9e0;
+    --max: 1150px;
+  }
+  * { box-sizing: border-box; }
+  html, body { background: var(--bg); color: var(--fg); }
+  body {
+    margin: 0;
+    font: 15.5px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+    padding: 0 24px 80px;
+  }
+  main { max-width: var(--max); margin: 0 auto; }
+  header.hero {
+    max-width: var(--max);
+    margin: 48px auto 32px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--line);
+  }
+  header.hero h1 { font-size: 34px; margin: 0 0 10px; letter-spacing: -0.02em; }
+  header.hero .sub { color: var(--muted); font-size: 17px; }
+  header.hero .meta { margin-top: 14px; color: var(--muted); font-size: 13px; }
+  h2 {
+    font-size: 22px;
+    margin: 48px 0 12px;
+    padding-top: 24px;
+    border-top: 1px solid var(--line);
+    letter-spacing: -0.01em;
+  }
+  h3 { font-size: 17px; margin: 24px 0 8px; color: var(--accent); }
+  h4 { font-size: 14px; margin: 16px 0 6px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  p { margin: 8px 0 12px; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre, .mono { font-family: ui-monospace, SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace; }
+  code { background: var(--code-bg); color: var(--code-fg); padding: 1px 5px; border-radius: 4px; font-size: 13px; }
+  pre {
+    background: var(--code-bg); color: var(--code-fg);
+    padding: 14px 16px; border-radius: 8px;
+    overflow-x: auto; font-size: 13px; line-height: 1.5;
+    border: 1px solid var(--line);
+  }
+  pre code { background: transparent; padding: 0; font-size: inherit; }
+  table { border-collapse: collapse; width: 100%; margin: 16px 0; font-size: 14px; }
+  th, td { padding: 9px 12px; text-align: left; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { background: var(--panel); color: var(--muted); font-weight: 600; font-size: 12.5px; text-transform: uppercase; letter-spacing: 0.04em; }
+  tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
+  td:first-child { color: var(--muted); }
+  .tag {
+    display: inline-block;
+    padding: 1px 8px; border-radius: 999px;
+    font-size: 11.5px; letter-spacing: 0.03em;
+    border: 1px solid var(--line); color: var(--muted);
+    margin-right: 4px;
+  }
+  .tag.moonbit { color: var(--moonbit); border-color: rgba(179,136,255,0.4); background: rgba(179,136,255,0.07); }
+  .tag.vera    { color: var(--vera);    border-color: rgba(232,122,93,0.4);  background: rgba(232,122,93,0.07); }
+  .tag.zero    { color: var(--zero);    border-color: rgba(240,180,41,0.4);  background: rgba(240,180,41,0.07); }
+  .tag.vow     { color: var(--vow);     border-color: rgba(126,231,135,0.4); background: rgba(126,231,135,0.07); }
+  .tag.warn    { color: var(--warn);    border-color: rgba(249,117,131,0.4); background: rgba(249,117,131,0.07); }
+  .tag.good    { color: var(--good);    border-color: rgba(86,211,100,0.4);  background: rgba(86,211,100,0.07); }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .grid4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+  @media (max-width: 880px) {
+    .grid2 { grid-template-columns: 1fr; }
+    .grid4 { grid-template-columns: 1fr 1fr; }
+  }
+  @media (max-width: 560px) { .grid4 { grid-template-columns: 1fr; } }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 14px 18px;
+  }
+  .panel.moonbit { border-top: 3px solid var(--moonbit); }
+  .panel.vera    { border-top: 3px solid var(--vera); }
+  .panel.zero    { border-top: 3px solid var(--zero); }
+  .panel.vow     { border-top: 3px solid var(--vow); }
+  .panel h3 { margin-top: 4px; }
+  .panel h4 { color: var(--muted); margin-top: 12px; }
+  .callout {
+    border-left: 3px solid var(--accent);
+    background: var(--panel-2);
+    padding: 12px 16px;
+    border-radius: 0 6px 6px 0;
+    margin: 16px 0;
+  }
+  .callout.warn { border-left-color: var(--warn); }
+  .callout.good { border-left-color: var(--good); }
+  ul { padding-left: 22px; }
+  li { margin: 4px 0; }
+  .lessons ol { padding-left: 22px; }
+  .lessons li { margin: 14px 0; }
+  .lessons li b { color: var(--accent); }
+  footer { color: var(--muted); font-size: 12.5px; margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line); }
+  .badge-row { margin-top: 8px; }
+  .tldr {
+    background: linear-gradient(180deg, rgba(126,231,135,0.08), rgba(126,231,135,0));
+    border: 1px solid rgba(126,231,135,0.3);
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin: 20px 0;
+  }
+  .tldr h3 { margin-top: 0; color: var(--vow); }
+  .toc {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 14px 22px;
+    margin: 24px 0;
+  }
+  .toc ol { columns: 2; column-gap: 32px; margin: 4px 0; padding-left: 20px; }
+  .toc li { margin: 3px 0; }
+  .nowrap { white-space: nowrap; }
+  details { margin: 8px 0; }
+  summary { cursor: pointer; color: var(--muted); }
+  summary:hover { color: var(--fg); }
+  .prio {
+    display: inline-block;
+    background: var(--accent); color: #0b0f14;
+    border-radius: 4px;
+    padding: 1px 7px;
+    font-size: 12px;
+    font-weight: 700;
+    margin-right: 8px;
+    vertical-align: 1px;
+  }
+  .prio.high { background: var(--vow); }
+  .prio.med  { background: var(--accent); }
+  .prio.low  { background: var(--dim); color: var(--fg); }
+  .src-tag { font-size: 11px; color: var(--muted); margin-left: 6px; }
+  .src-tag b { font-weight: 700; }
+  .src-tag .m { color: var(--moonbit); }
+  .src-tag .v { color: var(--vera); }
+  .src-tag .z { color: var(--zero); }
+  hr { border: none; border-top: 1px solid var(--line); margin: 28px 0; }
+  .col-mb { color: var(--moonbit); font-weight: 600; }
+  .col-v  { color: var(--vera);    font-weight: 600; }
+  .col-z  { color: var(--zero);    font-weight: 600; }
+  .col-vo { color: var(--vow);     font-weight: 600; }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <h1>Agent-oriented languages &mdash; what Vow can learn</h1>
+  <div class="sub">Unified synthesis of three comparisons: <span class="col-mb">MoonBit</span>, <span class="col-v">Vera</span>, and <span class="col-z">Zero</span> against <span class="col-vo">Vow</span>. The category is real. The bets diverge sharply. A handful of ideas are worth porting; most are identity choices that don't belong in Vow.</div>
+  <div class="meta">Compiled 2026-05-19 &middot; consolidates <code>moonbit-comparison</code>, <code>vera-vs-vow</code>, <code>vera-skill-report</code>, and <code>zero-vs-vow</code>.</div>
+  <div class="badge-row">
+    <span class="tag moonbit">MoonBit &middot; v0.9 &middot; Apr 2026</span>
+    <span class="tag vera">Vera &middot; v0.0.155 &middot; May 2026</span>
+    <span class="tag zero">Zero &middot; v0.1.2 &middot; May 2026</span>
+    <span class="tag vow">Vow &middot; self-hosted main</span>
+  </div>
+</header>
+
+<main>
+
+<div class="tldr">
+<h3>TL;DR</h3>
+<p>Four languages now pitch themselves at AI agents. They <b>agree on the diagnosis</b> &mdash; machine-first compiler output, contracts as source of truth, in-tree agent docs, stable error codes &mdash; and confirm the category. They diverge on the cure:</p>
+<ul>
+  <li><span class="col-mb">MoonBit</span> attacks the <b>sampling layer</b> (constrained decoding) plus a vertically integrated agent (Pilot, ASP). Verification arrived in 0.9 via Why3+SMT, opt-in per package, with separate <code>.mbtp</code> predicate files.</li>
+  <li><span class="col-v">Vera</span> attacks the <b>name layer</b>: typed De Bruijn slots (<code>@Int.0</code>) replace identifiers, plus mandatory contracts verified by Z3 in three tiers ending in runtime fallback.</li>
+  <li><span class="col-z">Zero</span> attacks the <b>diagnostic layer</b>: ~25 JSON-first subcommands, a <code>fixSafety</code> taxonomy on every repair, capability-passing for effects. No verifier, no contracts.</li>
+  <li><span class="col-vo">Vow</span> attacks the <b>verification layer</b>: inline contracts, ESBMC bounded model checking, <em>concrete</em> counterexamples, Caller/Callee blame, linear types, binary-fixed-point self-host.</li>
+</ul>
+<p><b>The action list for Vow</b>: borrow <i>Inference as a tracked effect</i> (Vera), a <i>fixSafety ladder + typed <code>repair</code> handles</i> (Zero), <i>fix examples per error code</i> + <i>spec_ref anchors</i> (Vera), <i>contract-driven property tests</i> (Vera), <i>bounded quantifiers</i> (Vera), and <i>two-phase <code>fix --plan --json</code> + <code>explain &lt;code&gt;</code></i> (Zero). Reject De Bruijn names, the runtime-fallback tier, generics+metaprogramming, monolithic <code>SKILL.md</code>, and Pilot-style proprietary protocols. Vow's moat is the verifier, blame, linear types, and self-hosting &mdash; none of the three threaten it.</p>
+</div>
+
+<div class="toc">
+<b>Contents</b>
+<ol>
+  <li><a href="#landscape">The landscape at a glance</a></li>
+  <li><a href="#converge">What everyone agrees on</a></li>
+  <li><a href="#diverge">The four bets</a></li>
+  <li><a href="#verif">Verification head-to-head</a></li>
+  <li><a href="#skill">Skill packaging compared</a></li>
+  <li><a href="#diag">Diagnostics &amp; repair</a></li>
+  <li><a href="#learn">Consolidated lessons for Vow</a></li>
+  <li><a href="#reject">What Vow should not borrow</a></li>
+  <li><a href="#moat">Where Vow's moat is</a></li>
+  <li><a href="#actions">Prioritised action list</a></li>
+</ol>
+</div>
+
+<h2 id="landscape">1 &middot; The landscape at a glance</h2>
+
+<div class="grid4">
+  <div class="panel moonbit">
+    <h3 style="color:var(--moonbit)">MoonBit</h3>
+    <h4>Identity</h4>
+    <p>IDEA (Shenzhen). Lead: Hongbo Zhang (ex-ReScript). Started Oct 2022; v0.9 April 2026. Source-available (MPSL, SSPL-style). Compiler in OCaml, distributed as WASM.</p>
+    <h4>Bet</h4>
+    <p>Constrained decoding at the sampler + first-party Pilot agent + custom ASP protocol + (new) Why3-backed deductive verification.</p>
+    <h4>Numbers</h4>
+    <p>~1.1k stars on core, ~2.3k on docs. Discord ~578. No named production users. LLM4Code 2024 paper.</p>
+  </div>
+  <div class="panel vera">
+    <h3 style="color:var(--vera)">Vera</h3>
+    <h4>Identity</h4>
+    <p>Alasdair Allan (Negroni Venture Studios), solo. Public April 2026. MIT. Python+Lark+Z3+wasmtime, ~10 KLOC. WASM-only target.</p>
+    <h4>Bet</h4>
+    <p>De Bruijn slot references replace variable names. Mandatory <code>requires</code>/<code>ensures</code>/<code>effects</code>. <code>Inference</code> as a first-class effect.</p>
+    <h4>Numbers</h4>
+    <p>~351 stars, 17 forks, 156 releases in ~3 months. One HN thread (95 comments, mostly skeptical). VeraBench: 50 problems &times; 6 models.</p>
+  </div>
+  <div class="panel zero">
+    <h3 style="color:var(--zero)">Zero</h3>
+    <h4>Identity</h4>
+    <p>Vercel Labs (Chris Tate, Matt Van Horn). Released v0.1.0 May 15, 2026. Apache-2.0. C compiler with direct native emitters (ELF / Mach-O / COFF / WASM). No LLVM.</p>
+    <h4>Bet</h4>
+    <p>Structured-JSON everywhere (~25 CLI subcommands). <code>fixSafety</code> ladder on every diagnostic. Capability-passing for effects (<code>world: World</code>).</p>
+    <h4>Numbers</h4>
+    <p>~1.9k stars in days. No published benchmarks. Sub-10 KiB native binaries. Self-host in progress.</p>
+  </div>
+  <div class="panel vow">
+    <h3 style="color:var(--vow)">Vow</h3>
+    <h4>Identity</h4>
+    <p>Paulo Matos &amp; collaborators. Open source. Cranelift native via FFI shim + ESBMC pipeline in parallel via C emitter. Binary fixed-point self-host.</p>
+    <h4>Bet</h4>
+    <p>Inline contracts (<code>requires</code>/<code>ensures</code>/<code>invariant</code>) verified by ESBMC BMC. <b>Concrete</b> counterexamples + Caller/Callee blame + CEGIS loop. Linear types. JSON-everywhere.</p>
+    <h4>Numbers</h4>
+    <p>36/36 Vow suite (sonnet-4-6); HumanEval 66/67 (sonnet-4); 103/103 non-stretch references verified by self-hosted compiler.</p>
+  </div>
+</div>
+
+<h2 id="converge">2 &middot; What everyone agrees on</h2>
+
+<p>Four projects, four bets, but a single converged thesis. Every one of them ships:</p>
+
+<ul>
+  <li><b>Machine-readable error output</b> as the primary surface, with human-readable as the alternate. Stable diagnostic codes (<code>E###</code>, <code>NAM003</code>, <code>VowViolation</code>) with <code>description</code> + <code>rationale</code> + <code>fix</code> + <code>spec_ref</code>-style fields.</li>
+  <li><b>Effects in the type system.</b> All four track side effects as part of the function type (or equivalent capability handle). Pure functions cannot accidentally do IO.</li>
+  <li><b>Agent-facing docs in-tree.</b> A <code>SKILL.md</code> (MoonBit is the lone holdout), <code>AGENTS.md</code>, <code>CLAUDE.md</code>, or compiler-served equivalent. Auto-discoverable, not buried in a wiki.</li>
+  <li><b>Contracts as the source of truth</b> (3 of 4 &mdash; Zero is the exception): MoonBit's <code>proof_require</code>/<code>proof_ensure</code>, Vera's mandatory <code>requires</code>/<code>ensures</code>, Vow's <code>vow</code> blocks. The disagreement is over the verifier, not the idea.</li>
+  <li><b>JSON build artifacts.</b> Diagnostic JSON, build JSON, verification JSON. Terminal output is for humans; agents consume the schema.</li>
+</ul>
+
+<div class="callout good">
+<p>Four projects converging on the same diagnosis within a 12-month window (MoonBit 0.9 Apr 2026, Vera Apr 2026, Zero May 2026, Vow self-host before that) is the strongest evidence yet that <b>"language designed for agents with mandatory contracts and machine-first output"</b> is a real category. The market is now contested. Vow's positioning needs to be sharper than "we also do this".</p>
+</div>
+
+<h2 id="diverge">3 &middot; The four bets</h2>
+
+<p>Where they diverge is more interesting than where they agree. Each project picked exactly one layer of the agentic-coding stack to attack:</p>
+
+<table>
+  <thead>
+    <tr><th>Layer attacked</th><th>Project</th><th>Mechanism</th><th>What it gives up</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Sampling</td>
+      <td><span class="col-mb">MoonBit</span></td>
+      <td>Constrained decoding (local syntactic + global type-checking samplers) running on hosted infra; ~3% latency penalty for large compile-rate wins on small models.</td>
+      <td>Coupling to hosted infra; closed sampler; not packaged as standalone lib.</td>
+    </tr>
+    <tr>
+      <td>Naming</td>
+      <td><span class="col-v">Vera</span></td>
+      <td>Eliminate variable names entirely. Typed De Bruijn slots (<code>@Int.0</code>) with per-type counters.</td>
+      <td>Grep-ability; local-reasoning when editing top of function; cross-model bench wins are mixed (Kimi K2.5 100%, Sonnet 4 79%).</td>
+    </tr>
+    <tr>
+      <td>Diagnostics</td>
+      <td><span class="col-z">Zero</span></td>
+      <td><code>fixSafety</code> ladder + typed <code>repair</code> handles + ~25 JSON-first subcommands + binary-pinned skills.</td>
+      <td>No verifier; no formal correctness story; types + capabilities only.</td>
+    </tr>
+    <tr>
+      <td>Verification</td>
+      <td><span class="col-vo">Vow</span></td>
+      <td>Inline contracts &rarr; ESBMC BMC &rarr; <i>concrete</i> counterexample with values + trace + blame &rarr; agent fixes &rarr; rerun. CEGIS loop is the headline.</td>
+      <td>No quantifiers in contracts; bounded by unwind depth; verifier latency.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>These are <b>complementary, not competing</b>. A serious agent-language toolchain could (in principle) compose all four: a constrained sampler emits tokens that satisfy the grammar; a small core surface keeps the verifier tractable; structured diagnostics drive the repair loop; concrete counterexamples close it.</p>
+
+<h2 id="verif">4 &middot; Verification head-to-head</h2>
+
+<p>The most consequential axis of comparison. Three of the four (MoonBit, Vera, Vow) ship a verifier; Zero deliberately doesn't.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th class="col-mb">MoonBit 0.9</th>
+      <th class="col-v">Vera</th>
+      <th class="col-z">Zero</th>
+      <th class="col-vo">Vow</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Backend</td>
+      <td>Why3 &rarr; Z3/Alt-Ergo/CVC5</td>
+      <td>Z3 SMT directly</td>
+      <td>None</td>
+      <td>ESBMC (BMC)</td>
+    </tr>
+    <tr>
+      <td>What's being decided</td>
+      <td>Validity of FO formulas in decidable theories.</td>
+      <td>Same, but no separate predicate logic.</td>
+      <td>N/A &mdash; types + capabilities only.</td>
+      <td>Reachability of assertion violation in bounded unwind.</td>
+    </tr>
+    <tr>
+      <td>Predicate location</td>
+      <td>Separate <code>.mbtp</code> file w/ dedicated logical sublanguage.</td>
+      <td>Inline.</td>
+      <td>N/A</td>
+      <td>Inline, same expression language as code.</td>
+    </tr>
+    <tr>
+      <td>Quantifiers</td>
+      <td><code>&forall;</code>, recursive predicates, finite-set/seq/map model libs.</td>
+      <td>Bounded <code>forall</code>/<code>exists</code> over <code>Nat</code> ranges.</td>
+      <td>N/A</td>
+      <td>None &mdash; boolean exprs only.</td>
+    </tr>
+    <tr>
+      <td>Failure shape</td>
+      <td>Per-VC verdict ("could not prove goal X" / Unknown / Timeout).</td>
+      <td>Per-VC verdict; if undecided, becomes Tier-3 runtime assert (E500&ndash;E525).</td>
+      <td>Type/capability error JSON.</td>
+      <td><b>Concrete failing input</b> + execution trace + JSON + Caller/Callee blame.</td>
+    </tr>
+    <tr>
+      <td>Termination</td>
+      <td><code>proof_decrease</code> measures.</td>
+      <td>Mandatory <code>decreases</code> on pure recursion (no loops in language).</td>
+      <td>N/A</td>
+      <td>Bounded unwinding instead.</td>
+    </tr>
+    <tr>
+      <td>Loops</td>
+      <td>Yes &mdash; <code>proof_invariant</code> clauses.</td>
+      <td>None &mdash; rejected at language level.</td>
+      <td>Yes &mdash; no formal reasoning.</td>
+      <td>Yes &mdash; <code>invariant</code> + bounded unwind.</td>
+    </tr>
+    <tr>
+      <td>Blame</td>
+      <td>None.</td>
+      <td>None.</td>
+      <td>N/A; <code>fixSafety</code> classifies repairs instead.</td>
+      <td>First-class Caller/Callee in JSON.</td>
+    </tr>
+    <tr>
+      <td>Trigger</td>
+      <td>Opt-in per package (<code>"proof-enabled": true</code>); <code>moon prove</code>.</td>
+      <td><code>vera verify</code>; Tier-3 contracts trap at runtime.</td>
+      <td>N/A</td>
+      <td><b>On by default</b> with <code>vowc build</code>; <code>--no-verify</code> to skip.</td>
+    </tr>
+    <tr>
+      <td>Repair loop</td>
+      <td>Implicit: Pilot drafts predicates, prover checks.</td>
+      <td>Implicit: write &rarr; verify &rarr; JSON error &rarr; fix.</td>
+      <td><code>fix --plan --json</code> proposes; agent applies.</td>
+      <td><b>Explicit CEGIS</b>, marketed as the workflow.</td>
+    </tr>
+    <tr>
+      <td>Honesty about uncertainty</td>
+      <td>Per-VC verdicts include "could not prove".</td>
+      <td>Silent Tier-3 fallback counted in <code>tier3_runtime</code>.</td>
+      <td>No claim being made.</td>
+      <td>Bounded; bound is stated; failure is explicit.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="callout good">
+<p><b>Z3/Why3 and ESBMC are complementary, not strictly ordered.</b> SMT-deductive systems are better at pure arithmetic and quantified contracts over abstract values. BMC is better at concrete bug-finding in imperative loops and memory access patterns. <i>Vow gets witnesses; MoonBit/Vera get quantifiers.</i> Witnesses are what the agent loop actually consumes &mdash; "here's the input that breaks it" is a stronger signal than "could not prove goal&nbsp;X" &mdash; which is why Vow's bet is well-positioned even though Why3+SMT is a more general formalism.</p>
+</div>
+
+<h2 id="skill">5 &middot; Skill packaging compared</h2>
+
+<p>How each project hands its language to the agent &mdash; an underrated UX axis. Four very different choices:</p>
+
+<table>
+  <thead>
+    <tr><th>Project</th><th>Always-loaded body</th><th>Where the rest lives</th><th>Version-pinning</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span class="col-mb">MoonBit</span></td>
+      <td><span class="tag warn">No SKILL.md</span></td>
+      <td>Pilot is the agent layer; no Claude Code skill, no Cursor profile, no system prompt. Pilot reads docs itself; closed loop.</td>
+      <td>By tool, not skill.</td>
+    </tr>
+    <tr>
+      <td><span class="col-v">Vera</span></td>
+      <td><b>99 KB / ~25 K tokens</b> single file.</td>
+      <td>All inline. Stdlib (7.8 K tokens) + Effects (3.2 K tokens) make up ~45% of the file.</td>
+      <td>By file content; manual sync.</td>
+    </tr>
+    <tr>
+      <td><span class="col-z">Zero</span></td>
+      <td>~1.5 KB <i>discovery stub</i>.</td>
+      <td>Inside the compiler binary. Served via <code>zero skills list</code> / <code>zero skills get &lt;id&gt; [--full]</code>. Seven micro-skills, ~17 KB total.</td>
+      <td><b>Binary-pinned</b>: skills move with compiler version; zero drift.</td>
+    </tr>
+    <tr>
+      <td><span class="col-vo">Vow</span></td>
+      <td>1.7 KB / 48-line entrypoint.</td>
+      <td>Linked reference files (<code>grammar.md</code>, <code>cli.md</code>, <code>contracts.md</code>, <code>errors.md</code>, <code>examples.md</code>) on disk; full self-contained bundle (~30 K tokens) printed on demand via <code>vowc skill print --bundle</code>.</td>
+      <td>Generated from compiler; <code>check_help_coverage.py</code> catches drift.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Vera's monolith is the comparison that proves Vow's progressive-disclosure choice. At <b>~5&times; the practical ceiling</b> for an always-loaded Claude Code skill, Vera is making a bet that the agent won't follow links &mdash; defensible only for agents that don't.</p>
+
+<p>Zero's <i>binary-pinned</i> twist is more interesting. Treating the skill as <i>something the compiler emits at runtime</i> closes the version-skew window completely. Vow has the affordance (<code>vowc skill print</code>) but ships the full content on disk; going further would mean turning the on-disk stub into a discovery pointer that says <i>"ask the binary"</i>.</p>
+
+<h2 id="diag">6 &middot; Diagnostics &amp; repair</h2>
+
+<p>The diagnostic JSON shape is converging. All four projects ship structured per-error objects with codes and severities. The variation is in <i>what extra fields the agent gets</i>:</p>
+
+<table>
+  <thead>
+    <tr><th>Field</th><th class="col-mb">MoonBit</th><th class="col-v">Vera</th><th class="col-z">Zero</th><th class="col-vo">Vow</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Stable code</td>
+      <td>Yes (Why3 VC ids)</td>
+      <td><b>Yes</b> (E001&ndash;E702)</td>
+      <td><b>Yes</b> (XXXNNN, 16 families)</td>
+      <td><b>Yes</b> (named codes)</td>
+    </tr>
+    <tr>
+      <td><code>rationale</code></td>
+      <td>&mdash;</td>
+      <td><b>Yes</b></td>
+      <td>(via <code>help</code>)</td>
+      <td>(in <code>errors.md</code>, not JSON)</td>
+    </tr>
+    <tr>
+      <td><code>fix</code> example</td>
+      <td>&mdash;</td>
+      <td><b>Yes</b> per code</td>
+      <td>via <code>repair</code> handle</td>
+      <td><span class="tag warn">Missing</span></td>
+    </tr>
+    <tr>
+      <td><code>spec_ref</code> anchor</td>
+      <td>&mdash;</td>
+      <td><b>Yes</b> (<code>spec/05-contracts.md#postconditions</code>)</td>
+      <td>(via <code>code</code>)</td>
+      <td><span class="tag warn">Missing</span></td>
+    </tr>
+    <tr>
+      <td>Blame attribution</td>
+      <td>&mdash;</td>
+      <td>&mdash;</td>
+      <td>&mdash;</td>
+      <td><b>Yes</b> (Caller/Callee)</td>
+    </tr>
+    <tr>
+      <td>Repair safety classification</td>
+      <td>&mdash;</td>
+      <td>&mdash;</td>
+      <td><b>Yes</b> (<code>fixSafety</code>, 5 levels)</td>
+      <td><span class="tag warn">Missing</span></td>
+    </tr>
+    <tr>
+      <td>Typed repair handle</td>
+      <td>&mdash;</td>
+      <td>&mdash;</td>
+      <td><b>Yes</b> (<code>repair: {id, summary}</code>)</td>
+      <td><span class="tag warn">Missing</span></td>
+    </tr>
+    <tr>
+      <td>Concrete witness</td>
+      <td>&mdash;</td>
+      <td>&mdash;</td>
+      <td>&mdash;</td>
+      <td><b>Yes</b> (failing input + trace + values)</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Vow has the unique <i>witness</i> + <i>blame</i> story. The missing pieces (italicised in the warning tags) are all <b>portable from Vera and Zero with no language-level changes</b> &mdash; documentation, plus an enrichment of the JSON emitter.</p>
+
+<h2 id="learn">7 &middot; Consolidated lessons for Vow</h2>
+
+<p>Deduplicated across all three comparisons, in rough priority order. Source attribution: <span class="src-tag"><b class="m">M</b> MoonBit</span> <span class="src-tag"><b class="v">V</b> Vera</span> <span class="src-tag"><b class="z">Z</b> Zero</span>.</p>
+
+<div class="lessons">
+<ol>
+
+<li>
+  <b>Inference as a tracked effect.</b> <span class="src-tag"><b class="v">V</b></span><br>
+  Vera puts LLM calls in the effect row: <code>Inference.complete : String -&gt; Result&lt;String, String&gt;</code>, <code>effects(&lt;Inference&gt;)</code>. A pure function can't accidentally call out to a remote model &mdash; it's a type error. If Vow ever grows agent-callable builtins (LLM-as-stdlib), this is the right shape. <i>Cost</i>: one effect kind, one runtime shim. <b>Zero verifier impact.</b> The single strongest portable idea across the three comparisons.
+</li>
+
+<li>
+  <b><code>fixSafety</code> ladder on every diagnostic.</b> <span class="src-tag"><b class="z">Z</b></span><br>
+  Vow has <code>Blame</code> (who is at fault) but no notion of <i>how dangerous a fix is</i>. A 5-level ladder &mdash; <code>format-only</code>, <code>behavior-preserving</code>, <code>local-edit</code>, <code>api-changing</code>, <code>requires-human-review</code> &mdash; lets an agent triage automatically. Vow mapping: strengthening a <code>requires</code> &rarr; <code>api-changing</code>; adding a loop <code>invariant</code> &rarr; <code>local-edit</code>; a counterexample showing a logic bug &rarr; <code>requires-human-review</code>. Complements blame.
+</li>
+
+<li>
+  <b>Typed <code>repair</code> handle alongside the diagnostic.</b> <span class="src-tag"><b class="z">Z</b></span><br>
+  Today a vow violation says <i>"<code>requires: y != 0</code> failed with <code>y == 0</code>"</i>. Adding <code>repair: { id: "guard-divisor", summary: "Add precondition or rescue" }</code> turns the diagnostic into an actionable JSON object the agent can dispatch on. The compiler doesn't have to <i>write</i> the patch &mdash; just <i>name</i> it.
+</li>
+
+<li>
+  <b>Fix example per error code.</b> <span class="src-tag"><b class="v">V</b></span><br>
+  Vera's <code>errors.md</code> ships a 4&ndash;6 line wrong/right snippet for every <code>E###</code>. Vow's <code>errors.md</code> has rationale and description but rarely a concrete fix shape. <b>Documentation-only change</b>; tightens the diagnostics-as-instructions story.
+</li>
+
+<li>
+  <b>Spec_ref anchors in diagnostic JSON.</b> <span class="src-tag"><b class="v">V</b></span><br>
+  Each Vera error carries <code>spec_ref: "spec/05-contracts.md#postconditions"</code>. Vow's spec is already cleanly chaptered (<code>docs/spec/{grammar,cli,contracts,errors,examples}.md</code>) &mdash; embedding the anchor in the diagnostic JSON closes the loop. The agent doesn't have to guess where to read.
+</li>
+
+<li>
+  <b>Contract-driven property testing.</b> <span class="src-tag"><b class="v">V</b></span><br>
+  <code>vera test --trials N</code> uses Z3 to synthesize inputs satisfying <code>requires</code>, runs the function, asserts <code>ensures</code>. Vow already has <code>vowc test</code>; adding a <code>--from-contracts --trials N</code> mode reuses CEGIS infrastructure to generate random witnesses and exercise <code>ensures</code> at runtime. Belt-and-braces beside ESBMC; useful where BMC bounds are tight.
+</li>
+
+<li>
+  <b>Two-phase fix: <code>vowc fix --plan --json</code>.</b> <span class="src-tag"><b class="z">Z</b></span><br>
+  <code>zero fix --plan --json</code> proposes; the agent applies. Vow could emit a structured proposal &mdash; not a patch &mdash; covering candidate strengthenings of contracts, loop invariants, or guards. The plan can be regression-tested independently of any patcher.
+</li>
+
+<li>
+  <b><code>vowc explain &lt;error_code&gt; --json</code>.</b> <span class="src-tag"><b class="z">Z</b></span><br>
+  Today <code>VowViolation</code> taxonomy / blame model / link to <code>contracts.md</code> live only in markdown. Lifting them into a runtime command makes them discoverable from the JSON itself: an agent that sees a code in build output can ask the binary what it means.
+</li>
+
+<li>
+  <b><code>vowc skill list</code> / <code>vowc skill get &lt;id&gt;</code>.</b> <span class="src-tag"><b class="z">Z</b></span><br>
+  Zero ships seven micro-skills (~2&ndash;3 KB each) the agent fetches on demand. Vow's reference files are already structured this way (<code>grammar</code>, <code>cli</code>, <code>contracts</code>, <code>errors</code>, <code>examples</code>) &mdash; the missing piece is a discoverable <i>index</i> command. Closes the version-skew window further.
+</li>
+
+<li>
+  <b>Centralized "Do nots" page in the skill.</b> <span class="src-tag"><b class="z">Z</b></span><br>
+  Zero's <code>zero-agent</code> opens with six imperatives. Vow's equivalents are spread across <code>contracts.md</code> and <code>CLAUDE.md</code>. A short, top-of-skill list. Vow-specific candidates: <i>don't weaken contracts to appease ESBMC</i>; <i>don't add <code>n &lt;= 10</code>-style verifier bounds to <code>requires</code></i>; <i>don't use <code>--no-verify</code> to skip a real failure</i>; <i>don't invent CLI fields or syntax</i>.
+</li>
+
+<li>
+  <b>Bounded quantifiers in contracts.</b> <span class="src-tag"><b class="v">V</b></span> <span class="src-tag"><b class="m">M</b></span><br>
+  Vera's <code>forall(@Nat, length, fn(...) {...})</code> and MoonBit's <code>&forall; idx : Int, 0 &lt;= idx &amp;&amp; idx &lt; h+1 &rarr; ...</code> are quantifiers over known-bounded ranges. <b>Translates straightforwardly to ESBMC as an unrolled loop of assertions.</b> A concrete win for contracts that today require N copy-pasted <code>ensures</code> lines (e.g. "every element of <code>xs[0..n]</code> is positive"). Stays within the verifier-friendliness gate of Vow's "crisp rule".
+</li>
+
+<li>
+  <b>Inline <code>test "name" { ... }</code> blocks.</b> <span class="src-tag"><b class="z">Z</b></span> <span class="src-tag"><b class="m">M</b></span><br>
+  Both Zero and MoonBit have inline tests in any source file. Vow has <code>tests/run/*.vow</code> directory tests; inline tests would be a complementary mode for unit-level coverage. <b>Bonus from Zero</b>: <code>xfail:</code>-prefixed test names that surface <code>unexpectedPasses</code> in JSON &mdash; an agent sees instantly when it has accidentally fixed something.
+</li>
+
+<li>
+  <b>Inline snapshot tests with auto-rewrite.</b> <span class="src-tag"><b class="m">M</b></span><br>
+  MoonBit's <code>inspect({ x: 10 }, content="{ x: 10 }")</code> rewrites the <code>content=</code> string in source on <code>--update</code>. No separate golden directory. Tight loop for golden-output tests. Worth borrowing for Vow's <code>tests/run/</code>.
+</li>
+
+<li>
+  <b>Surface the cache key / fingerprint in JSON build output.</b> <span class="src-tag"><b class="z">Z</b></span><br>
+  Zero exposes <code>cacheKeyInputs</code>, <code>snapshotKey</code>, <code>interfaceFingerprints</code>. Vow already has a deterministic compile-object cache (see <code>cli.md</code>); making the key visible gives agents a stable handle for cache diagnostics, regression detection, and reproducibility audits. Builds on the binary-fixed-point story.
+</li>
+
+<li>
+  <b>Mandatory <code>decreases</code> on pure recursion.</b> <span class="src-tag"><b class="v">V</b></span> <span class="src-tag"><b class="m">M</b></span><br>
+  Both Vera and MoonBit require an explicit termination measure on recursion. Vow uses bounded unwinding instead. Borrowing the <i>idea</i> &mdash; an explicit termination measure the agent has to state &mdash; might let Vow drop the unwind bound for some cases or sharpen counterexamples. <b>Feasibility note in the contracts ADR</b>, not an immediate change.
+</li>
+
+<li>
+  <b>Forward-looking: constrained decoding is the layer above Vow.</b> <span class="src-tag"><b class="m">M</b></span><br>
+  MoonBit attacks "agents emit invalid code" at the sampler; Vow attacks it at the verifier. <i>These compose</i>: a Vow-aware sampler could rule out unparseable or trivially ill-typed tokens before ESBMC ever runs. Worth a forward-looking note in <code>docs/spec/</code>. <b>Not an action item.</b>
+</li>
+
+<li>
+  <b>One canonical form, optionally enforced.</b> <span class="src-tag"><b class="v">V</b></span><br>
+  Vera ships <code>vera fmt --check</code> as part of the workflow; there is no style debate. Vow already has a canonical printer (a compiler pass), but doesn't enforce it as part of <code>vowc build</code>. Optional CI gate.
+</li>
+
+</ol>
+</div>
+
+<h2 id="reject">8 &middot; What Vow should not borrow</h2>
+
+<p>Each project's identity is built on choices that fight Vow's identity. Picking these up would dilute, not strengthen, what Vow is for:</p>
+
+<div class="callout warn">
+<h4 style="margin-top:0">From <span class="col-v">Vera</span></h4>
+<ul>
+  <li><b>De Bruijn slot references.</b> Vera's defining bet, and the most contested by every external reviewer. Bench wins are model-specific (Kimi K2.5 100%, Sonnet 4 79% &mdash; <i>worse</i> than Python). Names anchor LLM attention; <code>grep</code> matters; the cost to human collaborators is real. <b>Thesis too narrow and too disputed to bet on.</b></li>
+  <li><b>Tier-3 runtime fallback for verification.</b> If Z3 can't discharge a contract, Vera silently emits a runtime assert and counts it in <code>tier3_runtime</code>. <b>Breaks the "verified by default" pitch.</b> Adopt the <i>counting</i> in JSON; don't adopt the <i>fallback</i>.</li>
+  <li><b>WASM-only backend.</b> Cranelift native + binary fixed-point self-host is one of Vow's strongest credibility signals. Vera's Python-host + WASM-only target is research-grade.</li>
+  <li><b>Mandatory effect/visibility on every function.</b> Vera requires <code>public</code>/<code>private</code>, <code>requires</code>, <code>ensures</code>, <code>effects</code> on <i>every</i> declaration. Vow's "pure-by-default, effect annotations only when needed" carries the same information with less syntactic load.</li>
+  <li><b>No loops / no mutation / no linearity.</b> Vera's "everything is recursion, everything copies" gives up Vow's linear-types story. Linear types are <i>load-bearing</i> for Vow's memory-discipline brand. Don't trade them.</li>
+  <li><b>Async-as-a-marker-only.</b> Vera's <code>Async</code> effect has "no runtime overhead" because it's sequential. Same syntax, different semantics &mdash; an agent has no way to tell from the call site. If Vow ever adds async, it should be real.</li>
+  <li><b>Monolithic 99 KB <code>SKILL.md</code>.</b> Wrong default for Claude Code specifically. Vow already does the right thing.</li>
+</ul>
+
+<h4 style="margin-top:16px">From <span class="col-z">Zero</span></h4>
+<ul>
+  <li><b>Generics + <code>meta(...)</code> compile-time introspection.</b> Zero has both. Vow has deliberately rejected both because they expand the verification surface. Generics force monomorphization complexity that ESBMC has to chase. The "crisp rule" in <code>CLAUDE.md</code> &mdash; "add surface sugar only when it desugars to today's core semantics with near-zero verifier impact; reject anything that introduces a new type-system axis" &mdash; argues against this directly.</li>
+  <li><b>Sub-10 KiB binary chase.</b> Vow's binaries can be larger if it buys verification. Don't optimise away ESBMC's static C model for binary-size points.</li>
+  <li><b>Removing the C backend.</b> Zero removed its generated-C path in favour of direct emitters. Vow <i>needs</i> the C backend for ESBMC. Different priorities.</li>
+  <li><b>25 subcommands.</b> A lot of Zero's surface (<code>zero mem</code>, <code>zero ship</code>, <code>zero abi</code>, <code>zero doctor</code>) is useful only at productized-toolchain scale. Vow should pick subcommands by clear agent need, not parity.</li>
+  <li><b>Effect-as-capability syntax.</b> Threading <code>world: World</code> through every effectful function is grep-friendly but visually heavy. Vow's effect sets on function types do the same job structurally with less noise. <b>Adopt the explicitness; keep the syntax.</b></li>
+</ul>
+
+<h4 style="margin-top:16px">From <span class="col-mb">MoonBit</span></h4>
+<ul>
+  <li><b>Proprietary protocols (ASP).</b> Closed, undocumented, ships with the compiler. Vow's bet on "JSON-everywhere, no proprietary protocol" is the better story if the agent ecosystem is going to be Cambrian.</li>
+  <li><b>Source-available license.</b> MoonBit's MPSL (SSPL-style anti-cloud clause) is a recurring friction point in HN discussion. Vow's open-source posture is both straightforward marketing and engineering.</li>
+  <li><b>Vertically integrated agent (Pilot).</b> Pilot is a closed loop: own sampler, own protocol, own agent, own UI. Even if technically excellent, it's a separate <i>product</i> for the language team to maintain. Vow's "JSON-everywhere, any agent" is more leverage-efficient.</li>
+  <li><b>Separate predicate files (<code>.mbtp</code>).</b> Tempting for reuse and a richer logical sublanguage (quantifiers, recursive predicates) &mdash; but a new namespace, new file type, new logic. Fails the "doesn't make verification harder" gate <i>unless</i> there's a concrete reuse story Vow can't currently express. Inline contracts are simpler and currently sufficient.</li>
+  <li><b>Why3 as the verification primitive.</b> Real escape hatch if Vow ever needs unbounded <code>&forall;</code>/<code>&exist;</code>, but adopting it means giving up <b>concrete counterexamples</b>. The CEGIS loop changes shape from "here's the failing input" to "could not prove goal X". Not worth the trade.</li>
+</ul>
+</div>
+
+<h2 id="moat">9 &middot; Where Vow's moat is</h2>
+
+<p>After three comparisons, the picture is clearest about what Vow has that no one else does:</p>
+
+<table>
+  <thead><tr><th>Asset</th><th>Held by</th><th>Defensibility</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><b>Concrete counterexamples</b> (failing input + execution trace + values)</td>
+      <td>Vow alone</td>
+      <td>Architectural &mdash; tied to BMC. MoonBit (Why3) and Vera (Z3) can't get there without a different backend. Strong moat.</td>
+    </tr>
+    <tr>
+      <td><b>Caller/Callee blame on every violation</b></td>
+      <td>Vow alone</td>
+      <td>Cheap to copy; but no one else has thought to. Defensible by being first and getting it right.</td>
+    </tr>
+    <tr>
+      <td><b>Linear types + no GC</b></td>
+      <td>Vow alone (in this set)</td>
+      <td>MoonBit is GC; Vera has no memory story; Zero has owned/ref but not linearity. Linear types are <i>load-bearing</i> for Vow's brand. Hard to retrofit elsewhere.</td>
+    </tr>
+    <tr>
+      <td><b>Binary fixed-point self-host</b></td>
+      <td>Vow alone (in this set)</td>
+      <td>MoonBit isn't self-hosted; Vera isn't; Zero's self-host is in progress. Credibility signal that scales with time invested.</td>
+    </tr>
+    <tr>
+      <td><b>Verification on by default</b></td>
+      <td>Vow alone</td>
+      <td>MoonBit requires <code>"proof-enabled": true</code> per package; Vera's <code>verify</code> is a separate verb; Zero has no verifier. Vow's "<code>vowc build</code> verifies unless you opt out" is uniquely strong.</td>
+    </tr>
+    <tr>
+      <td><b>Small core surface</b> (no generics, no traits, no closures, no macros)</td>
+      <td>Vow alone</td>
+      <td>MoonBit, Vera, Zero all ship generics. Vow's "crisp rule" makes the verification surface tractable. Reverse-defensible: every feature Vow keeps out of the language is one ESBMC doesn't have to chase.</td>
+    </tr>
+    <tr>
+      <td><b>Published cross-language benchmarks</b> (36/36, HumanEval 66/67, 103/103 references)</td>
+      <td>Vow leads</td>
+      <td>Vera has VeraBench (single-run, self-acknowledged unreliable). MoonBit has the LLM4Code 2024 paper but no equivalent public agent bench. Zero has none.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>None of the three threaten any of these. Where the others <i>do</i> beat Vow &mdash; <code>fixSafety</code> ladders, typed repair handles, spec_ref anchors, the <code>Inference</code> effect &mdash; the gaps are either <b>documentation-only</b> or <b>JSON-shape</b> changes. They don't require language work or verifier changes.</p>
+
+<h2 id="actions">10 &middot; Prioritised action list</h2>
+
+<p>Concrete, in order. The first five are documentation-only or JSON-emitter changes; the rest involve modest language or tooling work. None of them touch the verifier core.</p>
+
+<table>
+  <thead>
+    <tr><th>#</th><th>Action</th><th>Effort</th><th>Surface affected</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span class="prio high">1</span></td>
+      <td><b>Add <code>fix:</code> wrong/right snippet to every <code>E###</code> in <code>errors.md</code>.</b> <span class="src-tag"><b class="v">V</b></span></td>
+      <td>Docs only.</td>
+      <td><code>docs/spec/errors.md</code></td>
+    </tr>
+    <tr>
+      <td><span class="prio high">2</span></td>
+      <td><b>Embed <code>spec_ref</code> anchors in diagnostic JSON.</b> <span class="src-tag"><b class="v">V</b></span></td>
+      <td>JSON emitter; trivial.</td>
+      <td><code>vow-diag</code></td>
+    </tr>
+    <tr>
+      <td><span class="prio high">3</span></td>
+      <td><b>Add <code>fixSafety</code> ladder field to every diagnostic JSON.</b> <span class="src-tag"><b class="z">Z</b></span></td>
+      <td>JSON emitter + classification table.</td>
+      <td><code>vow-diag</code></td>
+    </tr>
+    <tr>
+      <td><span class="prio high">4</span></td>
+      <td><b>Add typed <code>repair: {id, summary}</code> handle to diagnostics.</b> <span class="src-tag"><b class="z">Z</b></span></td>
+      <td>JSON emitter + repair-id taxonomy.</td>
+      <td><code>vow-diag</code></td>
+    </tr>
+    <tr>
+      <td><span class="prio high">5</span></td>
+      <td><b>Surface <code>vowc skill print --bundle</code> path in the entrypoint <code>SKILL.md</code>.</b> <span class="src-tag"><b class="v">V</b></span></td>
+      <td>One line of docs.</td>
+      <td>Skill entrypoint.</td>
+    </tr>
+    <tr>
+      <td><span class="prio med">6</span></td>
+      <td><b>Centralised "Do nots" page at top of the skill.</b> <span class="src-tag"><b class="z">Z</b></span></td>
+      <td>Docs only.</td>
+      <td>Skill entrypoint.</td>
+    </tr>
+    <tr>
+      <td><span class="prio med">7</span></td>
+      <td><b><code>vowc explain &lt;error_code&gt; --json</code> subcommand.</b> <span class="src-tag"><b class="z">Z</b></span></td>
+      <td>One subcommand + lookup table.</td>
+      <td>CLI.</td>
+    </tr>
+    <tr>
+      <td><span class="prio med">8</span></td>
+      <td><b><code>vowc skill list</code> + <code>vowc skill get &lt;id&gt;</code>.</b> <span class="src-tag"><b class="z">Z</b></span></td>
+      <td>Two subcommands; reuses existing skill content.</td>
+      <td>CLI.</td>
+    </tr>
+    <tr>
+      <td><span class="prio med">9</span></td>
+      <td><b>Surface cache key / interface fingerprint in <code>vowc build --json</code>.</b> <span class="src-tag"><b class="z">Z</b></span></td>
+      <td>JSON enrichment.</td>
+      <td><code>vow</code> driver.</td>
+    </tr>
+    <tr>
+      <td><span class="prio med">10</span></td>
+      <td><b>Inline <code>test "name" { ... }</code> blocks + <code>xfail:</code> / <code>unexpectedPasses</code>.</b> <span class="src-tag"><b class="z">Z</b></span> <span class="src-tag"><b class="m">M</b></span></td>
+      <td>Parser + test runner mode.</td>
+      <td>Language + tooling.</td>
+    </tr>
+    <tr>
+      <td><span class="prio med">11</span></td>
+      <td><b><code>vowc test --from-contracts --trials N</code> (contract-driven property tests).</b> <span class="src-tag"><b class="v">V</b></span></td>
+      <td>Random input generator + runtime assert; reuses CEGIS infra.</td>
+      <td>Tooling.</td>
+    </tr>
+    <tr>
+      <td><span class="prio med">12</span></td>
+      <td><b><code>vowc fix --plan --json</code> (plan-only fix proposal).</b> <span class="src-tag"><b class="z">Z</b></span></td>
+      <td>Structured proposal generator; no patcher.</td>
+      <td>CLI + diagnostic-to-plan mapping.</td>
+    </tr>
+    <tr>
+      <td><span class="prio low">13</span></td>
+      <td><b><code>Inference</code> as a tracked effect</b> &mdash; effect kind + runtime shim.<span class="src-tag"><b class="v">V</b></span></td>
+      <td>Modest. No verifier impact.</td>
+      <td>Effect system + stdlib. <i>Only when Vow grows LLM-callable builtins.</i></td>
+    </tr>
+    <tr>
+      <td><span class="prio low">14</span></td>
+      <td><b>Bounded quantifiers in contracts</b> (<code>forall i in 0..n: P(i)</code>) compiled to unrolled assertions.<span class="src-tag"><b class="v">V</b></span> <span class="src-tag"><b class="m">M</b></span></td>
+      <td>Surface syntax + desugar pass.</td>
+      <td>Grammar + ESBMC pipeline.</td>
+    </tr>
+    <tr>
+      <td><span class="prio low">15</span></td>
+      <td><b>Forward-looking note: constrained decoding is the layer above Vow.</b> <span class="src-tag"><b class="m">M</b></span></td>
+      <td>Docs only.</td>
+      <td><code>docs/spec/</code> rationale.</td>
+    </tr>
+    <tr>
+      <td><span class="prio low">16</span></td>
+      <td><b>Inline snapshot rewriting</b> (<code>inspect(...)</code>-style content auto-update).<span class="src-tag"><b class="m">M</b></span></td>
+      <td>Test runner mode.</td>
+      <td>Tooling.</td>
+    </tr>
+    <tr>
+      <td><span class="prio low">17</span></td>
+      <td><b>Feasibility note: explicit <code>decreases</code> on pure recursion.</b><span class="src-tag"><b class="v">V</b></span> <span class="src-tag"><b class="m">M</b></span></td>
+      <td>ADR.</td>
+      <td>Contracts ADR.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p style="color:var(--muted); font-size:13px;"><span class="prio high">High</span> &mdash; documentation or JSON-emitter changes; ship them now. &nbsp;<span class="prio med">Med</span> &mdash; modest tooling changes; cluster into a "diagnostic UX" release. &nbsp;<span class="prio low">Low</span> &mdash; language work or forward-looking notes; do when there's a concrete need.</p>
+
+<h2 id="bottom-line">Bottom line</h2>
+
+<p>In three months the agent-language landscape went from "is this a thing?" to four credible projects all converging on the same diagnosis. The right read for Vow is:</p>
+<ol>
+  <li><b>The category is real.</b> Stop hedging on positioning. <i>"AI-friendly language with provable contracts and concrete counterexamples"</i> is now a contested space; lean into it.</li>
+  <li><b>Vow's moat is structural</b> (BMC counterexamples, blame, linear types, self-host, verification-on-by-default), not cosmetic. None of MoonBit, Vera, or Zero threatens it.</li>
+  <li><b>Most of what's worth borrowing is documentation or JSON-shape work.</b> Five high-priority items above could ship in a single release without touching the verifier, the type system, or the compiler architecture.</li>
+  <li><b>The two language-level lessons that might be worth taking later</b> &mdash; bounded quantifiers and <code>Inference</code> as a tracked effect &mdash; both clear the "crisp rule" gate (no new type-system axis, no verifier impact). Hold them in reserve for when there's a concrete pull.</li>
+  <li><b>Reject loudly</b> the choices that <i>look</i> like wins but would dilute Vow: De Bruijn names, Tier-3 runtime fallback, generics+metaprogramming, monolithic <code>SKILL.md</code>, Pilot-style proprietary protocols. These are the others' identity, not Vow's.</li>
+</ol>
+
+<footer>
+<h4>Sources synthesised in this report</h4>
+<ul>
+  <li><code>~/tmp/moonbit-comparison.html</code> &mdash; MoonBit vs Vow, branch <code>vow/compareMoonbit</code>, 2026-05-18.</li>
+  <li><code>~/tmp/vera-vs-vow.html</code> &mdash; Vera vs Vow, branch <code>vow/compareVera</code>, 2026-05-18.</li>
+  <li><code>~/tmp/vera-skill-report.html</code> &mdash; Structural analysis of Vera's <code>SKILL.md</code>, 2026-05-18.</li>
+  <li><code>~/tmp/zero-vs-vow.html</code> &mdash; Zero vs Vow, 2026-05-18.</li>
+</ul>
+<p>Each source report contains the primary citations (HN threads, official docs, GitHub repos, papers). This unified report consolidates conclusions; consult the source reports for the underlying evidence.</p>
+</footer>
+
+</main>
+</body>
+</html>

--- a/docs/comparisons/vera-skill-analysis.html
+++ b/docs/comparisons/vera-skill-analysis.html
@@ -1,0 +1,361 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Vera SKILL.md — analysis &amp; lessons for Vow</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  :root {
+    --bg: #faf8f4;
+    --fg: #1b1b1b;
+    --muted: #5a5a5a;
+    --line: #d8d4ca;
+    --accent: #8b3a2f;     /* deep red — Vera */
+    --accent2: #1e5a8a;    /* deep blue — Vow */
+    --code-bg: #f0ece3;
+    --bad: #b3261e;
+    --ok: #185c3b;
+    --warn: #8a6d3b;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 0;
+    background: var(--bg); color: var(--fg);
+    font: 15px/1.55 ui-sans-serif, system-ui, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  }
+  main { max-width: 980px; margin: 0 auto; padding: 48px 28px 96px; }
+  header { border-bottom: 1px solid var(--line); padding-bottom: 18px; margin-bottom: 26px; }
+  h1 { font-size: 30px; margin: 0 0 6px; letter-spacing: -0.01em; }
+  h2 { font-size: 22px; margin: 40px 0 12px; padding-bottom: 4px; border-bottom: 1px solid var(--line); }
+  h3 { font-size: 17px; margin: 26px 0 8px; }
+  .lede { color: var(--muted); font-size: 15px; }
+  .meta { color: var(--muted); font-size: 13px; margin-top: 4px; }
+  code, pre, kbd { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+  code { background: var(--code-bg); padding: 1px 5px; border-radius: 3px; font-size: 0.92em; }
+  pre {
+    background: var(--code-bg); padding: 12px 14px; border-radius: 5px;
+    overflow-x: auto; font-size: 13px; line-height: 1.5;
+    border-left: 3px solid var(--line);
+  }
+  pre code { background: none; padding: 0; }
+  a { color: var(--accent2); }
+  a:hover { text-decoration: underline; }
+
+  table { border-collapse: collapse; width: 100%; margin: 10px 0 16px; font-size: 14px; }
+  th, td { border-bottom: 1px solid var(--line); padding: 6px 10px; text-align: left; vertical-align: top; }
+  th { background: var(--code-bg); font-weight: 600; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+  .pill {
+    display: inline-block; font-size: 11px; padding: 2px 7px; border-radius: 10px;
+    background: var(--code-bg); color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em;
+  }
+  .pill.bad { background: #f7e2e0; color: var(--bad); }
+  .pill.ok  { background: #e1f0e7; color: var(--ok); }
+  .pill.warn{ background: #f5ecd2; color: var(--warn); }
+
+  .vera { color: var(--accent); font-weight: 600; }
+  .vow  { color: var(--accent2); font-weight: 600; }
+
+  .callout {
+    background: #fff; border-left: 3px solid var(--accent2);
+    padding: 12px 16px; margin: 16px 0; border-radius: 0 4px 4px 0;
+  }
+  .callout.warn { border-color: var(--warn); background: #fdf8ea; }
+  .callout.bad  { border-color: var(--bad);  background: #fbeceb; }
+
+  .bar {
+    height: 10px; background: var(--code-bg); border-radius: 5px; overflow: hidden;
+    display: inline-block; width: 220px; vertical-align: middle; margin-right: 8px;
+  }
+  .bar > span { display: block; height: 100%; background: var(--accent); }
+  .bar.vow > span { background: var(--accent2); }
+
+  ul, ol { padding-left: 22px; }
+  li { margin: 4px 0; }
+  .footnote { font-size: 12px; color: var(--muted); border-top: 1px solid var(--line); margin-top: 40px; padding-top: 14px; }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  @media (max-width: 720px) { .grid2 { grid-template-columns: 1fr; } }
+
+  details { margin: 8px 0; }
+  summary { cursor: pointer; color: var(--accent2); }
+</style>
+</head>
+<body>
+<main>
+
+<header>
+  <h1>Vera <code>SKILL.md</code> — analysis &amp; lessons for Vow</h1>
+  <p class="lede">A structural look at the skill document <a href="https://veralang.dev/SKILL.md">veralang.dev/SKILL.md</a> ships, with a side-by-side comparison to how Vow ships its own Claude Code skill.</p>
+  <p class="meta">Vera <code>SKILL.md</code> snapshot fetched 2026-05-18 · Vow entrypoint + bundle built from <code>scripts/generate_help.py</code> at <code>vow/compareVera</code>.</p>
+</header>
+
+<h2>TL;DR</h2>
+<ul>
+  <li>Vera ships a <strong>single 99 KB / ~25 K-token</strong> <code>SKILL.md</code>. That is roughly <strong>5×</strong> the rough ceiling Anthropic suggests for a SKILL.md.</li>
+  <li>Two sections — <code>## Built-in Functions</code> (32 KB) and <code>## Effects</code> (13 KB) — make up <strong>~45 %</strong> of the file. They are reference material that would normally live behind a link.</li>
+  <li>Vow already does the thing Vera should do: a <strong>1.7 KB / 48-line</strong> entrypoint <code>SKILL.md</code> with reference links plus a separate <strong>~30 K-token bundle</strong> for raw-API contexts.</li>
+  <li>The right takeaway from Vera is not "shrink the skill". It is <strong>(a)</strong> Vera proves the stdlib-as-skill-content idea has a non-zero cost we should name, and <strong>(b)</strong> there are a handful of <em>content</em> ideas worth borrowing (Inference effect, tiered verification, fix-example-per-error-code) — independent of the skill packaging.</li>
+</ul>
+
+<h2>1. Size, at a glance</h2>
+
+<table>
+  <thead>
+    <tr><th>Artifact</th><th class="num">Bytes</th><th class="num">Lines</th><th class="num">~Tokens</th><th>Always-loaded?</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span class="vera">Vera</span> <code>SKILL.md</code> (single)</td>
+      <td class="num">99,631</td><td class="num">2,327</td><td class="num">~24,900</td>
+      <td><span class="pill bad">Yes — monolith</span></td>
+    </tr>
+    <tr>
+      <td><span class="vow">Vow</span> installed <code>SKILL.md</code> (entrypoint)</td>
+      <td class="num">1,680</td><td class="num">48</td><td class="num">~420</td>
+      <td><span class="pill ok">Yes — small</span></td>
+    </tr>
+    <tr>
+      <td><span class="vow">Vow</span> bundle (full spec, opt-in)</td>
+      <td class="num">120,600</td><td class="num">3,168</td><td class="num">~30,150</td>
+      <td><span class="pill">No — printed on demand</span></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Visualised against an informal 5,000-token ceiling for the always-loaded skill body:</p>
+
+<table>
+  <tr>
+    <td><span class="vera">Vera SKILL.md</span></td>
+    <td><span class="bar" title="24,900 tokens"><span style="width:100%"></span></span> ~24,900 tk <span class="pill bad">~5×</span></td>
+  </tr>
+  <tr>
+    <td><span class="vow">Vow entrypoint</span></td>
+    <td><span class="bar vow" title="420 tokens"><span style="width:8.4%"></span></span> ~420 tk <span class="pill ok">well under</span></td>
+  </tr>
+  <tr>
+    <td>Suggested ceiling</td>
+    <td><span class="bar" style="background:#e6e6e6"><span style="width:100%;background:#bdbdbd"></span></span> ~5,000 tk</td>
+  </tr>
+</table>
+
+<div class="callout warn">
+  <strong>What's bloating Vera's <code>SKILL.md</code>:</strong> two sections account for <strong>~45 %</strong> of the file —
+  <code>## Built-in Functions</code> (31 KB, ~7.8 K tokens) and <code>## Effects</code> (13 KB, ~3.2 K tokens). Together they are larger than the entire suggested skill ceiling.
+</div>
+
+<h2>2. Vera <code>SKILL.md</code> — structural breakdown</h2>
+<p class="meta">29 H2 sections, 74 H3 subsections, 131 fenced code blocks (1,082 lines of code, ~46 % of the file), 11 markdown tables.</p>
+
+<h3>Largest H2 sections</h3>
+<table>
+  <thead><tr><th>Section</th><th class="num">Bytes</th><th class="num">~Tokens</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>## Built-in Functions</code></td><td class="num">31,445</td><td class="num">~7,800</td><td>15 H3s: arrays, maps, sets, strings, JSON, HTML, markdown, regex, decimal, numeric, conversions, predicates.</td></tr>
+    <tr><td><code>## Effects</code></td><td class="num">12,667</td><td class="num">~3,200</td><td>11 H3s: 4 per-effect API tables (IO, Http, Inference, Random) plus handler examples.</td></tr>
+    <tr><td><code>## Toolchain</code></td><td class="num">7,362</td><td class="num">~1,800</td><td>Includes a 3.1 KB browser-compilation guide.</td></tr>
+    <tr><td><code>## Closures and captured bindings</code></td><td class="num">5,493</td><td class="num">~1,400</td><td></td></tr>
+    <tr><td><code>## Modules</code></td><td class="num">4,465</td><td class="num">~1,100</td><td></td></tr>
+    <tr><td><code>## Common Mistakes</code></td><td class="num">3,859</td><td class="num">~960</td><td>12 H3 subsections, each restating a rule taught positively elsewhere.</td></tr>
+    <tr><td><code>## Slot References (@T.n)</code></td><td class="num">3,481</td><td class="num">~870</td><td>Vera's signature feature: De Bruijn indices replace names.</td></tr>
+    <tr><td><code>## Types</code></td><td class="num">3,714</td><td class="num">~930</td><td></td></tr>
+    <tr><td><code>## Contracts</code></td><td class="num">2,433</td><td class="num">~610</td><td>requires / ensures / decreases / quantifiers.</td></tr>
+  </tbody>
+</table>
+
+<h3>What is in each chunk</h3>
+<div class="grid2">
+  <div>
+    <h3>Reference material</h3>
+    <ul>
+      <li><strong>Built-in Functions</strong> — ~160 standalone functions documented inline with signatures.</li>
+      <li><strong>Effects</strong> — 4 effect APIs as tables (IO, Http, Inference, Random) plus State / Exception / Async / Diverge.</li>
+      <li><strong>Operators</strong> — full precedence table.</li>
+      <li><strong>Modules</strong> — import syntax + escape table.</li>
+      <li><strong>Specification Reference</strong> — 11-chapter spec index (sits as a footer).</li>
+    </ul>
+  </div>
+  <div>
+    <h3>Teaching material</h3>
+    <ul>
+      <li><strong>Slot References</strong> — De Bruijn `@T.n` mechanics with multiple worked examples.</li>
+      <li><strong>Closures and captured bindings</strong> — capture rules including pair-typed values.</li>
+      <li><strong>Typed Holes</strong> — `?` workflow for incremental development.</li>
+      <li><strong>Common Mistakes</strong> — 12 wrong/right pairs.</li>
+      <li><strong>Complete Program Examples</strong> — five worked end-to-end programs.</li>
+    </ul>
+  </div>
+</div>
+
+<h3>Frontmatter (verbatim)</h3>
+<pre><code>---
+name: vera-language
+description: Write programs in the Vera programming language. Use when asked to write,
+  edit, debug, or review Vera code (.vera files). Vera is a statically typed, purely
+  functional language with algebraic effects, mandatory contracts, and typed slot
+  references (@T.n) instead of variable names.
+---</code></pre>
+<p>One field for triggers, but mixed with feature description (281 chars / ~70 tokens). Vow's equivalent splits triggers into a dedicated <code>when_to_use</code> field.</p>
+
+<h2>3. How Vera diverges from Vow's skill packaging</h2>
+
+<table>
+  <thead><tr><th>Aspect</th><th><span class="vera">Vera</span></th><th><span class="vow">Vow</span></th></tr></thead>
+  <tbody>
+    <tr>
+      <td>Loaded into context by default</td>
+      <td>Full 99 KB document</td>
+      <td>1.7 KB entrypoint that links to spec files</td>
+    </tr>
+    <tr>
+      <td>Progressive disclosure</td>
+      <td>None — single artifact</td>
+      <td>Entrypoint + <code>reference/</code> + <code>examples/</code> + <code>schemas/</code></td>
+    </tr>
+    <tr>
+      <td>Stdlib reference location</td>
+      <td>Inline in <code>SKILL.md</code> (~7.8 K tokens)</td>
+      <td>External (<code>reference/grammar.md</code> builtins section)</td>
+    </tr>
+    <tr>
+      <td>Effect API tables</td>
+      <td>Inline in <code>SKILL.md</code> (~3 K tokens)</td>
+      <td>External (<code>reference/grammar.md</code> effects section)</td>
+    </tr>
+    <tr>
+      <td>Self-contained API bundle</td>
+      <td>Same file</td>
+      <td>Separate <code>build/vowc skill print --bundle</code> output (120 KB / ~30 K tokens)</td>
+    </tr>
+    <tr>
+      <td>Trigger phrase</td>
+      <td>Embedded in description</td>
+      <td>Separate <code>when_to_use</code> field</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>The Vow entrypoint, in full, for scale:</p>
+<pre><code>---
+name: vow-toolchain
+description: Write, compile, debug, and verify Vow programs (.vow files) with
+  contracts, CEGIS, ESBMC counterexamples, diagnostics, and vow build / vow verify.
+when_to_use: Use when the user edits or creates .vow files, says "write a Vow
+  program", "fix this counterexample", "add contracts", "why did verification
+  failed", "ESBMC", "vow build", or "vow verify".
+argument-hint: "[file.vow]"
+---
+
+# Vow Toolchain
+[ workflow, minimal program, reference links ]
+
+## Reference files
+- reference/grammar.md
+- reference/cli.md
+- reference/contracts.md
+- reference/errors.md
+- examples/examples.md
+- schemas/</code></pre>
+
+<div class="callout">
+  <strong>Note on total volume.</strong> Vow's <em>bundle</em> (3,168 lines, ~30 K tokens) is actually <em>larger</em> than Vera's <code>SKILL.md</code>. The win is not "less material" — it is "less material loaded by default". The bundle is opt-in via <code>vowc skill print --bundle</code>.
+</div>
+
+<h2>4. Is Vera's SKILL.md really &ldquo;too large&rdquo;?</h2>
+
+<p>Two angles:</p>
+
+<h3>Angle A — packaging-as-a-Claude-Code-skill</h3>
+<p>Yes. A Claude Code skill is loaded on trigger and consumes context for the remainder of the session. At ~25 K tokens that is a significant slice of any context window before the user has typed anything. Anthropic's own skill examples target much smaller bodies with linked sub-resources. By that bar, Vera's <code>SKILL.md</code> is over by roughly 5×.</p>
+
+<h3>Angle B — packaging-as-a-self-contained-language-reference</h3>
+<p>Less obvious. Vera's design ethos is &ldquo;everything an agent needs in one fetch&rdquo;. The benchmark wins reported in <code>vera-bench</code> may partly rely on the full surface area of the stdlib being in context. Splitting it into linked docs has a real cost if the agent doesn't follow links — and many agents in production don't.</p>
+
+<p>So the more careful claim: Vera is making an explicit bet that <em>fetching the whole surface beats progressive disclosure</em>. That's a defensible bet for a language whose entire pitch is &ldquo;designed for LLMs to write&rdquo;. The skill being &ldquo;too large&rdquo; is true only if you accept the framing that a skill's job is to point at material, not to <em>be</em> the material.</p>
+
+<h2>5. What Vow can learn — concretely</h2>
+
+<p>Two categories: <strong>skill packaging</strong> (where Vow is already ahead) and <strong>content / language design</strong> (where Vera has a few ideas worth borrowing).</p>
+
+<h3>Skill packaging — what we already do right, but should formalize</h3>
+<ul>
+  <li><strong>Entrypoint + linked references is the right shape.</strong> Vera's monolith is the comparison that proves it. Keep doing this.</li>
+  <li><strong>Make the bundle discoverable.</strong> Right now <code>vowc skill print --bundle</code> exists but is undocumented in the entrypoint. Add a one-line "for raw-API use, fetch the bundle" note. Cost: trivial.</li>
+  <li><strong>Audit the bundle for sections that should be lazy.</strong> The bundle is ~30 K tokens. If anyone embeds it in a system prompt (the bench harness does), the same bloat critique applies. Candidates to elide from bundle: full error catalog (336 lines of <code>## Compile-Time Errors</code>), full JSON schemas.</li>
+  <li><strong>Keep <code>when_to_use</code> separate from <code>description</code>.</strong> Vera collapsing them is a packaging regression. Stay split.</li>
+</ul>
+
+<h3>Content / language design — ideas worth stealing</h3>
+<table>
+  <thead><tr><th>Idea</th><th>From</th><th>Worth it?</th><th>Cost</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><strong>Inference as a tracked effect</strong>. Calling an LLM is part of the effect row, so a pure function cannot accidentally call out.</td>
+      <td>Vera <code>&lt;Inference&gt;</code> effect with <code>Inference.complete : String -&gt; Result&lt;String, String&gt;</code></td>
+      <td><span class="pill ok">Yes if Vow grows agent-callable builtins</span></td>
+      <td>Effect kind + runtime shim. No verifier impact.</td>
+    </tr>
+    <tr>
+      <td><strong>Tier-3 runtime fallback</strong>. If an <code>ensures</code> can't discharge statically, emit a runtime assert and label the function "verified-with-runtime-fallback" in build output.</td>
+      <td>Vera's three-tier strategy</td>
+      <td><span class="pill warn">Possibly</span> — could weaken Vow's "verified by default" pitch.</td>
+      <td>Code emission + JSON status enum. Risk: distorts the brand.</td>
+    </tr>
+    <tr>
+      <td><strong>Fix-example per error code</strong>. Each <code>E###</code> ships a wrong/right snippet inline.</td>
+      <td>Vera's stable codes E001–E702 with examples</td>
+      <td><span class="pill ok">Yes</span></td>
+      <td>Documentation only. Vow's <code>errors.md</code> mostly has rationale, less often a fix example.</td>
+    </tr>
+    <tr>
+      <td><strong>Contract-driven property tests</strong>. <code>vera test --trials N</code> auto-generates inputs satisfying <code>requires</code>, runs them, asserts <code>ensures</code>.</td>
+      <td>Vera toolchain</td>
+      <td><span class="pill ok">Yes</span> — Vow has <code>vowc test</code> already; could grow a contract-driven mode.</td>
+      <td>Random input generator + runtime assert in debug mode. Reuses existing infrastructure.</td>
+    </tr>
+    <tr>
+      <td><strong>Typed holes (<code>?</code>) producing a warning, not an error</strong>. Lets the agent type-check incrementally.</td>
+      <td>Vera <code>W001</code></td>
+      <td><span class="pill warn">Maybe</span></td>
+      <td>Parser + checker support. Useful but small.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Ideas to <em>not</em> steal</h3>
+<ul>
+  <li><strong>De Bruijn slot references.</strong> Vera's defining feature, and the most contested. HN consensus was sceptical; cross-model bench numbers were mixed (Kimi K2.5 100 %, Claude Sonnet 4 79 %). Names anchor attention; grep matters; the cost to human collaborators is real even in an agent-first language.</li>
+  <li><strong>Effects without linear types.</strong> Vera has no mutability, no linearity, no ownership story — everything copies. Vow's linear types are differentiated and worth keeping.</li>
+  <li><strong>WASM-only backend.</strong> Vow's Cranelift native pipeline + binary fixed point is a credibility signal that Vera doesn't have.</li>
+</ul>
+
+<h2>6. What this means for Vow's own skill</h2>
+
+<p>Vow's entrypoint is already small. Two small improvements would still be worth making:</p>
+
+<ol>
+  <li><strong>Surface the bundle path in the entrypoint.</strong> One line: "For self-contained reference (e.g. raw API use), run <code>vowc skill print --bundle</code>." Helps anyone wiring Vow into a non-Claude-Code agent harness.</li>
+  <li><strong>Add a fix-example field to <code>errors.md</code>.</strong> Each <code>E###</code> already has a description; adding a 4–6 line <em>wrong</em> / <em>right</em> pair brings parity with Vera's diagnostics-as-instructions framing. The agent doesn't need to guess the fix shape.</li>
+</ol>
+
+<p>Both are low-cost and don't require changes to the language or the verifier.</p>
+
+<h2>7. Bottom line</h2>
+
+<p>Vera's <code>SKILL.md</code> is too large <em>as a Claude Code skill</em> — about 5× over the practical ceiling — and the bloat is concentrated in two reference-material sections (stdlib + effect APIs) that progressive disclosure handles cleanly. Vow already does the right thing by shipping a 1.7 KB entrypoint plus an opt-in bundle.</p>
+
+<p>The interesting lessons are <em>not</em> in the packaging, where Vera is just paying for a different choice. They are in three small content moves Vera makes that Vow could pick up for very low cost: <strong>Inference as an effect</strong>, <strong>fix examples per error code</strong>, and <strong>contract-driven test generation</strong>. Skip the De Bruijn names, the WASM-only target, and the runtime-fallback tier — those are Vera's identity, not Vow's.</p>
+
+<div class="footnote">
+  Sources: Vera <code>SKILL.md</code> (<a href="https://veralang.dev/SKILL.md">veralang.dev/SKILL.md</a>, 99,631 bytes, fetched 2026-05-18) ·
+  Vera repo (<a href="https://github.com/aallan/vera">github.com/aallan/vera</a>) ·
+  Vera benchmark (<a href="https://github.com/aallan/vera-bench">github.com/aallan/vera-bench</a>) ·
+  HN discussion (<a href="https://news.ycombinator.com/item?id=47955118">item #47955118</a>) ·
+  Launch post (<a href="https://negroniventurestudios.com/2026/04/13/language-design-doing-the-heavy-lifting/">Negroni Venture Studios, 2026-04-13</a>) ·
+  Vow skill artifacts derived from <code>scripts/generate_help.py</code> on branch <code>vow/compareVera</code>.
+</div>
+
+</main>
+</body>
+</html>

--- a/docs/comparisons/vs-moonbit.html
+++ b/docs/comparisons/vs-moonbit.html
@@ -1,0 +1,681 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MoonBit vs Vow — comparison report</title>
+<style>
+  :root {
+    --fg: #1a1a1a;
+    --muted: #5a5a5a;
+    --bg: #fbfaf7;
+    --card: #fff;
+    --rule: #e7e2d6;
+    --accent: #7a4c1b;
+    --accent-soft: #f2e8d4;
+    --code-bg: #f4f0e6;
+    --code-fg: #2b2b2b;
+    --vow: #2e6e3d;
+    --moonbit: #5b3e8a;
+    --warn-bg: #fff7e6;
+    --warn-border: #e9bf6d;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    line-height: 1.55;
+  }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 48px 32px 96px; }
+  header.page {
+    border-bottom: 2px solid var(--accent);
+    padding-bottom: 24px;
+    margin-bottom: 32px;
+  }
+  header.page h1 {
+    font-size: 2.1rem;
+    margin: 0 0 6px 0;
+    letter-spacing: -0.01em;
+  }
+  header.page .sub { color: var(--muted); font-size: 0.95rem; }
+  header.page .meta {
+    margin-top: 14px;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  h2 {
+    font-size: 1.4rem;
+    margin: 48px 0 14px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--rule);
+    letter-spacing: -0.01em;
+  }
+  h3 {
+    font-size: 1.08rem;
+    margin: 26px 0 8px;
+    color: var(--accent);
+  }
+  h4 { font-size: 0.98rem; margin: 18px 0 4px; }
+  p { margin: 8px 0 12px; }
+  ul, ol { margin: 8px 0 14px 0; padding-left: 22px; }
+  li { margin: 3px 0; }
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px dotted var(--accent); }
+  a:hover { border-bottom-style: solid; }
+  code, pre {
+    font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.86rem;
+  }
+  p code, li code, td code {
+    background: var(--code-bg);
+    padding: 1px 5px;
+    border-radius: 3px;
+    color: var(--code-fg);
+  }
+  pre {
+    background: var(--code-bg);
+    color: var(--code-fg);
+    padding: 14px 16px;
+    border-radius: 6px;
+    overflow-x: auto;
+    border: 1px solid var(--rule);
+    line-height: 1.45;
+  }
+  pre code { background: transparent; padding: 0; }
+  .tldr {
+    background: var(--card);
+    border: 1px solid var(--rule);
+    border-left: 4px solid var(--accent);
+    padding: 18px 22px;
+    border-radius: 6px;
+    margin-bottom: 28px;
+  }
+  .tldr h2 {
+    margin: 0 0 10px;
+    border: none;
+    padding: 0;
+    font-size: 1.05rem;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .note {
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-border);
+    padding: 10px 14px;
+    border-radius: 5px;
+    font-size: 0.9rem;
+    margin: 12px 0;
+  }
+  .note strong { color: #8a5a00; }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 14px 0;
+    font-size: 0.92rem;
+    background: var(--card);
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  th, td {
+    text-align: left;
+    padding: 9px 12px;
+    border-bottom: 1px solid var(--rule);
+    vertical-align: top;
+  }
+  th {
+    background: var(--accent-soft);
+    font-weight: 600;
+    color: var(--accent);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  tr:last-child td { border-bottom: none; }
+  td:first-child { font-weight: 600; width: 28%; }
+  .col-vow { color: var(--vow); }
+  .col-mb  { color: var(--moonbit); }
+  .pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
+  .pill.vow { background: #e0efe4; color: var(--vow); }
+  .pill.mb  { background: #ece4f5; color: var(--moonbit); }
+  .grid2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 18px;
+    margin: 16px 0;
+  }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 16px 18px;
+  }
+  .card h4 { margin-top: 0; }
+  ol.steps { counter-reset: step; list-style: none; padding-left: 0; }
+  ol.steps li {
+    counter-increment: step;
+    padding-left: 36px;
+    position: relative;
+    margin: 12px 0;
+  }
+  ol.steps li::before {
+    content: counter(step);
+    position: absolute;
+    left: 0; top: 0;
+    width: 26px; height: 26px;
+    background: var(--accent);
+    color: white;
+    border-radius: 50%;
+    text-align: center;
+    line-height: 26px;
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+  footer {
+    margin-top: 64px;
+    padding-top: 18px;
+    border-top: 1px solid var(--rule);
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+  footer ul { columns: 2; column-gap: 24px; }
+  .lead { font-size: 1.02rem; color: #2b2b2b; }
+  .small { font-size: 0.82rem; color: var(--muted); }
+  hr.section { border: 0; border-top: 1px solid var(--rule); margin: 32px 0; }
+  .toc { background: var(--card); border: 1px solid var(--rule); border-radius: 6px; padding: 14px 18px; }
+  .toc ol { columns: 2; column-gap: 24px; margin: 0; }
+  .toc li { margin: 2px 0; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="page">
+  <h1>MoonBit vs Vow</h1>
+  <div class="sub">A comparative report on two languages pitched at AI-agent code generation.</div>
+  <div class="meta">
+    Compiled 2026-05-18 &middot; branch <code>vow/compareMoonbit</code> &middot; MoonBit at 0.9 (Apr 2026)
+  </div>
+</header>
+
+<div class="tldr">
+  <h2>TL;DR</h2>
+  <p class="lead">MoonBit and Vow share a tagline ("a language for AI agents") and very little else. MoonBit is a broad, batteries-included WebAssembly-first language whose AI bet is at the <em>sampling</em> layer (constrained decoding) plus a vertically integrated agent (<strong>MoonBit Pilot</strong>). Verification, added in 0.9 (April 2026), is a Why3 + SMT deductive layer, opt-in per package, with separate <code>.mbtp</code> predicate files.</p>
+  <p class="lead">Vow is a deliberately small language whose AI bet is at the <em>verification</em> layer: inline <code>requires</code>/<code>ensures</code>/<code>invariant</code> verified by ESBMC, structured JSON counterexamples, blame attribution, linear types, and a CEGIS loop. No first-party agent, no closed compiler, no proprietary protocol.</p>
+  <p class="lead">They are <strong>not direct competitors</strong>. MoonBit confirms that the market for "AI-friendly languages with provable contracts" is real; Vow has a different and arguably tighter answer for the repair loop.</p>
+</div>
+
+<nav class="toc">
+  <strong>Contents</strong>
+  <ol>
+    <li><a href="#identity">Identity card</a></li>
+    <li><a href="#pitch">"For AI agents" — what each means</a></li>
+    <li><a href="#syntax">Syntax reference</a></li>
+    <li><a href="#stdlib">Standard library</a></li>
+    <li><a href="#tooling">Tooling</a></li>
+    <li><a href="#ai-tooling">AI tooling: Pilot, ASP, constrained decoding</a></li>
+    <li><a href="#verification">Verification (0.9)</a></li>
+    <li><a href="#ecosystem">Ecosystem &amp; adoption</a></li>
+    <li><a href="#compare">Side-by-side comparison</a></li>
+    <li><a href="#learn">What Vow can learn</a></li>
+  </ol>
+</nav>
+
+<h2 id="identity">1. Identity card</h2>
+<table>
+  <tr><th>Field</th><th>MoonBit</th><th>Vow</th></tr>
+  <tr><td>Built by</td><td>IDEA (Shenzhen). Lead: Hongbo Zhang (ex-ReScript/BuckleScript/Flow).</td><td>Paulo Matos &amp; collaborators.</td></tr>
+  <tr><td>Started</td><td>October 2022; v0.9 in April 2026.</td><td>2025.</td></tr>
+  <tr><td>License</td><td>Compiler: source-available under <em>MoonBit Public Source License v1</em> (SSPL-style anti-cloud-vendor clause). Stdlib + <code>moon</code>: open source.</td><td>Open source.</td></tr>
+  <tr><td>Pitch</td><td>"AI-native general-purpose language" for cloud + edge, WASM-first.</td><td>Language for AI agents, with first-class contracts statically verified.</td></tr>
+  <tr><td>Compilation</td><td>Multi-backend: WASM-GC (flagship), JS, native, riscv32. No LLVM.</td><td>Native via Cranelift.</td></tr>
+  <tr><td>Self-hosted?</td><td>No. Compiler in OCaml, distributed as WASM.</td><td>Yes. Binary fixed-point self-host.</td></tr>
+  <tr><td>Memory</td><td>Garbage collected.</td><td>No GC. Linear types + explicit ownership.</td></tr>
+  <tr><td>URL</td><td><a href="https://www.moonbitlang.com/">moonbitlang.com</a> &middot; <a href="https://docs.moonbitlang.com/en/latest/">docs</a> &middot; <a href="https://github.com/moonbitlang">github</a></td><td>This repo.</td></tr>
+</table>
+
+<h2 id="pitch">2. "For AI agents" — what each one means</h2>
+
+<div class="grid2">
+  <div class="card">
+    <h4><span class="pill mb">MoonBit</span> attacks the model layer</h4>
+    <ul>
+      <li><strong>Constrained decoding</strong>: a "local sampler" rejects syntactically invalid tokens during generation; a "global sampler" type-checks. Hosted at <a href="https://ai.moonbitlang.com">ai.moonbitlang.com</a>.</li>
+      <li><strong>Pilot</strong>: first-party multi-modal coding agent (CLI + IDE + cloud), BYO model key.</li>
+      <li>Custom <strong>Agent Server Protocol (ASP)</strong> for cloud agent orchestration (not MCP).</li>
+      <li>Syntax research: top-level type signatures mandatory, "no nesting" preference, "KV-cache friendly" structure. (LLM4Code 2024 paper.)</li>
+    </ul>
+  </div>
+  <div class="card">
+    <h4><span class="pill vow">Vow</span> attacks the verification layer</h4>
+    <ul>
+      <li><strong>Inline contracts</strong>: <code>requires</code> / <code>ensures</code> / <code>invariant</code> in the same expression language as code.</li>
+      <li><strong>ESBMC bounded model checking</strong>: returns concrete counterexample traces, not just "unknown."</li>
+      <li><strong>Blame semantics</strong>: <code>requires</code> blames Caller; <code>ensures</code>/<code>invariant</code> blames Callee.</li>
+      <li><strong>Structured JSON diagnostics</strong> as a first-class agent contract — no proprietary protocol layered on top.</li>
+      <li>Intentionally small surface: no generics, traits, closures, macros, async.</li>
+    </ul>
+  </div>
+</div>
+
+<p>Both projects converged on "verification matters" — MoonBit's 0.9 in April 2026 is direct evidence. They got there via different mechanisms (SMT/Why3 vs. BMC/ESBMC), with different ergonomics (separate predicate files vs. inline), and different counterexample shapes (per-VC verdict vs. concrete trace).</p>
+
+<h2 id="syntax">3. Syntax reference</h2>
+
+<p class="lead">MoonBit's surface is <strong>Rust-flavoured ML</strong>: <code>fn</code>, <code>let</code>, <code>match</code>, <code>enum</code>, <code>struct</code>, expression-oriented bodies. Examples below are verbatim from the official docs and the <code>moonbit-community/verified</code> repo.</p>
+
+<h3>3.1 Variables &amp; mutability</h3>
+<pre><code>let a = true
+let b = false
+let c = a &amp;&amp; b
+
+let mut i = 5
+while i &gt; 0 {
+  println(i)
+  i = i - 1
+}
+
+let r : Ref[Int] = { val: 100 }
+r.val = 200
+r.val += 1</code></pre>
+<p class="small"><code>Ref[T]</code> is a single-field <code>mut</code> struct — needed because closures cannot capture <code>let mut</code> bindings.</p>
+
+<h3>3.2 Functions</h3>
+<pre><code>fn add3(x : Int, y : Int, z : Int) -&gt; Int {
+  x + y + z
+}
+
+fn local_1() -&gt; Int {
+  fn inc(x) { x + 1 }                // local fn: inferred
+  (fn(x) { x + inc(2) })(6)          // anonymous fn
+}
+
+[1, 2, 3].each(x =&gt; println(x * x))  // arrow lambda
+
+fn labelled(arg1~ : Int, arg2~ : Int) -&gt; Int { arg1 + arg2 }
+let _ = labelled(arg2=2, arg1=1)</code></pre>
+<p class="small">Top-level signatures are mandatory; locals are inferred. <code>arg~</code> declares a labelled (keyword) argument.</p>
+
+<h3>3.3 Structs</h3>
+<pre><code>struct User {
+  id : Int
+  name : String
+  mut email : String
+}
+
+let u = User::{ id: 0, name: "John Doe", email: "john@doe.com" }
+u.email = "john@doe.name"
+
+let updated = { ..u, email: "john@doe.name" }  // functional record update</code></pre>
+
+<h3>3.4 Enums &amp; pattern matching</h3>
+<pre><code>enum Lst {
+  Nil
+  Cons(Int, Lst)
+}
+
+fn sum(l : Lst) -&gt; Int {
+  match l {
+    Nil =&gt; 0
+    Cons(x, xs) =&gt; x + sum(xs)
+  }
+}</code></pre>
+
+<h3>3.5 Generics &amp; traits</h3>
+<pre><code>fn[S, T] List::map(self : List[S], f : (S) -&gt; T) -&gt; List[T] {
+  match self {
+    Nil =&gt; Nil
+    Cons(x, xs) =&gt; Cons(f(x), xs.map(f))
+  }
+}
+
+pub(open) trait MyShow {
+  to_string(Self) -&gt; String
+}
+
+struct MyType {}
+pub impl MyShow for MyType with to_string(self) { "MyType{}" }
+
+struct T { a : Int; b : Int } derive(Eq, Compare, Debug, Default)</code></pre>
+<p class="small">Generic parameters come <em>before</em> the function name (<code>fn[T, U]</code>), which is unusual among ML-family languages.</p>
+
+<h3>3.6 Pattern exotics</h3>
+<pre><code>match ary {
+  [] =&gt; "empty"
+  [a, b, .. rest] =&gt; "head two"
+  [.., a, b] =&gt; "tail two"
+}
+
+match c {
+  'a'..='z' =&gt; "lower"
+  'A'..='Z' =&gt; "upper"
+  _         =&gt; "other"
+}
+
+match map {
+  { "b"? : None, "a": x, .. } =&gt; x   // "b" must be absent
+}
+
+match opt {
+  Some(a) if f(a) is [0, b] =&gt; a + b // guard + is-pattern
+  Some(b) =&gt; b
+  None    =&gt; -1
+}</code></pre>
+
+<h3>3.7 Error effects</h3>
+<pre><code>suberror DivError { DivError(String) } derive(Debug)
+
+fn div(x : Int, y : Int) -&gt; Int raise DivError {
+  if y == 0 { raise DivError("division by zero") }
+  x / y
+}
+
+fn main {
+  try div(42, 0) catch {
+    DivError(s) =&gt; println(s)
+  } noraise {
+    v =&gt; println(v)
+  }
+  let res = try? (div(6, 0) * div(6, 3))   // ? wraps into Result
+  let v   = try! div(6, 3)                 // ! panics on error
+}</code></pre>
+<p class="small">Errors are an <em>effect</em> on the return type (<code>-&gt; Int raise DivError</code>) — checked, with no <code>Result</code> plumbing at call sites.</p>
+
+<h3>3.8 Async</h3>
+<pre><code>async fn fetch_homepage() -&gt; String {
+  let (response, body) = @http.get("https://www.moonbitlang.com")
+  guard response.code is (200..&lt;300) else {
+    fail("server responded with \{response.code} \{response.reason}")
+  }
+  body.text()
+}
+
+async fn main {
+  @async.with_task_group(group =&gt; {
+    group.spawn_bg(() =&gt; { let _ = fetch_homepage() })
+  })
+}</code></pre>
+<p class="small">No <code>await</code> keyword — every call into an <code>async fn</code> is implicitly a suspend point. Structured concurrency via <code>with_task_group</code>.</p>
+
+<h3>3.9 Modules</h3>
+<pre><code>// moon.pkg.json
+{
+  "import": [
+    "moonbit-community/language/packages/pkgA",
+    { "path": "moonbit-community/language/packages/pkgC", "alias": "c" }
+  ]
+}
+
+// in source:
+pub fn add1(x : Int) -&gt; Int {
+  @c.incr(@pkgA.incr(x))
+}
+pub using @pkgA { incr, trait Trait, type Type }  // re-export</code></pre>
+
+<h3>3.10 Inline tests</h3>
+<pre><code>test "addition" {
+  assert_eq(1 + 1, 2)
+}
+
+test "snapshot" {
+  inspect({ x: 10 }, content="{ x: 10 }")  // --update auto-rewrites content=
+}</code></pre>
+<p class="small">Snapshot strings live inline in source and are rewritten in place by the test runner — no separate golden directory.</p>
+
+<h2 id="stdlib">4. Standard library — <code>moonbitlang/core</code></h2>
+
+<p>Roughly 50 packages, ~38k LOC, 2.5k+ tests, MIT licensed. One package per folder, each with a <code>moon.pkg.json</code> and a generated <code>pkg.generated.mbti</code> interface file.</p>
+
+<table>
+  <tr><th>Category</th><th>Packages</th></tr>
+  <tr><td>Scalars</td><td><code>bool</code>, <code>int</code>, <code>int16</code>, <code>int64</code>, <code>uint</code>, <code>uint16</code>, <code>uint64</code>, <code>byte</code>, <code>char</code>, <code>float</code>, <code>double</code>, <code>bigint</code>, <code>unit</code></td></tr>
+  <tr><td>Collections</td><td><code>array</code> (+ <code>FixedArray</code>), <code>list</code>, <code>lazy_list</code>, <code>deque</code>, <code>queue</code>, <code>priority_queue</code>, <code>hashmap</code>, <code>hashset</code>, <code>sorted_map</code>, <code>sorted_set</code>, <code>set</code>, persistent variants under <code>immut/</code></td></tr>
+  <tr><td>Strings &amp; bytes</td><td><code>string</code>, <code>bytes</code>, <code>buffer</code>, <code>strconv</code>, <code>encoding</code></td></tr>
+  <tr><td>Generics / util</td><td><code>option</code>, <code>result</code>, <code>ref</code>, <code>tuple</code>, <code>range</code>, <code>lazy</code>, <code>cmp</code>, <code>iter</code></td></tr>
+  <tr><td>Numeric</td><td><code>math</code>, <code>random</code></td></tr>
+  <tr><td>Structured data</td><td><code>json</code></td></tr>
+  <tr><td>Meta / tooling</td><td><code>builtin</code>, <code>prelude</code>, <code>internal</code>, <code>argparse</code>, <code>env</code>, <code>abort</code>, <code>debug</code>, <code>error</code>, <code>bench</code>, <code>test</code>, <code>quickcheck</code>, <code>coverage</code></td></tr>
+</table>
+
+<div class="note">
+<strong>Not in core:</strong> async runtime, IO/filesystem, networking, time, regex. Async is a language feature; runtime support is per-backend. IO etc. live out-of-tree under <code>moonbitlang/x</code> and community packages on <a href="https://mooncakes.io">mooncakes.io</a>.
+</div>
+
+<h2 id="tooling">5. Tooling</h2>
+
+<h3>5.1 The <code>moon</code> CLI</h3>
+<p>Single CLI surface. Subcommands:</p>
+<ul>
+  <li><code>new</code>, <code>build</code>, <code>check</code>, <code>run</code>, <code>test</code>, <code>bench</code>, <code>clean</code>, <code>fmt</code>, <code>doc</code>, <code>info</code></li>
+  <li><code>add</code>, <code>remove</code>, <code>install</code>, <code>tree</code>, <code>update</code> — dependency management</li>
+  <li><code>login</code>, <code>register</code>, <code>publish</code>, <code>package</code> — registry operations</li>
+  <li><code>coverage analyze | report | clean</code></li>
+  <li><code>prove</code> — new in 0.9 for formal verification (peer of <code>build</code>/<code>test</code>)</li>
+  <li><code>upgrade</code>, <code>shell-completion</code>, <code>generate-build-matrix</code>, <code>version</code></li>
+</ul>
+
+<h3>5.2 Files &amp; manifests</h3>
+<ul>
+  <li><code>.mbt</code> — source files.</li>
+  <li><code>.mbti</code> — generated interface file (<code>moon info</code>).</li>
+  <li><code>.mbtx</code> — runnable scripts.</li>
+  <li><code>.mbtp</code> — predicate file (0.9; appears in community verified-examples repo, not yet in the official file-extension reference).</li>
+  <li><code>moon.mod.json</code> — module manifest (semver, deps, license, supported-targets, scripts).</li>
+  <li><code>moon.pkg.json</code> — per-package config (imports, link, native-stub, formatter ignore, <code>"proof-enabled": true</code> for 0.9 verification).</li>
+</ul>
+
+<h3>5.3 Editor &amp; runner</h3>
+<ul>
+  <li><strong>LSP</strong>: separate binary installed by the MoonBit toolchain; flagship VSCode extension <code>moonbit.moonbit-lang</code>.</li>
+  <li><strong>Formatter</strong>: <code>moon fmt</code>.</li>
+  <li><strong>Tests</strong>: inline <code>test "name" { … }</code> blocks discovered automatically; parallel run; snapshot tests rewrite source in place.</li>
+  <li><strong>No REPL</strong>; closest is the web tour at <a href="https://tour.moonbitlang.com">tour.moonbitlang.com</a>.</li>
+  <li><strong>No first-party debugger</strong>; coverage instrumentation via <code>moon coverage</code>.</li>
+</ul>
+
+<h2 id="ai-tooling">6. AI tooling</h2>
+
+<h3>6.1 MoonBit Pilot</h3>
+<p>A multi-modal coding agent shipped with the toolchain:</p>
+<ul>
+  <li><strong>Three surfaces</strong>: CLI (<code>moon pilot</code>), IDE integration in VSCode, and a cloud UI for async agent execution.</li>
+  <li>BYO model API key — documented for Claude Sonnet 4, Kimi K2, DeepSeek V3, Gemini 2.5 Pro. Per-token costs go to the provider.</li>
+  <li>Local config under <code>~/.moonagent/</code> and per-project <code>.moonagent/moonagent.yml</code>.</li>
+  <li>No public price list. Practically free-to-try, with no commitment that it remains so.</li>
+</ul>
+
+<h3>6.2 Agent Server Protocol (ASP)</h3>
+<p>MoonBit-custom protocol announced alongside Pilot. No public spec page, no schema, no comparison-to-MCP document. Functionally it sits at a different layer than MCP — ASP is about <em>orchestrating multiple agent tasks</em>, MCP is about <em>exposing tools/resources to a single agent</em>.</p>
+
+<div class="note"><strong>No first-party MCP integration.</strong> Pilot's documented configuration has no MCP server entries. A community library <a href="https://github.com/gmlewis/moonbit-mcp">gmlewis/moonbit-mcp</a> exists for writing MCP servers <em>in</em> MoonBit, but there's nothing in the toolchain for consuming third-party MCP servers from Pilot.</div>
+
+<h3>6.3 Constrained decoding</h3>
+<p>The most distinctive AI bet. Documented in the LLM4Code 2024 paper and hosted at <a href="https://ai.moonbitlang.com">ai.moonbitlang.com</a>:</p>
+<ul>
+  <li><strong>Local sampling</strong> — real-time syntactic adjustment of generated tokens against the MoonBit grammar.</li>
+  <li><strong>Global sampling</strong> — type-checking accepted token spans; rejected spans backtrack with error fed to the model.</li>
+  <li>Reported large compilation-rate improvement at ~3% latency penalty.</li>
+  <li>Exploits MoonBit's "interface-before-implementation" linear program order to keep KV-cache misses low.</li>
+  <li>Not packaged as a standalone library — runs inside MoonBit's hosted AI service.</li>
+</ul>
+
+<h3>6.4 No "skill" for MoonBit</h3>
+<p>Despite the agent positioning, MoonBit does <em>not</em> publish a Claude Code / Cursor skill, agent profile, or system prompt. The agent angle is served by their own Pilot stack and ASP, not by integrating with the broader agent-tool ecosystem. This is a meaningful contrast with Vow, which ships a skill (<code>build/vowc skill install</code>) and depends on structured-JSON-everywhere as its agent contract.</p>
+
+<h2 id="verification">7. Verification (MoonBit 0.9, April 2026)</h2>
+
+<p>First-class formal verification keywords: <code>proof_require</code>, <code>proof_ensure</code>, <code>proof_invariant</code>, <code>proof_assert</code>, <code>proof_yield</code>, <code>proof_decrease</code>, <code>proof_reasoning</code>, and <code>#proof_pure</code>. Predicates live in sibling <code>.mbtp</code> files. Backend is <strong>Why3</strong> dispatching to a portfolio of SMT solvers (Z3, Alt-Ergo, CVC5). Opt-in per package via <code>"proof-enabled": true</code> in <code>moon.pkg</code>. Driven by <code>moon prove</code>.</p>
+
+<h3>7.1 Smallest example — <code>abs</code></h3>
+<p><code>abs.mbt</code>:</p>
+<pre><code>pub fn abs(x : Int) -&gt; Int where { proof_ensure: result =&gt; abs_ok(x, result) } {
+  if x &gt;= 0 { x } else { -x }
+}</code></pre>
+<p><code>abs.mbtp</code>:</p>
+<pre><code>predicate abs_ok(x : Int, result : Int) {
+  (result &gt;= 0) &amp;&amp; ((result == x) || (result == -x))
+}</code></pre>
+
+<h3>7.2 Binary search — function contract + loop invariants</h3>
+<pre><code>pub fn[T : Compare] binary_search(
+  xs : FixedArray[T], key : T,
+) -&gt; Int? where {
+  proof_require: sorted(xs),
+  proof_ensure: result =&gt; binary_search_ok(xs, key, result),
+} {
+  for i = 0, j = xs.length(); i &lt; j; {
+    let h = i + (j - i) / 2
+    if xs[h] &lt; key {
+      proof_assert ∀ idx : Int, 0 &lt;= idx &amp;&amp; idx &lt; h + 1 → xs[idx] &lt; key
+      continue h + 1, j
+    } else if key &lt; xs[h] {
+      proof_assert ∀ idx : Int, h &lt;= idx &amp;&amp; idx &lt; xs.length() → key &lt; xs[idx]
+      continue i, h
+    } else {
+      proof_assert xs[h] == key
+      break Some(h)
+    }
+  } nobreak { None } where {
+    proof_invariant: 0 &lt;= i,
+    proof_invariant: i &lt;= j,
+    proof_invariant: j &lt;= xs.length(),
+    proof_invariant: ∀ idx : Int, 0 &lt;= idx &amp;&amp; idx &lt; i → xs[idx] &lt; key,
+    proof_invariant: ∀ idx : Int, j &lt;= idx &amp;&amp; idx &lt; xs.length() → key &lt; xs[idx],
+    proof_yield: res =&gt; binary_search_ok(xs, key, res),
+  }
+}</code></pre>
+
+<h3>7.3 The predicate language</h3>
+<pre><code>predicate[T] in_bounds(xs : FixedArray[T], i : Int) {
+  (0 &lt;= i) &amp;&amp; (i &lt; xs.length())
+}
+predicate[T : Compare] sorted(xs : FixedArray[T]) {
+  ∀ i : Int, ∀ j : Int,
+    ((in_bounds(xs, i)) &amp;&amp; (in_bounds(xs, j)) &amp;&amp; (i &lt;= j)) → xs[i] &lt;= xs[j]
+}
+predicate[T : Compare] binary_search_ok(
+  xs : FixedArray[T], key : T, result : Option[Int],
+) {
+  match result {
+    None         =&gt; ∀ i : Int, in_bounds(xs, i) → xs[i] != key
+    Some(result) =&gt; (in_bounds(xs, result)) &amp;&amp; xs[result] == key
+  }
+}</code></pre>
+<p>Features of the predicate sublanguage: <strong>universal quantification</strong> via Unicode <code>∀</code>; <strong>implication</strong> via <code>→</code>; <strong>recursive predicates</strong> over ADTs via <code>match</code>; <strong>generic predicates</strong> with the same trait-bound syntax as functions; <strong>finite-set/sequence/map model libraries</strong> in <code>libs/</code>; explicit <code>proof_decrease</code> measures for termination of recursive predicates.</p>
+
+<h3>7.4 Counterexample shape</h3>
+<p>Per-VC verdict from Why3 ("could not prove goal X" / Unknown / Timeout). No published JSON schema, no concrete program-trace counterexample. Reports land in <code>_build/verif/</code>. Vow's ESBMC pipeline, by contrast, returns concrete failing inputs and execution traces — the difference between deductive verification and bounded model checking.</p>
+
+<h3>7.5 AI integration</h3>
+<p>The framing is <em>"AI guesses, prover checks."</em> Pilot drafts predicates, invariants, and <code>proof_assert</code> hints; <code>moon prove</code> is the oracle. The release notes credit AI for generating the binary-search and AVL invariants. There is no language-level CEGIS protocol; the agent loops on whatever the prover says it couldn't prove.</p>
+
+<h3>7.6 Scope</h3>
+<p>Opt-in per package, per function. Stdlib <code>moonbitlang/core</code> is <em>not</em> verified end-to-end; a parallel ecosystem <a href="https://github.com/moonbit-community/verified">moonbit-community/verified</a> hosts proven examples (binary search, AVL trees, heaps, plus finance case studies: stablecoin engine, AMM, lending, batch auction).</p>
+
+<h2 id="ecosystem">8. Ecosystem &amp; adoption</h2>
+
+<table>
+  <tr><th>Signal</th><th>Value</th></tr>
+  <tr><td>moonbitlang/core stars</td><td>~1.1k (Apache-2.0, 149 forks)</td></tr>
+  <tr><td>moonbit-docs stars</td><td>~2.3k</td></tr>
+  <tr><td>example-ai-agent stars</td><td>13 (demo, not a movement)</td></tr>
+  <tr><td>Discord</td><td>~578 members (small but real; ~10× smaller than Roc/Gleam)</td></tr>
+  <tr><td>Named production users</td><td>None found.</td></tr>
+  <tr><td>Paper</td><td>Fei et al., "MoonBit: Explore the Design of an AI-Friendly Programming Language," LLM4Code@ICSE 2024.</td></tr>
+  <tr><td>HN coverage</td><td>Multiple threads (Aug 2023 launch, Dec 2024 open-sourcing, Jan 2025 WASM post). Sentiment mixed.</td></tr>
+</table>
+
+<h3>8.1 Recurring critiques</h3>
+<ul>
+  <li><strong>Licensing isn't really open.</strong> The Dec 2024 "open-source" release used the MoonBit Public Source License — an SSPL-style anti-cloud clause that critics on HN flagged as source-available, not OSI-open.</li>
+  <li><strong>Benchmark concerns.</strong> A Lobsters thread documented a handicapped Rust FFT baseline used in a "30% faster than Rust" social-media campaign; corrective PRs reportedly went unaddressed.</li>
+  <li><strong>Governance.</strong> Project led by IDEA (Shenzhen). Generic "do your own due diligence" caution in commentary; no specific export-control incidents found.</li>
+</ul>
+
+<h3>8.2 Adjacent languages pitched at AI codegen</h3>
+<table>
+  <tr><th>Language</th><th>Self-marketed for AI?</th><th>Bet</th></tr>
+  <tr><td>MoonBit</td><td>Yes</td><td>Sampling + integrated agent + (new) deductive verification.</td></tr>
+  <tr><td>Dafny</td><td>Yes (2025)</td><td>Verification-aware IL; reported 89-96% verification success with modern LLMs.</td></tr>
+  <tr><td>Mojo</td><td>Yes</td><td>AI <em>workloads</em>, not agent codegen — GPU/accelerator Python.</td></tr>
+  <tr><td>F*</td><td>Not loudly</td><td>Used in LLM-assisted verified C synthesis research.</td></tr>
+  <tr><td>Lean</td><td>Community-driven</td><td>DeepSeek-Prover and similar use mathlib for theorem-proving.</td></tr>
+  <tr><td>Quasar / Pel</td><td>Yes (academic)</td><td>Python subset / Lisp-DSL for agent orchestration.</td></tr>
+  <tr><td>Roc / Gleam / Unison / Bend</td><td>No</td><td>Community sometimes labels them LLM-friendly; projects themselves don't pitch it.</td></tr>
+  <tr><td>Vow</td><td>Yes</td><td>BMC counterexamples + blame + JSON-as-contract + small core.</td></tr>
+</table>
+
+<h2 id="compare">9. Side-by-side comparison</h2>
+
+<table>
+  <tr><th>Axis</th><th class="col-mb">MoonBit</th><th class="col-vow">Vow</th></tr>
+  <tr><td>Verification backend</td><td>Why3 → Z3 / Alt-Ergo / CVC5 (deductive SMT)</td><td>ESBMC (bounded model checking)</td></tr>
+  <tr><td>Predicate location</td><td>Separate <code>.mbtp</code> file with dedicated logical sublanguage</td><td>Inline in source, same expression language as code</td></tr>
+  <tr><td>Quantifiers</td><td><code>∀</code>, recursive predicates, finite-set/seq/map models</td><td>None (boolean expressions only)</td></tr>
+  <tr><td>Failure shape</td><td>Per-VC "could not prove" verdict</td><td>Concrete failing inputs + execution trace + JSON</td></tr>
+  <tr><td>Blame attribution</td><td>None</td><td>Caller vs. Callee, encoded in diagnostic</td></tr>
+  <tr><td>Verification trigger</td><td>Opt-in per package, <code>moon prove</code> subcommand</td><td>On by default with <code>vowc build</code>; <code>--no-verify</code> to skip</td></tr>
+  <tr><td>Proof scripts</td><td>Yes — <code>proof_assert</code> hints, lemma fns, <code>proof_decrease</code>, <code>#proof_pure</code></td><td>No — contracts only; if BMC can't discharge, that's a verifier issue</td></tr>
+  <tr><td>Type system</td><td>Generics, traits, sum types, GC, async coloring, error effects</td><td>No generics, no traits, no closures, no GC; linear types; effect = pure/impure</td></tr>
+  <tr><td>Memory model</td><td>Garbage collected (host GC for wasm-gc)</td><td>No GC; linear ownership</td></tr>
+  <tr><td>Compilation</td><td>WASM-GC (flagship), JS, native, riscv32. No LLVM.</td><td>Native via Cranelift</td></tr>
+  <tr><td>Self-hosted</td><td>No (compiler in OCaml)</td><td>Yes (binary fixed-point)</td></tr>
+  <tr><td>Agent integration</td><td>First-party Pilot + custom ASP protocol; constrained decoding service</td><td>Skill installed via <code>vowc skill install</code>; JSON diagnostics consumed by any agent</td></tr>
+  <tr><td>MCP support</td><td>None first-party</td><td>Designed to be MCP-friendly via JSON output</td></tr>
+  <tr><td>License</td><td>Source-available (MPSL v1); SSPL-style anti-cloud clause</td><td>Open source</td></tr>
+  <tr><td>Maturity</td><td>0.9 (April 2026); pre-1.0, active</td><td>Early; self-hosted with fixed-point</td></tr>
+</table>
+
+<h2 id="learn">10. What Vow can learn (and what to reject)</h2>
+
+<ol class="steps">
+  <li><strong>Constrained decoding is the layer above Vow.</strong> MoonBit attacks "agents emit invalid code" at the sampler. Vow attacks the same problem at the verifier. These compose: a Vow-aware sampler could rule out unparseable or trivially ill-typed tokens before ESBMC ever runs. Worth a forward-looking note in <code>docs/spec/</code>.</li>
+  <li><strong>Predicate files are tempting but expensive.</strong> Splitting predicates into <code>.mbtp</code> gives reuse and a richer logical sublanguage (quantifiers, recursive predicates) — but it's a new namespace, a new file type, and a new logic that humans and agents have to learn separately from the rest of the language. Fails the "doesn't make verification harder" gate unless there's a concrete reuse story Vow can't currently express.</li>
+  <li><strong>Why3 is a real escape hatch.</strong> If Vow ever wants <code>∀</code>/<code>∃</code> over unbounded structures, dispatching to Why3 (rather than reimplementing) is the boring choice. But it means giving up concrete counterexamples — the CEGIS loop changes shape.</li>
+  <li><strong>Inline snapshot tests are good ergonomics.</strong> MoonBit's <code>inspect({ x: 10 }, content="...")</code> auto-rewriting on <code>--update</code> is a tight loop worth borrowing for Vow's <code>tests/run/</code> golden-output cases.</li>
+  <li><strong>Reject the proprietary protocol.</strong> ASP is closed, undocumented, and ships with the compiler. Vow's bet on "JSON-everywhere, no proprietary protocol" is the better story if the agent ecosystem is going to be Cambrian.</li>
+  <li><strong>Reject closed-source.</strong> MoonBit's source-available license is a recurring friction point in HN discussion. Vow's open-source posture is straightforward marketing as well as engineering.</li>
+  <li><strong>The big confirmation.</strong> MoonBit reaching for formal verification in 0.9 (April 2026) is direct market evidence that "AI-friendly language with provable contracts" is the right destination. Vow got there first via a different (arguably tighter for repair loops) route — BMC + concrete counterexamples + blame. Worth saying so loudly in any external-facing Vow material.</li>
+</ol>
+
+<footer>
+  <strong>Primary sources</strong>
+  <ul>
+    <li><a href="https://www.moonbitlang.com/">moonbitlang.com</a></li>
+    <li><a href="https://docs.moonbitlang.com/en/latest/">MoonBit docs</a></li>
+    <li><a href="https://docs.moonbitlang.com/en/latest/language/fundamentals.html">Language fundamentals</a></li>
+    <li><a href="https://docs.moonbitlang.com/en/latest/language/methods.html">Methods &amp; traits</a></li>
+    <li><a href="https://docs.moonbitlang.com/en/latest/language/error-handling.html">Error handling</a></li>
+    <li><a href="https://docs.moonbitlang.com/en/latest/language/async-experimental.html">Async</a></li>
+    <li><a href="https://docs.moonbitlang.com/en/latest/language/packages.html">Packages</a></li>
+    <li><a href="https://docs.moonbitlang.com/en/latest/language/tests.html">Tests</a></li>
+    <li><a href="https://docs.moonbitlang.com/en/latest/toolchain/moon/index.html">Moon CLI manual</a></li>
+    <li><a href="https://www.moonbitlang.com/blog/moonbit-0-9-release">0.9 verification release blog</a></li>
+    <li><a href="https://www.moonbitlang.com/blog/intro-moonbit-pilot">MoonBit Pilot announcement</a></li>
+    <li><a href="https://www.moonbitlang.com/blog/moonbit-ai">AI-Native Language Toolchain blog</a></li>
+    <li><a href="https://github.com/moonbitlang/core">moonbitlang/core</a></li>
+    <li><a href="https://github.com/moonbit-community/verified">moonbit-community/verified</a></li>
+    <li><a href="https://github.com/moonbitlang/example-ai-agent">example-ai-agent</a></li>
+    <li><a href="https://github.com/gmlewis/moonbit-mcp">gmlewis/moonbit-mcp</a></li>
+    <li><a href="https://dl.acm.org/doi/10.1145/3643795.3648376">LLM4Code 2024 paper</a></li>
+    <li><a href="https://www.moonbitlang.com/licenses/moonbit-public-source-license-v1">MoonBit Public Source License v1</a></li>
+    <li><a href="https://lobste.rs/s/vioikp/moonbit_developers_are_lying_you">Lobsters: benchmark critique</a></li>
+    <li><a href="https://news.ycombinator.com/item?id=42450274">HN: compiler open-sourcing</a></li>
+    <li><a href="https://mooncakes.io">mooncakes.io registry</a></li>
+  </ul>
+  <p>Report compiled by a parallel research fan-out (overview, syntax, stdlib/tooling, AI features, verification, ecosystem) and synthesized into this single page. Branch <code>vow/compareMoonbit</code>, 2026-05-18.</p>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/comparisons/vs-vera.html
+++ b/docs/comparisons/vs-vera.html
@@ -1,0 +1,615 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Vera vs Vow — agent-oriented language comparison</title>
+<style>
+  :root {
+    --bg: #0e1116;
+    --panel: #161b22;
+    --panel-2: #1c2330;
+    --fg: #e6edf3;
+    --muted: #8b949e;
+    --line: #30363d;
+    --accent: #58a6ff;
+    --vera: #e87a5d;     /* warm orange — Vera */
+    --vow:  #7ee787;
+    --warn: #f97583;
+    --code-bg: #0b0f14;
+    --code-fg: #d1d9e0;
+    --max: 1100px;
+  }
+  * { box-sizing: border-box; }
+  html, body { background: var(--bg); color: var(--fg); }
+  body {
+    margin: 0;
+    font: 15.5px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+    padding: 0 24px 80px;
+  }
+  main { max-width: var(--max); margin: 0 auto; }
+  header.hero {
+    max-width: var(--max);
+    margin: 48px auto 32px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--line);
+  }
+  header.hero h1 { font-size: 34px; margin: 0 0 10px; letter-spacing: -0.02em; }
+  header.hero .sub { color: var(--muted); font-size: 17px; }
+  header.hero .meta { margin-top: 14px; color: var(--muted); font-size: 13px; }
+  h2 {
+    font-size: 22px;
+    margin: 48px 0 12px;
+    padding-top: 24px;
+    border-top: 1px solid var(--line);
+    letter-spacing: -0.01em;
+  }
+  h3 { font-size: 17px; margin: 24px 0 8px; color: var(--accent); }
+  h4 { font-size: 14px; margin: 16px 0 6px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  p { margin: 8px 0 12px; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre, .mono { font-family: ui-monospace, SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace; }
+  code { background: var(--code-bg); color: var(--code-fg); padding: 1px 5px; border-radius: 4px; font-size: 13px; }
+  pre {
+    background: var(--code-bg); color: var(--code-fg);
+    padding: 14px 16px; border-radius: 8px;
+    overflow-x: auto; font-size: 13px; line-height: 1.5;
+    border: 1px solid var(--line);
+  }
+  pre code { background: transparent; padding: 0; font-size: inherit; }
+  table { border-collapse: collapse; width: 100%; margin: 16px 0; font-size: 14px; }
+  th, td { padding: 9px 12px; text-align: left; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { background: var(--panel); color: var(--muted); font-weight: 600; font-size: 12.5px; text-transform: uppercase; letter-spacing: 0.04em; }
+  tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
+  .tag {
+    display: inline-block;
+    padding: 1px 8px; border-radius: 999px;
+    font-size: 11.5px; letter-spacing: 0.03em;
+    border: 1px solid var(--line); color: var(--muted);
+    margin-right: 4px;
+  }
+  .tag.vera { color: var(--vera); border-color: rgba(232,122,93,0.4); background: rgba(232,122,93,0.07); }
+  .tag.vow  { color: var(--vow);  border-color: rgba(126,231,135,0.4); background: rgba(126,231,135,0.07); }
+  .tag.warn { color: var(--warn); border-color: rgba(249,117,131,0.4); background: rgba(249,117,131,0.07); }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 760px) { .grid2 { grid-template-columns: 1fr; } }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 14px 18px;
+  }
+  .panel h3 { margin-top: 4px; }
+  .callout {
+    border-left: 3px solid var(--accent);
+    background: var(--panel-2);
+    padding: 12px 16px;
+    border-radius: 0 6px 6px 0;
+    margin: 16px 0;
+  }
+  .callout.warn { border-left-color: var(--warn); }
+  .callout.good { border-left-color: var(--vow); }
+  ul { padding-left: 22px; }
+  li { margin: 4px 0; }
+  .kv td:first-child { color: var(--muted); width: 32%; }
+  .lessons ol { padding-left: 22px; }
+  .lessons li { margin: 14px 0; }
+  .lessons li b { color: var(--accent); }
+  footer { color: var(--muted); font-size: 12.5px; margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line); }
+  footer ul { columns: 2; column-gap: 24px; }
+  .badge-row { margin-top: 8px; }
+  .tldr {
+    background: linear-gradient(180deg, rgba(88,166,255,0.07), rgba(88,166,255,0));
+    border: 1px solid rgba(88,166,255,0.25);
+    border-radius: 10px;
+    padding: 16px 20px;
+    margin: 20px 0;
+  }
+  .tldr h3 { margin-top: 0; color: var(--accent); }
+  .nowrap { white-space: nowrap; }
+  .lang-vera, .lang-v { display: inline-block; font-weight: 600; }
+  .lang-vera { color: var(--vera); }
+  .lang-v    { color: var(--vow); }
+  details { margin: 8px 0; }
+  summary { cursor: pointer; color: var(--muted); }
+  summary:hover { color: var(--fg); }
+  .bar {
+    height: 8px; background: var(--code-bg); border-radius: 4px;
+    display: inline-block; width: 220px; vertical-align: middle; margin-right: 8px;
+    border: 1px solid var(--line);
+  }
+  .bar > span { display: block; height: 100%; background: var(--vera); border-radius: 4px; }
+  .bar.vow > span { background: var(--vow); }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <h1>Vera vs Vow &mdash; agent-oriented language comparison</h1>
+  <div class="sub">Two languages built for AI agents to <i>write</i>, not humans to read. Vera bets on <b>removing variable names</b> and <b>Z3 with a runtime-fallback tier</b>. Vow bets on <b>BMC counterexamples</b>, <b>blame</b>, and <b>linear types</b>. Where do they meet, and what is each worth learning from?</div>
+  <div class="meta">Compiled 2026-05-18 &middot; Vera v0.0.155 (2026-05-13) &middot; Vow self-hosted (current main) &middot; branch <code>vow/compareVera</code></div>
+  <div class="badge-row">
+    <span class="tag vera">Vera &middot; aallan/vera &middot; MIT &middot; .vera</span>
+    <span class="tag vow">Vow &middot; self-hosted &middot; .vow</span>
+  </div>
+</header>
+
+<main>
+
+<div class="tldr">
+  <h3>TL;DR</h3>
+  <p>Vera and Vow both claim the same tagline ("a language for AI agents") and they agree on the diagnosis: <i>mandatory contracts, structured diagnostics, machine-first output</i>. Then they diverge in almost every implementation choice. <b>Vera</b> drops variable names entirely &mdash; bindings are typed De Bruijn slots (<code>@Int.0</code>) &mdash; targets WebAssembly via a Python+Lark+Z3 toolchain, and discharges contracts with Z3 in three tiers (auto / hinted / runtime fallback). <b>Vow</b> keeps named variables, targets native via Cranelift, self-hosts to a binary fixed point, and discharges contracts with ESBMC bounded model checking that returns <b>concrete counterexamples and blame</b>. The two languages confirm the category is real but answer it very differently. Most directly portable from Vera: <b>Inference as a tracked effect</b>, <b>contract-driven property tests</b>, and <b>fix examples per error code</b>. Reject: De Bruijn names, WASM-only target, runtime-fallback verification tier.</p>
+</div>
+
+<h2>1 &middot; Identity</h2>
+<table class="kv">
+  <tr><td>Project</td><td><b>Vera</b> &mdash; "a programming language designed for LLMs to write, not humans"</td></tr>
+  <tr><td>Author</td><td><b>Alasdair Allan</b> (CTO, Negroni Venture Studios). Solo project.</td></tr>
+  <tr><td>Homepage</td><td><a href="https://veralang.dev/">veralang.dev</a></td></tr>
+  <tr><td>Repository</td><td><a href="https://github.com/aallan/vera">github.com/aallan/vera</a> &mdash; MIT</td></tr>
+  <tr><td>Benchmark repo</td><td><a href="https://github.com/aallan/vera-bench">github.com/aallan/vera-bench</a> &mdash; MIT</td></tr>
+  <tr><td>Launched</td><td>Feb 2026 (private/blog), April 2026 public; HN debut <a href="https://news.ycombinator.com/item?id=47955118">item #47955118</a></td></tr>
+  <tr><td>Current version</td><td>v0.0.155 (2026-05-13) &mdash; pre-1.0, daily releases (156 in ~3 months)</td></tr>
+  <tr><td>File extension</td><td><code>.vera</code> (source). No project manifest. Grammar in <code>*.lark</code>.</td></tr>
+  <tr><td>Compiler</td><td><b>Python</b> &mdash; <a href="https://github.com/lark-parser/lark">Lark LALR(1)</a> parser + <a href="https://pypi.org/project/z3-solver/">z3-solver</a> + <a href="https://pypi.org/project/wasmtime/">wasmtime</a>. ~10 KLOC. Distributed via <code>pip install -e .</code> from source.</td></tr>
+  <tr><td>Self-host status</td><td><b>None.</b> No plans surfaced. Compiler is Python; reference compiler is the only one.</td></tr>
+  <tr><td>Backend</td><td>WebAssembly only. <code>.wasm</code> + optional browser bundle (<code>module.wasm</code> + <code>vera-runtime.mjs</code> + <code>index.html</code>).</td></tr>
+  <tr><td>Memory model</td><td>Not documented. WASM-hosted; presumably runtime-managed. No mutation, no linearity, no ownership.</td></tr>
+  <tr><td>GitHub signals (2026-05-13)</td><td>351 stars &middot; 17 forks &middot; 1,263 commits &middot; 156 releases. <code>vera-bench</code>: 13 stars, 1 fork.</td></tr>
+  <tr><td>Community</td><td>One HN thread (95 comments, mostly skeptical). No Discord, no subreddit, no Lobsters submission, no academic paper, no named production users.</td></tr>
+  <tr><td>Spec</td><td>13-chapter draft (<code>spec/00-introduction.md</code> &hellip; <code>12-runtime.md</code>). 86-program conformance suite, 3,905 tests, 96% coverage (self-reported).</td></tr>
+</table>
+
+<h2>2 &middot; Side-by-side at a glance</h2>
+<table>
+  <thead>
+    <tr><th>Axis</th><th><span class="lang-vera">Vera</span></th><th><span class="lang-v">Vow</span></th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Core thesis</td><td>Names confuse LLMs; eliminate them. Make contracts mandatory. Tier-3 fallback to runtime when Z3 can't decide.</td><td>Agents generate buggy code. Prove it correct or return a concrete counterexample the agent can fix. CEGIS loop.</td></tr>
+    <tr><td>Tagline</td><td>"The model doesn't need to be right. It needs to be checkable."</td><td>"Built-in contracts statically verified at compile time."</td></tr>
+    <tr><td>Verification backend</td><td><b>Z3 SMT</b> (z3-solver &ge;4.12) &mdash; three tiers: auto / guided / runtime assert.</td><td><b>ESBMC</b> bounded model checking + structured counterexamples + JSON.</td></tr>
+    <tr><td>Failure shape</td><td>Per-VC verdict; if undecided, becomes a Tier-3 runtime check (E500&ndash;E525).</td><td>Concrete failing inputs + execution trace + JSON + Caller/Callee blame.</td></tr>
+    <tr><td>Variable names</td><td><b>None.</b> Typed De Bruijn slots: <code>@Int.0</code>, <code>@Int.1</code>, <code>@String.0</code>. Each type has its own counter.</td><td>Normal identifiers.</td></tr>
+    <tr><td>Mutation</td><td><b>None.</b> Pure functional. State change only via <code>&lt;State&lt;T&gt;&gt;</code> effect.</td><td>Yes &mdash; with explicit <code>linear struct</code> types tracked by the type checker.</td></tr>
+    <tr><td>Memory</td><td>WASM-managed; not specified in spec. No GC story documented.</td><td>No GC. <code>linear struct</code> values must be consumed exactly once.</td></tr>
+    <tr><td>Effects</td><td>Algebraic effects, mandatory effect row per function. 7 built-in: <code>IO, Http, State, Exn, Async, Inference, Random</code> (+ <code>Diverge</code>).</td><td>Effect sets per function type. Pure-by-default. No <code>Inference</code> effect.</td></tr>
+    <tr><td>Generics</td><td>Yes &mdash; <code>forall&lt;T where Eq&lt;T&gt;, Ord&lt;T&gt;&gt; fn ...</code>. Built-in abilities: <code>Eq, Ord, Hash, Show</code>.</td><td><span class="tag warn">No generics</span> &mdash; deliberately rejected to keep verifier surface small.</td></tr>
+    <tr><td>Quantifiers in contracts</td><td><b>Yes</b> &mdash; <code>forall</code>/<code>exists</code> bounded over <code>Nat</code> ranges.</td><td>None &mdash; boolean expressions only.</td></tr>
+    <tr><td>Loops</td><td><b>None.</b> No <code>while</code>, <code>for</code>, <code>break</code>, <code>continue</code>, or early return. Tail recursion + mandatory <code>decreases</code>.</td><td>Yes &mdash; <code>while</code>, <code>for-each</code>, <code>break-with-value</code>, <code>continue</code>; loop <code>invariant</code> clauses.</td></tr>
+    <tr><td>Compilation</td><td>WebAssembly only. Runs via <code>wasmtime</code> or in-browser. Needs <code>--experimental-wasm-exnref</code> on Node.</td><td>Native via Cranelift (<code>vow-clif-shim</code>). ESBMC pipeline in parallel via C emitter.</td></tr>
+    <tr><td>Self-hosted</td><td>No. Python host.</td><td>Yes &mdash; binary fixed-point (<code>build/vowc</code> compiles itself byte-identically).</td></tr>
+    <tr><td>Concurrency</td><td><code>Async</code> effect is a <b>type-system marker only</b>: "eager/sequential &mdash; <code>Future&lt;T&gt;</code> has the same WASM representation as <code>T</code> with no runtime overhead."</td><td>None in language. <code>std.proc</code> spawns external processes.</td></tr>
+    <tr><td>LLM as a builtin</td><td><b><code>Inference.complete : String -&gt; Result&lt;String, String&gt;</code></b> &mdash; first-class effect. Providers: Anthropic, OpenAI, Moonshot, Mistral, auto-detected from env vars.</td><td>None.</td></tr>
+    <tr><td>Comments</td><td><code>-- line</code> and <code>{- nested block -}</code>.</td><td>Line comments only (<code>//</code>); stripped at lex time.</td></tr>
+    <tr><td>Tooling</td><td>9 subcommands: <code>check, verify, compile, run, test, parse, ast, fmt, version</code>.</td><td>~6 subcommands: <code>build, verify, test, mutants, skill, --help</code>.</td></tr>
+    <tr><td>LSP / editor</td><td><span class="tag warn">No LSP</span>, no tree-sitter. VSCode extension + TextMate bundle in <code>editors/</code>.</td><td><span class="tag warn">No LSP</span> either; JSON-everywhere is the agent contract.</td></tr>
+    <tr><td>Stdlib breadth</td><td><b>~160 built-in functions</b>: Array, Map, Set, Decimal, JSON, HTML, Markdown, Regex, strings (40+ ops), trig/log, parse helpers, base64, URL.</td><td>Minimal: Vec, String, HashMap, BTreeMap, heap, fs, io &mdash; each with verification-aware bounded models.</td></tr>
+    <tr><td>Package manager</td><td>None for Vera code. Programs are single files + module loader. Vera itself ships as a Python package.</td><td>None. Single-file or DFS-loaded <code>use</code> modules.</td></tr>
+    <tr><td>Benchmarks</td><td>VeraBench: 50 problems &times; 6 models. Kimi K2.5 100% Vera vs 86% Python / 91% TS. Caveats: single run, self-acknowledged unreliability.</td><td>36/36 Vow suite (sonnet-4-6); HumanEval 66/67 (sonnet-4); 103/103 non-stretch references verified by self-hosted compiler.</td></tr>
+    <tr><td>License</td><td>MIT (clean OSI).</td><td>Open source.</td></tr>
+  </tbody>
+</table>
+
+<h2>3 &middot; Syntax catalog (Vera)</h2>
+
+<h3>Hello world &mdash; the surface shock</h3>
+<div class="grid2">
+  <div class="panel">
+    <h4>Vera &middot; <code>hello.vera</code></h4>
+<pre><code>module hello;
+
+public fn main(@Unit -&gt; @Unit)
+  requires(true)
+  ensures(true)
+  effects(&lt;IO&gt;)
+{
+  IO.print("Hello, world!\n")
+}</code></pre>
+  </div>
+  <div class="panel">
+    <h4>Vow &middot; <code>hello.vow</code></h4>
+<pre><code>module Hello
+
+fn main() -&gt; i32 [io] {
+    print_str("Hello, world!");
+    0
+}</code></pre>
+  </div>
+</div>
+
+<p>Even the trivial program is busier in Vera: <code>public</code>/<code>private</code> is mandatory, <code>requires</code>/<code>ensures</code>/<code>effects</code> are mandatory, the parameter is <code>@Unit</code>, the return is <code>@Unit</code>, and the call goes through the <code>IO</code> effect namespace.</p>
+
+<h3>De Bruijn slot references &mdash; the defining bet</h3>
+<p>Vera has <b>no variable names</b>. Every binding is a typed slot, referenced as <code>@Type.N</code>. Each type has its own counter; index <code>0</code> is the most recent binding of that type. Parameters bind left-to-right but the <i>rightmost</i> parameter of a given type is index <code>0</code>.</p>
+<pre><code>private fn add(@Int, @Int -&gt; @Int)
+  requires(true)
+  ensures(@Int.result == @Int.0 + @Int.1)
+  effects(pure)
+{ @Int.0 + @Int.1 }
+-- @Int.0 = SECOND param (rightmost), @Int.1 = first param
+
+private fn repeat(@String, @Int -&gt; @String)
+  requires(@Int.0 &gt;= 0)
+  ensures(true)
+  effects(pure)
+{ string_repeat(@String.0, @Int.0) }
+-- Mixed types each have their own counter
+
+-- let bindings push a new slot of that type, shifting older ones
+let @Int = @Int.0 * 2;   -- new @Int.0 = (old @Int.0) * 2; old becomes @Int.1
+let @Int = @Int.0 + 1;
+@Int.0
+
+-- Inside ensures, @T.result refers to the return value
+-- Debug with: vera check --explain-slots file.vera</code></pre>
+
+<h3>Functions, contracts, effects</h3>
+<pre><code>private fn clamp(@Int, @Int, @Int -&gt; @Int)
+  requires(@Int.1 &lt;= @Int.2)
+  ensures(@Int.result &gt;= @Int.1)
+  ensures(@Int.result &lt;= @Int.2)
+  decreases(@Int.0)              -- termination measure (mandatory on pure recursion)
+  effects(pure)
+{
+  if @Int.0 &lt; @Int.1 then { @Int.1 }
+  else { if @Int.0 &gt; @Int.2 then { @Int.2 } else { @Int.0 } }
+}</code></pre>
+<p class="meta"><i>Multiple <code>ensures</code> lines conjoin. <code>requires</code>, <code>ensures</code>, and <code>effects</code> are mandatory on every function. <code>decreases</code> is mandatory on pure recursive functions. There is no <code>invariant</code> &mdash; Vera has no loops.</i></p>
+
+<h3>Effect handlers</h3>
+<pre><code>-- Discharge a State effect with a pure handler
+handle[State&lt;Int&gt;](@Int = 0) {
+  get(@Unit) -&gt; { resume(@Int.0) },
+  put(@Int)  -&gt; { resume(()) } with @Int = @Int.0
+} in {
+  put(42);
+  get(())
+}
+
+-- Discharge an Exception effect
+handle[Exn&lt;String&gt;] {
+  throw(@String) -&gt; None
+} in { Some(safe_div(@Int.0, @Int.1)) }</code></pre>
+
+<h3>ADTs, pattern matching, generics, abilities</h3>
+<pre><code>private data List&lt;T&gt; { Nil, Cons(T, List&lt;T&gt;) }
+private data Tree&lt;T&gt;  { Leaf, Node(Tree&lt;T&gt;, T, Tree&lt;T&gt;) }
+
+-- Generic with ability (type-class) constraints
+private forall&lt;T where Eq&lt;T&gt;, Ord&lt;T&gt;&gt; fn sort(@List&lt;T&gt;.0 -&gt; @List&lt;T&gt;) ...
+
+match @Option&lt;Int&gt;.0 {
+  None        -&gt; @Int.0,
+  Some(@Int)  -&gt; @Int.0       -- payload binds as a new @Int.0 in this arm
+}</code></pre>
+<p class="meta"><i>Built-in abilities: <code>Eq, Ord, Hash, Show</code>. Match is exhaustive. Patterns: constructors, literals, wildcard <code>_</code>.</i></p>
+
+<h3>Refinement types &amp; typed holes</h3>
+<pre><code>type PosInt = { @Int | @Int.0 &gt; 0 };
+type Name   = String;
+type IntToInt = Fn(Int -&gt; Int) effects(pure)
+
+-- Typed holes (?) type-check but emit warning W001 and won't compile.
+-- Lets the agent work incrementally.
+private fn todo(@Int -&gt; @Int)
+  requires(true) ensures(true) effects(pure)
+{ ? }</code></pre>
+
+<h3>Quantified contracts</h3>
+<pre><code>requires(forall(@Nat, array_length(@Array&lt;Int&gt;.0),
+  fn(@Nat -&gt; @Bool) effects(pure) { @Array&lt;Int&gt;.0[@Nat.0] &gt; 0 }))
+
+ensures(exists(@Nat, array_length(@Array&lt;Int&gt;.0),
+  fn(@Nat -&gt; @Bool) effects(pure) { @Array&lt;Int&gt;.0[@Nat.0] == @Int.result }))</code></pre>
+<p class="meta"><i>Quantifiers are <b>bounded</b> over <code>Nat</code> ranges &mdash; not the unbounded <code>&forall;</code> of full SMT. Helps Z3 stay decidable.</i></p>
+
+<details>
+<summary>Operator precedence (loosest to tightest) &mdash; verbatim from <code>SKILL.md</code></summary>
+<pre><code>|&gt;        -- pipe
+==&gt;       -- implication (contracts only)
+||
+&amp;&amp;
+== != &lt; &lt;= &gt; &gt;=
++ - (binary)
+* / %
+! - (unary prefix)
+[] ()        -- index, apply (postfix)</code></pre>
+</details>
+
+<h2>4 &middot; Standard library</h2>
+<p>The stdlib is <b>wide</b>. Vera advertises "164 builtins"; a direct count of named entries in <code>SKILL.md</code> finds ~160 standalone functions plus ~18 effect operations &asymp; <b>~180 callable names</b>. Inlined into the skill document at ~840 lines, ~36% of the file.</p>
+
+<table>
+  <tr><th>Category</th><th>Members</th></tr>
+  <tr><td>Primitive types</td><td><code>Bool, Int, Nat, Float64, Byte, String, Unit, Never</code></td></tr>
+  <tr><td>Composite ADTs (no <code>data</code> decl)</td><td><code>Array&lt;T&gt;, Map&lt;K,V&gt;, Set&lt;T&gt;, Tuple, Option&lt;T&gt;, Result&lt;T,E&gt;, Future&lt;T&gt;, Ordering, Decimal, Json, HtmlNode, MdBlock, MdInline, UrlParts</code></td></tr>
+  <tr><td>Array ops</td><td><code>length, append, range, concat, slice, map, mapi, filter, fold, reverse, find, any, all, flatten, sort_by</code> &mdash; no <code>sort</code>/<code>contains</code>/<code>index_of</code> ("not yet implemented").</td></tr>
+  <tr><td>String ops</td><td>~40+ with <code>string_</code> prefix: <code>length, split, join, replace, contains, starts_with, ends_with, index_of, upper, lower, trim_start/end, pad_start/end, chars, lines, words, reverse, repeat, slice</code> &hellip;</td></tr>
+  <tr><td>Parsing / encoding</td><td><code>parse_int/nat/float64/bool : String -&gt; Result&lt;T, String&gt;</code>, <code>base64_encode/decode</code>, <code>url_encode/decode/parse/join</code>, char classifiers (<code>is_digit, is_alpha, is_whitespace</code>&hellip;).</td></tr>
+  <tr><td>JSON</td><td><code>Json</code> ADT with 6 constructors (<code>JNull, JBool, JNumber, JString, JArray, JObject</code>) + <code>json_parse, json_stringify, json_get, json_has_field, json_keys, json_array_length, json_type</code> + 6 <code>json_as_*</code> + 5 <code>json_get_*</code> typed accessors.</td></tr>
+  <tr><td>HTML</td><td><code>HtmlNode</code> ADT (<code>HtmlElement, HtmlText, HtmlComment</code>) + <code>html_parse, html_to_string, html_query</code> (CSS selectors: tag, .class, #id, [attr]) + <code>html_text, html_attr</code>.</td></tr>
+  <tr><td>Markdown</td><td><code>MdBlock</code> (8 constructors) + <code>MdInline</code> (6 constructors) + <code>md_parse, md_render, md_has_heading, md_has_code_block, md_extract_code_blocks</code>.</td></tr>
+  <tr><td>Regex</td><td>4 functions, all <code>Result</code>-wrapped: <code>regex_match, regex_find, regex_find_all, regex_replace</code> (first match only). Backed by Python <code>re</code> / JS <code>RegExp</code>.</td></tr>
+  <tr><td>Decimal</td><td>13 ops on opaque handle: <code>from_int/from_float/from_string/add/sub/mul/div/neg/abs/round/eq/compare/to_string/to_float</code>. <code>div</code> + <code>from_string</code> return <code>Option</code>.</td></tr>
+  <tr><td>Numeric / trig</td><td><code>abs, min, max, floor, ceil, round, sqrt, pow, log, log2, log10, sin, cos, tan, asin, acos, atan, atan2, pi(), e(), sign, clamp, float_clamp</code></td></tr>
+  <tr><td>Conversions</td><td><code>int_to_float, float_to_int, nat_to_int, int_to_nat, byte_to_int, int_to_byte</code> (checked versions return <code>Option</code>).</td></tr>
+</table>
+
+<h3>Effect operations (built-in)</h3>
+<table>
+  <tr><th>Effect</th><th>Ops</th></tr>
+  <tr><td><code>IO</code></td><td><code>print, read_line, read_file, write_file, args, exit, get_env, sleep, time, stderr</code> &mdash; 10 ops.</td></tr>
+  <tr><td><code>Http</code></td><td><code>Http.get  : String -&gt; Result&lt;String, String&gt;</code> &middot; <code>Http.post : String, String -&gt; Result&lt;String, String&gt;</code> &mdash; client only.</td></tr>
+  <tr><td><code>Inference</code></td><td><code>Inference.complete : String -&gt; Result&lt;String, String&gt;</code> &mdash; provider auto-detected from <code>VERA_ANTHROPIC_API_KEY</code> / <code>VERA_OPENAI_API_KEY</code> / <code>VERA_MOONSHOT_API_KEY</code> / <code>VERA_MISTRAL_API_KEY</code>. No max-tokens / temperature / system-prompt knobs.</td></tr>
+  <tr><td><code>Random</code></td><td><code>random_int, random_float, random_bool</code>. No seeding API.</td></tr>
+  <tr><td><code>State&lt;T&gt;</code></td><td><code>get, put</code>. Pre/post values via <code>old(State&lt;T&gt;)</code> / <code>new(State&lt;T&gt;)</code> in contracts.</td></tr>
+  <tr><td><code>Exn&lt;T&gt;</code></td><td><code>throw</code>. Handler is <code>handle[Exn&lt;T&gt;] { throw(x) -&gt; ... } in { ... }</code>.</td></tr>
+  <tr><td><code>Async</code></td><td><code>async(...) -&gt; Future&lt;T&gt;</code>, <code>await(...) -&gt; T</code>. Reference impl is sequential &mdash; pure type-system marker.</td></tr>
+</table>
+
+<div class="callout">
+  <b>Conspicuously absent from Vera:</b> no separate <code>List</code> type (use <code>Array</code> or define your own ADT), no <code>array_sort</code>/<code>contains</code>/<code>index_of</code>, no filesystem read directory / list, no networking beyond HTTP get/post, no threads, no real async runtime, no property-testing combinators (that lives in the toolchain via <code>vera test --trials N</code>).
+</div>
+
+<h2>5 &middot; Tooling</h2>
+
+<h3>CLI subcommands</h3>
+<div class="grid2">
+  <div class="panel">
+    <h4>Verbs &middot; common flags <code>--json --quiet --explain-slots</code></h4>
+    <ul>
+      <li><code>vera check file.vera</code> &mdash; parse + type-check</li>
+      <li><code>vera verify file.vera</code> &mdash; check + Z3 contract verification</li>
+      <li><code>vera compile file.vera [--wat] [--target browser] [-o dir]</code></li>
+      <li><code>vera run file.vera [--fn name -- args&hellip;]</code></li>
+      <li><code>vera test file.vera [--trials N] [--fn name] [--json]</code></li>
+      <li><code>vera parse file.vera</code> &mdash; parse tree dump</li>
+      <li><code>vera ast file.vera</code> &mdash; typed AST dump</li>
+      <li><code>vera fmt file.vera [--write] [--check]</code></li>
+      <li><code>vera version</code></li>
+    </ul>
+  </div>
+  <div class="panel">
+    <h4>Verification tiers (verbatim README)</h4>
+    <ol>
+      <li><b>Tier 1</b> &mdash; decidable arithmetic, comparisons, Booleans, ADTs, termination. Discharged automatically by Z3.</li>
+      <li><b>Tier 2</b> &mdash; guided. Hints supplied by the author when Z3 alone can't decide.</li>
+      <li><b>Tier 3</b> &mdash; runtime check. The undecided postcondition becomes a runtime assert at codegen time.</li>
+    </ol>
+    <p class="meta">Verify JSON includes <code>tier1_verified</code> and <code>tier3_runtime</code> counters. Tier 2 is described in the README but not directly exposed as a counter.</p>
+  </div>
+</div>
+
+<h3>Diagnostic JSON shape</h3>
+<pre><code>{
+  "ok": false,
+  "file": "...",
+  "diagnostics": [
+    {
+      "severity": "error",
+      "error_code": "E523",
+      "description": "...",
+      "rationale": "...",
+      "fix": "...",
+      "spec_ref": "spec/05-contracts.md#postconditions",
+      "location": { "file": "...", "line": 12, "column": 5 },
+      "source_line": "&hellip;"
+    }
+  ],
+  "warnings": [ /* W001 typed-hole warnings */ ],
+  "verification": { "tier1_verified": 3, "tier3_runtime": 1, "total": 4 }
+}</code></pre>
+<p>Error code ranges: <b>W001</b> (typed holes) &middot; <b>E001&ndash;E007</b> parse &middot; <b>E010</b> transform &middot; <b>E120&ndash;E176</b> type-check &middot; <b>E200&ndash;E233</b> calls &middot; <b>E300&ndash;E335</b> control-flow/handlers &middot; <b>E500&ndash;E525</b> verification &middot; <b>E600&ndash;E614</b> codegen &middot; <b>E700&ndash;E702</b> testing. Each error ships a <code>description</code> + <code>rationale</code> + <code>fix</code> + <code>spec_ref</code>.</p>
+
+<h3>Not present</h3>
+<ul>
+  <li><b>No LSP, no tree-sitter, no REPL.</b> Editor support: a VSCode extension + TextMate bundle in <code>editors/</code>.</li>
+  <li><b>No project manifest</b> for Vera code itself (no <code>vera.toml</code>). Vera is itself a Python package with a <code>pyproject.toml</code>.</li>
+  <li><b>No package registry / dependency manager</b> for Vera. PyPI name <code>vera</code> is squatted &mdash; install only from GitHub source.</li>
+  <li><b>No source maps, stack traces, or debugger.</b></li>
+  <li><b>No build cache / artifact directory convention</b> (<code>_build/</code>, <code>dist/</code>).</li>
+</ul>
+
+<h2>6 &middot; AI angle</h2>
+
+<h3>What Vera bets on at the AI layer</h3>
+<ul>
+  <li><b>De Bruijn names</b> &mdash; the headline bet. Hypothesis: removing names removes a hallucination class. Contested on HN.</li>
+  <li><b>Mandatory everything</b> &mdash; <code>public</code>/<code>private</code>, <code>requires</code>, <code>ensures</code>, <code>effects</code> on every function. Less to forget, more boilerplate.</li>
+  <li><b>One canonical form</b> &mdash; <code>vera fmt --check</code> means there is only one way to write any program.</li>
+  <li><b>Stable error codes with <code>fix</code> field</b> &mdash; each diagnostic carries an <code>error_code</code>, a <code>rationale</code>, a <code>fix</code> suggestion, and a <code>spec_ref</code>. Marketed as "diagnostics as instructions."</li>
+  <li><b>Contract-driven property testing</b> &mdash; <code>vera test --trials N</code> uses Z3 to synthesize inputs satisfying <code>requires</code>, runs them through WASM, checks <code>ensures</code>. No hand-written test cases needed.</li>
+  <li><b>Inference as a tracked effect</b> &mdash; <code>Inference.complete</code> sits in the effect row. Pure functions <i>cannot</i> accidentally call an LLM.</li>
+  <li><b>In-tree agent docs</b> &mdash; <code>SKILL.md</code> (Claude Code), <code>AGENTS.md</code> (Cursor/Windsurf/Copilot), <code>CLAUDE.md</code>, <code>DE_BRUIJN.md</code>, <code>llms.txt</code>. Auto-discovered.</li>
+</ul>
+
+<h3>VeraBench &mdash; the headline benchmark</h3>
+<p>50 problems &times; 6 models, 5 difficulty tiers (pure arithmetic &rarr; strings/arrays &rarr; ADTs &rarr; recursion+termination &rarr; multi-function with effects). Two modes: <b>full-spec</b> (problem ships contracts) and <b>spec-from-NL</b> (agent writes its own contracts).</p>
+<table>
+  <tr><th>Model</th><th class="nowrap">Vera %</th><th class="nowrap">Python %</th><th class="nowrap">TypeScript %</th></tr>
+  <tr><td>Kimi K2.5</td><td><b>100</b></td><td>86</td><td>91</td></tr>
+  <tr><td>GPT-4.1</td><td>91</td><td>96</td><td>96</td></tr>
+  <tr><td>Claude Opus 4</td><td>88</td><td>96</td><td>96</td></tr>
+  <tr><td>Kimi K2 Turbo</td><td>83</td><td>88</td><td>79</td></tr>
+  <tr><td>Claude Sonnet 4</td><td>79</td><td>96</td><td>88</td></tr>
+  <tr><td>GPT-4o</td><td>78</td><td>93</td><td>83</td></tr>
+</table>
+<p class="meta">Single run per model; no pass@k; non-deterministic outputs not averaged. Self-acknowledged in the bench README. No external methodology critique published yet. GPT-4.1 drops 91% &rarr; 50% in spec-from-NL mode &mdash; that gap matters more than the headline number.</p>
+
+<h3>The skill</h3>
+<p>Vera ships a single monolithic <code>SKILL.md</code>: <b>99 KB / 2,327 lines / ~24,900 tokens</b>. Two sections account for ~45% of the file:</p>
+<table>
+  <tr><th>Section</th><th>Tokens</th><th>Notes</th></tr>
+  <tr><td><code>## Built-in Functions</code></td><td>~7,800</td><td>~160 stdlib signatures inline, 15 H3 subsections.</td></tr>
+  <tr><td><code>## Effects</code></td><td>~3,200</td><td>11 H3s, four per-effect API tables (IO, Http, Inference, Random).</td></tr>
+  <tr><td><code>## Toolchain</code></td><td>~1,800</td><td>Includes a 3.1 KB browser-compilation guide.</td></tr>
+  <tr><td><code>## Common Mistakes</code></td><td>~960</td><td>12 H3 subsections restating rules taught positively earlier.</td></tr>
+</table>
+<p class="meta">For scale: typical Claude Code skill guidance suggests an always-loaded <code>SKILL.md</code> under ~5,000 tokens, with reference material loaded on demand via linked sub-files. Vera is ~5&times; over that.</p>
+<p>Vow ships a <b>1.7 KB / 48-line</b> entrypoint <code>SKILL.md</code> that links to <code>reference/grammar.md</code>, <code>reference/cli.md</code>, etc.; the full self-contained bundle (~30 K tokens, comparable to Vera's) is printed on demand via <code>vowc skill print --bundle</code> rather than loaded by default.</p>
+
+<div class="callout">
+  <b>The structural lesson on the skill.</b> Vera treats the skill as "everything an agent needs in one fetch"; Vow treats it as an entrypoint that points at reference files. The Vera choice is defensible <i>only</i> if you assume the agent won't follow links &mdash; which, for some agents in production, is currently true. It is the wrong default for the Claude Code skill format specifically, where the body is always-loaded.
+</div>
+
+<h2>7 &middot; Verification: Z3 vs ESBMC, head-to-head</h2>
+
+<table>
+  <thead>
+    <tr><th>Property</th><th><span class="lang-vera">Vera (Z3)</span></th><th><span class="lang-v">Vow (ESBMC)</span></th></tr>
+  </thead>
+  <tbody>
+    <tr><td>What's being decided</td><td>Validity of first-order formulas over decidable theories (arithmetic, BV, arrays, ADTs).</td><td>Reachability of assertion violations within a bounded unwinding of the program.</td></tr>
+    <tr><td>What you write</td><td>Mandatory <code>requires</code>/<code>ensures</code>/<code>decreases</code>/<code>effects</code> in source, with optional Z3-shaped hints (Tier 2). No loops.</td><td>Inline <code>requires</code>/<code>ensures</code>/<code>invariant</code> blocks. Loops have invariants; ESBMC unwinds to a bound.</td></tr>
+    <tr><td>Predicate language</td><td>Boolean ops + arithmetic + <code>forall</code>/<code>exists</code> bounded over <code>Nat</code> ranges + recursive predicates.</td><td>Boolean expressions only. No quantifiers.</td></tr>
+    <tr><td>What you get on failure</td><td>Per-VC verdict ("could not prove goal X" / Unknown / Timeout). Tier-3 fallback rewrites unprovable <code>ensures</code> as runtime assert.</td><td><b>Concrete counterexample</b>: failing input values, full execution trace, blame attribution (Caller/Callee).</td></tr>
+    <tr><td>Termination</td><td>Mandatory <code>decreases</code> measure on pure recursion. Lexicographic supported.</td><td>Bounded unwinding (no explicit <code>decreases</code>).</td></tr>
+    <tr><td>Loops</td><td>None &mdash; rejected at the language level. Iteration via tail recursion.</td><td>First-class. <code>invariant</code> + <code>decreases</code> in <code>while</code>; <code>break-with-value</code>, <code>continue</code>.</td></tr>
+    <tr><td>Blame</td><td>None.</td><td>First-class: <code>requires</code> &rarr; Caller, <code>ensures</code>/<code>invariant</code> &rarr; Callee. Encoded in JSON.</td></tr>
+    <tr><td>Trigger</td><td><code>vera verify</code>. Programs run via WASM; failed Tier-3 contracts trap at runtime.</td><td>On by default with <code>vowc build</code>; <code>--no-verify</code> to skip. <code>vowc verify</code> for verify-only.</td></tr>
+    <tr><td>Repair loop</td><td>Implicit: write &rarr; verify &rarr; JSON error &rarr; fix.</td><td>Explicit CEGIS, marketed as the workflow.</td></tr>
+    <tr><td>Honest about uncertainty</td><td>Yes &mdash; Tier 3 is documented and counts undecided contracts in the JSON.</td><td>Bounded: claims hold within the unwinding depth; clearly stated.</td></tr>
+  </tbody>
+</table>
+
+<div class="callout good">
+  <b>These are complementary, not strictly stronger/weaker.</b> Z3 is better at pure arithmetic and quantified contracts. ESBMC is better at concrete bug-finding in imperative loops and memory access patterns. Vow gets <i>witnesses</i>; Vera gets <i>quantifiers</i>.
+</div>
+
+<h2>8 &middot; Ecosystem &amp; adoption</h2>
+
+<table class="kv">
+  <tr><td>Stars</td><td><code>aallan/vera</code>: 351 &middot; <code>aallan/vera-bench</code>: 13</td></tr>
+  <tr><td>Forks</td><td>17 &middot; 1</td></tr>
+  <tr><td>Commits</td><td>1,263 on main, ~daily release cadence (156 releases)</td></tr>
+  <tr><td>Discord / subreddit / Lobsters</td><td>None found</td></tr>
+  <tr><td>Hacker News</td><td><a href="https://news.ycombinator.com/item?id=47955118">item #47955118</a> &mdash; 95 comments, predominantly skeptical</td></tr>
+  <tr><td>Named production users</td><td>None</td></tr>
+  <tr><td>Academic paper</td><td>None (contrast: MoonBit has LLM4Code 2024)</td></tr>
+  <tr><td>Sponsor / governance</td><td>Solo project. Allan is CTO of Negroni Venture Studios; launch posts hosted on the studio's blog.</td></tr>
+  <tr><td>License</td><td>MIT &mdash; cleaner than e.g. MoonBit's source-available MPSL.</td></tr>
+</table>
+
+<h3>HN criticism &mdash; strongest threads</h3>
+<ol>
+  <li><b>De Bruijn names</b>. <i>danpalmer</i>: "LLMs code better the less of a mental model you need&hellip; Go is great, Haskell pretty bad" &mdash; names <i>are</i> the mental model. <i>Dragon-Hatcher</i>: "It becomes impossible to grep for a variable&hellip; editing code at the top of a function can require editing all the code in the rest." Indices are non-local. Author (<code>unignorant</code>) replied once, pivoting away from the naming debate to capability/effect proofs.</li>
+  <li><b>Pre-agent research framing</b>. The "names confuse models" finding cited is from 2021, before agent loops; modern coding agents thrive on semantic names.</li>
+  <li><b>Token cost</b>. Shipping a 25 K-token language reference on every prompt is expensive.</li>
+  <li><b>Single-run benchmark</b>. Author acknowledged this in <code>vera-bench</code> README.</li>
+</ol>
+
+<h3>Adjacent languages pitched at AI codegen</h3>
+<table>
+  <tr><th>Language</th><th>AI bet</th><th>Verification</th></tr>
+  <tr><td>Vera</td><td>De Bruijn names, mandatory contracts, Inference effect, monolithic skill</td><td>Z3 + 3 tiers (auto / hinted / runtime)</td></tr>
+  <tr><td>Vow</td><td>Structured JSON, blame, CEGIS, linear types, named variables</td><td>ESBMC bounded model checking + counterexamples</td></tr>
+  <tr><td>MoonBit</td><td>Constrained decoding + first-party Pilot agent + ASP protocol</td><td>Why3 &rarr; Z3/Alt-Ergo/CVC5 (0.9, April 2026)</td></tr>
+  <tr><td>Zero (Vercel Labs)</td><td>25 JSON-first subcommands, <code>fixSafety</code> ladder, binary-pinned skills</td><td>None &mdash; types + capabilities only</td></tr>
+  <tr><td>Dafny</td><td>Verification-aware IL; modern LLMs at 89&ndash;96%</td><td>Z3 deductive verification</td></tr>
+  <tr><td>F* / Lean / Idris / SPARK</td><td>Not self-marketed for AI, but research use</td><td>Dependent types or SMT-backed</td></tr>
+</table>
+
+<h2>9 &middot; What Vow can borrow from Vera</h2>
+
+<div class="lessons">
+<ol>
+
+<li>
+  <b>Inference as a first-class effect.</b><br>
+  Vera puts LLM calls in the effect row: <code>Inference.complete : String -&gt; Result&lt;String, String&gt;</code>, <code>effects(&lt;Inference&gt;)</code>. A pure function can't accidentally call out to a remote model &mdash; it's a type error. If Vow ever grows agent-callable builtins (LLM-as-stdlib), this is the right shape. Cost: one effect kind, one runtime shim, no verifier impact. <i>Strongest portable idea.</i>
+</li>
+
+<li>
+  <b>Contract-driven property testing.</b><br>
+  <code>vera test --trials N</code> uses Z3 to synthesize inputs satisfying <code>requires</code>, then runs the function and asserts <code>ensures</code>. Functions taking ADT or function-type params are skipped with a message. Vow already has <code>vowc test</code>; adding a <code>--from-contracts --trials N</code> mode reuses the existing CEGIS infrastructure to generate random witnesses and exercise <code>ensures</code> at runtime. Useful belt-and-braces beside ESBMC.
+</li>
+
+<li>
+  <b>Each error code ships a <code>fix</code> example.</b><br>
+  Vera's diagnostics carry <code>description</code>, <code>rationale</code>, <code>fix</code>, and <code>spec_ref</code>. Vow's <code>errors.md</code> has rationale and description but less often a concrete wrong/right snippet. Documentation-only change; tightens the diagnostics-as-instructions story.
+</li>
+
+<li>
+  <b>Typed holes (<code>?</code>) as a warning, not a hard error.</b><br>
+  Vera lets you write <code>{ ? }</code> as a function body. It type-checks (good shape, good name resolution) and emits <code>W001</code>, but won't compile. Lets an agent stub and iterate. Cost: parser + checker hook; small win for incremental development.
+</li>
+
+<li>
+  <b>Mandatory <code>decreases</code> on pure recursion (or some equivalent).</b><br>
+  Vera doesn't have loops, so it requires <code>decreases</code> on recursive pure functions. Vow uses bounded unwinding instead. But borrowing the <i>idea</i> &mdash; an explicit termination measure that the agent has to state &mdash; might let Vow drop ESBMC's unwind bound for some cases or sharpen counterexamples. Worth a feasibility note in the contracts ADR.
+</li>
+
+<li>
+  <b>One canonical form, enforced.</b><br>
+  Vera ships <code>vera fmt --check</code> as part of the workflow &mdash; there is no &ldquo;style&rdquo; debate. Vow already has a canonical printer (a compiler pass, not a formatter), but doesn't enforce it as part of <code>vowc build</code>. Optional CI gate.
+</li>
+
+<li>
+  <b>Bounded quantifiers in contracts.</b><br>
+  Vera's <code>forall(@Nat, length, fn(...) {...})</code> is a quantifier over a known-bounded range. Translates straightforwardly to ESBMC as an unrolled loop of assertions. A small concrete win for contracts that today require N copy-pasted <code>ensures</code> lines.
+</li>
+
+<li>
+  <b>Spec chapter cross-references in diagnostics.</b><br>
+  Each Vera error carries <code>spec_ref: "spec/05-contracts.md#postconditions"</code>. Vow's spec is already cleanly chaptered (<code>docs/spec/{grammar,cli,contracts,errors,examples}.md</code>); embedding the anchor in the diagnostic JSON closes the loop. The agent doesn't have to guess where to read.
+</li>
+
+</ol>
+</div>
+
+<h2>10 &middot; What Vow should <i>not</i> borrow</h2>
+
+<div class="callout warn">
+<p>Vera's identity is built on choices that fight Vow's identity. Picking these up would dilute, not strengthen, what Vow is for.</p>
+<ul>
+  <li><b>De Bruijn slot references.</b> Vera's defining bet, and the most contested by every external reviewer. The benchmark wins are model-specific (Kimi K2.5 100%, Claude Sonnet 4 79% &mdash; <i>worse</i> than Python). Names anchor LLM attention; <code>grep</code> matters; the cost to human collaborators is real even in an agent-first language. The thesis is too narrow and too disputed to bet on.</li>
+  <li><b>Tier-3 runtime fallback for verification.</b> If Z3 can't discharge a contract, Vera silently emits a runtime assert and counts it in <code>tier3_runtime</code>. That breaks the "verified by default" pitch. Vow's "if ESBMC can't prove it, mark it as such and don't lie about the status" is the more honest position. Adopt the <i>counting</i> in JSON if you like &mdash; don't adopt the <i>fallback</i>.</li>
+  <li><b>WASM-only backend.</b> Cranelift native + a binary fixed-point self-host is one of Vow's strongest credibility signals. Vera's Python-host + WASM-only target is a research-grade pipeline; do not chase it.</li>
+  <li><b>Mandatory effect &amp; visibility on every function.</b> Vera requires <code>public</code>/<code>private</code>, <code>requires</code>, <code>ensures</code>, and <code>effects</code> on every declaration. Even for trivial helpers. Vow's "pure-by-default, effect annotations only when needed" carries the same information with less syntactic load.</li>
+  <li><b>Monolithic 99 KB <code>SKILL.md</code>.</b> Vow already does the right thing &mdash; small entrypoint, linked references, opt-in bundle. Vera's choice is defensible only for non-link-following agents; the always-loaded budget makes it the wrong default for Claude Code specifically.</li>
+  <li><b>No loops, no mutation, no linearity.</b> Vera's "everything is recursion, everything copies, no ownership" model gives up Vow's linear-types story. Linear types are <i>load-bearing</i> for Vow's memory-discipline brand. Don't trade them.</li>
+  <li><b>Async-as-a-marker-only.</b> Vera's <code>Async</code> effect is documented as having "no runtime overhead" because it's sequential. That's a UX trap &mdash; same syntax, different semantics, and an agent has no way to tell from the call site. If Vow ever adds async, it should be real.</li>
+</ul>
+</div>
+
+<h2>11 &middot; Bottom line</h2>
+
+<p>Vera is the second strong signal in two months (after MoonBit's 0.9 verification release) that "languages for AI agents with mandatory contracts" is a real category, not a fad. Both projects converged on the same diagnosis: <i>machine-first error output, contracts as the source of truth, agent-facing docs in-tree</i>. They diverge on three big bets:</p>
+<ol>
+  <li><b>Names</b>: Vera removes them. Vow keeps them. The external evidence so far favors Vow.</li>
+  <li><b>Verifier</b>: Vera uses Z3 with a runtime-fallback tier. Vow uses ESBMC with concrete counterexamples and blame. Complementary, not strictly ordered.</li>
+  <li><b>Implementation maturity</b>: Vera is a 3-month-old solo project with a Python reference compiler and ~350 stars. Vow is self-hosted to a binary fixed point with a published benchmark suite. The maturity gap matters more than the design gap.</li>
+</ol>
+
+<p>Vow's moat is the <b>verifier, blame, linear types, and self-hosting</b>. Vera doesn't threaten any of those. The most actionable items from this comparison, in priority order:</p>
+<ol>
+  <li><b>Add <code>Inference</code> as a tracked effect</b> &mdash; clean win when Vow grows LLM-callable builtins.</li>
+  <li><b>Add a <code>--from-contracts</code> mode to <code>vowc test</code></b> &mdash; reuses CEGIS infrastructure for property tests.</li>
+  <li><b>Add a <code>fix:</code> wrong/right snippet to every <code>E###</code> in <code>errors.md</code></b> &mdash; documentation-only, no code changes.</li>
+  <li><b>Embed <code>spec_ref</code> anchors in diagnostic JSON</b> &mdash; tightens the agent loop.</li>
+  <li><b>Consider bounded quantifiers in contracts</b> &mdash; small win, ESBMC-compatible via unrolling.</li>
+</ol>
+<p>Reject De Bruijn names, the runtime-fallback tier, WASM-only target, and the monolithic skill. Those are Vera's identity, not Vow's.</p>
+
+<footer>
+<h4>Sources</h4>
+<ul>
+  <li><a href="https://veralang.dev/">veralang.dev</a></li>
+  <li><a href="https://veralang.dev/SKILL.md">veralang.dev/SKILL.md</a> (99,631 bytes, fetched 2026-05-18)</li>
+  <li><a href="https://github.com/aallan/vera">github.com/aallan/vera</a></li>
+  <li><a href="https://github.com/aallan/vera-bench">github.com/aallan/vera-bench</a></li>
+  <li><a href="https://news.ycombinator.com/item?id=47955118">HN item #47955118 (95 comments)</a></li>
+  <li><a href="https://negroniventurestudios.com/2026/02/28/a-language-designed-for-machines-to-write/">Negroni VS &mdash; "A language designed for machines to write" (2026-02-28)</a></li>
+  <li><a href="https://negroniventurestudios.com/2026/04/13/language-design-doing-the-heavy-lifting/">Negroni VS &mdash; "Language design doing the heavy lifting" (2026-04-13)</a></li>
+  <li><a href="https://www.linkedin.com/posts/alasdairallan_a-language-designed-for-machines-to-write-activity-7433861060694085632-EseM">Alasdair Allan LinkedIn launch post</a></li>
+  <li><a href="https://www.dafny.org/">Dafny</a> (adjacent comparison)</li>
+  <li>Vow skill artifacts derived from <code>scripts/generate_help.py</code> on branch <code>vow/compareVera</code>.</li>
+</ul>
+<p>Report compiled by a parallel research fan-out (skill structure, syntax, stdlib, tooling, ecosystem, verification) and synthesised into this single page.</p>
+</footer>
+
+</main>
+</body>
+</html>

--- a/docs/comparisons/vs-zero.html
+++ b/docs/comparisons/vs-zero.html
@@ -1,0 +1,467 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Zero vs Vow — agent-oriented language comparison</title>
+<style>
+  :root {
+    --bg: #0e1116;
+    --panel: #161b22;
+    --panel-2: #1c2330;
+    --fg: #e6edf3;
+    --muted: #8b949e;
+    --line: #30363d;
+    --accent: #58a6ff;
+    --zero: #f0b429;
+    --vow: #7ee787;
+    --warn: #f97583;
+    --code-bg: #0b0f14;
+    --code-fg: #d1d9e0;
+    --max: 1100px;
+  }
+  * { box-sizing: border-box; }
+  html, body { background: var(--bg); color: var(--fg); }
+  body {
+    margin: 0;
+    font: 15.5px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+    padding: 0 24px 80px;
+  }
+  main { max-width: var(--max); margin: 0 auto; }
+  header.hero {
+    max-width: var(--max);
+    margin: 48px auto 32px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--line);
+  }
+  header.hero h1 { font-size: 34px; margin: 0 0 10px; letter-spacing: -0.02em; }
+  header.hero .sub { color: var(--muted); font-size: 17px; }
+  header.hero .meta { margin-top: 14px; color: var(--muted); font-size: 13px; }
+  h2 {
+    font-size: 22px;
+    margin: 48px 0 12px;
+    padding-top: 24px;
+    border-top: 1px solid var(--line);
+    letter-spacing: -0.01em;
+  }
+  h3 { font-size: 17px; margin: 24px 0 8px; color: var(--accent); }
+  h4 { font-size: 14px; margin: 16px 0 6px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  p { margin: 8px 0 12px; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre, .mono { font-family: ui-monospace, SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace; }
+  code { background: var(--code-bg); color: var(--code-fg); padding: 1px 5px; border-radius: 4px; font-size: 13px; }
+  pre {
+    background: var(--code-bg); color: var(--code-fg);
+    padding: 14px 16px; border-radius: 8px;
+    overflow-x: auto; font-size: 13px; line-height: 1.5;
+    border: 1px solid var(--line);
+  }
+  pre code { background: transparent; padding: 0; font-size: inherit; }
+  table { border-collapse: collapse; width: 100%; margin: 16px 0; font-size: 14px; }
+  th, td { padding: 9px 12px; text-align: left; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { background: var(--panel); color: var(--muted); font-weight: 600; font-size: 12.5px; text-transform: uppercase; letter-spacing: 0.04em; }
+  tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
+  .tag {
+    display: inline-block;
+    padding: 1px 8px; border-radius: 999px;
+    font-size: 11.5px; letter-spacing: 0.03em;
+    border: 1px solid var(--line); color: var(--muted);
+    margin-right: 4px;
+  }
+  .tag.zero { color: var(--zero); border-color: rgba(240,180,41,0.4); background: rgba(240,180,41,0.07); }
+  .tag.vow  { color: var(--vow);  border-color: rgba(126,231,135,0.4); background: rgba(126,231,135,0.07); }
+  .tag.warn { color: var(--warn); border-color: rgba(249,117,131,0.4); background: rgba(249,117,131,0.07); }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 760px) { .grid2 { grid-template-columns: 1fr; } }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 14px 18px;
+  }
+  .panel h3 { margin-top: 4px; }
+  .callout {
+    border-left: 3px solid var(--accent);
+    background: var(--panel-2);
+    padding: 12px 16px;
+    border-radius: 0 6px 6px 0;
+    margin: 16px 0;
+  }
+  .callout.warn { border-left-color: var(--warn); }
+  .callout.good { border-left-color: var(--vow); }
+  ul { padding-left: 22px; }
+  li { margin: 4px 0; }
+  .kv td:first-child { color: var(--muted); width: 35%; }
+  .lessons ol { padding-left: 22px; }
+  .lessons li { margin: 14px 0; }
+  .lessons li b { color: var(--accent); }
+  footer { color: var(--muted); font-size: 12.5px; margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line); }
+  footer ul { columns: 2; column-gap: 24px; }
+  .badge-row { margin-top: 8px; }
+  .tldr {
+    background: linear-gradient(180deg, rgba(88,166,255,0.07), rgba(88,166,255,0));
+    border: 1px solid rgba(88,166,255,0.25);
+    border-radius: 10px;
+    padding: 16px 20px;
+    margin: 20px 0;
+  }
+  .tldr h3 { margin-top: 0; color: var(--accent); }
+  .nowrap { white-space: nowrap; }
+  .lang-z, .lang-v { display: inline-block; font-weight: 600; }
+  .lang-z { color: var(--zero); }
+  .lang-v { color: var(--vow); }
+  details { margin: 8px 0; }
+  summary { cursor: pointer; color: var(--muted); }
+  summary:hover { color: var(--fg); }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <h1>Zero vs Vow — agent-oriented language comparison</h1>
+  <div class="sub">Two languages built for AI agents. One bets on <b>structured diagnostics</b>. The other bets on <b>formal verification</b>. Where do they meet, and what does each have to teach the other?</div>
+  <div class="meta">Compiled May 18, 2026 · Zero v0.1.2 (released May 15, 2026) · Vow self-hosted (current main)</div>
+  <div class="badge-row">
+    <span class="tag zero">Zero · vercel-labs/zero · Apache-2.0 · .0</span>
+    <span class="tag vow">Vow · self-hosted · .vow</span>
+  </div>
+</header>
+
+<main>
+
+<div class="tldr">
+  <h3>TL;DR</h3>
+  <p>Zero and Vow agree on the diagnosis: error messages should be machine-readable first, humans second. They diverge sharply on the cure. <b>Zero</b> ships a richly structured JSON surface across every CLI subcommand and a <b>fixSafety</b> taxonomy on each diagnostic — but has no formal verifier, no contracts, and no theorem prover. <b>Vow</b> ships ESBMC bounded model checking with <code>requires</code> / <code>ensures</code> / <code>invariant</code> contracts, blame semantics, and a CEGIS loop — but has less variety in agent-facing JSON surfaces. The two designs are <b>complementary, not competitive</b>. The most directly portable ideas Vow can borrow from Zero are: the <b>discovery-stub + binary-pinned skill bundle</b> (<code>zero skills get</code>), the <b>fixSafety ladder on every diagnostic</b>, and <b>typed <code>repair</code> handles</b> that name a fix rather than just describing the failure.</p>
+</div>
+
+<h2>1 · Identity</h2>
+<table class="kv">
+  <tr><td>Project</td><td><b>Zero</b> &mdash; "the programming language for agents"</td></tr>
+  <tr><td>Author</td><td>Vercel Labs (Chris Tate, Matt Van Horn)</td></tr>
+  <tr><td>Homepage</td><td><a href="https://zerolang.ai/">zerolang.ai</a></td></tr>
+  <tr><td>Repository</td><td><a href="https://github.com/vercel-labs/zero">github.com/vercel-labs/zero</a> &mdash; Apache-2.0</td></tr>
+  <tr><td>Launched</td><td>May 15, 2026 &mdash; v0.1.0; v0.1.2 two days later</td></tr>
+  <tr><td>File extension</td><td><code>.0</code></td></tr>
+  <tr><td>Compiler</td><td>C (<code>native/zero-c/</code>) &mdash; ~10 source files plus 5 native object emitters (<code>emit_elf64</code>, <code>emit_elf_aarch64</code>, <code>emit_macho64</code>, <code>emit_coff</code>, <code>emit_wasm</code>). No LLVM dependency.</td></tr>
+  <tr><td>Self-host status</td><td>In progress (<code>compiler-zero/src/*.0</code>, 11 modules). Not a fixed-point yet.</td></tr>
+  <tr><td>Binary size claim</td><td>Sub-10 KiB native binaries; "rebuilds in milliseconds."</td></tr>
+  <tr><td>Stability</td><td>Explicitly experimental &mdash; "language, compiler, and stdlib are not stable yet."</td></tr>
+  <tr><td>Reception</td><td>~1.9k GitHub stars in days. Only 2 low-engagement HN submissions. No published LLM benchmarks. Comparisons drawn most often to <b>Zig</b> (memory model) and <b>Rust</b> (look-and-feel, but "borrow checker is basic, not Rust-grade" &mdash; Mehul Mohan). No public comparison to Dafny / F* / Idris / Verus / Vow.</td></tr>
+</table>
+
+<h2>2 · Side-by-side at a glance</h2>
+<table>
+  <thead>
+    <tr><th>Axis</th><th><span class="lang-z">Zero</span></th><th><span class="lang-v">Vow</span></th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Core thesis</td><td>Errors written for humans break agentic coding. Fix by emitting structured JSON for every compiler surface.</td><td>Agents generate buggy code. Fix by proving programs correct (or returning a counterexample the agent can fix).</td></tr>
+    <tr><td>Correctness story</td><td>Type + effect + capability checking. <span class="tag warn">No formal verifier</span></td><td>ESBMC bounded model checking + CEGIS loop. <code>requires</code> / <code>ensures</code> / <code>invariant</code>.</td></tr>
+    <tr><td>Blame</td><td><b>fixSafety</b> ladder on each repair: <code>format-only</code>, <code>behavior-preserving</code>, <code>local-edit</code>, <code>api-changing</code>, <code>requires-human-review</code>.</td><td><b>Caller / Callee</b> blame on vow violations. <code>requires</code>&nbsp;&rarr;&nbsp;Caller, <code>ensures</code>/<code>invariant</code>&nbsp;&rarr;&nbsp;Callee.</td></tr>
+    <tr><td>Memory</td><td>Explicit; no GC, no lifetimes. <code>owned&lt;T&gt;</code> RAII handles, <code>ref&lt;T&gt;</code>/<code>mutref&lt;T&gt;</code> lexical borrows, <code>defer</code>, multiple allocators (<code>pageAlloc</code>, <code>arena</code>, <code>fixedBufAlloc</code>).</td><td>Manual with arena discipline. <code>linear struct</code> types must be consumed exactly once (type-checker enforced).</td></tr>
+    <tr><td>Effects</td><td><b>Capability passing</b>: <code>main(world: World)</code>, sub-capabilities like <code>world.out</code>, <code>std.fs.host()</code>. Non-host targets reject hosted APIs with <code>TAR002</code>.</td><td><b>Effect sets</b> on every function type. Pure functions have empty sets. Calling effectful from pure is a type error.</td></tr>
+    <tr><td>Error propagation</td><td><code>raises { InvalidInput }</code> + <code>check</code> + <code>raise</code> + <code>rescue err { ... }</code>.</td><td>Vow violations + structured diagnostics. <code>?</code> propagation in regular control flow.</td></tr>
+    <tr><td>Generics</td><td>Yes &mdash; type params + <code>static N: usize</code> value params, plus <code>interface</code> constraints (static dispatch, no vtables).</td><td><span class="tag warn">No generics</span> &mdash; deliberately rejected to keep the verifier surface small.</td></tr>
+    <tr><td>Metaprogramming</td><td><code>meta(...)</code> compile-time introspection: <code>fieldCount(T)</code>, <code>fieldType(T, "x")</code>, <code>target.pointerWidth</code>. Sandboxed evaluator.</td><td>None. Linear, hand-written code only.</td></tr>
+    <tr><td>Concurrency</td><td><span class="tag warn">None.</span> No async, threads, channels, or coroutines.</td><td>None in language. <code>std.proc</code> spawns external processes.</td></tr>
+    <tr><td>Sum types</td><td><code>choice</code> (payload variants) <i>and</i> <code>enum</code> (C-like, optional backing type).</td><td><code>enum</code> with payloads + exhaustive <code>match</code>.</td></tr>
+    <tr><td>Backend</td><td>Direct native object emission (ELF/Mach-O/COFF/WASM). C backend <b>removed</b> &mdash; emits <code>BLD003</code>.</td><td>Cranelift via FFI shim (<code>vow-clif-shim</code>); ESBMC pipeline runs in parallel via C emitter.</td></tr>
+    <tr><td>Diagnostic codes</td><td><code>XXXNNN</code> &mdash; <code>PAR</code>, <code>NAM</code>, <code>IMP</code>, <code>PKG</code>, <code>BLD</code>, <code>TYP</code>, <code>BOR</code>, <code>OWN</code>, <code>TAR</code>, <code>MAT</code>, ~16 families. Stable.</td><td>Named codes (<code>UnexpectedToken</code>, <code>VowViolation</code>, etc.) with JSON schemas under <code>schemas/</code>.</td></tr>
+    <tr><td>Tooling spread</td><td>~25 subcommands, nearly all with <code>--json</code>: <code>check</code>, <code>build</code>, <code>run</code>, <code>test</code>, <code>fix --plan</code>, <code>explain</code>, <code>graph</code>, <code>size</code>, <code>mem</code>, <code>time</code>, <code>ship</code>, <code>doctor</code>, <code>doc</code>, <code>abi</code>, <code>fmt</code>, <code>routes</code>, <code>skills</code>, ...</td><td>~6 subcommands: <code>build</code>, <code>verify</code>, <code>test</code>, <code>mutants</code>, <code>skill</code>, <code>--help</code>. All structured JSON.</td></tr>
+    <tr><td>Stdlib breadth</td><td>~14 modules: <code>std.mem</code>, <code>io</code>, <code>fs</code>, <code>net</code>, <code>http</code>, <code>json</code>, <code>codec</code>, <code>crypto</code>, <code>parse</code>, <code>time</code>, <code>rand</code>, <code>proc</code>, <code>path</code>, <code>args/env</code>.</td><td>Vec, String, HashMap, BTreeMap, heap, fs, io &mdash; all with verification-aware bounded models.</td></tr>
+    <tr><td>Package manager</td><td><code>zero.json</code> manifest; <span class="tag warn">no registry yet</span>, no <code>zero add</code>. Local path deps only.</td><td>None. Single-file or DFS-loaded <code>use</code> modules.</td></tr>
+    <tr><td>Cross-compilation</td><td>9 targets, Zig-toolchain shim: <code>darwin-arm64/x64</code>, <code>linux-musl-x64/arm64</code>, <code>linux-x64/arm64</code>, <code>win32-x64/arm64</code>, <code>wasm32-wasi/web</code>.</td><td>Host target only.</td></tr>
+    <tr><td>Verification benchmarks</td><td>None published.</td><td>36/36 Vow suite (sonnet-4-6); HumanEval 66/67 (sonnet-4); 103/103 non-stretch references verified by self-hosted compiler.</td></tr>
+  </tbody>
+</table>
+
+<h2>3 · Syntax catalog (Zero)</h2>
+
+<h3>Hello world</h3>
+<div class="grid2">
+  <div class="panel">
+    <h4>Zero · <code>examples/hello.0</code></h4>
+<pre><code>pub fun main(world: World) -&gt; Void raises {
+    check world.out.write("hello from zero\n")
+}</code></pre>
+  </div>
+  <div class="panel">
+    <h4>Vow · canonical hello</h4>
+<pre><code>module Hello
+
+fn main() -&gt; i32 [io] {
+    print_str("Hello, world!");
+    0
+}</code></pre>
+  </div>
+</div>
+
+<h3>Functions, types, error handling</h3>
+<table>
+  <tr><th>Feature</th><th>Zero syntax</th></tr>
+  <tr><td>Functions</td><td><code>fun foo() -&gt; i32 { ... }</code> · <code>pub fun</code> for export · <code>export c fun</code> for C-ABI</td></tr>
+  <tr><td>Variables</td><td><code>let x = 1</code> · <code>let mut y = 0</code> · <code>const base: i32 = 40</code></td></tr>
+  <tr><td>Records</td><td><code>shape Point { x: i32, y: i32 }</code></td></tr>
+  <tr><td>Sum types</td><td><code>choice Result { ok: i32, err: String }</code> · <code>enum Mode : u8 { fast, tiny }</code></td></tr>
+  <tr><td>Match</td><td><code>match r { .ok =&gt; v { ... } .err =&gt; m { ... } }</code></td></tr>
+  <tr><td>Error sets</td><td><code>fun parse() -&gt; i32 raises { InvalidInput } { raise InvalidInput }</code></td></tr>
+  <tr><td>Propagation</td><td><code>let v = check parse(ok)</code> · <code>parse(false) rescue err { fallback }</code></td></tr>
+  <tr><td>References</td><td><code>&amp;value</code>&nbsp;&rarr;&nbsp;<code>ref&lt;T&gt;</code> · <code>&amp;mut value</code>&nbsp;&rarr;&nbsp;<code>mutref&lt;T&gt;</code></td></tr>
+  <tr><td>Owned RAII</td><td><code>let mut f: owned&lt;File&gt; = ...</code> with optional <code>fun drop(self: mutref&lt;Self&gt;)</code></td></tr>
+  <tr><td>Generics</td><td><code>shape FixedVec&lt;T, static N: usize&gt; { items: [N]T }</code></td></tr>
+  <tr><td>Static interfaces</td><td><code>interface Readable&lt;T&gt; { fun read(self: ref&lt;T&gt;) -&gt; i32 }</code></td></tr>
+  <tr><td>Compile-time</td><td><code>const fields: usize = meta fieldCount(Point)</code></td></tr>
+  <tr><td>Loops</td><td><code>while cond { ... }</code> · <code>for i in 0..4 { ... }</code> (no <code>loop</code>, no labels)</td></tr>
+  <tr><td>Tests</td><td><code>test "addition works" { expect(add(2, 3) == 5) }</code> &mdash; inline in any <code>.0</code> file</td></tr>
+</table>
+
+<details>
+<summary>Longer example: error handling + records + match (composed from <code>fallibility.0</code> + <code>result-choice.0</code>)</summary>
+<pre><code>choice ParseResult {
+    ok: i32,
+    err: String,
+}
+
+fun validate(ok: Bool) -&gt; i32 raises { InvalidInput } {
+    if ok == false { raise InvalidInput }
+    return 42
+}
+
+fun classify(raw: Bool) -&gt; ParseResult {
+    let value = validate(raw) rescue err { return ParseResult.err("bad input") }
+    return ParseResult.ok(value)
+}
+
+pub fun main(world: World) -&gt; Void raises {
+    let result = classify(true)
+    match result {
+        .ok =&gt; value {
+            if value == 42 { check world.out.write("validated\n") }
+        }
+        .err =&gt; message {
+            check world.err.write("failed\n")
+        }
+    }
+}</code></pre>
+</details>
+
+<h2>4 · Standard library &amp; tooling (Zero)</h2>
+
+<h3>Modules</h3>
+<p>14 stdlib modules, all marked experimental. Hosted modules (<code>fs</code>, <code>net</code>, <code>http</code>, <code>proc</code>, <code>args</code>, <code>env</code>) gate on target capabilities and fail with <code>TAR002</code> on non-host targets.</p>
+<table>
+  <tr><th>Module</th><th>Role</th></tr>
+  <tr><td><code>std.mem</code></td><td>Spans, byte ops, allocators (<code>pageAlloc</code>, <code>arena</code>, <code>fixedBufAlloc</code>, <code>generalAlloc</code>, <code>nullAlloc</code>), <code>vec</code>, <code>ByteBuf</code></td></tr>
+  <tr><td><code>std.io</code></td><td>Buffered reader/writer metadata, byte copy</td></tr>
+  <tr><td><code>std.fs</code></td><td>File ops returning <code>owned&lt;File&gt;</code> or raising <code>{NotFound, TooLarge, Io}</code></td></tr>
+  <tr><td><code>std.net</code> / <code>std.http</code></td><td>Address, dnsName, connect/listen (no socket read/write yet), HTTP client/server scaffolding</td></tr>
+  <tr><td><code>std.json</code></td><td><code>validate</code>, <code>parse</code>, <code>streamTokens</code>, <code>writeString</code></td></tr>
+  <tr><td><code>std.codec</code></td><td>CRC32, varint, raw u8/u16/u32 read/write</td></tr>
+  <tr><td><code>std.crypto</code></td><td>hash32, hmac32, <code>constantTimeEql</code>, secure random</td></tr>
+  <tr><td><code>std.parse</code></td><td>Allocation-free ASCII scanners</td></tr>
+  <tr><td><code>std.time</code></td><td>Monotonic, wall-clock, durations</td></tr>
+  <tr><td><code>std.rand</code></td><td>Seeded source + entropy</td></tr>
+  <tr><td><code>std.proc</code></td><td>Spawn external processes</td></tr>
+  <tr><td><code>std.path</code></td><td>Fixed-buffer path joining</td></tr>
+  <tr><td><code>std.args</code> / <code>std.env</code></td><td>Hosted process args, env-var lookup</td></tr>
+</table>
+
+<h3>CLI subcommands</h3>
+<p>Roughly 25 subcommands; nearly every one has <code>--json</code>. Vow has 6.</p>
+<div class="grid2">
+  <div class="panel">
+    <h4>Build &amp; run</h4>
+    <ul>
+      <li><code>zero check [--json]</code></li>
+      <li><code>zero run [--target] [--profile]</code></li>
+      <li><code>zero build --emit exe|obj|wasm --target ... --out ...</code></li>
+      <li><code>zero test [--json] [--filter]</code></li>
+      <li><code>zero fmt [--check]</code></li>
+      <li><code>zero ship [--json] --profile release-small|tiny|audit</code></li>
+      <li><code>zero new cli|lib|package &lt;path&gt;</code></li>
+      <li><code>zero clean [--all]</code></li>
+    </ul>
+  </div>
+  <div class="panel">
+    <h4>Agent-facing surfaces</h4>
+    <ul>
+      <li><code>zero explain [--json] &lt;code&gt;</code></li>
+      <li><code>zero fix --plan --json</code> (also <code>--apply</code> / <code>--patch</code>)</li>
+      <li><code>zero graph --json</code> &mdash; module/symbol/capability graph</li>
+      <li><code>zero size --json</code> &mdash; profile budgets, stdlib helpers</li>
+      <li><code>zero mem --json</code> &mdash; allocator facts, instrumentation</li>
+      <li><code>zero time --json</code> &mdash; phase timing, interface fingerprints</li>
+      <li><code>zero doctor [--json]</code> &mdash; host + target toolchain readiness</li>
+      <li><code>zero abi check|dump --json</code></li>
+      <li><code>zero tokens --json</code>, <code>zero parse --json</code></li>
+      <li><code>zero dev --json --trace</code> &mdash; watch mode w/ cache facts</li>
+      <li><code>zero skills list|get &lt;id&gt; [--full]</code> &mdash; binary-pinned skills</li>
+      <li><code>zero targets</code>, <code>zero doc --json</code></li>
+    </ul>
+  </div>
+</div>
+
+<h3>Diagnostic JSON shape</h3>
+<pre><code>{
+  "schemaVersion": 1,
+  "ok": false,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "NAM003",
+      "message": "...",
+      "path": "src/main.0",
+      "line": 12, "column": 5, "length": 7,
+      "expected": "...", "actual": "...",
+      "help": "...",
+      "fixSafety": "local-edit",
+      "repair": { "id": "fix-import-path", "summary": "..." },
+      "related": [ ... ]
+    }
+  ]
+}</code></pre>
+<p><b>fixSafety</b> classifies the <i>repair</i>, not the violation, on a 5-level ladder:</p>
+<ul>
+  <li><code>format-only</code> &mdash; whitespace, formatting</li>
+  <li><code>behavior-preserving</code> &mdash; refactor with no semantic change</li>
+  <li><code>local-edit</code> &mdash; localized semantic change</li>
+  <li><code>api-changing</code> &mdash; changes public surface</li>
+  <li><code>requires-human-review</code> &mdash; "planning hint, not an automatic patch"</li>
+</ul>
+
+<h2>5 · The skill: Zero vs Vow</h2>
+
+<p>Both projects ship a Claude Code skill. They make <b>radically different</b> structural choices.</p>
+
+<table>
+  <thead>
+    <tr><th>Aspect</th><th><span class="lang-z">Zero</span></th><th><span class="lang-v">Vow</span></th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Top-level <code>SKILL.md</code></td><td><b>~50 lines · 1.5 KB stub</b>. "This file is a discovery stub. Do not treat it as the full Zero workflow."</td><td>48 lines · ~1.5 KB stub pointing to local <code>reference/</code> + <code>examples/</code> + <code>schemas/</code></td></tr>
+    <tr><td>Where the content lives</td><td><b>Inside the compiler binary</b>. Served at runtime via <code>zero skills list</code> / <code>zero skills get &lt;id&gt; [--full]</code>. Seven micro-skills, ~17 KB total: <code>zero-agent</code>, <code>zero-language</code>, <code>zero-diagnostics</code>, <code>zero-builds</code>, <code>zero-packages</code>, <code>zero-stdlib</code>, <code>zero-testing</code>.</td><td>Inside the compiler binary too &mdash; <code>vowc skill print</code> / <code>vowc skill install</code>. Installs ~2,600 lines split across <code>reference/{grammar,cli,contracts,errors}.md</code> + <code>examples/examples.md</code> + JSON <code>schemas/</code>.</td></tr>
+    <tr><td>Versioning</td><td>"Binary-pinned." Agent told to use the same binary that will run the project. Skills move with the compiler version.</td><td>Same idea &mdash; skill is generated from the compiler. <code>scripts/check_help_coverage.py</code> catches drift.</td></tr>
+    <tr><td>Workflow</td><td>Numbered <b>edit loop</b>: read context &rarr; smallest change &rarr; <code>zero check --json</code> &rarr; <code>zero explain</code> &rarr; <code>zero fix --plan --json</code> &rarr; update tests &rarr; rerun.</td><td><b>CEGIS loop</b>: write contracts &rarr; <code>vowc build</code> &rarr; parse JSON &rarr; inspect <code>status</code>/<code>diagnostics</code>/<code>counterexamples</code> &rarr; fix &rarr; rerun until <code>Verified</code>.</td></tr>
+    <tr><td>Tone</td><td>Terse, imperative, list-of-don'ts: "Do not invent syntax", "Do not invent CLI fields", "Do not scrape terminal prose when JSON is available."</td><td>Terse, imperative, but progressive disclosure-first &mdash; defers detail to reference files.</td></tr>
+    <tr><td>Error-code reference</td><td>10 codes inlined into <code>zero-diagnostics</code> with one-liners. Full list via <code>zero explain</code>.</td><td>Full error catalog (<code>reference/errors.md</code>, 447 lines) shipped alongside the stub.</td></tr>
+    <tr><td>Fix metadata</td><td><b><code>fixSafety</code> ladder</b> (5 levels) on every diagnostic + <code>repair: { id, summary }</code>. <code>zero fix</code> is <b>plan-only</b>: the compiler proposes, the agent applies.</td><td><b>Blame</b> (<code>Caller</code>/<code>Callee</code>) on every vow violation + values of free variables in the predicate. Counterexamples include concrete witness traces.</td></tr>
+    <tr><td>Anti-pattern list</td><td>Explicit and short. Don't invent syntax. Don't invent CLI fields. Don't scrape terminal prose. Treat effects as capabilities, not ambient globals. Don't leave <code>xfail:</code> on a fixed bug.</td><td>Embedded in references and contract-authoring guidance. No central "things not to do" page.</td></tr>
+    <tr><td>Test idiom</td><td><code>test "name" { expect(...) }</code> inline in any <code>.0</code> file. Expected-fail encoded in the test <i>name</i> (<code>xfail:</code>); the JSON surfaces <code>unexpectedPasses</code> so an agent learns when it has accidentally fixed something.</td><td>Runtime tests in <code>tests/run/*.vow</code>; mutation testing via <code>vowc mutants</code> shards.</td></tr>
+  </tbody>
+</table>
+
+<div class="callout">
+  <b>The big structural lesson.</b> Zero treats the skill itself as a <i>thing the compiler emits</i>, just like diagnostics or build output. The on-disk <code>SKILL.md</code> is a 1.5 KB pointer; the agent asks the running compiler what its skill is, and the answer matches that compiler's exact version. Vow has the same affordance (<code>vowc skill print</code>) but ships the full content on disk rather than indexing into the binary. Zero's choice is more aggressive about closing the version-skew loophole, at the cost of needing a working binary before you can read the skill.
+</div>
+
+<h2>6 · What Vow can borrow from Zero</h2>
+
+<div class="lessons">
+<ol>
+
+<li>
+  <b>Add a <code>fixSafety</code>-style ladder on every diagnostic.</b><br>
+  Vow already has <code>Blame</code> (who is at fault) but no notion of <i>how dangerous the fix is</i>. A 5-level ladder &mdash; <code>format-only</code>, <code>behavior-preserving</code>, <code>local-edit</code>, <code>api-changing</code>, <code>requires-human-review</code> &mdash; would let an agent triage automatically. For Vow specifically: a violation that suggests strengthening a <code>requires</code> clause is <code>api-changing</code>; one that suggests adding a loop <code>invariant</code> is <code>local-edit</code>; a counterexample showing a genuine logic bug is <code>requires-human-review</code>.
+</li>
+
+<li>
+  <b>Emit a typed <code>repair</code> handle alongside the diagnostic.</b><br>
+  Today a vow violation says <i>"<code>requires: y != 0</code> failed with <code>y == 0</code>"</i>. Adding <code>repair: { id: "guard-divisor", summary: "Add precondition or rescue" }</code> turns the diagnostic into an actionable JSON object the agent can dispatch on. The compiler doesn't have to write the patch &mdash; just name it. <a href="https://github.com/vercel-labs/zero/blob/main/skills/zero/SKILL.md">Zero's <code>zero-diagnostics</code></a> shows the shape.
+</li>
+
+<li>
+  <b>Discovery-stub pattern for the on-disk skill.</b><br>
+  Vow already ships a stub <code>SKILL.md</code> with progressive disclosure. Going further &mdash; making it <i>truly</i> a discovery stub that says "ask the binary" &mdash; would close the version-skew window. Replace inline reference content with <code>!`vowc skill get grammar --json`</code>-style runtime queries. Practical hybrid: keep the on-disk reference for offline use, but stamp it with the compiler version it was generated from and have the skill tell the agent to regenerate if versions diverge.
+</li>
+
+<li>
+  <b>Split the skill into named sub-skills.</b><br>
+  Zero's seven micro-skills (<code>zero-agent</code>, <code>zero-language</code>, <code>zero-diagnostics</code>, <code>zero-builds</code>, <code>zero-packages</code>, <code>zero-stdlib</code>, <code>zero-testing</code>) average 2&ndash;3 KB each. An agent loads only what it needs. Vow's reference files are already structured this way (<code>grammar.md</code>, <code>cli.md</code>, <code>contracts.md</code>, <code>errors.md</code>, <code>examples.md</code>) &mdash; the missing piece is a discoverable <i>index</i> command: <code>vowc skill list</code> / <code>vowc skill get contracts</code>.
+</li>
+
+<li>
+  <b>Add <code>vowc explain &lt;error_code&gt;</code> as a first-class subcommand.</b><br>
+  Zero's <code>zero explain NAM003 --json</code> returns <code>{ code, title, fixSafety, defaultOutput }</code>. For Vow, <code>vowc explain VowViolation --json</code> could return the violation taxonomy, blame model, and a pointer to <code>contracts.md</code>. Today this content lives only in <code>errors.md</code>; lifting it into a runtime command makes it discoverable from the JSON itself.
+</li>
+
+<li>
+  <b>An explicit "Do nots" page in the skill.</b><br>
+  Zero's <code>zero-agent</code> opens with six imperatives: don't invent syntax, don't invent CLI fields, don't scrape prose when JSON is available, treat effects as capabilities, prefer narrow commands, don't auto-apply <code>requires-human-review</code>. Vow's equivalents are spread across <code>contracts.md</code> and CLAUDE.md. Centralizing them into a short, list-of-don'ts page (or top of <code>SKILL.md</code>) would make them harder to miss. Vow-specific candidates: "Don't weaken contracts to appease ESBMC", "Don't add <code>n &lt;= 10</code>-style verifier bounds to <code>requires</code>", "Don't use <code>--no-verify</code> to skip a real failure".
+</li>
+
+<li>
+  <b>Two-phase fix: plan, then apply.</b><br>
+  <code>zero fix --plan --json</code> proposes; the agent applies. Vow could add <code>vowc fix --plan --json &lt;file.vow&gt;</code> that, given a vow violation, emits a structured proposal &mdash; not a patch &mdash; covering candidate strengthenings of contracts, loop invariants, or guards. The agent decides whether to apply. The plan can be regression-tested independently of any patcher.
+</li>
+
+<li>
+  <b>Capability-passing as a UX layer over Vow's effect sets.</b><br>
+  Vow's effect sets are type-checked but invisible at the call site. Zero forces <code>world: World</code> through every effectful function, which is agent-greppable. This is probably too verbose for Vow's taste &mdash; but it's worth considering whether <i>some</i> effects (e.g. unbounded allocation, network) should be passed explicitly. The reverse question is also worth asking: should Zero adopt Vow-style implicit effect sets to reduce visual noise? Neither answer is obvious.
+</li>
+
+<li>
+  <b>Surface every cache/key/fingerprint that affects determinism.</b><br>
+  Zero exposes <code>cacheKeyInputs</code>, <code>snapshotKey</code>, <code>releaseTargetContract</code>, <code>interfaceFingerprints</code>. Vow already has a deterministic compile-object cache with a content-addressed key (see <code>cli.md</code>); making that key visible in the JSON build output gives agents a stable handle for cache diagnostics, regression detection, and reproducibility audits.
+</li>
+
+<li>
+  <b>Inline <code>test "name" { expect(...) }</code> blocks.</b><br>
+  Zero's inline test blocks (any <code>.0</code> file can carry tests) lower the friction of test-writing for agents. Vow has <code>tests/run/*.vow</code> directory-based tests; inline tests would be a complementary mode for unit-level coverage. The <code>unexpectedPasses</code> idea &mdash; flagging when an <code>xfail:</code> starts passing &mdash; is independently useful as a regression-direction signal.
+</li>
+
+</ol>
+</div>
+
+<h2>7 · What Vow should <i>not</i> borrow</h2>
+
+<div class="callout warn">
+<p><b>Zero's correctness story is the shallow-end version of Vow's.</b> "Types + capabilities + structured diagnostics" is real value but it's not formal verification. Vow shouldn't dilute its CEGIS / ESBMC story to chase Zero's UX. The two design positions are <i>complementary, not competing</i>:</p>
+<ul>
+  <li><b>Generics &amp; <code>meta(...)</code>.</b> Zero has both. Vow has deliberately rejected both because they expand the verification surface. The "crisp rule" in <code>CLAUDE.md</code> &mdash; "add surface sugar only when it desugars to today's core semantics with near-zero verifier impact; reject anything that introduces a new type-system axis" &mdash; argues against this directly. Generics introduce monomorphization complexity that ESBMC has to chase.</li>
+  <li><b>Sub-10 KiB binary chase.</b> Vow's binaries can be larger if it buys verification. Don't optimize away ESBMC's static C model for binary-size points.</li>
+  <li><b>Removing the C backend.</b> Zero removed its generated-C backend in favor of direct emitters. Vow needs the C backend for ESBMC. Different priorities.</li>
+  <li><b>25 subcommands.</b> Zero's surface area is impressive but a lot of it (<code>zero mem</code>, <code>zero ship</code>, <code>zero abi</code>, <code>zero doctor</code>) is genuinely useful only at the scale of a productized toolchain. Vow should pick subcommands by clear agent need, not by parity.</li>
+  <li><b>Effect-as-capability syntax.</b> Threading <code>world: World</code> through every effectful function is grep-friendly but visually heavy. Vow's effect sets on function types do the same job structurally with less noise. Adopt the explicitness; keep the syntax.</li>
+</ul>
+</div>
+
+<h2>8 · Bottom line</h2>
+
+<p>Zero is the strongest signal yet that "languages designed for AI agents" is a real category, not a fad. It validates Vow's bet that machine-readable, structured compiler output is the right default. But it leaves the <b>formal verification</b> ground entirely uncontested. There is no other language in the agent-first niche that ships a bounded model checker, contracts with blame, and a CEGIS loop. Vow's moat is the verifier and the published benchmarks.</p>
+
+<p>The most actionable items, in priority order:</p>
+<ol>
+  <li>Add <code>fixSafety</code> on every diagnostic.</li>
+  <li>Add typed <code>repair</code> handles in diagnostic JSON.</li>
+  <li>Add <code>vowc explain &lt;code&gt;</code> and <code>vowc skill list / get</code>.</li>
+  <li>Centralize a "Do nots" page in the skill.</li>
+  <li>Two-phase <code>vowc fix --plan --json</code>.</li>
+</ol>
+
+<footer>
+<h4>Sources</h4>
+<ul>
+  <li><a href="https://zerolang.ai/">zerolang.ai</a></li>
+  <li><a href="https://github.com/vercel-labs/zero">vercel-labs/zero (GitHub)</a></li>
+  <li><a href="https://raw.githubusercontent.com/vercel-labs/zero/main/skills/zero/SKILL.md">skills/zero/SKILL.md</a></li>
+  <li><a href="https://github.com/vercel-labs/zero/tree/main/skill-data">skill-data/ (binary-pinned skills)</a></li>
+  <li><a href="https://raw.githubusercontent.com/vercel-labs/zero/main/docs-site/articles/language-reference.md">language-reference.md</a></li>
+  <li><a href="https://raw.githubusercontent.com/vercel-labs/zero/main/docs-site/articles/diagnostics.md">diagnostics.md</a></li>
+  <li><a href="https://raw.githubusercontent.com/vercel-labs/zero/main/docs-site/articles/cli-reference.md">cli-reference.md</a></li>
+  <li><a href="https://raw.githubusercontent.com/vercel-labs/zero/main/docs-site/articles/standard-library.md">standard-library.md</a></li>
+  <li><a href="https://raw.githubusercontent.com/vercel-labs/zero/main/docs-site/articles/cross-compilation.md">cross-compilation.md</a></li>
+  <li><a href="https://raw.githubusercontent.com/vercel-labs/zero/main/docs-site/articles/package-manifest.md">package-manifest.md</a></li>
+  <li><a href="https://raw.githubusercontent.com/vercel-labs/zero/main/docs-site/articles/testing.md">testing.md</a></li>
+  <li><a href="https://raw.githubusercontent.com/vercel-labs/zero/main/native/zero-c/targets/targets.manifest">targets.manifest</a></li>
+  <li><a href="https://www.marktechpost.com/2026/05/17/vercel-labs-introduces-zero-a-systems-programming-language-designed-so-ai-agents-can-read-repair-and-ship-native-programs/">MarkTechPost &mdash; Vercel Labs Introduces Zero (2026-05-17)</a></li>
+  <li><a href="https://firethering.com/vercel-zero-programming-language-ai-agents/">Firethering analysis</a></li>
+  <li><a href="https://byteiota.com/vercels-zero-a-programming-language-built-for-ai-agents/">byteiota writeup</a></li>
+  <li><a href="https://x.com/ctatedev/status/2055434061322039377">Chris Tate launch (X)</a></li>
+  <li><a href="https://x.com/mehulmpt/status/2055721670334369915">Mehul Mohan critique (X)</a></li>
+</ul>
+</footer>
+
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds four per-language comparison reports under `docs/comparisons/`:
  - `vs-moonbit.html` — MoonBit 0.9 (Why3 + SMT, Pilot, ASP, constrained decoding)
  - `vs-vera.html` — Vera (De Bruijn slots, Z3 + tiered runtime fallback, `Inference` effect)
  - `vera-skill-analysis.html` — structural deep-dive on Vera's 99 KB monolithic `SKILL.md`
  - `vs-zero.html` — Zero (Vercel Labs; `fixSafety`, typed `repair` handles, binary-pinned skills)
- Adds `index.html`, a unified synthesis: convergent diagnosis across the category, the four divergent bets, verification head-to-head (Why3/SMT vs Z3+tiers vs none vs ESBMC), skill packaging comparison, and a 17-item prioritised action list for Vow (5 high, 7 medium, 5 low — most of the high-priority items are documentation or JSON-emitter changes).
- `README.md` indexes the set.

Closes #267
Closes #268

## Test plan
- [x] HTML opens in a browser locally (5 reports + index, all self-contained, no external assets required beyond the embedded inline CSS).
- [ ] Verify the `Closes #267` / `Closes #268` keywords work on merge (auto-close after merge commit lands).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vow-lang/codesmith/vow/pr/453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->