### PR TITLE
build(deps): bump cranelift family from 0.131 to 0.132

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      cranelift:
+        patterns:
+          - "cranelift-*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "target-lexicon",
  "tempfile",
 ]
 
@@ -901,6 +902,7 @@ dependencies = [
  "cranelift-object",
  "object",
  "proptest",
+ "target-lexicon",
  "tempfile",
  "vow-diag",
  "vow-ir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,27 +166,27 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008f1a8d1da5074ad858f398775a6d1989031892e46927df5ed18d3be1ed8717"
+checksum = "77c4ebb31662e2051dcc49b7342d222405a99e951720756cc4b93315972abd67"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd76237df1f4e26edb5ad7971d20280ed1e193331fd257f1b4e4dfefd88dda2"
+checksum = "106dfc2ec96ec1c3a8a250602e936712e00a381df032f7a8ad175c8f768c03bb"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380f0bc43e535df6855bbee649efb00bde39c3f33434c47c8e10ac836d21bf47"
+checksum = "5694aa8a2eb2571a15b3feee38d16ccaf2712200e7b5c9ae0479069bdfb46949"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -194,18 +194,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4811e3e4502de04257e90c0a93225b56d9b85e0f9ad10b81446b415511009610"
+checksum = "93ab349d30a5fad9699440ee7ccb435374e8a8735dcca26696a4245bcefcc47e"
 dependencies = [
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ffadb34d497f3e76fb3b4baf764c24ba8a51512976a1b77f78bdbf8f4aa687"
+checksum = "3e95970bdb51d145c828a114a1084cb8b63e65569a51600ad398cb49fa78b062"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -217,7 +217,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "log",
  "regalloc2",
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4f6992eb6faf086ddc7deaaa5f279abfe7f5fd5ae5709bd38253450fc7b945"
+checksum = "0e8414b8ecc81f89f8a3f2c5cbc785b9ed690200cd6f9d780e96a92f88879704"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -242,24 +242,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e1b2aad7d055925a4ea9cdbfa9d1d987f9dfc8ad6b708be28f901ac620a298"
+checksum = "631c4e5db42e6a0f9e7a68f18f7faba3692862114870c7c598aee7e0e5677e59"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a355348325e0a63b65c00def3871597b9fcc79d25456397010d16d872b3772"
+checksum = "09c6e92c825abfbb739a4beaa5db3988f98a96a68d6ea656f562098efc142976"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f4847d93ce2c80d2bff929aa1004dfb3ce2cf5d881f6ced54b8d654d967ba3"
+checksum = "55e57cd185782abada9ab2606bfe88d0abc0d42d83a7d432dcf69991e17fe76e"
 dependencies = [
  "cranelift-bitset",
  "wasmtime-internal-core",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba24e5fe5242cc445e7892ef0a51a4351cf716e3a04ac7a3a05820d056c39818"
+checksum = "8a0f17e48d15e29552e2f264d302c31a661a830196d879bbdaf4d7b2bf2f7011"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -279,15 +279,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bc2035de85c4f04ba7bd57eb5bd3a8b775235bf28852dbf87105115cb8919a"
+checksum = "407b80b46934c9dce9a6581f0e80d079b7a69e11372fb03d7dce4c7ba3fee4e3"
 
 [[package]]
 name = "cranelift-module"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680bd0df1ea88dc543eaa6aadf326200640be7603c5f36f9d5c1230b784ad8bc"
+checksum = "4bd3b5369ba0f409b9b218e2356a71285c6e2815e187329a59db09228fd927c4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea6630c16921ab087792750f239d0c0173411e80179ca7c0ce0710ce9e7646a"
+checksum = "3a40e056e421d9a6c757983f2184f765ae1c28a51555d3877e98afc97ce5705b"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.131.1"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6cfa3a6ed5cc9a616cd5ef5dd4d26f683175737b1541679214da7ca12c2b43"
+checksum = "f306796804a85973d7336671c7ea7f280def13c33a6ac20d84d12c1ea16e0837"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.2"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4bbad54fc28cc0da1f9a5d7f7f826ec8cafda3d503b401b2daaaa93c63ef0"
+checksum = "2cdbadda21e49798825a1ec795dab30bcb03235891f662b5ccf23fa45b39682f"
 
 [[package]]
 name = "crc32fast"
@@ -436,9 +436,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashbrown"
@@ -674,13 +671,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash",
  "smallvec",
@@ -1027,11 +1024,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.2"
+version = "45.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4364d345719bba7fc4c435992ea1cb0c118f1e90a88c6e6f22a7a4fc507700c6"
+checksum = "110bf85122cd451d3b9ff67f8911d428ec9b729208abe950a0333c3244660e88"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
 ]
 

--- a/vow-clif-shim/Cargo.toml
+++ b/vow-clif-shim/Cargo.toml
@@ -12,6 +12,7 @@ cranelift-frontend = "0.132"
 cranelift-module = "0.132"
 cranelift-object = "0.132"
 cranelift-native = "0.132"
+target-lexicon = "0.13"
 
 [dev-dependencies]
 tempfile = "3"

--- a/vow-clif-shim/Cargo.toml
+++ b/vow-clif-shim/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2024"
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
-cranelift-codegen = "0.131"
-cranelift-frontend = "0.131"
-cranelift-module = "0.131"
-cranelift-object = "0.131"
-cranelift-native = "0.131"
+cranelift-codegen = "0.132"
+cranelift-frontend = "0.132"
+cranelift-module = "0.132"
+cranelift-object = "0.132"
+cranelift-native = "0.132"
 
 [dev-dependencies]
 tempfile = "3"

--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -31,13 +31,14 @@ use cranelift_codegen::ir::{
     AbiParam, Block, FuncRef, GlobalValue, InstBuilder, MemFlags, Signature, StackSlot,
     StackSlotData, StackSlotKind, TrapCode, Value, types,
 };
-use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::isa::{self, TargetIsa};
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{
     DataDescription, DataId, FuncId as CraneliftFuncId, Linkage, Module as CraneliftModule,
 };
 use cranelift_object::{ObjectBuilder, ObjectModule};
+use target_lexicon::{OperatingSystem, Triple};
 
 // ---------------------------------------------------------------------------
 // VowVec layout: { ptr: *mut u8, len: usize, cap: usize } = 24 bytes
@@ -793,6 +794,19 @@ impl FnScratch {
 // FFI: create / destroy
 // ---------------------------------------------------------------------------
 
+// `Triple::host()` reports macOS as `*-apple-darwin`. cranelift-object 0.132
+// maps a `Darwin` OS to Mach-O `PLATFORM_UNKNOWN` when writing its new
+// `LC_BUILD_VERSION` load command, which the macOS linker rejects with
+// "unknown platform". Rewriting `Darwin` to `MacOSX` yields `PLATFORM_MACOS`.
+// Every non-Darwin host (e.g. Linux/ELF) is returned unchanged.
+fn host_triple() -> Triple {
+    let mut triple = Triple::host();
+    if let OperatingSystem::Darwin(v) = triple.operating_system {
+        triple.operating_system = OperatingSystem::MacOSX(v);
+    }
+    triple
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __vow_clif_create(mode: i64, trace_mode: i64) -> i64 {
     let mut flag_builder = settings::builder();
@@ -811,16 +825,21 @@ pub extern "C" fn __vow_clif_create(mode: i64, trace_mode: i64) -> i64 {
         return 0;
     }
     let flags = settings::Flags::new(flag_builder);
-    let isa = match cranelift_native::builder() {
-        Ok(b) => match b.finish(flags) {
-            Ok(i) => i,
-            Err(e) => {
-                eprintln!("clif_shim: ISA build error: {e}");
-                return 0;
-            }
-        },
+    let mut isa_builder = match isa::lookup(host_triple()) {
+        Ok(b) => b,
         Err(e) => {
-            eprintln!("clif_shim: native builder error: {e}");
+            eprintln!("clif_shim: isa lookup error: {e}");
+            return 0;
+        }
+    };
+    if let Err(e) = cranelift_native::infer_native_flags(&mut isa_builder) {
+        eprintln!("clif_shim: infer native flags error: {e}");
+        return 0;
+    }
+    let isa = match isa_builder.finish(flags) {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("clif_shim: ISA build error: {e}");
             return 0;
         }
     };

--- a/vow-codegen/Cargo.toml
+++ b/vow-codegen/Cargo.toml
@@ -11,6 +11,7 @@ cranelift-frontend = "0.132"
 cranelift-module = "0.132"
 cranelift-object = "0.132"
 cranelift-native = "0.132"
+target-lexicon = "0.13"
 
 [dev-dependencies]
 vow-syntax = { path = "../vow-syntax" }

--- a/vow-codegen/Cargo.toml
+++ b/vow-codegen/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2024"
 [dependencies]
 vow-ir = { path = "../vow-ir" }
 vow-diag = { path = "../vow-diag" }
-cranelift-codegen = "0.131"
-cranelift-frontend = "0.131"
-cranelift-module = "0.131"
-cranelift-object = "0.131"
-cranelift-native = "0.131"
+cranelift-codegen = "0.132"
+cranelift-frontend = "0.132"
+cranelift-module = "0.132"
+cranelift-object = "0.132"
+cranelift-native = "0.132"
 
 [dev-dependencies]
 vow-syntax = { path = "../vow-syntax" }

--- a/vow-codegen/src/cranelift_backend.rs
+++ b/vow-codegen/src/cranelift_backend.rs
@@ -4,7 +4,7 @@ use cranelift_codegen::ir::{
     AbiParam, Block, BlockArg, FuncRef, GlobalValue, InstBuilder, MemFlags, Signature, StackSlot,
     StackSlotData, StackSlotKind, TrapCode, Value, types,
 };
-use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::isa::{self, TargetIsa};
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{
@@ -13,6 +13,7 @@ use cranelift_module::{
 use cranelift_object::{ObjectBuilder, ObjectModule};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
+use target_lexicon::{OperatingSystem, Triple};
 use vow_ir::{
     BlockId, FuncId as IrFuncId, Function as IrFunction, HiddenRegionIdx, Inst, InstData, InstId,
     Module as IrModule, Opcode, RegionConstraint, RegionId, RegionSummary, Ty as IrTy,
@@ -150,10 +151,26 @@ fn make_isa(mode: BuildMode) -> Result<Arc<dyn TargetIsa>, CodegenError> {
             .map_err(|e| CodegenError::IsaBuild(e.to_string()))?;
     }
     let flags = settings::Flags::new(flag_builder);
-    cranelift_native::builder()
-        .map_err(|e| CodegenError::IsaBuild(e.to_string()))?
+    let mut isa_builder =
+        isa::lookup(host_triple()).map_err(|e| CodegenError::IsaBuild(e.to_string()))?;
+    cranelift_native::infer_native_flags(&mut isa_builder)
+        .map_err(|e| CodegenError::IsaBuild(e.to_string()))?;
+    isa_builder
         .finish(flags)
         .map_err(|e| CodegenError::IsaBuild(e.to_string()))
+}
+
+// `Triple::host()` reports macOS as `*-apple-darwin`. cranelift-object 0.132
+// maps a `Darwin` OS to Mach-O `PLATFORM_UNKNOWN` when writing its new
+// `LC_BUILD_VERSION` load command, which the macOS linker rejects with
+// "unknown platform". Rewriting `Darwin` to `MacOSX` yields `PLATFORM_MACOS`.
+// Every non-Darwin host (e.g. Linux/ELF) is returned unchanged.
+fn host_triple() -> Triple {
+    let mut triple = Triple::host();
+    if let OperatingSystem::Darwin(v) = triple.operating_system {
+        triple.operating_system = OperatingSystem::MacOSX(v);
+    }
+    triple
 }
 
 fn ir_ty_to_cranelift(ty: IrTy) -> Option<types::Type> {


### PR DESCRIPTION
Consolidates the four open Dependabot cranelift PRs into one atomic bump.

## Why one PR
The cranelift crates (`cranelift-codegen`, `-frontend`, `-module`, `-object`, `-native`) all share `cranelift-codegen`. Dependabot opens **one PR per crate**, each bumping a single crate to `0.132` while leaving the others at `^0.131`. That resolves **two incompatible `cranelift-codegen` versions** (0.131.x + 0.132.x) into the build:

```
Compiling cranelift-codegen v0.131.2
Compiling cranelift-codegen v0.132.0
help: trait `Module` ... is implemented but not in scope
```

The `Module` trait from the bumped crate no longer applies to the other crates' `FunctionBuilder`/object-module types, so every single-crate PR fails `cargo build`. The family must move together.

## What this does
- Bumps all five cranelift deps `0.131` → `0.132` in `vow-codegen/Cargo.toml` and `vow-clif-shim/Cargo.toml`; `Cargo.lock` unified at **0.132.1** (single `cranelift-codegen`).
- Adds a dependabot `cranelift` group so future `cranelift-*` updates arrive as one combined PR.

## Verification (local, Rust workspace)
- `cargo build --all` ✓
- `cargo clippy --all -- -D warnings` ✓ (zero warnings)
- `cargo test --all` ✓ (0 failures)

Full self-hosted `bootstrap` + `full_test.sh` run as CI on this PR.

Supersedes #560, #561, #562, #563.

> **Merge policy:** per CLAUDE.md, merge via merge commit (`gh pr merge --merge`) — not squash/rebase.