### PR TITLE
Add release.sh wrapper for triggering the Release workflow

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,6 +22,10 @@ esac
 command -v gh >/dev/null || { echo "Error: gh CLI not found. Install from https://cli.github.com/" >&2; exit 1; }
 
 CURRENT=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' vow/Cargo.toml | head -1)
+if [ -z "$CURRENT" ]; then
+    echo "Error: could not extract version from vow/Cargo.toml" >&2
+    exit 1
+fi
 IFS='.' read -r MAJOR MINOR REV <<< "$CURRENT"
 case "$BUMP" in
     major) NEXT="$((MAJOR + 1)).0.0" ;;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,10 +20,14 @@ case "$BUMP" in
 esac
 
 command -v gh >/dev/null || { echo "Error: gh CLI not found. Install from https://cli.github.com/" >&2; exit 1; }
+command -v git >/dev/null || { echo "Error: git not found." >&2; exit 1; }
 
-CURRENT=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' vow/Cargo.toml | head -1)
+# The workflow runs against main, so derive the preview from origin/main
+# (not the local working tree, which may be ahead/behind).
+git fetch --quiet origin main || echo "Warning: could not fetch origin/main; using cached ref" >&2
+CURRENT=$(git show origin/main:vow/Cargo.toml 2>/dev/null | sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' | head -1)
 if [ -z "$CURRENT" ]; then
-    echo "Error: could not extract version from vow/Cargo.toml" >&2
+    echo "Error: could not extract version from origin/main:vow/Cargo.toml" >&2
     exit 1
 fi
 IFS='.' read -r MAJOR MINOR REV <<< "$CURRENT"
@@ -33,7 +37,7 @@ case "$BUMP" in
     rev)   NEXT="${MAJOR}.${MINOR}.$((REV + 1))" ;;
 esac
 
-echo "Current version: $CURRENT"
+echo "Current version: $CURRENT  (from origin/main)"
 echo "Next version:    $NEXT  ($BUMP bump)"
 echo "Triggers: .github/workflows/release.yml on main"
 echo

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Trigger the Release workflow on GitHub Actions.
+# Usage: release.sh <rev|minor|major>
+
+cd "$(dirname "$0")/.."
+
+usage() {
+    echo "Usage: $0 <rev|minor|major>" >&2
+    exit 1
+}
+
+[ $# -eq 1 ] || usage
+
+BUMP="$1"
+case "$BUMP" in
+    rev|minor|major) ;;
+    *) echo "Error: bump type must be rev, minor, or major (got '$BUMP')" >&2; usage ;;
+esac
+
+command -v gh >/dev/null || { echo "Error: gh CLI not found. Install from https://cli.github.com/" >&2; exit 1; }
+
+CURRENT=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' vow/Cargo.toml | head -1)
+IFS='.' read -r MAJOR MINOR REV <<< "$CURRENT"
+case "$BUMP" in
+    major) NEXT="$((MAJOR + 1)).0.0" ;;
+    minor) NEXT="${MAJOR}.$((MINOR + 1)).0" ;;
+    rev)   NEXT="${MAJOR}.${MINOR}.$((REV + 1))" ;;
+esac
+
+echo "Current version: $CURRENT"
+echo "Next version:    $NEXT  ($BUMP bump)"
+echo "Triggers: .github/workflows/release.yml on main"
+echo
+read -r -p "Proceed? [y/N] " reply
+case "$reply" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted." >&2; exit 1 ;;
+esac
+
+gh workflow run release.yml --ref main -f bump="$BUMP"
+
+echo
+echo "Workflow dispatched. Watch with:"
+echo "  gh run list --workflow=release.yml --limit 1"
+echo "  gh run watch"


### PR DESCRIPTION
## Summary
- Adds `scripts/release.sh <rev|minor|major>` that wraps `gh workflow run release.yml --ref main -f bump=...`
- Reads the current workspace version from `vow/Cargo.toml`, computes the next version locally, and prints both before asking for confirmation
- Bails out early if `gh` is missing or the bump argument is invalid

## Test plan
- [ ] `scripts/release.sh` (no args) prints usage and exits 1
- [ ] `scripts/release.sh foo` rejects unknown bump type
- [ ] `scripts/release.sh rev` shows current+next version, prompts, and answering `n` aborts without dispatching
- [ ] Answering `y` triggers the workflow (verify via `gh run list --workflow=release.yml --limit 1`)