### PR TITLE
fix(clif-shim): make macOS link reproducible (#500)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Bootstrap (Stages 1-2 verify, Stage 3 fixed-point check)
         run: scripts/bootstrap.sh --stage3-no-verify
 
-  # ─── macOS jobs (advisory) ─────────────────────────────────────────
+  # ─── macOS jobs ───────────────────────────────────────────────────
   #
   # ESBMC ships no macOS release artifact (only Ubuntu + Windows zips on
   # https://github.com/esbmc/esbmc/releases), so verification is skipped
@@ -122,9 +122,9 @@ jobs:
   # does not affect codegen, so identical Stage 2/Stage 3 SHA-256s prove
   # the self-hosted compiler reaches a fixed point on this platform.
   #
-  # continue-on-error is on while we shake out platform-specific issues
-  # (libdl quirks, ulimit -v semantics, etc.). The intent is to flip
-  # these to required once they go green; tracked in a follow-up issue.
+  # `bootstrap-macos` is required (the fixed-point check is reliable here).
+  # `build-and-test-macos` remains advisory via continue-on-error while we
+  # shake out platform-specific test issues (tracked in #501).
 
   build-and-test-macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,6 @@ jobs:
     # change codegen, so a successful match here still proves the
     # self-hosted compiler is a fixed point on macOS.
     runs-on: macos-latest
-    continue-on-error: true
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2638,12 +2638,7 @@ pub unsafe extern "C" fn __vow_clif_link(obj_path_ptr: i64, output_path_ptr: i64
         cmd.arg("-ldl");
     }
     if cfg!(target_os = "macos") {
-        // `-reproducible` makes ld's LC_UUID a stable hash of the output
-        // content rather than including link-time ephemera. `-final_output,vow`
-        // pins the linker-signed ad-hoc CodeDirectory identifier to a fixed
-        // string so two builds with different `-o` names (e.g. vowc2 vs vowc3
-        // during bootstrap) produce identical CDHashes. Together they make
-        // the bootstrap SHA-256 fixed point reachable on macOS. See #500.
+        // Stabilise LC_UUID and CDHash across different -o names; see #500.
         cmd.args(["-Wl,-reproducible", "-Wl,-final_output,vow"]);
     }
 

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2637,6 +2637,15 @@ pub unsafe extern "C" fn __vow_clif_link(obj_path_ptr: i64, output_path_ptr: i64
     if cfg!(target_os = "linux") {
         cmd.arg("-ldl");
     }
+    if cfg!(target_os = "macos") {
+        // `-reproducible` makes ld's LC_UUID a stable hash of the output
+        // content rather than including link-time ephemera. `-final_output,vow`
+        // pins the linker-signed ad-hoc CodeDirectory identifier to a fixed
+        // string so two builds with different `-o` names (e.g. vowc2 vs vowc3
+        // during bootstrap) produce identical CDHashes. Together they make
+        // the bootstrap SHA-256 fixed point reachable on macOS. See #500.
+        cmd.args(["-Wl,-reproducible", "-Wl,-final_output,vow"]);
+    }
 
     match cmd.status() {
         Ok(s) if s.success() => {


### PR DESCRIPTION
## Summary

- Pass `-Wl,-reproducible -Wl,-final_output,vow` to `cc` on macOS in `__vow_clif_link`, making the produced executable a deterministic function of the input source rather than of link-time ephemera + the output filename.
- Drop `continue-on-error: true` from the `bootstrap-macos` CI job now that the SHA-256 fixed point is reachable on that platform.

Fixes #500.

## Root cause

The Apple linker by default:

1. Generates an LC_UUID per link. The default is supposed to be a hash of output content, but it includes link-time ephemera that varies run-to-run.
2. Emits a linker-signed ad-hoc CodeDirectory whose CDHash incorporates the output basename (`vowc2` vs `vowc3`) — so even if the binary content were identical, the CodeDirectory wouldn't be.

Bootstrap Stage 2 (`build/vowc build -o build/vowc2`) and Stage 3 (`build/vowc2 build -o build/vowc3`) compile the same `compiler/main.vow` source. On Linux they produce byte-identical ELF binaries; on macOS the LC_UUID + CDHash diverged, breaking the fixed-point invariant.

Empirically — verified on a Mac mini M1 (macOS 26.3.1, ld-1230.1) — exactly **49 bytes** differed between `vowc2` and `vowc3`: the 16-byte UUID payload plus 33 bytes of CDHash. `.o` output from Cranelift is already deterministic; only the linker stage was at fault.

## Why these flags

| Flag | Effect |
|---|---|
| `-Wl,-no_uuid` | Removes UUID — but Apple Silicon `dyld` rejects Mach-Os without LC_UUID (binaries killed with exit 134). Not viable. |
| `-Wl,-reproducible` | Documented as ignoring certain input properties so output is deterministic. Keeps LC_UUID. |
| `-Wl,-final_output,vow` | Pins the linker-signed CodeDirectory identifier to a fixed string regardless of the `-o` filename. |

With both flags applied, two builds of the same `.o` with different `-o` targets produce identical SHA-256s and remain runnable.

## Verification

On a Mac mini M1, before the fix:
```
Verify:  SHA-256 fixed point (vowc2 == vowc3)
  MISMATCH
  vowc2: 969fc98c6af2a2852b53cafa94cd16e25661dfdd82d67e6086a0d20526b2eed4
  vowc3: b996205d0602b36783c3221595b0606a5f9541722214c3c3a200eb00f13d1711
```

After the fix:
```
Verify:  SHA-256 fixed point (vowc2 == vowc3)
  MATCH  aaff4aae8e25e24541a0bafe239abc3cfa9e59dc987acb27a3112f7979beacbd
```

Linux bootstrap still reaches its own fixed point (`1058e6dc...`); `cfg!(target_os = "macos")` gates the new flags so Linux paths are unchanged. Cargo tests for `vow-clif-shim` still pass.

## Test plan

- [x] Reproduce mismatch on macOS without the fix
- [x] Confirm vowc2 == vowc3 SHA-256 on macOS with the fix
- [x] Confirm rebuilt self-hosted compiler still compiles and runs `examples/hello.vow` (prints `Hello, world!`, exit 0)
- [x] Confirm Linux bootstrap still MATCHes
- [x] `cargo test -p vow-clif-shim` passes
- [ ] CI `bootstrap-macos` reports MATCH and is now required
