### PR TITLE
fix(verifier): bound ESBMC memory usage

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -443,9 +443,10 @@ fn verify_collect_and_report(
         return 0;
     }
     if st == VERIFY_TIMEOUT() || st == VERIFY_UNKNOWN() {
-        // BV timeout may retry with IR before failing (Phase D fallback).
-        // UNKNOWN is an explicit inconclusive ESBMC result; do not let an IR
-        // proof hide it. Mirrors run_with_fallback in vow-verify.
+        // BV timeout or memlimit exhaustion may retry with IR before failing
+        // (Phase D fallback). Other UNKNOWN outcomes are explicit inconclusive
+        // ESBMC results; do not let an IR proof hide them. Mirrors
+        // run_with_fallback in vow-verify.
         let bv_is_unknown: bool = st == VERIFY_UNKNOWN();
         let bv_label: String = { if bv_is_unknown { String::from("unknown") } else { String::from("timeout") } };
         let bv_label_upper: String = { if bv_is_unknown { String::from("UNKNOWN") } else { String::from("TIMEOUT") } };
@@ -454,9 +455,10 @@ fn verify_collect_and_report(
             if bv_is_unknown { parse_unknown_reason(vr.raw_output) }
             else { String::from("") }
         };
+        let bv_memory_limit: bool = bv_is_unknown && bv_msg_initial == memory_limit_reason();
         let bv_solver: String = resolve_auto_bv_solver(solver);
         let auto_enc: bool = is_auto_encoding(encoding);
-        if !bv_is_unknown && auto_enc && bv_solver != String::from("bitwuzla") {
+        if (!bv_is_unknown || bv_memory_limit) && auto_enc && bv_solver != String::from("bitwuzla") {
             eprintln_str(str3(String::from("  "), f.name, String::from(": BV inconclusive, retrying with --z3 --ir...")));
             let vr2: VerifyResult = verify_function_ir_fallback(f, ir_mod, max_k_step, use_cache, timeout_secs, vec_max, string_max, hashmap_max, btreemap_max);
             let st2: i64 = vr2.status;

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -496,10 +496,10 @@ fn verify_collect_and_report(
         record_soft_fail(soft_meta, String::from("tool_not_found"), String::from("ESBMC not found"), f.name);
         return 0;
     }
-    eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
     let error_message: String = {
         if vr.raw_output.len() > 0 { vr.raw_output } else { String::from("unrecognized ESBMC outcome") }
     };
+    eprintln_str(str5(String::from("  "), f.name, String::from(": ERROR ("), error_message, String::from(")")));
     record_soft_fail(soft_meta, String::from("error"), error_message, f.name);
     0
 }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -446,6 +446,7 @@ fn verify_collect_and_report(
             if bv_is_unknown { parse_unknown_reason(vr.raw_output) }
             else { String::from("") }
         };
+        // Reuse the parsed UNKNOWN message here; this path needs it for reporting.
         let bv_memory_limit: bool = bv_is_unknown && bv_msg_initial == memory_limit_reason();
         let bv_solver: String = resolve_auto_bv_solver(solver);
         let auto_enc: bool = is_auto_encoding(encoding);
@@ -1103,7 +1104,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                                 let ovr: VerifyResult = verify_collect(oh, ovf, t_eff, otmp);
                                 if ovr.status == VERIFY_FAILED() {
                                     verify_failed = true;
-                                } else if ovr.status == VERIFY_TIMEOUT() || (ovr.status == VERIFY_UNKNOWN() && parse_unknown_reason(ovr.raw_output) == memory_limit_reason()) {
+                                } else if ovr.status == VERIFY_TIMEOUT() || (ovr.status == VERIFY_UNKNOWN() && output_has_memory_limit(ovr.raw_output)) {
                                     // BV timed out or hit the memory cap; retry with IR before failing.
                                     let ovr2: VerifyResult = verify_function_ir_fallback(ovf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
                                     if ovr2.status != VERIFY_PROVEN() && ovr2.status != VERIFY_PROVEN_IR() {
@@ -1147,7 +1148,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                         let ovr: VerifyResult = verify_collect(oh, ovf, t_eff, otmp);
                         if ovr.status == VERIFY_FAILED() {
                             verify_failed = true;
-                        } else if ovr.status == VERIFY_TIMEOUT() || (ovr.status == VERIFY_UNKNOWN() && parse_unknown_reason(ovr.raw_output) == memory_limit_reason()) {
+                        } else if ovr.status == VERIFY_TIMEOUT() || (ovr.status == VERIFY_UNKNOWN() && output_has_memory_limit(ovr.raw_output)) {
                             // Mirror the bounded-pool drain: retry IR before treating Timeout or memlimit as passing.
                             // Without this, the common nfns <= t_jobs case silently accepts unverified functions.
                             let ovr2: VerifyResult = verify_function_ir_fallback(ovf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -497,7 +497,10 @@ fn verify_collect_and_report(
         return 0;
     }
     eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR")));
-    record_soft_fail(soft_meta, String::from("error"), String::from("unrecognized ESBMC outcome"), f.name);
+    let error_message: String = {
+        if vr.raw_output.len() > 0 { vr.raw_output } else { String::from("unrecognized ESBMC outcome") }
+    };
+    record_soft_fail(soft_meta, String::from("error"), error_message, f.name);
     0
 }
 

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -1092,8 +1092,8 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                             vec_i64_remove_front(vin_flight_h);
                             vec_i64_remove_front(vin_flight_fi);
                             vec_string_remove_front(vin_flight_tmp);
-                            if oh == -1 {
-                                // process_start failed — treat as verification failure, not silent success.
+                            if oh == -1 || oh == -3 {
+                                // ESBMC spawn/not-found failure: treat as verification failure, not silent success.
                                 cleanup_verify_tmp_path(otmp);
                                 verify_failed = true;
                             } else if oh != -2 {
@@ -1138,8 +1138,8 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                     vec_i64_remove_front(vin_flight_h);
                     vec_i64_remove_front(vin_flight_fi);
                     vec_string_remove_front(vin_flight_tmp);
-                    if oh == -1 {
-                        // Spawn failure — critical when t_jobs >= nfns and every handle lands here.
+                    if oh == -1 || oh == -3 {
+                        // Spawn/not-found failure: critical when t_jobs >= nfns and every handle lands here.
                         cleanup_verify_tmp_path(otmp);
                         verify_failed = true;
                     } else if oh != -2 {

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -446,8 +446,7 @@ fn verify_collect_and_report(
             if bv_is_unknown { parse_unknown_reason(vr.raw_output) }
             else { String::from("") }
         };
-        // Reuse the parsed UNKNOWN message here; this path needs it for reporting.
-        let bv_memory_limit: bool = bv_is_unknown && bv_msg_initial == memory_limit_reason();
+        let bv_memory_limit: bool = bv_is_unknown && output_has_memory_limit(vr.raw_output);
         let bv_solver: String = resolve_auto_bv_solver(solver);
         let auto_enc: bool = is_auto_encoding(encoding);
         if (!bv_is_unknown || bv_memory_limit) && auto_enc && bv_solver != String::from("bitwuzla") {

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -414,15 +414,6 @@ fn verify_collect_and_report(
     max_k_step: String, use_cache: bool, solver: String, encoding: String, timeout_secs: String,
     vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64,
 ) -> i64 [io] {
-    if h == -1 {
-        // process_start failed (fork/exec error, OOM, rlimit, etc.) — this
-        // is distinct from "no vows", which the caller already filters.
-        // Silently skipping would mis-report an un-verified function as proven.
-        cleanup_verify_tmp_path(tmp_path);
-        eprintln_str(str3(String::from("  "), f.name, String::from(": ERROR (failed to start ESBMC)")));
-        record_soft_fail(soft_meta, String::from("error"), String::from("failed to start ESBMC"), f.name);
-        return 0;
-    }
     let effective_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
     let vr: VerifyResult = verify_collect(h, f, effective_timeout, tmp_path);
     let st: i64 = vr.status;

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -1103,8 +1103,8 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                                 let ovr: VerifyResult = verify_collect(oh, ovf, t_eff, otmp);
                                 if ovr.status == VERIFY_FAILED() {
                                     verify_failed = true;
-                                } else if ovr.status == VERIFY_TIMEOUT() {
-                                    // BV timed out; retry with IR before failing.
+                                } else if ovr.status == VERIFY_TIMEOUT() || (ovr.status == VERIFY_UNKNOWN() && parse_unknown_reason(ovr.raw_output) == memory_limit_reason()) {
+                                    // BV timed out or hit the memory cap; retry with IR before failing.
                                     let ovr2: VerifyResult = verify_function_ir_fallback(ovf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
                                     if ovr2.status != VERIFY_PROVEN() && ovr2.status != VERIFY_PROVEN_IR() {
                                         verify_failed = true;
@@ -1147,8 +1147,8 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                         let ovr: VerifyResult = verify_collect(oh, ovf, t_eff, otmp);
                         if ovr.status == VERIFY_FAILED() {
                             verify_failed = true;
-                        } else if ovr.status == VERIFY_TIMEOUT() {
-                            // Mirror the bounded-pool drain: retry IR before treating Timeout as passing.
+                        } else if ovr.status == VERIFY_TIMEOUT() || (ovr.status == VERIFY_UNKNOWN() && parse_unknown_reason(ovr.raw_output) == memory_limit_reason()) {
+                            // Mirror the bounded-pool drain: retry IR before treating Timeout or memlimit as passing.
                             // Without this, the common nfns <= t_jobs case silently accepts unverified functions.
                             let ovr2: VerifyResult = verify_function_ir_fallback(ovf, ir_mod, t_max_k_step, false, String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
                             if ovr2.status != VERIFY_PROVEN() && ovr2.status != VERIFY_PROVEN_IR() {

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -811,6 +811,8 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
             raw_output: String::from("esbmc not found"),
         };
     }
+    // Spawn failures remain VERIFY_ERROR via r.combined; only the explicit
+    // not-found sentinel becomes VERIFY_NOT_FOUND.
     let combined: String = r.combined;
     let mut status: i64 = {
         if r.exit_code == -2 { VERIFY_TIMEOUT() } else { parse_verify_status(combined) }

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -333,7 +333,7 @@ fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func
 
 fn DEFAULT_AUTO_TIMEOUT_STR() -> String { String::from("30") }
 
-// Mirrors DEFAULT_ESBMC_MEMLIMIT_MB in vow-verify/src/solver_strategy.rs.
+// Mirrors DEFAULT_ESBMC_MEMLIMIT_MB = 4096 in vow-verify/src/solver_strategy.rs.
 // This is a per-ESBMC-process cap, emitted as `--memlimit 4096m`.
 fn DEFAULT_ESBMC_MEMLIMIT_ARG() -> String { String::from("4096m") }
 
@@ -440,6 +440,7 @@ fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name
     append_memlimit_arg(esbmc_args, memlimit_arg);
     let esbmc_bin: String = esbmc_path();
     if esbmc_bin.len() == 0 {
+        // Cleanup is deferred to verify_collect, which owns tmp_path after start.
         return -3;
     }
     let handle: i64 = process_start(esbmc_bin, esbmc_args);

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -499,6 +499,8 @@ fn output_has_memory_limit(combined: String) -> bool {
         || str_find_str(lower, String::from("memory limit exceeded")) >= 0
         || str_find_str(lower, String::from("exceeded memory limit")) >= 0
         || str_find_str(lower, String::from("cannot allocate memory")) >= 0
+        // Vow programs compile to C, so this C++ allocator diagnostic can only
+        // come from ESBMC itself, not from the program being verified.
         || str_find_str(lower, String::from("bad_alloc")) >= 0
 }
 
@@ -958,6 +960,9 @@ fn verify_collect(handle: i64, f: IrFunction, effective_timeout: String, tmp_pat
     }
     // Kernel watchdog sized to match ESBMC's --timeout so a runaway process can't block indefinitely.
     let exit_code: i64 = process_wait_timeout(handle, watchdog_ms_for(effective_timeout));
+    // exit_code == -1 is a wait/runtime error, not a missing ESBMC binary.
+    // Let it fall through to VERIFY_ERROR below; process_kill still evicts the
+    // completed handle entry from PROCESS_MAP.
     if exit_code == -2 {
         process_kill(handle);
         cleanup_verify_tmp_path(tmp_path);

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -307,11 +307,17 @@ fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func
     cmd.push_str(c_path);
     cmd.push_str(String::from(" --no-bounds-check --no-pointer-check --incremental-bmc --max-k-step "));
     cmd.push_str(max_k_step);
-    cmd.push_str(String::from(" --64\n"));
+    cmd.push_str(String::from(" --64 --memlimit "));
+    cmd.push_str(DEFAULT_ESBMC_MEMLIMIT_ARG());
+    cmd.push_str(String::from("\n"));
     fs_write(cmd_path, cmd);
 }
 
 fn DEFAULT_AUTO_TIMEOUT_STR() -> String { String::from("30") }
+
+// Mirrors DEFAULT_ESBMC_MEMLIMIT_MB in vow-verify/src/solver_strategy.rs.
+// This is a per-ESBMC-process cap, emitted as `--memlimit 4096m`.
+fn DEFAULT_ESBMC_MEMLIMIT_ARG() -> String { String::from("4096m") }
 
 // Mirrors DEFAULT_ESBMC_TIMEOUT_SECS in vow-verify/src/esbmc.rs.
 fn DEFAULT_ESBMC_TIMEOUT_MS() -> i64 { 300000 }
@@ -346,6 +352,11 @@ fn append_timeout_arg(args: Vec<String>, timeout_secs: String) {
     }
 }
 
+fn append_memlimit_arg(args: Vec<String>) {
+    args.push(String::from("--memlimit"));
+    args.push(DEFAULT_ESBMC_MEMLIMIT_ARG());
+}
+
 fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: String, solver: String, encoding: String, timeout_secs: String) -> EsbmcRun [io] {
     fs_write(tmp_path, c_source);
     save_esbmc_debug(c_source, tmp_path, max_k_step, func_name, false);
@@ -359,11 +370,12 @@ fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: 
     esbmc_args.push(String::from("--64"));
     append_solver_args(esbmc_args, solver, encoding);
     append_timeout_arg(esbmc_args, timeout_secs);
+    append_memlimit_arg(esbmc_args);
     // Kernel watchdog kills the child if ESBMC's own --timeout doesn't fire.
     let handle: i64 = process_start(esbmc_path(), esbmc_args);
     if handle == -1 {
         cleanup_verify_tmp_path(tmp_path);
-        return EsbmcRun { exit_code: -1, combined: String::from("") };
+        return EsbmcRun { exit_code: -3, combined: String::from("") };
     }
     let watchdog_ms: i64 = watchdog_ms_for(timeout_secs);
     let exit_code: i64 = process_wait_timeout(handle, watchdog_ms);
@@ -397,6 +409,7 @@ fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name
     esbmc_args.push(String::from("--64"));
     append_solver_args(esbmc_args, solver, encoding);
     append_timeout_arg(esbmc_args, timeout_secs);
+    append_memlimit_arg(esbmc_args);
     let handle: i64 = process_start(esbmc_path(), esbmc_args);
     handle
 }
@@ -423,6 +436,9 @@ fn parse_verify_status(combined: String) -> i64 {
     if str_find_str(combined, String::from("VERIFICATION FAILED")) >= 0 {
         return VERIFY_FAILED();
     }
+    if output_has_memory_limit(combined) {
+        return VERIFY_UNKNOWN();
+    }
     // ESBMC's third legitimate outcome: it finished without proving or
     // falsifying (e.g. k-induction's forward condition couldn't establish
     // the property). Must be checked before the generic ERROR fallback.
@@ -441,9 +457,27 @@ fn parse_verify_status(combined: String) -> i64 {
     VERIFY_ERROR()
 }
 
+fn memory_limit_reason() -> String {
+    String::from("memory limit exceeded")
+}
+
+fn output_has_memory_limit(combined: String) -> bool {
+    str_find_str(combined, String::from("Out of memory")) >= 0
+        || str_find_str(combined, String::from("out of memory")) >= 0
+        || str_find_str(combined, String::from("memory limit")) >= 0
+        || str_find_str(combined, String::from("Memory limit")) >= 0
+        || str_find_str(combined, String::from("memlimit")) >= 0
+        || str_find_str(combined, String::from("Cannot allocate memory")) >= 0
+        || str_find_str(combined, String::from("cannot allocate memory")) >= 0
+        || str_find_str(combined, String::from("std::bad_alloc")) >= 0
+}
+
 // Extract a short explanation from an ESBMC `VERIFICATION UNKNOWN` log.
 // Mirrors `parse_unknown_reason` in vow-verify/src/esbmc.rs.
 fn parse_unknown_reason(combined: String) -> String {
+    if output_has_memory_limit(combined) {
+        return memory_limit_reason();
+    }
     let lines: Vec<String> = Vec::new();
     split_lines(combined, lines);
     let n: i64 = lines.len();
@@ -740,7 +774,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
     let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
     let tmp_path: String = verify_tmp_path();
     let r: EsbmcRun = run_esbmc(c_source, max_k_step, tmp_path, fn_name, solver, encoding, bv_timeout);
-    if r.exit_code == -1 {
+    if r.exit_code == -3 {
         return VerifyResult {
             status: VERIFY_NOT_FOUND(),
             vow_id: -1,
@@ -756,10 +790,12 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
     };
     let mut used_combined: String = combined;
 
-    // Phase D: if BV times out under Auto encoding and the BV solver is not
-    // Bitwuzla, retry once with --z3 --ir (integer encoding). UNKNOWN is an
-    // explicit inconclusive ESBMC result; do not let an IR proof hide it.
-    if status == VERIFY_TIMEOUT() && auto_enc && bv_solver != String::from("bitwuzla") {
+    // Phase D: if BV exhausts a resource budget under Auto encoding and the
+    // BV solver is not Bitwuzla, retry once with --z3 --ir (integer encoding).
+    // Other UNKNOWN outcomes are explicit inconclusive ESBMC results; do not
+    // let an IR proof hide them.
+    let bv_memory_limit: bool = status == VERIFY_UNKNOWN() && parse_unknown_reason(combined) == memory_limit_reason();
+    if (status == VERIFY_TIMEOUT() || bv_memory_limit) && auto_enc && bv_solver != String::from("bitwuzla") {
         let ir_solver: String = String::from("z3");
         let ir_encoding: String = String::from("ir");
         let ir_timeout: String = {
@@ -767,7 +803,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
         };
         let tmp_path2: String = verify_tmp_path();
         let r2: EsbmcRun = run_esbmc(c_source, max_k_step, tmp_path2, fn_name, ir_solver, ir_encoding, ir_timeout);
-        if r2.exit_code == -1 {
+        if r2.exit_code == -3 {
             // ESBMC disappeared between BV and IR runs; surface consistently with verify_function_ir_fallback.
             return VerifyResult {
                 status: VERIFY_NOT_FOUND(),
@@ -822,7 +858,7 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
     // Rust toolchain but has no effect.
     let tmp_path: String = verify_tmp_path();
     let r: EsbmcRun = run_esbmc(c_source, max_k_step, tmp_path, fn_name, ir_solver, ir_encoding, ir_timeout);
-    if r.exit_code == -1 {
+    if r.exit_code == -3 {
         return VerifyResult {
             status: VERIFY_NOT_FOUND(),
             vow_id: -1,
@@ -878,21 +914,6 @@ fn verify_collect(handle: i64, f: IrFunction, effective_timeout: String, tmp_pat
             var_values: Vec::new(),
             block_visits: Vec::new(),
             raw_output: String::from("(watchdog timeout)"),
-        };
-    }
-    if exit_code == -1 {
-        // try_wait error: runtime kills the child and stores a Completed entry
-        // before returning -1, so we still need to evict the PROCESS_MAP entry.
-        // For the handle-not-found case, process_kill is a no-op.
-        process_kill(handle);
-        cleanup_verify_tmp_path(tmp_path);
-        return VerifyResult {
-            status: VERIFY_NOT_FOUND(),
-            vow_id: -1,
-            var_names: Vec::new(),
-            var_values: Vec::new(),
-            block_visits: Vec::new(),
-            raw_output: String::from("esbmc not found"),
         };
     }
     let stdout: String = process_stdout_for(handle);

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -307,7 +307,7 @@ fn cleanup_verify_tmp_path(tmp_path: String) [io] {
     }
 }
 
-fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func_name: String, debug: bool) [io] {
+fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func_name: String, memlimit_arg: String, debug: bool) [io] {
     if !debug {
         return;
     }
@@ -326,7 +326,7 @@ fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func
     cmd.push_str(String::from(" --no-bounds-check --no-pointer-check --incremental-bmc --max-k-step "));
     cmd.push_str(max_k_step);
     cmd.push_str(String::from(" --64 --memlimit "));
-    cmd.push_str(DEFAULT_ESBMC_MEMLIMIT_ARG());
+    cmd.push_str(memlimit_arg);
     cmd.push_str(String::from("\n"));
     fs_write(cmd_path, cmd);
 }
@@ -370,16 +370,18 @@ fn append_timeout_arg(args: Vec<String>, timeout_secs: String) {
     }
 }
 
-fn append_memlimit_arg(args: Vec<String>) {
+fn append_memlimit_arg(args: Vec<String>, memlimit_arg: String) {
     // Self-hosted Vow has no memlimit opt-out CLI today; emit the default cap
-    // unconditionally. If Rust grows a user-facing opt-out, thread it here too.
+    // unconditionally. Keep callers passing the same value to save_esbmc_debug
+    // and this helper if Rust grows a user-facing opt-out.
     args.push(String::from("--memlimit"));
-    args.push(DEFAULT_ESBMC_MEMLIMIT_ARG());
+    args.push(memlimit_arg);
 }
 
 fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: String, solver: String, encoding: String, timeout_secs: String) -> EsbmcRun [io] {
     fs_write(tmp_path, c_source);
-    save_esbmc_debug(c_source, tmp_path, max_k_step, func_name, false);
+    let memlimit_arg: String = DEFAULT_ESBMC_MEMLIMIT_ARG();
+    save_esbmc_debug(c_source, tmp_path, max_k_step, func_name, memlimit_arg, false);
     let esbmc_args: Vec<String> = Vec::new();
     esbmc_args.push(tmp_path);
     esbmc_args.push(String::from("--no-bounds-check"));
@@ -390,7 +392,7 @@ fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: 
     esbmc_args.push(String::from("--64"));
     append_solver_args(esbmc_args, solver, encoding);
     append_timeout_arg(esbmc_args, timeout_secs);
-    append_memlimit_arg(esbmc_args);
+    append_memlimit_arg(esbmc_args, memlimit_arg);
     // Kernel watchdog kills the child if ESBMC's own --timeout doesn't fire.
     let esbmc_bin: String = esbmc_path();
     if esbmc_bin.len() == 0 {
@@ -423,7 +425,8 @@ fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: 
 
 fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: String, solver: String, encoding: String, timeout_secs: String) -> i64 [io] {
     fs_write(tmp_path, c_source);
-    save_esbmc_debug(c_source, tmp_path, max_k_step, func_name, false);
+    let memlimit_arg: String = DEFAULT_ESBMC_MEMLIMIT_ARG();
+    save_esbmc_debug(c_source, tmp_path, max_k_step, func_name, memlimit_arg, false);
     let esbmc_args: Vec<String> = Vec::new();
     esbmc_args.push(tmp_path);
     esbmc_args.push(String::from("--no-bounds-check"));
@@ -434,7 +437,7 @@ fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name
     esbmc_args.push(String::from("--64"));
     append_solver_args(esbmc_args, solver, encoding);
     append_timeout_arg(esbmc_args, timeout_secs);
-    append_memlimit_arg(esbmc_args);
+    append_memlimit_arg(esbmc_args, memlimit_arg);
     let esbmc_bin: String = esbmc_path();
     if esbmc_bin.len() == 0 {
         return -3;

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -371,6 +371,8 @@ fn append_timeout_arg(args: Vec<String>, timeout_secs: String) {
 }
 
 fn append_memlimit_arg(args: Vec<String>) {
+    // Self-hosted Vow has no memlimit opt-out CLI today; emit the default cap
+    // unconditionally. If Rust grows a user-facing opt-out, thread it here too.
     args.push(String::from("--memlimit"));
     args.push(DEFAULT_ESBMC_MEMLIMIT_ARG());
 }
@@ -390,10 +392,15 @@ fn run_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name: 
     append_timeout_arg(esbmc_args, timeout_secs);
     append_memlimit_arg(esbmc_args);
     // Kernel watchdog kills the child if ESBMC's own --timeout doesn't fire.
-    let handle: i64 = process_start(esbmc_path(), esbmc_args);
-    if handle == -1 {
+    let esbmc_bin: String = esbmc_path();
+    if esbmc_bin.len() == 0 {
         cleanup_verify_tmp_path(tmp_path);
         return EsbmcRun { exit_code: -3, combined: String::from("") };
+    }
+    let handle: i64 = process_start(esbmc_bin, esbmc_args);
+    if handle == -1 {
+        cleanup_verify_tmp_path(tmp_path);
+        return EsbmcRun { exit_code: -1, combined: String::from("failed to start ESBMC") };
     }
     let watchdog_ms: i64 = watchdog_ms_for(timeout_secs);
     let exit_code: i64 = process_wait_timeout(handle, watchdog_ms);
@@ -428,7 +435,11 @@ fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name
     append_solver_args(esbmc_args, solver, encoding);
     append_timeout_arg(esbmc_args, timeout_secs);
     append_memlimit_arg(esbmc_args);
-    let handle: i64 = process_start(esbmc_path(), esbmc_args);
+    let esbmc_bin: String = esbmc_path();
+    if esbmc_bin.len() == 0 {
+        return -3;
+    }
+    let handle: i64 = process_start(esbmc_bin, esbmc_args);
     handle
 }
 
@@ -918,7 +929,7 @@ fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_ca
 }
 
 fn verify_collect(handle: i64, f: IrFunction, effective_timeout: String, tmp_path: String) -> VerifyResult [io] {
-    if handle == -1 {
+    if handle == -3 {
         cleanup_verify_tmp_path(tmp_path);
         return VerifyResult {
             status: VERIFY_NOT_FOUND(),
@@ -927,6 +938,17 @@ fn verify_collect(handle: i64, f: IrFunction, effective_timeout: String, tmp_pat
             var_values: Vec::new(),
             block_visits: Vec::new(),
             raw_output: String::from("esbmc not found"),
+        };
+    }
+    if handle == -1 {
+        cleanup_verify_tmp_path(tmp_path);
+        return VerifyResult {
+            status: VERIFY_ERROR(),
+            vow_id: -1,
+            var_names: Vec::new(),
+            var_values: Vec::new(),
+            block_visits: Vec::new(),
+            raw_output: String::from("failed to start ESBMC"),
         };
     }
     // Kernel watchdog sized to match ESBMC's --timeout so a runaway process can't block indefinitely.

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -308,6 +308,9 @@ fn cleanup_verify_tmp_path(tmp_path: String) [io] {
 }
 
 fn save_esbmc_debug(c_source: String, tmp_path: String, max_k_step: String, func_name: String, memlimit_arg: String, debug: bool) [io] {
+    // Self-hosted VOW_VERIFY_DEBUG is not wired yet: compiler code has no
+    // getenv builtin, so callers pass false. Keep this template aligned with
+    // the real ESBMC args for the future env-var hook.
     if !debug {
         return;
     }

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -918,6 +918,17 @@ fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_ca
 }
 
 fn verify_collect(handle: i64, f: IrFunction, effective_timeout: String, tmp_path: String) -> VerifyResult [io] {
+    if handle == -1 {
+        cleanup_verify_tmp_path(tmp_path);
+        return VerifyResult {
+            status: VERIFY_NOT_FOUND(),
+            vow_id: -1,
+            var_names: Vec::new(),
+            var_values: Vec::new(),
+            block_visits: Vec::new(),
+            raw_output: String::from("esbmc not found"),
+        };
+    }
     // Kernel watchdog sized to match ESBMC's --timeout so a runaway process can't block indefinitely.
     let exit_code: i64 = process_wait_timeout(handle, watchdog_ms_for(effective_timeout));
     if exit_code == -2 {

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -443,7 +443,7 @@ fn start_esbmc(c_source: String, max_k_step: String, tmp_path: String, func_name
     append_memlimit_arg(esbmc_args, memlimit_arg);
     let esbmc_bin: String = esbmc_path();
     if esbmc_bin.len() == 0 {
-        // Cleanup is deferred to verify_collect, which owns tmp_path after start.
+        // Cleanup is handled by the caller: verify_collect or run_test's sentinel branch.
         return -3;
     }
     let handle: i64 = process_start(esbmc_bin, esbmc_args);
@@ -832,7 +832,7 @@ fn verify_function_full(f: IrFunction, m: IrModule, max_k_step: String, use_cach
     // BV solver is not Bitwuzla, retry once with --z3 --ir (integer encoding).
     // Other UNKNOWN outcomes are explicit inconclusive ESBMC results; do not
     // let an IR proof hide them.
-    let bv_memory_limit: bool = status == VERIFY_UNKNOWN() && parse_unknown_reason(combined) == memory_limit_reason();
+    let bv_memory_limit: bool = status == VERIFY_UNKNOWN() && output_has_memory_limit(combined);
     if (status == VERIFY_TIMEOUT() || bv_memory_limit) && auto_enc && bv_solver != String::from("bitwuzla") {
         let ir_solver: String = String::from("z3");
         let ir_encoding: String = String::from("ir");

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -22,7 +22,7 @@ struct VerifyResult {
     raw_output: String,
 }
 
-// exit_code sentinels: -1 spawn failure, -2 kernel watchdog kill, else child exit code.
+// exit_code sentinels: -3 ESBMC not found, -1 spawn failure, -2 kernel watchdog kill, else child exit code.
 struct EsbmcRun {
     exit_code: i64,
     combined: String,

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -67,6 +67,24 @@ fn str_find_str(haystack: String, needle: String) -> i64 {
     -1
 }
 
+fn ascii_lower_byte(b: i64) -> i64 {
+    if b >= 65 && b <= 90 {
+        return b + 32;
+    }
+    b
+}
+
+fn str_ascii_lower(s: String) -> String {
+    let out: String = String::from("");
+    let n: i64 = s.len();
+    let mut i: i64 = 0;
+    while i < n {
+        out.push_byte(ascii_lower_byte(s.byte_at(i)));
+        i = i + 1;
+    }
+    out
+}
+
 fn str_substring(s: String, start: i64, end: i64) -> String {
     let r: String = String::from("");
     let mut i: i64 = start;
@@ -462,17 +480,12 @@ fn memory_limit_reason() -> String {
 }
 
 fn output_has_memory_limit(combined: String) -> bool {
-    str_find_str(combined, String::from("Out of memory")) >= 0
-        || str_find_str(combined, String::from("out of memory")) >= 0
-        || str_find_str(combined, String::from("OUT OF MEMORY")) >= 0
-        || str_find_str(combined, String::from("memory limit exceeded")) >= 0
-        || str_find_str(combined, String::from("Memory limit exceeded")) >= 0
-        || str_find_str(combined, String::from("exceeded memory limit")) >= 0
-        || str_find_str(combined, String::from("Exceeded memory limit")) >= 0
-        || str_find_str(combined, String::from("Cannot allocate memory")) >= 0
-        || str_find_str(combined, String::from("cannot allocate memory")) >= 0
-        || str_find_str(combined, String::from("bad_alloc")) >= 0
-        || str_find_str(combined, String::from("std::bad_alloc")) >= 0
+    let lower: String = str_ascii_lower(combined);
+    str_find_str(lower, String::from("out of memory")) >= 0
+        || str_find_str(lower, String::from("memory limit exceeded")) >= 0
+        || str_find_str(lower, String::from("exceeded memory limit")) >= 0
+        || str_find_str(lower, String::from("cannot allocate memory")) >= 0
+        || str_find_str(lower, String::from("bad_alloc")) >= 0
 }
 
 // Extract a short explanation from an ESBMC `VERIFICATION UNKNOWN` log.

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -464,11 +464,14 @@ fn memory_limit_reason() -> String {
 fn output_has_memory_limit(combined: String) -> bool {
     str_find_str(combined, String::from("Out of memory")) >= 0
         || str_find_str(combined, String::from("out of memory")) >= 0
-        || str_find_str(combined, String::from("memory limit")) >= 0
-        || str_find_str(combined, String::from("Memory limit")) >= 0
-        || str_find_str(combined, String::from("memlimit")) >= 0
+        || str_find_str(combined, String::from("OUT OF MEMORY")) >= 0
+        || str_find_str(combined, String::from("memory limit exceeded")) >= 0
+        || str_find_str(combined, String::from("Memory limit exceeded")) >= 0
+        || str_find_str(combined, String::from("exceeded memory limit")) >= 0
+        || str_find_str(combined, String::from("Exceeded memory limit")) >= 0
         || str_find_str(combined, String::from("Cannot allocate memory")) >= 0
         || str_find_str(combined, String::from("cannot allocate memory")) >= 0
+        || str_find_str(combined, String::from("bad_alloc")) >= 0
         || str_find_str(combined, String::from("std::bad_alloc")) >= 0
 }
 

--- a/docs/live-programming-research.md
+++ b/docs/live-programming-research.md
@@ -143,13 +143,12 @@ fundamental redesign:
   full `DependencyManifest` (FNV-1a hashes of every transitive dependency
   source) plus mode and trace settings, so a single-file edit only invalidates
   the cache for translation units that actually depend on it. `VerifyCache`
-  persists both `Proven` and `Failed` results (failures carry counterexample
-  bindings), keyed by FNV-1a of the C source content plus the unwind bound.
-  An incremental-recompilation design layered on top of this cache must be
-  careful about what additional ESBMC parameters belong in the key — anything
-  the verifier actually varies (solver choice, encoding, additional flags)
-  needs to be part of the key or the cache will return stale results from a
-  different verification configuration.
+  persists failed results with counterexample bindings, keyed by FNV-1a of the
+  C source content plus the unwind bound, solver choice, encoding, and ESBMC
+  memory cap. An incremental-recompilation design layered on top of this cache
+  must be careful about what additional ESBMC parameters belong in the key —
+  anything the verifier actually varies needs to be part of the key or the
+  cache will return stale results from a different verification configuration.
 - **Source location tracking.** Every IR instruction carries `origin: Span`.
   Every function has `local_names` mapping instruction IDs to variable names.
 - **Effect system.** Functions declare effects (`io`, `read`, `write`, `panic`,

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use vow_ir::{FuncId, Function, InstData, Module, Ty};
@@ -198,7 +198,33 @@ fn parse_assignment_line(line: &str) -> Option<(String, String)> {
 // Debug: save C source and command for ESBMC debugging
 // ---------------------------------------------------------------------------
 
-fn save_esbmc_debug(esbmc: &std::path::Path, c_src: &str, func_name: &str, max_k_step: u32) {
+fn esbmc_debug_command(
+    esbmc: &Path,
+    c_name: &str,
+    max_k_step: u32,
+    config: &SolverConfig,
+) -> String {
+    let mut cmd = format!(
+        "{} /tmp/vow-verify-debug/{} --no-bounds-check --no-pointer-check --incremental-bmc --max-k-step {} --64",
+        esbmc.display(),
+        c_name,
+        max_k_step,
+    );
+    for arg in config.esbmc_args() {
+        cmd.push(' ');
+        cmd.push_str(&arg);
+    }
+    cmd.push('\n');
+    cmd
+}
+
+fn save_esbmc_debug(
+    esbmc: &Path,
+    c_src: &str,
+    func_name: &str,
+    max_k_step: u32,
+    config: &SolverConfig,
+) {
     if std::env::var("VOW_VERIFY_DEBUG").is_err() {
         return;
     }
@@ -211,12 +237,7 @@ fn save_esbmc_debug(esbmc: &std::path::Path, c_src: &str, func_name: &str, max_k
 
     let _ = std::fs::write(debug_dir.join(&c_name), c_src);
 
-    let cmd = format!(
-        "{} /tmp/vow-verify-debug/{} --no-bounds-check --no-pointer-check --incremental-bmc --max-k-step {} --64\n",
-        esbmc.display(),
-        c_name,
-        max_k_step,
-    );
+    let cmd = esbmc_debug_command(esbmc, &c_name, max_k_step, config);
     let _ = std::fs::write(debug_dir.join(&cmd_name), cmd);
 }
 
@@ -393,7 +414,7 @@ pub fn run_esbmc_with_max_k_step(
         return VerificationResult::ToolError(e.to_string());
     }
 
-    save_esbmc_debug(esbmc, c_src, func_name, max_k_step);
+    save_esbmc_debug(esbmc, c_src, func_name, max_k_step, config);
 
     let mut cmd = Command::new(esbmc);
     cmd.arg(tmp.path())
@@ -951,6 +972,39 @@ VERIFICATION FAILED";
         assert_eq!(
             parse_unknown_reason(combined),
             "ESBMC returned VERIFICATION UNKNOWN"
+        );
+    }
+
+    #[test]
+    fn esbmc_debug_command_includes_solver_config_args() {
+        let config = SolverConfig {
+            solver: crate::solver_strategy::Solver::Z3,
+            encoding: crate::solver_strategy::Encoding::Ir,
+            timeout_secs: None,
+            memlimit_mb: Some(1024),
+        };
+        let cmd = esbmc_debug_command(std::path::Path::new("/usr/bin/esbmc"), "main.c", 7, &config);
+
+        assert_eq!(
+            cmd,
+            "/usr/bin/esbmc /tmp/vow-verify-debug/main.c --no-bounds-check --no-pointer-check --incremental-bmc --max-k-step 7 --64 --z3 --ir --memlimit 1024m\n"
+        );
+    }
+
+    #[test]
+    fn esbmc_debug_command_omits_memlimit_when_config_omits_it() {
+        let config = SolverConfig {
+            solver: crate::solver_strategy::Solver::Boolector,
+            encoding: crate::solver_strategy::Encoding::Bv,
+            timeout_secs: None,
+            memlimit_mb: None,
+        };
+        let cmd = esbmc_debug_command(std::path::Path::new("/usr/bin/esbmc"), "main.c", 7, &config);
+
+        assert!(!cmd.contains("--memlimit"));
+        assert_eq!(
+            cmd,
+            "/usr/bin/esbmc /tmp/vow-verify-debug/main.c --no-bounds-check --no-pointer-check --incremental-bmc --max-k-step 7 --64\n"
         );
     }
 

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -494,6 +494,10 @@ pub fn run_esbmc_with_max_k_step(
         VerificationResult::Proven
     } else if combined.contains("VERIFICATION FAILED") {
         VerificationResult::Failed(parse_esbmc_output(&combined))
+    } else if is_memory_limit_output(&combined) {
+        VerificationResult::Unknown {
+            reason: memory_limit_reason(),
+        }
     } else if combined.contains("VERIFICATION UNKNOWN") {
         VerificationResult::Unknown {
             reason: parse_unknown_reason(&combined),
@@ -505,11 +509,27 @@ pub fn run_esbmc_with_max_k_step(
     }
 }
 
+fn memory_limit_reason() -> String {
+    "memory limit exceeded".to_string()
+}
+
+fn is_memory_limit_output(combined: &str) -> bool {
+    let lower = combined.to_ascii_lowercase();
+    lower.contains("out of memory")
+        || lower.contains("memory limit")
+        || lower.contains("memlimit")
+        || lower.contains("cannot allocate memory")
+        || lower.contains("std::bad_alloc")
+}
+
 /// Extract the short explanation that precedes `VERIFICATION UNKNOWN` from an
 /// ESBMC log. Typical lines: `The forward condition is unable to prove the
 /// property` or `Unable to prove or falsify the program, giving up.` — we
 /// keep the most informative of these and fall back to a generic message.
 fn parse_unknown_reason(combined: &str) -> String {
+    if is_memory_limit_output(combined) {
+        return memory_limit_reason();
+    }
     let mut reason = String::new();
     for line in combined.lines() {
         let t = line.trim();
@@ -920,6 +940,70 @@ VERIFICATION FAILED";
         let combined = "ESBMC version 8.2.0\nSome unrelated output\nVERIFICATION UNKNOWN\n";
         let reason = parse_unknown_reason(combined);
         assert_eq!(reason, "ESBMC returned VERIFICATION UNKNOWN");
+    }
+
+    #[cfg(unix)]
+    fn fake_esbmc_script(body: &str) -> (tempfile::TempDir, PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let esbmc = dir.path().join("fake-esbmc");
+        std::fs::write(&esbmc, body).expect("write fake esbmc");
+        let mut perms = std::fs::metadata(&esbmc).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&esbmc, perms).expect("chmod fake esbmc");
+        (dir, esbmc)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_esbmc_reports_memlimit_output_as_unknown() {
+        let (_dir, esbmc) = fake_esbmc_script(
+            r#"#!/bin/sh
+echo "Out of memory: memory limit exceeded"
+exit 6
+"#,
+        );
+        let result = run_esbmc_with_max_k_step(
+            &esbmc,
+            "int main(void) { return 0; }",
+            5,
+            "main",
+            &SolverConfig::default_config(),
+        );
+
+        match result {
+            VerificationResult::Unknown { reason } => {
+                assert_eq!(reason, "memory limit exceeded");
+            }
+            other => panic!("expected memory-limit Unknown, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_esbmc_prefers_memlimit_reason_over_generic_unknown() {
+        let (_dir, esbmc) = fake_esbmc_script(
+            r#"#!/bin/sh
+echo "ESBMC was unable to finish before the memory limit"
+echo "VERIFICATION UNKNOWN"
+exit 6
+"#,
+        );
+        let result = run_esbmc_with_max_k_step(
+            &esbmc,
+            "int main(void) { return 0; }",
+            5,
+            "main",
+            &SolverConfig::default_config(),
+        );
+
+        match result {
+            VerificationResult::Unknown { reason } => {
+                assert_eq!(reason, "memory limit exceeded");
+            }
+            other => panic!("expected memory-limit Unknown, got {other:?}"),
+        }
     }
 
     #[test]

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -955,6 +955,26 @@ VERIFICATION FAILED";
     }
 
     #[cfg(unix)]
+    #[test]
+    fn failed_output_takes_priority_over_memory_limit_text() {
+        let (_dir, esbmc) = fake_esbmc_script(
+            r#"#!/bin/sh
+echo "VERIFICATION FAILED"
+echo "std::bad_alloc"
+exit 10
+"#,
+        );
+        let result = run_esbmc_with_max_k_step(
+            &esbmc,
+            "int main(void) { __ESBMC_assert(0, \"vow:1\"); return 0; }",
+            1,
+            "main",
+            &SolverConfig::default_config(),
+        );
+        assert!(matches!(result, VerificationResult::Failed(_)));
+    }
+
+    #[cfg(unix)]
     fn fake_esbmc_script(body: &str) -> (tempfile::TempDir, PathBuf) {
         use std::os::unix::fs::PermissionsExt;
 

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -550,8 +550,10 @@ fn is_memory_limit_output(combined: &str) -> bool {
 /// property` or `Unable to prove or falsify the program, giving up.` — we
 /// keep the most informative of these and fall back to a generic message.
 fn parse_unknown_reason(combined: &str) -> String {
-    // Defensive: reachable from the self-hosted path after OOM has already
-    // been mapped to UNKNOWN; run_esbmc_with_max_k_step handles this earlier.
+    // Defensive: handles the edge case where combined contains both OOM markers
+    // and "VERIFICATION UNKNOWN" -- the earlier is_memory_limit_output check in
+    // run_esbmc_with_max_k_step would normally fire first, but this guard
+    // ensures correct behavior if parse_unknown_reason gains new call sites.
     if is_memory_limit_output(combined) {
         return memory_limit_reason();
     }

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -527,6 +527,8 @@ fn is_memory_limit_output(combined: &str) -> bool {
 /// property` or `Unable to prove or falsify the program, giving up.` — we
 /// keep the most informative of these and fall back to a generic message.
 fn parse_unknown_reason(combined: &str) -> String {
+    // Defensive: reachable from the self-hosted path after OOM has already
+    // been mapped to UNKNOWN; run_esbmc_with_max_k_step handles this earlier.
     if is_memory_limit_output(combined) {
         return memory_limit_reason();
     }

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -540,6 +540,8 @@ fn is_memory_limit_output(combined: &str) -> bool {
         || lower.contains("memory limit exceeded")
         || lower.contains("exceeded memory limit")
         || lower.contains("cannot allocate memory")
+        // Vow programs compile to C, so this C++ allocator diagnostic can only
+        // come from ESBMC itself, not from the program being verified.
         || lower.contains("bad_alloc")
 }
 

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -509,7 +509,7 @@ pub fn run_esbmc_with_max_k_step(
     }
 }
 
-fn memory_limit_reason() -> String {
+pub(crate) fn memory_limit_reason() -> String {
     "memory limit exceeded".to_string()
 }
 

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -516,10 +516,10 @@ fn memory_limit_reason() -> String {
 fn is_memory_limit_output(combined: &str) -> bool {
     let lower = combined.to_ascii_lowercase();
     lower.contains("out of memory")
-        || lower.contains("memory limit")
-        || lower.contains("memlimit")
+        || lower.contains("memory limit exceeded")
+        || lower.contains("exceeded memory limit")
         || lower.contains("cannot allocate memory")
-        || lower.contains("std::bad_alloc")
+        || lower.contains("bad_alloc")
 }
 
 /// Extract the short explanation that precedes `VERIFICATION UNKNOWN` from an
@@ -942,6 +942,16 @@ VERIFICATION FAILED";
         assert_eq!(reason, "ESBMC returned VERIFICATION UNKNOWN");
     }
 
+    #[test]
+    fn memory_limit_classifier_ignores_echoed_memlimit_option() {
+        let combined = "wrapper: esbmc test.c --memlimit 4096m\nVERIFICATION UNKNOWN\n";
+        assert!(!is_memory_limit_output(combined));
+        assert_eq!(
+            parse_unknown_reason(combined),
+            "ESBMC returned VERIFICATION UNKNOWN"
+        );
+    }
+
     #[cfg(unix)]
     fn fake_esbmc_script(body: &str) -> (tempfile::TempDir, PathBuf) {
         use std::os::unix::fs::PermissionsExt;
@@ -985,7 +995,7 @@ exit 6
     fn run_esbmc_prefers_memlimit_reason_over_generic_unknown() {
         let (_dir, esbmc) = fake_esbmc_script(
             r#"#!/bin/sh
-echo "ESBMC was unable to finish before the memory limit"
+echo "terminate called after throwing an instance of std::bad_alloc"
 echo "VERIFICATION UNKNOWN"
 exit 6
 "#,

--- a/vow-verify/src/lib.rs
+++ b/vow-verify/src/lib.rs
@@ -15,5 +15,6 @@ pub use esbmc::{
     verify_function_with_module_and_const_fns_with_max_k_step,
 };
 pub use solver_strategy::{
-    DEFAULT_AUTO_TIMEOUT_SECS, Encoding, Solver, SolverConfig, classify_function, run_with_fallback,
+    DEFAULT_AUTO_TIMEOUT_SECS, DEFAULT_ESBMC_MEMLIMIT_MB, Encoding, Solver, SolverConfig,
+    classify_function, run_with_fallback,
 };

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -26,9 +26,13 @@ pub struct SolverConfig {
     pub solver: Solver,
     pub encoding: Encoding,
     pub timeout_secs: Option<u32>,
+    /// Per-ESBMC-process memory cap. `Some(n)` is emitted as `--memlimit nm`.
+    pub memlimit_mb: Option<u32>,
 }
 
 pub const DEFAULT_AUTO_TIMEOUT_SECS: u32 = 30;
+/// Default per-ESBMC-process cap. This bounds solver RSS without changing Vow contracts.
+pub const DEFAULT_ESBMC_MEMLIMIT_MB: u32 = 4096;
 
 impl SolverConfig {
     pub fn default_config() -> Self {
@@ -36,6 +40,7 @@ impl SolverConfig {
             solver: Solver::Auto,
             encoding: Encoding::Auto,
             timeout_secs: None,
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         }
     }
 
@@ -71,6 +76,7 @@ impl SolverConfig {
             solver,
             encoding,
             timeout_secs: self.timeout_secs,
+            memlimit_mb: self.memlimit_mb,
         }
     }
 
@@ -86,6 +92,10 @@ impl SolverConfig {
         match resolved.encoding {
             Encoding::Ir => args.push("--ir".to_string()),
             Encoding::Bv | Encoding::Auto => {} // bv is ESBMC default
+        }
+        if let Some(mb) = resolved.memlimit_mb {
+            args.push("--memlimit".to_string());
+            args.push(format!("{mb}m"));
         }
         args
     }
@@ -187,6 +197,7 @@ pub fn classify_function(func: &Function) -> SolverConfig {
         solver,
         encoding: Encoding::Bv, // never auto-select Ir
         timeout_secs: None,
+        memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
     }
 }
 
@@ -233,45 +244,44 @@ pub fn run_with_fallback(
         solver: config.solver,
         encoding: Encoding::Bv,
         timeout_secs,
+        memlimit_mb: config.memlimit_mb,
     }
     .resolve();
 
     let result = run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, &bv_config);
 
-    match result {
-        // Timeout means BV could neither prove nor disprove within the time
-        // budget, so auto mode may retry with Z3+IR. UNKNOWN is different:
-        // ESBMC reached an inconclusive verification result, and proving the
-        // weaker IR abstraction must not hide that BV outcome.
-        VerificationResult::Timeout => {
-            // IR encoding only works with Z3. If the resolved BV solver was
-            // Boolector or Z3, we can switch to Z3+IR. Bitwuzla cannot do IR.
-            let can_ir = !matches!(bv_config.solver, Solver::Bitwuzla);
-            if !can_ir {
-                return (result, bv_config);
-            }
-
-            // Reuse the same timeout policy for the IR retry: user override
-            // if set, else the 30s default (IR is always reachable here).
-            let ir_timeout = config.timeout_secs.or(Some(DEFAULT_AUTO_TIMEOUT_SECS));
-            let ir_config = SolverConfig {
-                solver: Solver::Z3,
-                encoding: Encoding::Ir,
-                timeout_secs: ir_timeout,
-            };
-            let ir_result =
-                run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, &ir_config);
-            match ir_result {
-                VerificationResult::Proven => (VerificationResult::ProvenIr, ir_config),
-                // IR returned a counterexample, but IR does not model
-                // overflow — a CE found only under IR can be infeasible
-                // under BV. Report the original timeout rather than an
-                // unsound definitive Failed.
-                VerificationResult::Failed(_) => (result, ir_config),
-                other => (other, ir_config),
-            }
+    let resource_limited = matches!(&result, VerificationResult::Timeout)
+        || matches!(&result, VerificationResult::Unknown { reason } if reason == "memory limit exceeded");
+    if resource_limited {
+        // Timeout/memlimit means BV could neither prove nor disprove within
+        // the resource budget, so auto mode may retry with Z3+IR. Other
+        // UNKNOWN outcomes are explicit ESBMC inconclusive results and must
+        // not be hidden by proving the weaker IR abstraction.
+        let can_ir = !matches!(bv_config.solver, Solver::Bitwuzla);
+        if !can_ir {
+            return (result, bv_config);
         }
-        other => (other, bv_config),
+
+        // Reuse the same timeout/memlimit policy for the IR retry: user
+        // timeout override if set, else the 30s default.
+        let ir_timeout = config.timeout_secs.or(Some(DEFAULT_AUTO_TIMEOUT_SECS));
+        let ir_config = SolverConfig {
+            solver: Solver::Z3,
+            encoding: Encoding::Ir,
+            timeout_secs: ir_timeout,
+            memlimit_mb: config.memlimit_mb,
+        };
+        let ir_result = run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, &ir_config);
+        match ir_result {
+            VerificationResult::Proven => (VerificationResult::ProvenIr, ir_config),
+            // IR returned a counterexample, but IR does not model overflow —
+            // a CE found only under IR can be infeasible under BV. Report the
+            // original resource-limited result rather than an unsound Failed.
+            VerificationResult::Failed(_) => (result, ir_config),
+            other => (other, ir_config),
+        }
+    } else {
+        (result, bv_config)
     }
 }
 
@@ -324,6 +334,7 @@ mod tests {
             solver: Solver::Boolector,
             encoding: Encoding::Ir,
             timeout_secs: None,
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         assert!(c.validate().is_err());
     }
@@ -334,6 +345,7 @@ mod tests {
             solver: Solver::Bitwuzla,
             encoding: Encoding::Ir,
             timeout_secs: None,
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         assert!(c.validate().is_err());
     }
@@ -344,6 +356,7 @@ mod tests {
             solver: Solver::Z3,
             encoding: Encoding::Ir,
             timeout_secs: None,
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         assert!(c.validate().is_ok());
     }
@@ -354,6 +367,7 @@ mod tests {
             solver: Solver::Auto,
             encoding: Encoding::Ir,
             timeout_secs: None,
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         assert!(c.validate().is_ok());
     }
@@ -364,6 +378,7 @@ mod tests {
             solver: Solver::Auto,
             encoding: Encoding::Ir,
             timeout_secs: None,
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         let r = c.resolve();
         assert_eq!(r.solver, Solver::Z3);
@@ -379,9 +394,27 @@ mod tests {
     }
 
     #[test]
+    fn test_default_config_sets_esbmc_memlimit() {
+        let c = SolverConfig::default_config();
+        assert_eq!(c.memlimit_mb, Some(DEFAULT_ESBMC_MEMLIMIT_MB));
+    }
+
+    #[test]
+    fn test_resolve_preserves_esbmc_memlimit() {
+        let c = SolverConfig {
+            solver: Solver::Auto,
+            encoding: Encoding::Auto,
+            timeout_secs: None,
+            memlimit_mb: Some(1024),
+        };
+        let r = c.resolve();
+        assert_eq!(r.memlimit_mb, Some(1024));
+    }
+
+    #[test]
     fn test_esbmc_args_default() {
         let c = SolverConfig::default_config();
-        assert!(c.esbmc_args().is_empty());
+        assert_eq!(c.esbmc_args(), vec!["--memlimit", "4096m"]);
     }
 
     #[test]
@@ -390,9 +423,10 @@ mod tests {
             solver: Solver::Z3,
             encoding: Encoding::Ir,
             timeout_secs: None,
+            memlimit_mb: Some(2048),
         };
         let args = c.esbmc_args();
-        assert_eq!(args, vec!["--z3", "--ir"]);
+        assert_eq!(args, vec!["--z3", "--ir", "--memlimit", "2048m"]);
     }
 
     #[test]
@@ -401,9 +435,21 @@ mod tests {
             solver: Solver::Bitwuzla,
             encoding: Encoding::Bv,
             timeout_secs: None,
+            memlimit_mb: Some(512),
         };
         let args = c.esbmc_args();
-        assert_eq!(args, vec!["--bitwuzla"]);
+        assert_eq!(args, vec!["--bitwuzla", "--memlimit", "512m"]);
+    }
+
+    #[test]
+    fn test_esbmc_args_omits_memlimit_when_none() {
+        let c = SolverConfig {
+            solver: Solver::Boolector,
+            encoding: Encoding::Bv,
+            timeout_secs: None,
+            memlimit_mb: None,
+        };
+        assert!(c.esbmc_args().is_empty());
     }
 
     // -- Heuristic tests --
@@ -649,6 +695,7 @@ mod tests {
             solver: Solver::Boolector,
             encoding: Encoding::Bv,
             timeout_secs: None,
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         let (result, resolved) = run_with_fallback(&esbmc, &c_src, 5, &func.name, &cfg);
         assert!(matches!(result, VerificationResult::Proven));
@@ -673,6 +720,7 @@ mod tests {
             solver: Solver::Auto,
             encoding: Encoding::Auto,
             timeout_secs: None,
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         let (result, resolved) = run_with_fallback(&esbmc, &c_src, 5, &func.name, &cfg);
         assert!(matches!(result, VerificationResult::Proven));
@@ -698,6 +746,7 @@ mod tests {
             solver: Solver::Bitwuzla,
             encoding: Encoding::Auto,
             timeout_secs: Some(0), // force BV to time out immediately
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         let (result, resolved) = run_with_fallback(&esbmc, &c_src, 5, &func.name, &cfg);
         // The BV run might finish between spawn and the first 50ms poll; if
@@ -753,6 +802,7 @@ echo "VERIFICATION UNKNOWN"
             solver: Solver::Auto,
             encoding: Encoding::Auto,
             timeout_secs: Some(5),
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         let (result, resolved) =
             run_with_fallback(&esbmc, "int main(void) { return 0; }", 5, "main", &cfg);
@@ -765,6 +815,47 @@ echo "VERIFICATION UNKNOWN"
         }
         assert_eq!(resolved.solver, Solver::Boolector);
         assert_eq!(resolved.encoding, Encoding::Bv);
+    }
+
+    /// A memory-limit hit is a verifier resource exhaustion, like timeout,
+    /// not ESBMC's logical `VERIFICATION UNKNOWN`. Auto mode may retry IR.
+    #[cfg(unix)]
+    #[test]
+    fn fallback_auto_bv_memlimit_retries_with_ir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let esbmc = dir.path().join("fake-esbmc");
+        std::fs::write(
+            &esbmc,
+            r#"#!/bin/sh
+for arg in "$@"; do
+    if [ "$arg" = "--ir" ]; then
+        echo "VERIFICATION SUCCESSFUL"
+        exit 0
+    fi
+done
+echo "Out of memory: memory limit exceeded"
+exit 6
+"#,
+        )
+        .expect("write fake esbmc");
+        let mut perms = std::fs::metadata(&esbmc).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&esbmc, perms).expect("chmod fake esbmc");
+
+        let cfg = SolverConfig {
+            solver: Solver::Auto,
+            encoding: Encoding::Auto,
+            timeout_secs: Some(5),
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
+        };
+        let (result, resolved) =
+            run_with_fallback(&esbmc, "int main(void) { return 0; }", 5, "main", &cfg);
+
+        assert!(matches!(result, VerificationResult::ProvenIr));
+        assert_eq!(resolved.solver, Solver::Z3);
+        assert_eq!(resolved.encoding, Encoding::Ir);
     }
 
     /// Phase D: when BV times out under Auto encoding (non-Bitwuzla solver),
@@ -786,6 +877,7 @@ echo "VERIFICATION UNKNOWN"
             solver: Solver::Boolector,
             encoding: Encoding::Auto,
             timeout_secs: Some(0),
+            memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
         };
         let (result, resolved) = run_with_fallback(&esbmc, &c_src, 5, &func.name, &cfg);
         // The BV run may or may not race the 50ms poll; accept either

--- a/vow-verify/src/solver_strategy.rs
+++ b/vow-verify/src/solver_strategy.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::esbmc::{VerificationResult, run_esbmc_with_max_k_step};
+use crate::esbmc::{VerificationResult, memory_limit_reason, run_esbmc_with_max_k_step};
 
 // ---------------------------------------------------------------------------
 // Solver / Encoding / Config types
@@ -251,7 +251,7 @@ pub fn run_with_fallback(
     let result = run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, &bv_config);
 
     let resource_limited = matches!(&result, VerificationResult::Timeout)
-        || matches!(&result, VerificationResult::Unknown { reason } if reason == "memory limit exceeded");
+        || matches!(&result, VerificationResult::Unknown { reason } if reason == &memory_limit_reason());
     if resource_limited {
         // Timeout/memlimit means BV could neither prove nor disprove within
         // the resource budget, so auto mode may retry with Z3+IR. Other

--- a/vow-verify/tests/memlimit.rs
+++ b/vow-verify/tests/memlimit.rs
@@ -97,6 +97,11 @@ fn memlimit_probe_bounds_real_esbmc_rss_when_enabled() {
         .trim()
         .parse()
         .expect("rss kb");
+    // Sanity bound, not proof that this specific synthetic case always hits
+    // the cap: some ESBMC/solver versions discharge the tautology cheaply. The
+    // deterministic unit tests cover flag wiring and OOM classification; this
+    // env-gated probe checks that a capped real invocation returns a structured
+    // result and does not escape by many hundreds of MiB.
     let allowed_kb = u64::from(memlimit_mb + 512) * 1024;
     assert!(
         rss_kb <= allowed_kb,

--- a/vow-verify/tests/memlimit.rs
+++ b/vow-verify/tests/memlimit.rs
@@ -88,7 +88,10 @@ fn memlimit_probe_bounds_real_esbmc_rss_when_enabled() {
         }
         VerificationResult::Proven
         | VerificationResult::Failed(_)
-        | VerificationResult::ProvenIr => {}
+        | VerificationResult::ProvenIr => {
+            // Accept successful structured outcomes: this env-gated probe is an
+            // RSS sanity check, not the deterministic memory-limit classifier.
+        }
         other => panic!("expected a structured verifier result, got {other:?}"),
     }
 

--- a/vow-verify/tests/memlimit.rs
+++ b/vow-verify/tests/memlimit.rs
@@ -28,6 +28,15 @@ fn synthetic_solver_pressure_c_source(vars: usize) -> String {
     c
 }
 
+fn parse_time_max_rss_kb(output: &str) -> Option<u64> {
+    output
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && line.bytes().all(|b| b.is_ascii_digit()))
+        .and_then(|line| line.parse().ok())
+}
+
 #[cfg(unix)]
 #[test]
 fn memlimit_probe_bounds_real_esbmc_rss_when_enabled() {
@@ -95,11 +104,9 @@ fn memlimit_probe_bounds_real_esbmc_rss_when_enabled() {
         other => panic!("expected a structured verifier result, got {other:?}"),
     }
 
-    let rss_kb: u64 = std::fs::read_to_string(&rss_path)
-        .expect("rss file")
-        .trim()
-        .parse()
-        .expect("rss kb");
+    let rss_output = std::fs::read_to_string(&rss_path).expect("rss file");
+    let rss_kb: u64 = parse_time_max_rss_kb(&rss_output)
+        .unwrap_or_else(|| panic!("could not parse /usr/bin/time RSS output: {rss_output:?}"));
     // Sanity bound, not proof that this specific synthetic case always hits
     // the cap: some ESBMC/solver versions discharge the tautology cheaply. The
     // deterministic unit tests cover flag wiring and OOM classification; this
@@ -109,5 +116,18 @@ fn memlimit_probe_bounds_real_esbmc_rss_when_enabled() {
     assert!(
         rss_kb <= allowed_kb,
         "ESBMC max RSS {rss_kb} KiB exceeded capped run allowance {allowed_kb} KiB"
+    );
+}
+
+#[test]
+fn parses_plain_time_max_rss_output() {
+    assert_eq!(parse_time_max_rss_kb("131072\n"), Some(131072));
+}
+
+#[test]
+fn parses_time_output_after_signal_message() {
+    assert_eq!(
+        parse_time_max_rss_kb("Command terminated by signal 6\n131072\n"),
+        Some(131072)
     );
 }

--- a/vow-verify/tests/memlimit.rs
+++ b/vow-verify/tests/memlimit.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+
+use vow_verify::{
+    Encoding, Solver, SolverConfig, VerificationResult, find_esbmc, run_esbmc_with_max_k_step,
+};
+
+fn sh_quote(path: &Path) -> String {
+    let s = path.to_string_lossy().replace('\'', "'\\''");
+    format!("'{s}'")
+}
+
+fn synthetic_solver_pressure_c_source(vars: usize) -> String {
+    let mut c = String::from(
+        "extern _Bool __VERIFIER_nondet_bool(void);\n\
+         int main(void) {\n",
+    );
+    for i in 0..vars {
+        c.push_str(&format!("  _Bool b{i} = __VERIFIER_nondet_bool();\n"));
+    }
+    c.push_str("  __ESBMC_assert((");
+    for i in 0..vars {
+        if i > 0 {
+            c.push_str(") && (");
+        }
+        c.push_str(&format!("b{i} || !b{i}"));
+    }
+    c.push_str("), \"tautology\");\n  return 0;\n}\n");
+    c
+}
+
+#[cfg(unix)]
+#[test]
+fn memlimit_probe_bounds_real_esbmc_rss_when_enabled() {
+    if std::env::var("VOW_VERIFY_RUN_MEMLIMIT_RSS").as_deref() != Ok("1") {
+        eprintln!("SKIP: set VOW_VERIFY_RUN_MEMLIMIT_RSS=1 to run the real ESBMC RSS probe");
+        return;
+    }
+
+    let real_esbmc = match find_esbmc() {
+        Some(path) => path,
+        None => {
+            eprintln!("SKIP: esbmc not found");
+            return;
+        }
+    };
+    let time = Path::new("/usr/bin/time");
+    if !time.is_file() {
+        eprintln!("SKIP: /usr/bin/time not found");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let rss_path = dir.path().join("max-rss-kb.txt");
+    let wrapper = dir.path().join("esbmc-with-rss");
+    let script = format!(
+        "#!/bin/sh\nexec {} -f '%M' -o {} {} \"$@\"\n",
+        sh_quote(time),
+        sh_quote(&rss_path),
+        sh_quote(&real_esbmc)
+    );
+    std::fs::write(&wrapper, script).expect("write wrapper");
+
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&wrapper).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&wrapper, perms).expect("chmod wrapper");
+
+    let memlimit_mb = 128;
+    let config = SolverConfig {
+        solver: Solver::Boolector,
+        encoding: Encoding::Bv,
+        timeout_secs: Some(60),
+        memlimit_mb: Some(memlimit_mb),
+    };
+    let result = run_esbmc_with_max_k_step(
+        &wrapper,
+        &synthetic_solver_pressure_c_source(4096),
+        5,
+        "memlimit_probe",
+        &config,
+    );
+
+    match &result {
+        VerificationResult::Unknown { reason } => {
+            if reason == "memory limit exceeded" {
+                // This is the expected result when the synthetic case hits the cap.
+            }
+        }
+        VerificationResult::Proven
+        | VerificationResult::Failed(_)
+        | VerificationResult::ProvenIr => {}
+        other => panic!("expected a structured verifier result, got {other:?}"),
+    }
+
+    let rss_kb: u64 = std::fs::read_to_string(&rss_path)
+        .expect("rss file")
+        .trim()
+        .parse()
+        .expect("rss kb");
+    let allowed_kb = u64::from(memlimit_mb + 512) * 1024;
+    assert!(
+        rss_kb <= allowed_kb,
+        "ESBMC max RSS {rss_kb} KiB exceeded capped run allowance {allowed_kb} KiB"
+    );
+}

--- a/vow/src/cache.rs
+++ b/vow/src/cache.rs
@@ -157,9 +157,19 @@ impl VerifyCache {
         Some(Self { dir })
     }
 
-    pub fn cache_key(c_source: &str, max_k_step: u32, solver: &str, encoding: &str) -> String {
+    pub fn cache_key(
+        c_source: &str,
+        max_k_step: u32,
+        solver: &str,
+        encoding: &str,
+        memlimit_mb: Option<u32>,
+    ) -> String {
+        let memlimit = match memlimit_mb {
+            Some(mb) => format!("{mb}m"),
+            None => "none".to_string(),
+        };
         let combined = format!(
-            "{c_source}\n__max_k_step={max_k_step}\n__solver={solver}\n__encoding={encoding}"
+            "{c_source}\n__max_k_step={max_k_step}\n__solver={solver}\n__encoding={encoding}\n__memlimit={memlimit}"
         );
         let hash = fnv1a_hash(combined.as_bytes());
         format!("{hash:016x}")
@@ -298,16 +308,31 @@ mod tests {
 
     #[test]
     fn cache_key_includes_max_k_step() {
-        let k1 = VerifyCache::cache_key("int f() { return 0; }", 10, "boolector", "bv");
-        let k2 = VerifyCache::cache_key("int f() { return 0; }", 20, "boolector", "bv");
+        let k1 = VerifyCache::cache_key("int f() { return 0; }", 10, "boolector", "bv", Some(4096));
+        let k2 = VerifyCache::cache_key("int f() { return 0; }", 20, "boolector", "bv", Some(4096));
         assert_ne!(k1, k2);
     }
 
     #[test]
     fn cache_key_includes_solver_encoding() {
-        let k1 = VerifyCache::cache_key("int f() { return 0; }", 10, "boolector", "bv");
-        let k2 = VerifyCache::cache_key("int f() { return 0; }", 10, "z3", "ir");
+        let k1 = VerifyCache::cache_key("int f() { return 0; }", 10, "boolector", "bv", Some(4096));
+        let k2 = VerifyCache::cache_key("int f() { return 0; }", 10, "z3", "ir", Some(4096));
         assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_includes_esbmc_memlimit() {
+        let k1 = VerifyCache::cache_key("int f() { return 0; }", 10, "boolector", "bv", Some(1024));
+        let k2 = VerifyCache::cache_key("int f() { return 0; }", 10, "boolector", "bv", Some(4096));
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_distinguishes_uncapped_esbmc_runs() {
+        let capped =
+            VerifyCache::cache_key("int f() { return 0; }", 10, "boolector", "bv", Some(4096));
+        let uncapped = VerifyCache::cache_key("int f() { return 0; }", 10, "boolector", "bv", None);
+        assert_ne!(capped, uncapped);
     }
 
     #[test]

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -17,10 +17,10 @@ use vow_codegen::linker::{find_runtime_lib, find_shim_lib, link};
 use vow_codegen::{Backend, BuildMode, TraceMode};
 use vow_diag::{Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
 use vow_verify::{
-    ConstantValue, Counterexample, DEFAULT_MAX_K_STEP, Encoding, Solver, SolverConfig,
-    UNSUPPORTED_OP_VOW_ID, VerificationResult, VerifyLimits, detect_constant_functions,
-    emit_verify_c_source, find_esbmc, non_modelable_reason, run_with_fallback,
-    verify_function_with_module_and_const_fns_configured,
+    ConstantValue, Counterexample, DEFAULT_ESBMC_MEMLIMIT_MB, DEFAULT_MAX_K_STEP, Encoding, Solver,
+    SolverConfig, UNSUPPORTED_OP_VOW_ID, VerificationResult, VerifyLimits,
+    detect_constant_functions, emit_verify_c_source, find_esbmc, non_modelable_reason,
+    run_with_fallback, verify_function_with_module_and_const_fns_configured,
 };
 
 use cache::{CachedFailure, VerifyCache};
@@ -82,7 +82,7 @@ fn make_solver_config(
         solver: s,
         encoding: e,
         timeout_secs: timeout,
-        memlimit_mb: SolverConfig::default_config().memlimit_mb,
+        memlimit_mb: Some(DEFAULT_ESBMC_MEMLIMIT_MB),
     };
     if let Err(msg) = config.validate() {
         eprintln!("error: {msg}");

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -82,6 +82,7 @@ fn make_solver_config(
         solver: s,
         encoding: e,
         timeout_secs: timeout,
+        memlimit_mb: SolverConfig::default_config().memlimit_mb,
     };
     if let Err(msg) = config.validate() {
         eprintln!("error: {msg}");
@@ -8754,6 +8755,7 @@ fn verify_one_function(
             solver: heuristic.solver,
             encoding: config.encoding,
             timeout_secs: config.timeout_secs,
+            memlimit_mb: config.memlimit_mb,
         }
     } else {
         *config
@@ -8766,6 +8768,7 @@ fn verify_one_function(
             limits.max_k_step,
             func_config.solver_str(),
             func_config.encoding_str(),
+            func_config.memlimit_mb,
         );
 
         // Security: lookup only returns FAILED entries (PROVEN is never trusted
@@ -8789,6 +8792,7 @@ fn verify_one_function(
                     limits.max_k_step,
                     resolved_config.solver_str(),
                     resolved_config.encoding_str(),
+                    resolved_config.memlimit_mb,
                 );
                 vc.store(
                     &store_key,
@@ -10012,6 +10016,7 @@ fn update_contract_statuses(
                 limits.max_k_step,
                 config.solver_str(),
                 config.encoding_str(),
+                config.memlimit_mb,
             );
 
             // Security: lookup only returns FAILED (PROVEN is never trusted
@@ -10040,6 +10045,7 @@ fn update_contract_statuses(
                         limits.max_k_step,
                         resolved_config.solver_str(),
                         resolved_config.encoding_str(),
+                        resolved_config.memlimit_mb,
                     );
                     vc.store(
                         &store_key,


### PR DESCRIPTION
Summary:
- add a default 4096 MB ESBMC memlimit to SolverConfig and pass it through Rust and self-hosted verifier invocations
- normalize ESBMC/solver memory-limit output to verify_status=unknown with reason "memory limit exceeded"; auto mode may retry IR for resource-limited BV results while preserving ordinary UNKNOWN behavior
- include memlimit in VerifyCache keys and add unit plus env-gated RSS probe coverage

Validation:
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- cargo build --release --all
- ulimit -v 2000000; scripts/bootstrap.sh --skip-cargo
- build/vowc verify --verify-jobs 1 examples/geometry/main.vow
- target/release/vow verify examples/geometry/main.vow
- ulimit -v 2000000; scripts/full_test.sh (389 passed, 2 failed, 1 skipped; residual failures are issue400_internal_call_root_escape/test-expected existing memory-root delta and arena/esbmc Bitwuzla OOM in vow-runtime/verify outside the vow-verify launcher)

Closes #492

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**