### PR TITLE
docs(spec): design narrow-int numeric tower (ADR 0001)

### DIFF
--- a/docs/adr/0001-numeric-tower-narrow-ints.md
+++ b/docs/adr/0001-numeric-tower-narrow-ints.md
@@ -70,9 +70,10 @@ Decimal / Rational) work are separate subprojects and out of scope here.
    formatting. Parsing exposes `parse_X(s: String) -> Option<X>` for every
    width (the narrow variants reject out-of-range).
 
-9. **Struct field layout.** All struct fields remain 8-byte slots; narrow
-   ints are stored padded. No packing, no natural-alignment layout, no FFI
-   layout matching in Phase 1.
+9. **Struct field layout.** Struct fields up to 64 bits wide each occupy one
+   8-byte slot (narrow ints stored padded); `i128`/`u128` fields occupy two
+   consecutive 8-byte slots (16 bytes). No packing, no natural-alignment
+   layout, no FFI layout matching in Phase 1.
 
 10. **Rollout.** Tracer-bullet by width, not by layer. Phase 1: `u8`
     end-to-end (typechecker, IR, codegen, verifier, narrowing intrinsics for

--- a/docs/adr/0001-numeric-tower-narrow-ints.md
+++ b/docs/adr/0001-numeric-tower-narrow-ints.md
@@ -118,8 +118,9 @@ BigInt subprojects.
 
 ## Open follow-ups
 
-- Const declarations: extend the existing `i32/i64/bool` restriction to all 10
-  widths (mechanical).
+- Const declarations: grammar.md §Const Declarations already specifies all 10
+  integer widths plus `bool`; the implementation widening (still `i32/i64/bool`)
+  is tracked in #527 (mechanical).
 - Validate Cranelift `I128` codegen on the supported backends.
 - Benchmark ESBMC `__int128` predicate complexity on real Vow contracts.
 - Floats and BigInt subprojects: separate ADRs.

--- a/docs/adr/0001-numeric-tower-narrow-ints.md
+++ b/docs/adr/0001-numeric-tower-narrow-ints.md
@@ -1,0 +1,122 @@
+# 0001. Numeric tower — narrow integer types
+
+**Status:** accepted (2026-05-22)
+
+## Context
+
+Vow today documents `i32`, `i64`, `u8`, `u64`, `f32`, `f64` as primitive numeric
+types. The Rust-side typechecker silently accepts `i8`, `i16`, `i128`, `u16`,
+`u32`, `u128` (`vow-types/src/types.rs`) and the self-hosted compiler has
+matching token-suffix and type-tag scaffolding (`compiler/token.vow`,
+`compiler/types.vow`) but the IR (`vow-ir/src/types.rs`) only has `I32`, `I64`,
+`U64`, `F32`, `F64`. Casts (`vow-types/src/check.rs` ~L1542) are limited to
+`i32 → i64`, `i32 → u64`, `i64 ↔ u64`. Vec<u8> works as an opaque slot but `u8`
+arithmetic doesn't lower. Agents writing parsers, hashes, byte protocols, or
+FFI shims hit this inconsistency.
+
+This ADR records the decisions from the 2026-05-22 design session for the
+*narrow integer* slice of the numeric tower. Floats and big-number (BigInt /
+Decimal / Rational) work are separate subprojects and out of scope here.
+
+## Decisions
+
+1. **Width set.** Commit to the full Rust fixed-width matrix as first-class:
+   `i8`, `i16`, `i32`, `i64`, `i128`, `u8`, `u16`, `u32`, `u64`, `u128`. No
+   `isize`/`usize`. `Vec::len() -> i64` stays. Vow remains 64-bit-only to
+   preserve binary-fixed-point reproducibility.
+
+2. **IR opcodes.** Refactor the per-width arithmetic opcodes
+   (`WrappingAddI32`, `WrappingAddI64`, `WrappingAddU64`, ...) into
+   width-parametric opcodes (`WrappingAdd` with width + signedness carried on
+   the instruction). Same plan applies to comparison and bitwise ops.
+
+3. **Casts.** `as` is **widening-only**: any narrower int → wider int (signed
+   sign-extends, unsigned zero-extends). Narrowing via `as` is a compile-time
+   error. Narrowing intent must be spelled at the call site with one of three
+   compiler-emitted free functions per `(src, tgt)` pair:
+   `<src>_to_<tgt>_try(x) -> Option<tgt>` (range-checked),
+   `<src>_to_<tgt>_wrap(x) -> tgt` (truncate),
+   `<src>_to_<tgt>_sat(x) -> tgt` (clamp).
+   Emitted as intrinsics so ESBMC sees their semantics directly.
+
+4. **Literals.** Unsuffixed integer literals default to `i64` and
+   context-coerce to the annotated target type when the surrounding context
+   fixes one (`let`, fn arg, struct field, bitwise/arith with typed operand).
+   Out-of-range literals (`let x: u8 = 300;`) are a compile-time error
+   (`LiteralOutOfRange`). Suffixed literals `42u8`, `42i128`, etc. are
+   supported for all 10 widths.
+
+5. **Arithmetic operators.** Keep `+` (wrapping) and `+!` (checked / traps on
+   overflow) only. Saturating arithmetic is exposed as compiler-emitted
+   intrinsic free functions (`add_sat_u8(a, b) -> u8`, etc.) — needs verifier
+   semantics so it can't be pure stdlib. No new operator family.
+
+6. **Bitwise.** `& | ^ << >>` work on all 10 int widths. Shift count is `u32`
+   with literal coercion. Right-shift is arithmetic for signed types and
+   logical for unsigned. A shift count that is a const expression `>= width`
+   is a compile-time error (`ShiftCountOutOfRange`); dynamic shifts get a
+   runtime contract.
+
+7. **128-bit verification.** `i128`/`u128` are first-class for source, IR,
+   codegen (Cranelift `I128`), and ESBMC (`__int128`). Predicates over 128-bit
+   values may time out in the SMT solver; a `--no-128-verify` opt-out is
+   provided. Contract authoring rules (CLAUDE.md "Contract Authoring") still
+   apply — never weaken contracts to fit the verifier.
+
+8. **Format / parse.** Two formatter baselines: `int_to_string(x: i64) -> String`
+   and `uint_to_string(x: u64) -> String`. Agents widen via `as` before
+   formatting. Parsing exposes `parse_X(s: String) -> Option<X>` for every
+   width (the narrow variants reject out-of-range).
+
+9. **Struct field layout.** All struct fields remain 8-byte slots; narrow
+   ints are stored padded. No packing, no natural-alignment layout, no FFI
+   layout matching in Phase 1.
+
+10. **Rollout.** Tracer-bullet by width, not by layer. Phase 1: `u8`
+    end-to-end (typechecker, IR, codegen, verifier, narrowing intrinsics for
+    `u8`, `parse_u8`, docs). Subsequent phases: `i32` (already partial),
+    `i8`/`i16`/`u16`/`u32`, then `i128`/`u128`. Each phase is a complete
+    vertical slice that lands as a small PR set.
+
+## Compiler vs stdlib boundary
+
+The rule that emerged: **a numeric feature belongs in the compiler iff it
+requires a new IR opcode, a new type-system axis, or special verifier
+modeling; otherwise stdlib.**
+
+- **Compiler:** types, IR opcodes, codegen, verifier C model, arithmetic /
+  bitwise operators, literal coercion, widening `as`, narrowing intrinsics,
+  saturating arithmetic intrinsics, format/parse baselines, hardware-mapped
+  bit-count intrinsics (`leading_zeros`, `popcount`, `byte_swap`).
+- **Stdlib:** width-generalised math helpers (`abs`, `min`, `max`, `clamp`)
+  per width — repetitive but no special verifier needs.
+
+This rule is provisional. It needs to survive contact with the float and
+BigInt subprojects.
+
+## Considered options (and why rejected)
+
+- **Just add `u8`.** Smallest surface, but the typechecker / self-hosted
+  compiler already name the rest; leaving them as silent ghost types is worse
+  than committing to the full matrix.
+- **Add `isize`/`usize`.** Breaks 64-bit-only determinism; cross-compilation
+  would produce different binaries. Rejected to preserve binary fixed point.
+- **Full Rust-style `as` (silent wrapping narrows).** Vow's mission is to
+  eliminate agent bug classes; silent narrowing is exactly such a class.
+  Rejected.
+- **Method-style narrowing (`x.to_u8()`).** Requires primitive-type methods —
+  a new type-system axis. Rejected per the compiler/stdlib rule.
+- **Add saturating operators (`+|`, `-|`, ...).** New lexer surface and
+  precedence rules for a rarely-needed third arithmetic mode. Rejected;
+  saturating ships as named intrinsics.
+- **Packed / naturally-aligned struct fields for narrow ints.** Real win for
+  FFI and wire formats, but redesigns `FieldGet`/`FieldSet`. Deferred; revisit
+  when there's a concrete agent-driven need.
+
+## Open follow-ups
+
+- Const declarations: extend the existing `i32/i64/bool` restriction to all 10
+  widths (mechanical).
+- Validate Cranelift `I128` codegen on the supported backends.
+- Benchmark ESBMC `__int128` predicate complexity on real Vow contracts.
+- Floats and BigInt subprojects: separate ADRs.

--- a/docs/adr/0001-numeric-tower-narrow-ints.md
+++ b/docs/adr/0001-numeric-tower-narrow-ints.md
@@ -30,10 +30,12 @@ Decimal / Rational) work are separate subprojects and out of scope here.
    width-parametric opcodes (`WrappingAdd` with width + signedness carried on
    the instruction). Same plan applies to comparison and bitwise ops.
 
-3. **Casts.** `as` is **widening-only**: any narrower int → wider int (signed
-   sign-extends, unsigned zero-extends). Narrowing via `as` is a compile-time
-   error. Narrowing intent must be spelled at the call site with one of three
-   compiler-emitted free functions per `(src, tgt)` pair:
+3. **Casts.** `as` covers **widening** (any narrower int → wider int; signed
+   sign-extends, unsigned zero-extends) and **same-width signed/unsigned
+   reinterpretation** (`i64 as u64`, `u64 as i64`, `i32 as u32`, etc. —
+   machine-level bit reinterpretation, no range check). Narrowing via `as` is a
+   compile-time error. Narrowing intent must be spelled at the call site with one
+   of three compiler-emitted free functions per `(src, tgt)` pair:
    `<src>_to_<tgt>_try(x) -> Option<tgt>` (range-checked),
    `<src>_to_<tgt>_wrap(x) -> tgt` (truncate),
    `<src>_to_<tgt>_sat(x) -> tgt` (clamp).

--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -115,7 +115,7 @@ fn f(x: u8) -> u8 {
 
 **Output:** `shift count 8 is out of range for u8 (max 7)`
 
-**Fix:** Use a count less than the LHS bit-width. To shift a narrow value by a larger amount, widen first: `((x as u32) << 12) as u8` is illegal under widening-only `as`; use `(x as u32) << 12` and then a narrowing intrinsic.
+**Fix:** Use a count less than the LHS bit-width. To shift a narrow value by a larger amount, widen first: `(x as u32) << 8` is legal (it shifts the widened `u32` value by 8), but the result is `u32`; to get back to `u8`, use a narrowing intrinsic such as `u32_to_u8_wrap`.
 
 ### StaticLiteralRequired
 

--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -70,6 +70,53 @@ fn f() -> i32 {
 
 **Fix:** Change the expression or the declared type to match.
 
+### LiteralOutOfRange
+
+**Phase:** Type Checker
+**Meaning:** An integer literal appears in a typed context (annotated `let`, function argument, struct field, or const declaration) whose target type cannot hold the literal's value. The check runs after context coercion, so the offending literal is the one written in the source, not a widened intermediate.
+
+```vow
+let x: u8 = 300;
+const NEG: u16 = -1;
+```
+
+**Output:** `literal 300 does not fit in u8 (range 0..=255)`
+
+**Fix:** Use a value within the target type's range, change the target type, or write an explicit narrowing intrinsic (`i64_to_u8_try`, `i64_to_u8_wrap`, `i64_to_u8_sat`) if you intend to convert a wider value at runtime.
+
+### NarrowingCastNotAllowed
+
+**Phase:** Type Checker
+**Meaning:** The `as` operator was used to convert a wider integer type to a narrower one. `as` is widening-only; narrowing must use a named intrinsic so the agent chooses an explicit semantics (range-checked vs. truncating vs. saturating). See `grammar.md` §Type Cast.
+
+```vow
+fn f(big: i64) -> u8 {
+    big as u8
+}
+```
+
+**Output:** `cannot cast 'i64' to 'u8' via 'as'; use 'i64_to_u8_try', 'i64_to_u8_wrap', or 'i64_to_u8_sat' to choose the narrowing semantics`
+
+**Fix:** Replace the cast with the narrowing intrinsic that matches your intent:
+- `i64_to_u8_try(big) -> Option<u8>` — reject out-of-range with `None`
+- `i64_to_u8_wrap(big) -> u8` — truncate (keep low bits)
+- `i64_to_u8_sat(big) -> u8` — clamp to `0..=255`
+
+### ShiftCountOutOfRange
+
+**Phase:** Type Checker
+**Meaning:** A constant-expression shift count is greater than or equal to the bit-width of the left operand. Shifting an `N`-bit value by `>= N` bits is undefined in the underlying C model and is rejected at compile time when the count is statically known. Dynamic shift counts (non-const expressions) get a Vow contract on the operation and are checked by ESBMC and at runtime in debug mode.
+
+```vow
+fn f(x: u8) -> u8 {
+    x << 8
+}
+```
+
+**Output:** `shift count 8 is out of range for u8 (max 7)`
+
+**Fix:** Use a count less than the LHS bit-width. To shift a narrow value by a larger amount, widen first: `((x as u32) << 12) as u8` is illegal under widening-only `as`; use `(x as u32) << 12` and then a narrowing intrinsic.
+
 ### StaticLiteralRequired
 
 **Phase:** Type Checker

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -844,7 +844,6 @@ For pointer-containing C payloads, a wrapper must be written per type: call the 
 | `int_to_string`  | `fn(v: i64) -> String`                     | `[]`       |
 | `uint_to_string` | `fn(v: u64) -> String`                     | `[]`       |
 | `i64_to_string`  | `fn(v: i64) -> String` (alias of `int_to_string`) | `[]` |
-| `parse_i64`      | `fn(s: String) -> i64`                     | `[]`       |
 
 ```vow
 let small: u8 = 42;

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -137,10 +137,11 @@ exceed reasonable SMT solver timeouts; the `--no-128-verify` flag skips
 verification for functions whose contracts mention 128-bit values while still
 generating native code for them.
 
-**Struct field layout:** every struct field is an 8-byte slot regardless of
-declared type. Narrow ints stored in struct fields are padded. There is no
-packing or natural-alignment layout today; FFI structs that need a specific C
-layout must shim through `Vec<u8>` or extern wrappers.
+**Struct field layout:** every struct field up to 64 bits wide occupies one
+8-byte slot regardless of declared type (narrow ints are padded); `i128`/`u128`
+fields occupy two consecutive 8-byte slots (16 bytes). There is no packing or
+natural-alignment layout today; FFI structs that need a specific C layout must
+shim through `Vec<u8>` or extern wrappers.
 
 ### Built-in Parameterized Types
 

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -34,7 +34,7 @@ const NEG_ONE: i64 = -1;
 const DEBUG: bool = true;
 ```
 
-Supported value forms: integer literals, boolean literals, negated integer literals. Constants are inlined at every use site (zero runtime cost). The type must be `i64`, `i32`, or `bool`. Constants are referenced by name in expressions like any other identifier.
+Supported value forms: integer literals, boolean literals, negated integer literals. Constants are inlined at every use site (zero runtime cost). The type must be any of the 10 integer types (`i8`, `i16`, `i32`, `i64`, `i128`, `u8`, `u16`, `u32`, `u64`, `u128`) or `bool`. Integer constants are subject to the same compile-time range check as integer literals. Constants are referenced by name in expressions like any other identifier.
 
 ## Functions
 
@@ -111,15 +111,36 @@ pub fn api_function(x: i64) -> i64 {
 
 | Type   | Description              |
 |--------|--------------------------|
+| `i8`   | 8-bit signed integer     |
+| `i16`  | 16-bit signed integer    |
 | `i32`  | 32-bit signed integer    |
 | `i64`  | 64-bit signed integer    |
+| `i128` | 128-bit signed integer (verifier may time out; see below) |
 | `u8`   | 8-bit unsigned integer   |
+| `u16`  | 16-bit unsigned integer  |
+| `u32`  | 32-bit unsigned integer  |
 | `u64`  | 64-bit unsigned integer  |
+| `u128` | 128-bit unsigned integer (verifier may time out; see below) |
 | `f32`  | 32-bit float (limited support — avoid in contracts) |
 | `f64`  | 64-bit float (limited support — avoid in contracts) |
 | `bool` | Boolean                  |
 | `()`   | Unit type                |
 | `!`    | Never type (diverges)    |
+
+There is no `isize`/`usize`. Vow targets 64-bit only; `Vec::len()` returns `i64`,
+indices are `i64`. This is deliberate — it preserves binary fixed point
+reproducibility across compilations. See [ADR 0001](../adr/0001-numeric-tower-narrow-ints.md).
+
+**128-bit verification:** `i128`/`u128` arithmetic codegens via Cranelift's
+`I128` and verifies via ESBMC's `__int128`. Predicates over 128-bit values may
+exceed reasonable SMT solver timeouts; the `--no-128-verify` flag skips
+verification for functions whose contracts mention 128-bit values while still
+generating native code for them.
+
+**Struct field layout:** every struct field is an 8-byte slot regardless of
+declared type. Narrow ints stored in struct fields are padded. There is no
+packing or natural-alignment layout today; FFI structs that need a specific C
+layout must shim through `Vec<u8>` or extern wrappers.
 
 ### Built-in Parameterized Types
 
@@ -146,9 +167,29 @@ Structs and enums (see below).
 0
 ```
 
-All unsuffixed integer literals are `i64`. Integer literals coerce to `u64` in annotation context (e.g. `let x: u64 = 42;`).
+Unsuffixed integer literals default to `i64` in expression position, and
+**context-coerce** to a narrower or unsigned annotated type when the
+surrounding context fixes one — `let` bindings, function arguments, struct
+fields, and the typed operand of an arithmetic, bitwise, or comparison
+operator. The same coercion applies to constant expressions composed entirely
+of unsuffixed integer literals (e.g. `1 + 2`, `1 << 3`, `-5`).
 
-Suffixed integer literals: `42u64` produces a `u64` value directly.
+Out-of-range literals in a typed context are a compile-time error:
+
+```vow
+let x: u8 = 300;   // error: LiteralOutOfRange — 300 does not fit in u8
+let y: i8 = 200;   // error: LiteralOutOfRange — i8 range is -128..=127
+```
+
+**Suffixed integer literals** force the type at the literal:
+
+```vow
+42u8     42u16     42u32     42u64     42u128
+42i8     42i16     42i32     42i64     42i128
+```
+
+Suffixed forms are supported for all 10 integer widths. They override context
+coercion and are still subject to the same compile-time range check.
 
 ### Float Literals
 
@@ -228,9 +269,26 @@ Checked operators abort with `ArithmeticOverflow` on overflow.
 | `<<`     | Left shift   |
 | `>>`     | Right shift  |
 
-Bitwise operators require integer operands of the same type. Shift expressions return the left operand's type. `>>` is arithmetic for `i64` and logical for `u64`.
+Bitwise `& | ^` require integer operands of the same type and work on all 10
+integer widths. `>>` is **arithmetic** (sign-extending) for signed types
+(`i8`..`i128`) and **logical** (zero-extending) for unsigned types
+(`u8`..`u128`).
 
-Unsuffixed integer literals are `i64` by default but coerce to the other operand's integer type when used with a bitwise or shift operator. The same coercion applies to constant expressions composed entirely of unsuffixed integer literals — including arithmetic (`1 + 1`), bitwise (`1 << 3`), and unary negation (`-5`). For example, given `let x: u64 = ...`, the expressions `x << 3`, `3 & x`, and `x << (1 + 1)` all type-check (the literal-constant side coerces to `u64`). This matches the coercion rule already used by arithmetic operators and comparisons. Use a `u64` suffix (`3u64`) to force the `u64` type explicitly.
+**Shift count type.** The right operand of `<<` and `>>` is `u32`. Unsuffixed
+integer literals on the right side context-coerce to `u32`: given
+`let x: u8 = ...`, `x << 3` is well-typed (`3` coerces to `u32`). The left
+operand keeps its own integer type; the shift result has the left operand's
+type.
+
+**Shift count range.** A const-expression shift count `>= bit-width(LHS)` is a
+compile-time error (`ShiftCountOutOfRange`). For example, `(x: u8) << 8` does
+not compile. Dynamic shift counts (`x << n` where `n` is not a const
+expression) get a contract on the operation that ESBMC checks: the count must
+be less than the LHS width at the point of the shift.
+
+Unsuffixed literal coercion still applies for `&`, `|`, `^` operands: with
+`let x: u64 = ...`, `3 & x` and `x | 0xff` type-check because the literal
+side coerces to `u64`. Use a suffix to force a different type explicitly.
 
 ### Logical Operators
 
@@ -263,14 +321,56 @@ Single `&` is overloaded by position: prefix `&expr` is borrow, while infix `lhs
 
 ### Type Cast
 
+`as` is **widening-only** across integer types. Any narrower integer can be
+cast to any wider integer; signed sources sign-extend, unsigned sources
+zero-extend:
+
 ```vow
-x as u64    // i64 -> u64
-y as i64    // u64 -> i64
+let a: i32 = -1;
+let b: i64 = a as i64;     // sign-extend: -1_i64
+let c: u8  = 200;
+let d: u64 = c as u64;     // zero-extend: 200_u64
+let e: u32 = 1;
+let f: i64 = e as i64;     // unsigned-to-signed widening, value preserved
 ```
 
-The `as` operator converts between `i64` and `u64`. No implicit conversions: `i64 + u64` is a type error.
+`as` between signed and unsigned of **the same width** is also allowed
+(machine-level bit reinterpretation): `i64 as u64`, `u64 as i64`, `i32 as u32`,
+etc.
 
-In debug mode, out-of-range casts (negative i64 to u64, or u64 > i64::MAX to i64) are no-ops at the machine level (bit reinterpretation). In release mode, the same applies.
+**Narrowing via `as` is a compile-time error** (`NarrowingCastNotAllowed`):
+
+```vow
+let big: i64 = 300;
+let small: u8 = big as u8;     // error — narrowing not allowed via `as`
+```
+
+To narrow, use a named intrinsic that makes the intent explicit. For every
+narrowing pair `(src, tgt)` the compiler exposes three free functions:
+
+| Intrinsic                         | Behavior on out-of-range input          |
+|-----------------------------------|-----------------------------------------|
+| `<src>_to_<tgt>_try(x) -> Option<tgt>` | returns `Option::None`             |
+| `<src>_to_<tgt>_wrap(x) -> tgt`   | truncates (low bits, two's-complement)  |
+| `<src>_to_<tgt>_sat(x) -> tgt`    | clamps to the target type's range       |
+
+Example:
+
+```vow
+let big: i64 = 300;
+match i64_to_u8_try(big) {
+    Option::Some(b) => use_byte(b),
+    Option::None    => fallback(),
+}
+```
+
+These intrinsics are emitted by the compiler so ESBMC sees their semantics
+directly in the verification C model.
+
+No implicit conversions: `i64 + u64` and `u8 + i32` are type errors. The
+operands must already have the same type. The compiler does not coerce
+across integer types at operator sites — only literals coerce, per the
+[Integer Literals](#integer-literals) rules.
 
 ## Let Bindings
 
@@ -737,10 +837,42 @@ For pointer-containing C payloads, a wrapper must be written per type: call the 
 
 #### Conversion
 
+**Formatting** uses two baselines; widen via `as` for narrower types:
+
 | Function         | Signature                                  | Effects    |
 |------------------|--------------------------------------------|------------|
+| `int_to_string`  | `fn(v: i64) -> String`                     | `[]`       |
+| `uint_to_string` | `fn(v: u64) -> String`                     | `[]`       |
+| `i64_to_string`  | `fn(v: i64) -> String` (alias of `int_to_string`) | `[]` |
 | `parse_i64`      | `fn(s: String) -> i64`                     | `[]`       |
-| `i64_to_string`  | `fn(v: i64) -> String`                     | `[]`       |
+
+```vow
+let small: u8 = 42;
+print_str(uint_to_string(small as u64));  // widen then format
+```
+
+**Parsing** exposes a try-form for every integer width:
+
+| Function       | Signature                                |
+|----------------|------------------------------------------|
+| `parse_i8`     | `fn(s: String) -> Option<i8>`            |
+| `parse_i16`    | `fn(s: String) -> Option<i16>`           |
+| `parse_i32`    | `fn(s: String) -> Option<i32>`           |
+| `parse_i64`    | `fn(s: String) -> Option<i64>` (also see `String.parse_i64()`) |
+| `parse_i128`   | `fn(s: String) -> Option<i128>`          |
+| `parse_u8`     | `fn(s: String) -> Option<u8>`            |
+| `parse_u16`    | `fn(s: String) -> Option<u16>`           |
+| `parse_u32`    | `fn(s: String) -> Option<u32>`           |
+| `parse_u64`    | `fn(s: String) -> Option<u64>` (also see `String.parse_u64()`) |
+| `parse_u128`   | `fn(s: String) -> Option<u128>`          |
+
+Each `parse_X` returns `Option::None` for malformed input, empty strings, or
+values outside the target type's range.
+
+**Narrowing intrinsics** (per [Type Cast](#type-cast)): for every narrowing
+pair the compiler emits `<src>_to_<tgt>_try`, `<src>_to_<tgt>_wrap`, and
+`<src>_to_<tgt>_sat` free functions with the semantics described in that
+section.
 
 #### Collections
 

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -169,7 +169,7 @@ Structs and enums (see below).
 ```
 
 Unsuffixed integer literals default to `i64` in expression position, and
-**context-coerce** to a narrower or unsigned annotated type when the
+**context-coerce** to any of the 10 integer types when the
 surrounding context fixes one — `let` bindings, function arguments, struct
 fields, and the typed operand of an arithmetic, bitwise, or comparison
 operator. The same coercion applies to constant expressions composed entirely


### PR DESCRIPTION
## Summary

Records the design for the narrow-integer slice of the Vow numeric tower
worked out in a `grill-with-docs` session on 2026-05-22. No implementation
changes — pure docs + spec. Follow-up issues track the tracer-bullet
implementation phases.

- New ADR [`docs/adr/0001-numeric-tower-narrow-ints.md`](../blob/vow/vowNumeric/docs/adr/0001-numeric-tower-narrow-ints.md) capturing 10 decisions
  with rejected alternatives:
  - Width set: full Rust matrix `i8 i16 i32 i64 i128 u8 u16 u32 u64 u128`;
    no `isize/usize` (preserves binary fixed point on 64-bit-only targets).
  - IR: refactor existing per-width opcodes to width-parametric.
  - Casts: widening-only `as`; narrowing via compiler-emitted
    `<src>_to_<tgt>_try / _wrap / _sat` intrinsics.
  - Literals: context-coerce + compile-time range check; `42u8`/`42i128`
    suffixed forms for all 10 widths.
  - Arithmetic operators: keep only `+` (wrapping) and `+!` (checked);
    saturating arithmetic exposed as compiler intrinsics, not operators.
  - Bitwise on all widths; shift count is `u32`; const-expression shift
    `>= bit-width` is a compile error.
  - 128-bit first-class for source/IR/codegen/verify, with `--no-128-verify`
    opt-out for slow predicates.
  - Format/parse: `int_to_string`/`uint_to_string` baselines + per-width
    `parse_X -> Option<X>`.
  - Struct fields stay 8-byte slots (no packing).
  - Rollout: tracer-bullet by width starting with `u8`.

- `docs/spec/grammar.md` updates:
  - Primitive types table expanded to all 10 ints + 128-bit verification
    caveat + struct layout note.
  - Const declarations widened to all 10 ints + bool.
  - Integer Literals rewritten (context-coerce + range check + suffix forms).
  - Type Cast rewritten (widening-only + narrowing intrinsic table).
  - Bitwise Operators rewritten (all widths + `u32` shift count).
  - Conversion subsection restructured (baselines + per-width `parse_X`).

- `docs/spec/errors.md`: adds `LiteralOutOfRange`,
  `NarrowingCastNotAllowed`, `ShiftCountOutOfRange`.

## Compiler-vs-stdlib rule

The session crystallised a working rule that should survive contact with the
float and BigInt subprojects: **a numeric feature belongs in the compiler iff
it requires a new IR opcode, a new type-system axis, or special verifier
modeling; otherwise stdlib.**

## Follow-up issues

Implementation rollout (tracer-bullet by width):
- #523 — Phase 1: `u8` first-class end-to-end (includes width-parametric IR refactor)
- #524 — Phase 2: complete `i32` under the new IR scheme
- #525 — Phase 3: `i8`/`i16`/`u16`/`u32` first-class
- #526 — Phase 4: `i128`/`u128` + Cranelift `I128` validation + ESBMC `__int128` benchmark
- #527 — Widen const declarations to all 10 integer widths (good first issue, depends on phases above)

Out-of-scope subprojects deferred to their own `grill-with-docs` sessions:
- #528 — Float (`f32`/`f64`) subproject design
- #529 — Arbitrary-precision (BigInt / Decimal / Rational) subproject design

## Out of scope (in this PR)

- Floats (`f32`/`f64`) — see #528.
- Arbitrary-precision (BigInt / Decimal / Rational) — see #529.
- Implementation code for any phase — see #523–#527.

## Test plan

- [ ] Manual read of `docs/adr/0001-numeric-tower-narrow-ints.md`.
- [ ] Manual read of grammar.md diff (primitive types, literals, casts,
      bitwise, conversion sections).
- [ ] Manual read of errors.md diff (three new entries).
- No code changes; nothing to compile or test.