### PR TITLE
fix(sat): add overflow guards to lit_var/lit_bucket/lit_value contracts

### DIFF
--- a/examples/sat/types.vow
+++ b/examples/sat/types.vow
@@ -99,7 +99,7 @@ fn is_digit_byte(b: i64) -> bool {
 
 fn lit_var(lit: i64) -> i64 vow {
     requires: lit != 0,
-    requires: lit > -9223372036854775807,
+    requires: lit >= -9223372036854775807,
     ensures: result > 0
 } {
     if lit < 0 {
@@ -124,7 +124,7 @@ fn lit_bucket(lit: i64) -> i64 vow {
 
 fn lit_value(assigns: Vec<i64>, lit: i64) -> i64 vow {
     requires: lit != 0,
-    requires: lit > -9223372036854775807,
+    requires: lit >= -9223372036854775807,
     requires: lit_var(lit) >= 0,
     requires: lit_var(lit) < assigns.len()
 } {

--- a/examples/sat/types.vow
+++ b/examples/sat/types.vow
@@ -111,8 +111,8 @@ fn lit_var(lit: i64) -> i64 vow {
 
 fn lit_bucket(lit: i64) -> i64 vow {
     requires: lit != 0,
-    requires: lit > -4611686018427387904,
-    requires: lit < 4611686018427387904,
+    requires: lit > -4611686018427387905,
+    requires: lit < 4611686018427387905,
     ensures: result >= 0
 } {
     if lit > 0 {

--- a/examples/sat/types.vow
+++ b/examples/sat/types.vow
@@ -99,6 +99,7 @@ fn is_digit_byte(b: i64) -> bool {
 
 fn lit_var(lit: i64) -> i64 vow {
     requires: lit != 0,
+    requires: lit > -9223372036854775807,
     ensures: result > 0
 } {
     if lit < 0 {
@@ -110,6 +111,8 @@ fn lit_var(lit: i64) -> i64 vow {
 
 fn lit_bucket(lit: i64) -> i64 vow {
     requires: lit != 0,
+    requires: lit > -4611686018427387904,
+    requires: lit < 4611686018427387904,
     ensures: result >= 0
 } {
     if lit > 0 {
@@ -121,10 +124,9 @@ fn lit_bucket(lit: i64) -> i64 vow {
 
 fn lit_value(assigns: Vec<i64>, lit: i64) -> i64 vow {
     requires: lit != 0,
+    requires: lit > -9223372036854775807,
     requires: lit_var(lit) >= 0,
-    requires: lit_var(lit) < assigns.len(),
-    ensures: result >= -1,
-    ensures: result <= 1
+    requires: lit_var(lit) < assigns.len()
 } {
     let v: i64 = assigns[lit_var(lit)];
     if lit < 0 {


### PR DESCRIPTION
## Summary

Fixes #504. Tightens three SAT helper contracts in `examples/sat/types.vow` that ESBMC flagged as FAILED due to overflow on negation:

- **`lit_var`**: add `requires: lit > -9223372036854775807` — canonical i64::MIN exclusion (same pattern as `lib/math/arithmetic.vow:abs`)
- **`lit_bucket`**: add two-sided `|lit| < 2^62` bound — ESBMC actually surfaced a *positive-extreme* counterexample at `lit = -(2^62+1)` where `(-lit-1)*2` wraps, not just i64::MIN
- **`lit_value`**: forward the i64::MIN guard for `lit_var` calls in requires; drop weak `ensures: result in [-1,1]` — assigns elements are unconstrained and `forall` is not yet supported, so the postcondition was unverifiable

No solver.vow changes needed — `enqueue` and `lit_removable` verify clean without forwarding.

**Note:** parallel `vowc build` now exposes 4 pre-existing `clause_*` contract bugs in `solver.vow` (cross-vec length mismatch in `Solver` struct) that were previously masked by verifier-time exhaustion on the lit_* failures. These are out of scope for this PR.

## Test plan

- [x] `vowc verify --verify-jobs 1 examples/sat/main.vow` — lit_var, lit_bucket, lit_value all clean
- [x] `examples/sat/run_tests.sh` — 97 items, 0 errors
- [x] `scripts/full_test.sh` — 389 passed, 2 failed (pre-existing OOM), 1 skipped