### PR TITLE
build(deps): bump all cranelift crates from 0.131 to 0.132

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,27 +166,27 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008f1a8d1da5074ad858f398775a6d1989031892e46927df5ed18d3be1ed8717"
+checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd76237df1f4e26edb5ad7971d20280ed1e193331fd257f1b4e4dfefd88dda2"
+checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380f0bc43e535df6855bbee649efb00bde39c3f33434c47c8e10ac836d21bf47"
+checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -194,18 +194,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4811e3e4502de04257e90c0a93225b56d9b85e0f9ad10b81446b415511009610"
+checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
 dependencies = [
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ffadb34d497f3e76fb3b4baf764c24ba8a51512976a1b77f78bdbf8f4aa687"
+checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -217,7 +217,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "log",
  "regalloc2",
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4f6992eb6faf086ddc7deaaa5f279abfe7f5fd5ae5709bd38253450fc7b945"
+checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -242,24 +242,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e1b2aad7d055925a4ea9cdbfa9d1d987f9dfc8ad6b708be28f901ac620a298"
+checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a355348325e0a63b65c00def3871597b9fcc79d25456397010d16d872b3772"
+checksum = "f5b19c81145146da1f7afda2e7f52111842fe6793512e740ad5cf3f5639e6212"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f4847d93ce2c80d2bff929aa1004dfb3ce2cf5d881f6ced54b8d654d967ba3"
+checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
 dependencies = [
  "cranelift-bitset",
  "wasmtime-internal-core",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba24e5fe5242cc445e7892ef0a51a4351cf716e3a04ac7a3a05820d056c39818"
+checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -279,15 +279,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bc2035de85c4f04ba7bd57eb5bd3a8b775235bf28852dbf87105115cb8919a"
+checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
 
 [[package]]
 name = "cranelift-module"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680bd0df1ea88dc543eaa6aadf326200640be7603c5f36f9d5c1230b784ad8bc"
+checksum = "28f05d9efce7a4e8c2ceec49c76d26e53f1ee8cb13de822b6ca5118d48f50976"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea6630c16921ab087792750f239d0c0173411e80179ca7c0ce0710ce9e7646a"
+checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.131.1"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6cfa3a6ed5cc9a616cd5ef5dd4d26f683175737b1541679214da7ca12c2b43"
+checksum = "5f7a263727954f7b310796e1b5543e6dfd6afed7e15c62f2454b51b6f38a39e1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4bbad54fc28cc0da1f9a5d7f7f826ec8cafda3d503b401b2daaaa93c63ef0"
+checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
 
 [[package]]
 name = "crc32fast"
@@ -436,9 +436,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashbrown"
@@ -674,13 +671,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash",
  "smallvec",
@@ -1027,11 +1024,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4364d345719bba7fc4c435992ea1cb0c118f1e90a88c6e6f22a7a4fc507700c6"
+checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "target-lexicon",
  "tempfile",
 ]
 
@@ -901,6 +902,7 @@ dependencies = [
  "cranelift-object",
  "object",
  "proptest",
+ "target-lexicon",
  "tempfile",
  "vow-diag",
  "vow-ir",

--- a/vow-clif-shim/Cargo.toml
+++ b/vow-clif-shim/Cargo.toml
@@ -12,6 +12,7 @@ cranelift-frontend = "0.132"
 cranelift-module = "0.132"
 cranelift-object = "0.132"
 cranelift-native = "0.132"
+target-lexicon = "0.13"
 
 [dev-dependencies]
 tempfile = "3"

--- a/vow-clif-shim/Cargo.toml
+++ b/vow-clif-shim/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2024"
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
-cranelift-codegen = "0.131"
-cranelift-frontend = "0.131"
-cranelift-module = "0.131"
-cranelift-object = "0.131"
-cranelift-native = "0.131"
+cranelift-codegen = "0.132"
+cranelift-frontend = "0.132"
+cranelift-module = "0.132"
+cranelift-object = "0.132"
+cranelift-native = "0.132"
 
 [dev-dependencies]
 tempfile = "3"

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -790,6 +790,30 @@ impl FnScratch {
 }
 
 // ---------------------------------------------------------------------------
+// ISA builder with corrected macOS triple
+// ---------------------------------------------------------------------------
+//
+// cranelift-object 0.132 writes LC_BUILD_VERSION into Mach-O .o files.
+// `Triple::host()` on macOS returns `*-apple-darwin`, which maps to
+// PLATFORM_UNKNOWN (0) — the macOS linker rejects this.  Replacing the
+// generic `Darwin` OS with `MacOSX` produces PLATFORM_MACOS instead.
+
+fn native_isa_builder() -> Result<cranelift_codegen::isa::Builder, &'static str> {
+    let mut triple = target_lexicon::Triple::host();
+    if let target_lexicon::OperatingSystem::Darwin(v) = triple.operating_system {
+        triple.operating_system = target_lexicon::OperatingSystem::MacOSX(v);
+    }
+    let mut builder = cranelift_codegen::isa::lookup(triple).map_err(|e| match e {
+        cranelift_codegen::isa::LookupError::SupportDisabled => {
+            "support for architecture disabled at compile time"
+        }
+        cranelift_codegen::isa::LookupError::Unsupported => "unsupported architecture",
+    })?;
+    cranelift_native::infer_native_flags(&mut builder)?;
+    Ok(builder)
+}
+
+// ---------------------------------------------------------------------------
 // FFI: create / destroy
 // ---------------------------------------------------------------------------
 
@@ -811,7 +835,7 @@ pub extern "C" fn __vow_clif_create(mode: i64, trace_mode: i64) -> i64 {
         return 0;
     }
     let flags = settings::Flags::new(flag_builder);
-    let isa = match cranelift_native::builder() {
+    let isa = match native_isa_builder() {
         Ok(b) => match b.finish(flags) {
             Ok(i) => i,
             Err(e) => {

--- a/vow-codegen/Cargo.toml
+++ b/vow-codegen/Cargo.toml
@@ -11,6 +11,7 @@ cranelift-frontend = "0.132"
 cranelift-module = "0.132"
 cranelift-object = "0.132"
 cranelift-native = "0.132"
+target-lexicon = "0.13"
 
 [dev-dependencies]
 vow-syntax = { path = "../vow-syntax" }

--- a/vow-codegen/Cargo.toml
+++ b/vow-codegen/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2024"
 [dependencies]
 vow-ir = { path = "../vow-ir" }
 vow-diag = { path = "../vow-diag" }
-cranelift-codegen = "0.131"
-cranelift-frontend = "0.131"
-cranelift-module = "0.131"
-cranelift-object = "0.131"
-cranelift-native = "0.131"
+cranelift-codegen = "0.132"
+cranelift-frontend = "0.132"
+cranelift-module = "0.132"
+cranelift-object = "0.132"
+cranelift-native = "0.132"
 
 [dev-dependencies]
 vow-syntax = { path = "../vow-syntax" }

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -136,6 +136,22 @@ fn collect_target_block_args(
 // ISA and type helpers
 // ---------------------------------------------------------------------------
 
+// cranelift-object 0.132 writes LC_BUILD_VERSION into Mach-O .o files.
+// `Triple::host()` on macOS returns `*-apple-darwin`, which maps to
+// PLATFORM_UNKNOWN (0) — the macOS linker rejects this.  Replacing the
+// generic `Darwin` OS with `MacOSX` produces PLATFORM_MACOS instead.
+fn native_isa_builder() -> Result<cranelift_codegen::isa::Builder, CodegenError> {
+    let mut triple = target_lexicon::Triple::host();
+    if let target_lexicon::OperatingSystem::Darwin(v) = triple.operating_system {
+        triple.operating_system = target_lexicon::OperatingSystem::MacOSX(v);
+    }
+    let mut builder = cranelift_codegen::isa::lookup(triple)
+        .map_err(|e| CodegenError::IsaBuild(format!("{e:?}")))?;
+    cranelift_native::infer_native_flags(&mut builder)
+        .map_err(|e| CodegenError::IsaBuild(e.to_string()))?;
+    Ok(builder)
+}
+
 fn make_isa(mode: BuildMode) -> Result<Arc<dyn TargetIsa>, CodegenError> {
     let mut flag_builder = settings::builder();
     flag_builder
@@ -150,8 +166,7 @@ fn make_isa(mode: BuildMode) -> Result<Arc<dyn TargetIsa>, CodegenError> {
             .map_err(|e| CodegenError::IsaBuild(e.to_string()))?;
     }
     let flags = settings::Flags::new(flag_builder);
-    cranelift_native::builder()
-        .map_err(|e| CodegenError::IsaBuild(e.to_string()))?
+    native_isa_builder()?
         .finish(flags)
         .map_err(|e| CodegenError::IsaBuild(e.to_string()))
 }


### PR DESCRIPTION
## Summary
- Bumps all 5 cranelift crates (`cranelift-codegen`, `cranelift-frontend`, `cranelift-module`, `cranelift-object`, `cranelift-native`) from 0.131 to 0.132 in both `vow-clif-shim` and `vow-codegen`.
- Supersedes #541 which only bumped `cranelift-codegen` alone, causing type mismatches because all cranelift crates share internal types and must be upgraded together.
- `cargo build --all` and `cargo test --all` pass locally.

Closes #541

## Test plan
- [x] `cargo build --all` succeeds
- [x] `cargo test --all` — all tests pass
- [ ] CI bootstrap + build-and-test pass