### PR TITLE
Fix C emitter emitting `return value;` in void functions

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -1081,6 +1081,10 @@ fn emit_inst(out: String, inst: IrInst, f: IrFunction, vec_vars: Vec<i64>, strin
         return;
     }
     if op == IOP_RETURN() {
+        if f.return_ty == ITY_UNIT() {
+            out.push_str(String::from("  return;\n"));
+            return;
+        }
         if iargs.len() > 0 {
             let val_id: i64 = iargs[0];
             if vec_contains_i64(vec_vars, val_id) || vec_contains_i64(string_vars, val_id) || vec_contains_i64(hashmap_vars, val_id) || vec_contains_i64(btreemap_vars, val_id) || vec_contains_i64(option_vars, val_id) {

--- a/tests/verify/void_loop_invariant.vow
+++ b/tests/verify/void_loop_invariant.vow
@@ -3,22 +3,23 @@
 // the fix, the C emitter inserted `return v{N};` inside the C function
 // declared `void`, and ESBMC rejected the model with -Wreturn-mismatch
 // (causing the function to be reported FAILED for the wrong reason).
+//
+// The loop bound is a concrete literal, not a `requires` upper bound on a
+// parameter: ESBMC unwind limits must never be encoded as contract clauses
+// (see the contract-authoring rules — bounds are verification artifacts).
 module VoidLoopInvariant
 
-fn count_up(n: i64) vow {
-  requires: n >= 0,
-  requires: n <= 8
-} {
+fn count_up() {
     let mut i: i64 = 0;
-    while i < n vow {
+    while i < 8 vow {
         invariant: i >= 0,
-        invariant: i <= n
+        invariant: i <= 8
     } {
         i = i + 1;
     }
 }
 
 fn main() -> i32 [io] {
-    count_up(5);
+    count_up();
     0
 }

--- a/tests/verify/void_loop_invariant.vow
+++ b/tests/verify/void_loop_invariant.vow
@@ -1,0 +1,24 @@
+// Regression for issue #506: a void function whose body ends with a
+// vow-annotated while loop must produce a well-formed C model. Before
+// the fix, the C emitter inserted `return v{N};` inside the C function
+// declared `void`, and ESBMC rejected the model with -Wreturn-mismatch
+// (causing the function to be reported FAILED for the wrong reason).
+module VoidLoopInvariant
+
+fn count_up(n: i64) vow {
+  requires: n >= 0,
+  requires: n <= 8
+} {
+    let mut i: i64 = 0;
+    while i < n vow {
+        invariant: i >= 0,
+        invariant: i <= n
+    } {
+        i = i + 1;
+    }
+}
+
+fn main() -> i32 [io] {
+    count_up(5);
+    0
+}

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -700,6 +700,7 @@ fn emit_inst(
     inst_by_id: &HashMap<u32, &Inst>,
     module: &Module,
     limits: &VerifyLimits,
+    func_return_ty: Ty,
 ) {
     let id = inst.id.0;
     match inst.opcode {
@@ -926,7 +927,9 @@ fn emit_inst(
             out.push_str(&format!("  goto block{};\n", target));
         }
         Opcode::Return => {
-            if let Some(&val_id) = inst.args.first() {
+            if func_return_ty == Ty::Unit {
+                out.push_str("  return;\n");
+            } else if let Some(&val_id) = inst.args.first() {
                 if vec_vars.contains(&val_id.0)
                     || string_vars.contains(&val_id.0)
                     || hashmap_vars.contains(&val_id.0)
@@ -1916,6 +1919,7 @@ pub fn emit_c_function_full(
                 &inst_by_id,
                 module,
                 limits,
+                func.return_ty,
             );
         }
         // Emit Upsilons: read all sources first, then write all targets.
@@ -1943,6 +1947,7 @@ pub fn emit_c_function_full(
                 &inst_by_id,
                 module,
                 limits,
+                func.return_ty,
             );
         }
     }
@@ -2539,6 +2544,29 @@ mod tests {
     }
 
     #[test]
+    fn emit_void_function_returns_bare() {
+        // Regression for issue #506: void functions must emit `return;`,
+        // not `return v{N};` or `return 0;`. The IR lowerer always attaches
+        // a ConstUnit value arg to Return, even for source-level `return;`
+        // and implicit fall-through; so the gate must be on the function's
+        // declared return type, not on whether the Return inst has args.
+        let func = make_func(
+            "void_fn",
+            vec![],
+            Ty::Unit,
+            vec![
+                inst(0, Opcode::ConstUnit, Ty::Unit, vec![], InstData::None),
+                inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+            ],
+        );
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+        assert!(c.contains("void void_fn("), "void signature: {c}");
+        assert!(c.contains("  return;\n"), "bare return: {c}");
+        assert!(!c.contains("return v0;"), "no value returned: {c}");
+        assert!(!c.contains("return 0;"), "no value returned: {c}");
+    }
+
+    #[test]
     fn emit_arithmetic_ops() {
         let func = make_func(
             "arith",
@@ -2981,7 +3009,8 @@ mod tests {
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
-        assert!(c.contains("return 0;"), "void return: {c}");
+        assert!(c.contains("return;"), "bare void return: {c}");
+        assert!(!c.contains("return 0;"), "no value in void return: {c}");
     }
 
     #[test]
@@ -5765,6 +5794,7 @@ mod tests {
             &HashMap::new(),
             &empty_module,
             &VerifyLimits::default(),
+            Ty::I64,
         );
         assert!(out.contains("v5 = 42LL;"), "inlined constant: {out}");
     }
@@ -5804,6 +5834,7 @@ mod tests {
             &HashMap::new(),
             &empty_module,
             &VerifyLimits::default(),
+            Ty::I64,
         );
         assert!(
             out.contains("__VERIFIER_nondet_long()"),


### PR DESCRIPTION
## Summary

Closes #506.

- Both C emitters (Rust `vow-verify/src/c_emitter.rs` and self-hosted `compiler/c_emitter.vow`) unconditionally emitted `return v{N};` for every IR `Return` instruction, regardless of the function's declared return type. For void functions this produced invalid C, and ESBMC rejected the model with `-Wreturn-mismatch`, falsely reporting verification failures.
- Gate Return emission on the function's return type: emit bare `return;` when `Ty::Unit` / `ITY_UNIT()`, preserving existing value-return logic for non-void functions.
- Add end-to-end regression fixture `tests/verify/void_loop_invariant.vow` (void function with vow-annotated while loop — the exact bug shape from the issue).

## Test plan

- [x] New Rust unit test `emit_void_function_returns_bare` — asserts `void` signature + bare `return;` + no `return v0;` or `return 0;`
- [x] Updated existing `emit_return_no_value` test (was asserting the buggy `return 0;` for void functions)
- [x] New end-to-end `tests/verify/void_loop_invariant.vow` — passes Section 4b under both compilers
- [x] Manual smoke-test: `examples/sat/main.vow` no longer triggers `-Wreturn-mismatch`
- [x] `cargo test --all` — all pass
- [x] `scripts/full_test.sh` — all pass except pre-existing `issue400_internal_call_root_escape` (unrelated region-pass leak, tracked by #400)