### PR TITLE
ci: add advisory macOS bootstrap + test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,47 @@ jobs:
       - run: echo "$HOME/esbmc/bin" >> "$GITHUB_PATH"
       - name: Bootstrap (Stages 1-2 verify, Stage 3 fixed-point check)
         run: scripts/bootstrap.sh --stage3-no-verify
+
+  # ─── macOS jobs (advisory) ─────────────────────────────────────────
+  #
+  # ESBMC ships no macOS release artifact (only Ubuntu + Windows zips on
+  # https://github.com/esbmc/esbmc/releases), so verification is skipped
+  # on macOS. The fixed-point bootstrap is still meaningful: verification
+  # does not affect codegen, so identical Stage 2/Stage 3 SHA-256s prove
+  # the self-hosted compiler reaches a fixed point on this platform.
+  #
+  # continue-on-error is on while we shake out platform-specific issues
+  # (libdl quirks, ulimit -v semantics, etc.). The intent is to flip
+  # these to required once they go green; tracked in a follow-up issue.
+
+  build-and-test-macos:
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --all
+      - name: Build concatenated self-hosted compiler
+        run: |
+          bash scripts/concat_vow.sh clif > /tmp/compiler_clif.vow
+          ./target/debug/vow build --no-verify --no-cache /tmp/compiler_clif.vow -o /tmp/vowc_concat
+          test -x /tmp/vowc_concat
+      - run: cargo test --all
+      - run: cargo clippy --all -- -D warnings
+      - run: cargo fmt --all -- --check
+
+  bootstrap-macos:
+    # Mirrors `bootstrap` but with --no-verify (no ESBMC on macOS).
+    # The SHA-256 fixed-point check is preserved: verification does not
+    # change codegen, so a successful match here still proves the
+    # self-hosted compiler is a fixed point on macOS.
+    runs-on: macos-latest
+    continue-on-error: true
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Bootstrap (no verification — ESBMC unavailable on macOS)
+        run: scripts/bootstrap.sh --no-verify

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -142,8 +142,11 @@ fi
 # Stage 1 runs the Rust compiler (well-behaved release binary) — no vmem cap.
 # Stages 2+3 run the self-hosted compiler under VOW_BOOTSTRAP_VMEM_KB if set.
 # With --no-verify ESBMC never runs, so the "Skipped" handling in
-# run_verify_* is dead code but harmless; reusing the wrappers keeps the
-# verify-on/verify-off paths identical.
+# run_verify_* is dead code but harmless. The Stage 1/2/3 call sites
+# always invoke run_rust_stage / run_self_stage; these wrappers do the
+# conditional dispatch (verify-aware vs plain logger), so the stage
+# invocation code itself is identical in both modes — only the wrappers
+# differ.
 run_rust_stage() {
     local cmd="$1"
     if [ "$NO_VERIFY" = true ]; then

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -11,6 +11,7 @@ mkdir -p build
 
 SKIP_CARGO=false
 STAGE3_NO_VERIFY=false
+NO_VERIFY=false
 VMEM_LIMIT_KB="${VOW_BOOTSTRAP_VMEM_KB:-0}"
 if ! [[ "$VMEM_LIMIT_KB" =~ ^[0-9]+$ ]]; then
     echo "Error: VOW_BOOTSTRAP_VMEM_KB must be a non-negative integer (got: '$VMEM_LIMIT_KB')" >&2
@@ -18,7 +19,7 @@ if ! [[ "$VMEM_LIMIT_KB" =~ ^[0-9]+$ ]]; then
 fi
 
 usage() {
-    echo "Usage: $0 [--skip-cargo] [--stage3-no-verify] [--help|-h]"
+    echo "Usage: $0 [--skip-cargo] [--no-verify] [--stage3-no-verify] [--help|-h]"
     echo ""
     echo "Bootstrap the self-hosted Vow compiler and verify the fixed point."
     echo ""
@@ -31,6 +32,10 @@ usage() {
     echo ""
     echo "Options:"
     echo "  --skip-cargo         Skip Stage 0 if Rust binary already built"
+    echo "  --no-verify          Skip ESBMC verification at every stage. Useful on"
+    echo "                       platforms where ESBMC is unavailable (e.g. macOS)."
+    echo "                       Verification does not change codegen, so the"
+    echo "                       SHA-256 fixed-point check remains meaningful."
     echo "  --stage3-no-verify   Skip ESBMC verification on Stage 3 only (Stages 1-2"
     echo "                       still verify). Verification does not change codegen,"
     echo "                       so the SHA-256 fixed-point check remains meaningful."
@@ -118,16 +123,44 @@ run_verify_stage_cmd() {
 for arg in "$@"; do
     case "$arg" in
         --skip-cargo)        SKIP_CARGO=true ;;
+        --no-verify)         NO_VERIFY=true ;;
         --stage3-no-verify)  STAGE3_NO_VERIFY=true ;;
         -h|--help)           usage ;;
         *)                   echo "Unknown flag: $arg"; usage ;;
     esac
 done
 
+stage12_build_flags="--verify-jobs 1"
 stage3_build_flags="--verify-jobs 1"
-if [ "$STAGE3_NO_VERIFY" = true ]; then
+if [ "$NO_VERIFY" = true ]; then
+    stage12_build_flags="--no-verify"
+    stage3_build_flags="--no-verify"
+elif [ "$STAGE3_NO_VERIFY" = true ]; then
     stage3_build_flags="--no-verify"
 fi
+
+# Stage 1 runs the Rust compiler (well-behaved release binary) — no vmem cap.
+# Stages 2+3 run the self-hosted compiler under VOW_BOOTSTRAP_VMEM_KB if set.
+# With --no-verify ESBMC never runs, so the "Skipped" handling in
+# run_verify_* is dead code but harmless; reusing the wrappers keeps the
+# verify-on/verify-off paths identical.
+run_rust_stage() {
+    local cmd="$1"
+    if [ "$NO_VERIFY" = true ]; then
+        run_logged "$cmd"
+    else
+        run_verify_logged "$cmd"
+    fi
+}
+
+run_self_stage() {
+    local cmd="$1"
+    if [ "$NO_VERIFY" = true ]; then
+        run_stage_cmd "$cmd"
+    else
+        run_verify_stage_cmd "$cmd"
+    fi
+}
 
 # ─── Stage 0: Build Rust compiler ────────────────────────────────────
 
@@ -148,7 +181,7 @@ fi
 # codegen + one ESBMC instead of codegen + N-fold ESBMC fan-out. See #175.
 printf "${BOLD}Stage 1:${RESET} Rust compiler -> build/vowc\n"
 t0=$(date +%s)
-if ! run_verify_logged "./target/release/vow build --verify-jobs 1 compiler/main.vow -o build/vowc"; then
+if ! run_rust_stage "./target/release/vow build $stage12_build_flags compiler/main.vow -o build/vowc"; then
     printf "  ${RED}FAILED${RESET}\n"
     exit 1
 fi
@@ -159,7 +192,7 @@ printf "  done in %ds\n" $((t1 - t0))
 
 printf "${BOLD}Stage 2:${RESET} build/vowc -> build/vowc2\n"
 t0=$(date +%s)
-if ! run_verify_stage_cmd "build/vowc build --verify-jobs 1 compiler/main.vow -o build/vowc2"; then
+if ! run_self_stage "build/vowc build $stage12_build_flags compiler/main.vow -o build/vowc2"; then
     printf "  ${RED}FAILED${RESET}\n"
     if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
         printf "  Hint: rerun with a higher VOW_BOOTSTRAP_VMEM_KB or unset it for no cap.\n"
@@ -173,7 +206,7 @@ printf "  done in %ds\n" $((t1 - t0))
 
 printf "${BOLD}Stage 3:${RESET} build/vowc2 -> build/vowc3\n"
 t0=$(date +%s)
-if ! run_verify_stage_cmd "build/vowc2 build $stage3_build_flags compiler/main.vow -o build/vowc3"; then
+if ! run_self_stage "build/vowc2 build $stage3_build_flags compiler/main.vow -o build/vowc3"; then
     printf "  ${RED}FAILED${RESET}\n"
     if [ "$VMEM_LIMIT_KB" -gt 0 ]; then
         printf "  Hint: rerun with a higher VOW_BOOTSTRAP_VMEM_KB or unset it for no cap.\n"

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2630,7 +2630,13 @@ pub unsafe extern "C" fn __vow_clif_link(obj_path_ptr: i64, output_path_ptr: i64
         cmd.arg(sl);
     }
     cmd.arg("-o").arg(output_path);
-    cmd.args(["-lpthread", "-ldl", "-lm"]);
+    // On macOS the dl* symbols live in libc (no separate libdl), so -ldl
+    // would cause "library not found" — only pass it on platforms that
+    // actually ship libdl as a standalone library.
+    cmd.args(["-lpthread", "-lm"]);
+    if cfg!(target_os = "linux") {
+        cmd.arg("-ldl");
+    }
 
     match cmd.status() {
         Ok(s) if s.success() => {

--- a/vow-codegen/src/linker.rs
+++ b/vow-codegen/src/linker.rs
@@ -101,8 +101,14 @@ pub fn link(
         cmd.arg(shim);
     }
     cmd.arg("-o").arg(output);
-    // Needed when linking a Rust staticlib that uses std
-    cmd.args(["-lpthread", "-ldl", "-lm"]);
+    // Needed when linking a Rust staticlib that uses std.
+    // On macOS the dl* symbols live in libc (no separate libdl), so -ldl
+    // would cause "library not found" — only pass it on platforms that
+    // actually ship libdl as a standalone library.
+    cmd.args(["-lpthread", "-lm"]);
+    if cfg!(target_os = "linux") {
+        cmd.arg("-ldl");
+    }
 
     let status = cmd
         .status()


### PR DESCRIPTION
## Summary

Adds macOS CI jobs (`build-and-test-macos`, `bootstrap-macos`) on `macos-latest`. They run `cargo build/test/clippy/fmt`, the concatenated self-hosted build, and a full bootstrap. **Advisory only** (`continue-on-error: true`) while we shake out platform-specific quirks — intent is to flip them to required once they go green.

Windows is intentionally out of scope here; tracked in #495.

## Why three small code changes were needed

1. **`scripts/bootstrap.sh` — new `--no-verify` flag.** ESBMC ships no macOS release artifact (only Ubuntu and Windows on https://github.com/esbmc/esbmc/releases), so we cannot verify on macOS. The existing `--stage3-no-verify` only skips Stage 3; this PR adds `--no-verify` that skips all three. Verification does not affect codegen, so the SHA-256 fixed-point check at the end of bootstrap remains a meaningful smoke test of "the self-hosted compiler reaches a fixed point on this platform."

2. **`vow-codegen/src/linker.rs` + `vow-clif-shim/src/lib.rs` — guard `-ldl` to Linux.** Both linker call sites hardcoded `cc … -lpthread -ldl -lm`. On macOS the `dl*` symbols live in libc (no separate libdl), and `cc -ldl` errors with "library not found." Wrapped in `cfg!(target_os = "linux")`. `-lpthread` and `-lm` are kept on all Unix-likes — macOS clang silently accepts `-lpthread`.

3. **CI matrix.** Two new jobs, no ESBMC install, no Codecov upload (Linux remains the canonical coverage source).

## Test plan

- [x] `cargo build --all` on Linux — passes
- [x] `cargo clippy --all -- -D warnings` on Linux — passes
- [x] `cargo test -p vow-codegen --lib` — 81 pass
- [x] `bash -n scripts/bootstrap.sh` — syntax-checks
- [x] `scripts/bootstrap.sh --help` — shows new flag
- [ ] macOS CI runs green (this is what the new advisory jobs are for)
- [ ] Linux CI still green (unchanged)
