### PR TITLE
feat(contracts): static contract-quality classifier (#81)

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3883,7 +3883,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Quality Values\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the \"proven but trivial\" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.\n"));
+    r.push_str(String::from("`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the \"proven but trivial\" problem: a `weak` contract can be `proven` while constraining almost nothing. See `docs/spec/contracts-methodology.md` for the full taxonomy.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("| Quality        | Meaning                                                                                      |\n"));
     r.push_str(String::from("|----------------|----------------------------------------------------------------------------------------------|\n"));
@@ -7041,7 +7041,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Quality Values\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the \"proven but trivial\" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.\n"));
+    r.push_str(String::from("`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the \"proven but trivial\" problem: a `weak` contract can be `proven` while constraining almost nothing. See `docs/spec/contracts-methodology.md` for the full taxonomy.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("| Quality        | Meaning                                                                                      |\n"));
     r.push_str(String::from("|----------------|----------------------------------------------------------------------------------------------|\n"));

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3827,10 +3827,11 @@ fn skill_bundle() -> String {
     r.push_str(String::from("      \"description\": \"requires y != 0\",\n"));
     r.push_str(String::from("      \"blame\": \"Caller\",\n"));
     r.push_str(String::from("      \"source\": { \"file\": \"divide.vow\", \"offset\": 42 },\n"));
-    r.push_str(String::from("      \"status\": \"not_verified\"\n"));
+    r.push_str(String::from("      \"status\": \"not_verified\",\n"));
+    r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0 }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -3846,10 +3847,11 @@ fn skill_bundle() -> String {
     r.push_str(String::from("      \"description\": \"requires y != 0\",\n"));
     r.push_str(String::from("      \"blame\": \"Caller\",\n"));
     r.push_str(String::from("      \"source\": { \"file\": \"divide.vow\", \"offset\": 42 },\n"));
-    r.push_str(String::from("      \"status\": \"proven\"\n"));
+    r.push_str(String::from("      \"status\": \"proven\",\n"));
+    r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0 }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -3864,6 +3866,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `blame`       | string  | `\"Caller\"` (requires) or `\"Callee\"` (ensures/invariant)  |\n"));
     r.push_str(String::from("| `source`      | object  | `{ \"file\": string, \"offset\": integer }`                  |\n"));
     r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, `\"not_verified\"`, or `\"skipped\"` |\n"));
+    r.push_str(String::from("| `quality`     | string  | Static clause-shape classification (no ESBMC): `\"weak\"`, `\"tautological\"`, or `\"substantive\"` |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Status Values\n"));
     r.push_str(String::from("\n"));
@@ -3877,6 +3880,16 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `timeout`       | ESBMC timed out on the containing function (BV and -- when applicable -- IR fallback both timed out) |\n"));
     r.push_str(String::from("| `error`         | ESBMC error or tool not found                        |\n"));
     r.push_str(String::from("| `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) -- use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("### Quality Values\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the \"proven but trivial\" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("| Quality        | Meaning                                                                                      |\n"));
+    r.push_str(String::from("|----------------|----------------------------------------------------------------------------------------------|\n"));
+    r.push_str(String::from("| `weak`         | An `ensures` that only bounds `result` by an integer literal (e.g. `result >= 0`). Satisfied by almost any implementation. |\n"));
+    r.push_str(String::from("| `tautological` | A constant clause that references no program value (e.g. `true`, `0 >= 0`). Constrains nothing. |\n"));
+    r.push_str(String::from("| `substantive`  | Everything else -- equality, relational, inverse/round-trip, dispatch-totality, or function-call shapes. The classifier is conservative: anything not provably weak/tautological is reported `substantive`. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Trace Output (stderr, --debug-trace)\n"));
     r.push_str(String::from("\n"));
@@ -5329,7 +5342,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("      \"type\": \"array\",\n"));
     r.push_str(String::from("      \"items\": {\n"));
     r.push_str(String::from("        \"type\": \"object\",\n"));
-    r.push_str(String::from("        \"required\": [\"vow_id\", \"function\", \"kind\", \"description\", \"blame\", \"source\", \"status\"],\n"));
+    r.push_str(String::from("        \"required\": [\"vow_id\", \"function\", \"kind\", \"description\", \"blame\", \"source\", \"status\", \"quality\"],\n"));
     r.push_str(String::from("        \"properties\": {\n"));
     r.push_str(String::from("          \"vow_id\": {\n"));
     r.push_str(String::from("            \"type\": \"integer\",\n"));
@@ -5372,6 +5385,11 @@ fn skill_bundle() -> String {
     r.push_str(String::from("            \"type\": \"string\",\n"));
     r.push_str(String::from("            \"enum\": [\"proven\", \"proven-ir\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\", \"skipped\"],\n"));
     r.push_str(String::from("            \"description\": \"Verification status\"\n"));
+    r.push_str(String::from("          },\n"));
+    r.push_str(String::from("          \"quality\": {\n"));
+    r.push_str(String::from("            \"type\": \"string\",\n"));
+    r.push_str(String::from("            \"enum\": [\"weak\", \"tautological\", \"substantive\"],\n"));
+    r.push_str(String::from("            \"description\": \"Static, no-ESBMC classification of the clause shape: weak (an ensures that only bounds result by a constant), tautological (constant clause that says nothing), or substantive (equality/relational/inverse/call). See contracts-methodology.md\"\n"));
     r.push_str(String::from("          }\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        \"additionalProperties\": false\n"));
@@ -5379,7 +5397,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"summary\": {\n"));
     r.push_str(String::from("      \"type\": \"object\",\n"));
-    r.push_str(String::from("      \"required\": [\"total\", \"proven\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\", \"skipped\"],\n"));
+    r.push_str(String::from("      \"required\": [\"total\", \"proven\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\", \"skipped\", \"quality\"],\n"));
     r.push_str(String::from("      \"properties\": {\n"));
     r.push_str(String::from("        \"total\": { \"type\": \"integer\" },\n"));
     r.push_str(String::from("        \"proven\": { \"type\": \"integer\" },\n"));
@@ -5388,7 +5406,18 @@ fn skill_bundle() -> String {
     r.push_str(String::from("        \"timeout\": { \"type\": \"integer\" },\n"));
     r.push_str(String::from("        \"error\": { \"type\": \"integer\" },\n"));
     r.push_str(String::from("        \"not_verified\": { \"type\": \"integer\" },\n"));
-    r.push_str(String::from("        \"skipped\": { \"type\": \"integer\" }\n"));
+    r.push_str(String::from("        \"skipped\": { \"type\": \"integer\" },\n"));
+    r.push_str(String::from("        \"quality\": {\n"));
+    r.push_str(String::from("          \"type\": \"object\",\n"));
+    r.push_str(String::from("          \"description\": \"Static contract-quality tallies independent of verification status\",\n"));
+    r.push_str(String::from("          \"required\": [\"weak\", \"tautological\", \"substantive\"],\n"));
+    r.push_str(String::from("          \"properties\": {\n"));
+    r.push_str(String::from("            \"weak\": { \"type\": \"integer\" },\n"));
+    r.push_str(String::from("            \"tautological\": { \"type\": \"integer\" },\n"));
+    r.push_str(String::from("            \"substantive\": { \"type\": \"integer\" }\n"));
+    r.push_str(String::from("          },\n"));
+    r.push_str(String::from("          \"additionalProperties\": false\n"));
+    r.push_str(String::from("        }\n"));
     r.push_str(String::from("      },\n"));
     r.push_str(String::from("      \"additionalProperties\": false\n"));
     r.push_str(String::from("    }\n"));
@@ -6956,10 +6985,11 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("      \"description\": \"requires y != 0\",\n"));
     r.push_str(String::from("      \"blame\": \"Caller\",\n"));
     r.push_str(String::from("      \"source\": { \"file\": \"divide.vow\", \"offset\": 42 },\n"));
-    r.push_str(String::from("      \"status\": \"not_verified\"\n"));
+    r.push_str(String::from("      \"status\": \"not_verified\",\n"));
+    r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0 }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -6975,10 +7005,11 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("      \"description\": \"requires y != 0\",\n"));
     r.push_str(String::from("      \"blame\": \"Caller\",\n"));
     r.push_str(String::from("      \"source\": { \"file\": \"divide.vow\", \"offset\": 42 },\n"));
-    r.push_str(String::from("      \"status\": \"proven\"\n"));
+    r.push_str(String::from("      \"status\": \"proven\",\n"));
+    r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0 }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -6993,6 +7024,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `blame`       | string  | `\"Caller\"` (requires) or `\"Callee\"` (ensures/invariant)  |\n"));
     r.push_str(String::from("| `source`      | object  | `{ \"file\": string, \"offset\": integer }`                  |\n"));
     r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, `\"not_verified\"`, or `\"skipped\"` |\n"));
+    r.push_str(String::from("| `quality`     | string  | Static clause-shape classification (no ESBMC): `\"weak\"`, `\"tautological\"`, or `\"substantive\"` |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Status Values\n"));
     r.push_str(String::from("\n"));
@@ -7006,6 +7038,16 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `timeout`       | ESBMC timed out on the containing function (BV and -- when applicable -- IR fallback both timed out) |\n"));
     r.push_str(String::from("| `error`         | ESBMC error or tool not found                        |\n"));
     r.push_str(String::from("| `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) -- use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("### Quality Values\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the \"proven but trivial\" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("| Quality        | Meaning                                                                                      |\n"));
+    r.push_str(String::from("|----------------|----------------------------------------------------------------------------------------------|\n"));
+    r.push_str(String::from("| `weak`         | An `ensures` that only bounds `result` by an integer literal (e.g. `result >= 0`). Satisfied by almost any implementation. |\n"));
+    r.push_str(String::from("| `tautological` | A constant clause that references no program value (e.g. `true`, `0 >= 0`). Constrains nothing. |\n"));
+    r.push_str(String::from("| `substantive`  | Everything else -- equality, relational, inverse/round-trip, dispatch-totality, or function-call shapes. The classifier is conservative: anything not provably weak/tautological is reported `substantive`. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Trace Output (stderr, --debug-trace)\n"));
     r.push_str(String::from("\n"));
@@ -8461,7 +8503,7 @@ fn skill_support_content_6() -> String {
     r.push_str(String::from("      \"type\": \"array\",\n"));
     r.push_str(String::from("      \"items\": {\n"));
     r.push_str(String::from("        \"type\": \"object\",\n"));
-    r.push_str(String::from("        \"required\": [\"vow_id\", \"function\", \"kind\", \"description\", \"blame\", \"source\", \"status\"],\n"));
+    r.push_str(String::from("        \"required\": [\"vow_id\", \"function\", \"kind\", \"description\", \"blame\", \"source\", \"status\", \"quality\"],\n"));
     r.push_str(String::from("        \"properties\": {\n"));
     r.push_str(String::from("          \"vow_id\": {\n"));
     r.push_str(String::from("            \"type\": \"integer\",\n"));
@@ -8504,6 +8546,11 @@ fn skill_support_content_6() -> String {
     r.push_str(String::from("            \"type\": \"string\",\n"));
     r.push_str(String::from("            \"enum\": [\"proven\", \"proven-ir\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\", \"skipped\"],\n"));
     r.push_str(String::from("            \"description\": \"Verification status\"\n"));
+    r.push_str(String::from("          },\n"));
+    r.push_str(String::from("          \"quality\": {\n"));
+    r.push_str(String::from("            \"type\": \"string\",\n"));
+    r.push_str(String::from("            \"enum\": [\"weak\", \"tautological\", \"substantive\"],\n"));
+    r.push_str(String::from("            \"description\": \"Static, no-ESBMC classification of the clause shape: weak (an ensures that only bounds result by a constant), tautological (constant clause that says nothing), or substantive (equality/relational/inverse/call). See contracts-methodology.md\"\n"));
     r.push_str(String::from("          }\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        \"additionalProperties\": false\n"));
@@ -8511,7 +8558,7 @@ fn skill_support_content_6() -> String {
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"summary\": {\n"));
     r.push_str(String::from("      \"type\": \"object\",\n"));
-    r.push_str(String::from("      \"required\": [\"total\", \"proven\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\", \"skipped\"],\n"));
+    r.push_str(String::from("      \"required\": [\"total\", \"proven\", \"failed\", \"unknown\", \"timeout\", \"error\", \"not_verified\", \"skipped\", \"quality\"],\n"));
     r.push_str(String::from("      \"properties\": {\n"));
     r.push_str(String::from("        \"total\": { \"type\": \"integer\" },\n"));
     r.push_str(String::from("        \"proven\": { \"type\": \"integer\" },\n"));
@@ -8520,7 +8567,18 @@ fn skill_support_content_6() -> String {
     r.push_str(String::from("        \"timeout\": { \"type\": \"integer\" },\n"));
     r.push_str(String::from("        \"error\": { \"type\": \"integer\" },\n"));
     r.push_str(String::from("        \"not_verified\": { \"type\": \"integer\" },\n"));
-    r.push_str(String::from("        \"skipped\": { \"type\": \"integer\" }\n"));
+    r.push_str(String::from("        \"skipped\": { \"type\": \"integer\" },\n"));
+    r.push_str(String::from("        \"quality\": {\n"));
+    r.push_str(String::from("          \"type\": \"object\",\n"));
+    r.push_str(String::from("          \"description\": \"Static contract-quality tallies independent of verification status\",\n"));
+    r.push_str(String::from("          \"required\": [\"weak\", \"tautological\", \"substantive\"],\n"));
+    r.push_str(String::from("          \"properties\": {\n"));
+    r.push_str(String::from("            \"weak\": { \"type\": \"integer\" },\n"));
+    r.push_str(String::from("            \"tautological\": { \"type\": \"integer\" },\n"));
+    r.push_str(String::from("            \"substantive\": { \"type\": \"integer\" }\n"));
+    r.push_str(String::from("          },\n"));
+    r.push_str(String::from("          \"additionalProperties\": false\n"));
+    r.push_str(String::from("        }\n"));
     r.push_str(String::from("      },\n"));
     r.push_str(String::from("      \"additionalProperties\": false\n"));
     r.push_str(String::from("    }\n"));
@@ -9071,6 +9129,130 @@ fn vow_kind_from_desc(desc: String) -> String {
     String::from("unknown")
 }
 
+// Static contract-quality classification of a clause by shape (no ESBMC).
+// Mirrors classify_contract_quality in vow/src/main.rs. See
+// docs/spec/contracts-methodology.md for the methodology.
+
+fn cq_byte_is_alpha(b: i64) -> bool {
+    (b >= 65 && b <= 90) || (b >= 97 && b <= 122)
+}
+
+fn cq_has_alpha(s: String) -> bool {
+    let n: i64 = s.len();
+    let mut i: i64 = 0;
+    while i < n {
+        if cq_byte_is_alpha(s.byte_at(i)) {
+            return true;
+        }
+        i = i + 1;
+    }
+    false
+}
+
+fn cq_is_int_literal(s: String) -> bool {
+    let t: String = str_trim(s);
+    let n: i64 = t.len();
+    if n == 0 {
+        return false;
+    }
+    let mut i: i64 = 0;
+    if t.byte_at(0) == 45 {
+        if n == 1 {
+            return false;
+        }
+        i = 1;
+    }
+    while i < n {
+        let b: i64 = t.byte_at(i);
+        if b < 48 || b > 57 {
+            return false;
+        }
+        i = i + 1;
+    }
+    true
+}
+
+// Strip the leading requires/ensures/invariant keyword, leaving the predicate.
+// clause descriptions are formatted as "{kind} {printed_expr}".
+fn cq_predicate(desc: String) -> String {
+    let sp: i64 = str_find_byte(desc, 32);
+    if sp < 0 {
+        return String::from("");
+    }
+    str_trim(str_substring(desc, sp + 1, desc.len()))
+}
+
+fn cq_side_has_ordering(s: String) -> bool {
+    str_contains_byte(s, 60) || str_contains_byte(s, 62)
+}
+
+fn cq_weak_sides(lhs: String, rhs: String) -> bool {
+    let l: String = str_trim(lhs);
+    let r: String = str_trim(rhs);
+    if cq_side_has_ordering(l) || cq_side_has_ordering(r) {
+        return false;
+    }
+    let result_s: String = String::from("result");
+    (l == result_s && cq_is_int_literal(r)) || (r == result_s && cq_is_int_literal(l))
+}
+
+// True for a single ordering comparison between `result` and an integer literal.
+fn cq_is_weak_result_bound(pred: String) -> bool {
+    if str_find_str(pred, String::from("&&")) >= 0 {
+        return false;
+    }
+    if str_find_str(pred, String::from("||")) >= 0 {
+        return false;
+    }
+    if str_find_str(pred, String::from("==")) >= 0 {
+        return false;
+    }
+    if str_find_str(pred, String::from("!=")) >= 0 {
+        return false;
+    }
+    if str_contains_byte(pred, 40) {
+        return false;
+    }
+    let n: i64 = pred.len();
+    let p_le: i64 = str_find_str(pred, String::from("<="));
+    if p_le >= 0 {
+        return cq_weak_sides(str_substring(pred, 0, p_le), str_substring(pred, p_le + 2, n));
+    }
+    let p_ge: i64 = str_find_str(pred, String::from(">="));
+    if p_ge >= 0 {
+        return cq_weak_sides(str_substring(pred, 0, p_ge), str_substring(pred, p_ge + 2, n));
+    }
+    let p_lt: i64 = str_find_byte(pred, 60);
+    if p_lt >= 0 {
+        return cq_weak_sides(str_substring(pred, 0, p_lt), str_substring(pred, p_lt + 1, n));
+    }
+    let p_gt: i64 = str_find_byte(pred, 62);
+    if p_gt >= 0 {
+        return cq_weak_sides(str_substring(pred, 0, p_gt), str_substring(pred, p_gt + 1, n));
+    }
+    false
+}
+
+fn cq_classify(kind: String, desc: String) -> String {
+    let pred: String = cq_predicate(desc);
+    if pred.len() == 0 {
+        return String::from("tautological");
+    }
+    if pred == String::from("true") {
+        return String::from("tautological");
+    }
+    if pred == String::from("false") {
+        return String::from("tautological");
+    }
+    if !cq_has_alpha(pred) {
+        return String::from("tautological");
+    }
+    if kind == String::from("ensures") && cq_is_weak_result_bound(pred) {
+        return String::from("weak");
+    }
+    String::from("substantive")
+}
+
 fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let path: String = frontend_path_from_argv(argv, true);
     let fr: LoweredFrontend = frontend_lower_path(path);
@@ -9122,6 +9304,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let e_files: Vec<String> = Vec::new();
     let e_offsets: Vec<i64> = Vec::new();
     let e_statuses: Vec<String> = Vec::new();
+    let e_qualities: Vec<String> = Vec::new();
 
     let nf: i64 = ir_mod.functions.len();
     let mut fi: i64 = 0;
@@ -9131,11 +9314,14 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
         let mut vi: i64 = 0;
         while vi < nv {
             let ve: IrVowEntry = func.vows[vi];
+            let ve_desc: String = ve.description;
+            let ve_kind: String = vow_kind_from_desc(ve_desc);
             e_vow_ids.push(ve.id);
             e_func_ids.push(func.id);
             e_func_names.push(func.name);
-            e_kinds.push(vow_kind_from_desc(ve.description));
-            e_descs.push(ve.description);
+            e_kinds.push(ve_kind);
+            e_descs.push(ve_desc);
+            e_qualities.push(cq_classify(ve_kind, ve_desc));
             if ve.blame == BLAME_CALLER() {
                 e_blames.push(String::from("Caller"));
             } else {
@@ -9231,6 +9417,8 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
         json.push_str(i64_to_str(e_offsets[ci]));
         json.push_str(String::from("},\"status\":\""));
         json.push_str(e_statuses[ci]);
+        json.push_str(String::from("\",\"quality\":\""));
+        json.push_str(e_qualities[ci]);
         json.push_str(String::from("\"}"));
         ci = ci + 1;
     }
@@ -9264,6 +9452,23 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
         si = si + 1;
     }
 
+    // Static contract-quality tallies (independent of verification status).
+    let n_weak: i64 = 0;
+    let n_taut: i64 = 0;
+    let n_subst: i64 = 0;
+    let mut qi: i64 = 0;
+    while qi < total {
+        let q: String = e_qualities[qi];
+        if q == String::from("weak") {
+            n_weak = n_weak + 1;
+        } else if q == String::from("tautological") {
+            n_taut = n_taut + 1;
+        } else {
+            n_subst = n_subst + 1;
+        }
+        qi = qi + 1;
+    }
+
     json.push_str(String::from("],\"summary\":{\"total\":"));
     json.push_str(i64_to_str(total));
     json.push_str(String::from(",\"proven\":"));
@@ -9280,7 +9485,13 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     json.push_str(i64_to_str(n_not_verified));
     json.push_str(String::from(",\"skipped\":"));
     json.push_str(i64_to_str(n_skipped));
-    json.push_str(String::from("}}"));
+    json.push_str(String::from(",\"quality\":{\"weak\":"));
+    json.push_str(i64_to_str(n_weak));
+    json.push_str(String::from(",\"tautological\":"));
+    json.push_str(i64_to_str(n_taut));
+    json.push_str(String::from(",\"substantive\":"));
+    json.push_str(i64_to_str(n_subst));
+    json.push_str(String::from("}}}"));
     print_str(json);
     exit_code
 }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -9241,9 +9241,6 @@ fn cq_classify(kind: String, desc: String) -> String {
     if pred == String::from("true") {
         return String::from("tautological");
     }
-    if pred == String::from("false") {
-        return String::from("tautological");
-    }
     if !cq_has_alpha(pred) {
         return String::from("tautological");
     }

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -398,7 +398,7 @@ that path produces `Unverified` (exit 0).
 
 ### Quality Values
 
-`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.
+`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See `docs/spec/contracts-methodology.md` for the full taxonomy.
 
 | Quality        | Meaning                                                                                      |
 |----------------|----------------------------------------------------------------------------------------------|

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -342,10 +342,11 @@ that path produces `Unverified` (exit 0).
       "description": "requires y != 0",
       "blame": "Caller",
       "source": { "file": "divide.vow", "offset": 42 },
-      "status": "not_verified"
+      "status": "not_verified",
+      "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0 }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -361,10 +362,11 @@ that path produces `Unverified` (exit 0).
       "description": "requires y != 0",
       "blame": "Caller",
       "source": { "file": "divide.vow", "offset": 42 },
-      "status": "proven"
+      "status": "proven",
+      "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0 }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -379,6 +381,7 @@ that path produces `Unverified` (exit 0).
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
 | `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
+| `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
 
 ### Status Values
 
@@ -392,6 +395,16 @@ that path produces `Unverified` (exit 0).
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) — use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |
+
+### Quality Values
+
+`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.
+
+| Quality        | Meaning                                                                                      |
+|----------------|----------------------------------------------------------------------------------------------|
+| `weak`         | An `ensures` that only bounds `result` by an integer literal (e.g. `result >= 0`). Satisfied by almost any implementation. |
+| `tautological` | A constant clause that references no program value (e.g. `true`, `0 >= 0`). Constrains nothing. |
+| `substantive`  | Everything else — equality, relational, inverse/round-trip, dispatch-totality, or function-call shapes. The classifier is conservative: anything not provably weak/tautological is reported `substantive`. |
 
 ## Trace Output (stderr, --debug-trace)
 

--- a/docs/spec/schemas/contracts-result.schema.json
+++ b/docs/spec/schemas/contracts-result.schema.json
@@ -10,7 +10,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["vow_id", "function", "kind", "description", "blame", "source", "status"],
+        "required": ["vow_id", "function", "kind", "description", "blame", "source", "status", "quality"],
         "properties": {
           "vow_id": {
             "type": "integer",
@@ -53,6 +53,11 @@
             "type": "string",
             "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
             "description": "Verification status"
+          },
+          "quality": {
+            "type": "string",
+            "enum": ["weak", "tautological", "substantive"],
+            "description": "Static, no-ESBMC classification of the clause shape: weak (an ensures that only bounds result by a constant), tautological (constant clause that says nothing), or substantive (equality/relational/inverse/call). See contracts-methodology.md"
           }
         },
         "additionalProperties": false
@@ -60,7 +65,7 @@
     },
     "summary": {
       "type": "object",
-      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
+      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified", "skipped", "quality"],
       "properties": {
         "total": { "type": "integer" },
         "proven": { "type": "integer" },
@@ -69,7 +74,18 @@
         "timeout": { "type": "integer" },
         "error": { "type": "integer" },
         "not_verified": { "type": "integer" },
-        "skipped": { "type": "integer" }
+        "skipped": { "type": "integer" },
+        "quality": {
+          "type": "object",
+          "description": "Static contract-quality tallies independent of verification status",
+          "required": ["weak", "tautological", "substantive"],
+          "properties": {
+            "weak": { "type": "integer" },
+            "tautological": { "type": "integer" },
+            "substantive": { "type": "integer" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     }

--- a/skills/vow/reference/cli.md
+++ b/skills/vow/reference/cli.md
@@ -398,7 +398,7 @@ that path produces `Unverified` (exit 0).
 
 ### Quality Values
 
-`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.
+`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See `docs/spec/contracts-methodology.md` for the full taxonomy.
 
 | Quality        | Meaning                                                                                      |
 |----------------|----------------------------------------------------------------------------------------------|

--- a/skills/vow/reference/cli.md
+++ b/skills/vow/reference/cli.md
@@ -342,10 +342,11 @@ that path produces `Unverified` (exit 0).
       "description": "requires y != 0",
       "blame": "Caller",
       "source": { "file": "divide.vow", "offset": 42 },
-      "status": "not_verified"
+      "status": "not_verified",
+      "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0 }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -361,10 +362,11 @@ that path produces `Unverified` (exit 0).
       "description": "requires y != 0",
       "blame": "Caller",
       "source": { "file": "divide.vow", "offset": 42 },
-      "status": "proven"
+      "status": "proven",
+      "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0 }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -379,6 +381,7 @@ that path produces `Unverified` (exit 0).
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
 | `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
+| `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
 
 ### Status Values
 
@@ -392,6 +395,16 @@ that path produces `Unverified` (exit 0).
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) — use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |
+
+### Quality Values
+
+`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.
+
+| Quality        | Meaning                                                                                      |
+|----------------|----------------------------------------------------------------------------------------------|
+| `weak`         | An `ensures` that only bounds `result` by an integer literal (e.g. `result >= 0`). Satisfied by almost any implementation. |
+| `tautological` | A constant clause that references no program value (e.g. `true`, `0 >= 0`). Constrains nothing. |
+| `substantive`  | Everything else — equality, relational, inverse/round-trip, dispatch-totality, or function-call shapes. The classifier is conservative: anything not provably weak/tautological is reported `substantive`. |
 
 ## Trace Output (stderr, --debug-trace)
 

--- a/skills/vow/schemas/contracts-result.schema.json
+++ b/skills/vow/schemas/contracts-result.schema.json
@@ -10,7 +10,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["vow_id", "function", "kind", "description", "blame", "source", "status"],
+        "required": ["vow_id", "function", "kind", "description", "blame", "source", "status", "quality"],
         "properties": {
           "vow_id": {
             "type": "integer",
@@ -53,6 +53,11 @@
             "type": "string",
             "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
             "description": "Verification status"
+          },
+          "quality": {
+            "type": "string",
+            "enum": ["weak", "tautological", "substantive"],
+            "description": "Static, no-ESBMC classification of the clause shape: weak (an ensures that only bounds result by a constant), tautological (constant clause that says nothing), or substantive (equality/relational/inverse/call). See contracts-methodology.md"
           }
         },
         "additionalProperties": false
@@ -60,7 +65,7 @@
     },
     "summary": {
       "type": "object",
-      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
+      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified", "skipped", "quality"],
       "properties": {
         "total": { "type": "integer" },
         "proven": { "type": "integer" },
@@ -69,7 +74,18 @@
         "timeout": { "type": "integer" },
         "error": { "type": "integer" },
         "not_verified": { "type": "integer" },
-        "skipped": { "type": "integer" }
+        "skipped": { "type": "integer" },
+        "quality": {
+          "type": "object",
+          "description": "Static contract-quality tallies independent of verification status",
+          "required": ["weak", "tautological", "substantive"],
+          "properties": {
+            "weak": { "type": "integer" },
+            "tautological": { "type": "integer" },
+            "substantive": { "type": "integer" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     }

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -10055,8 +10055,10 @@ fn contract_predicate_text(description: &str) -> &str {
 /// Static, no-ESBMC quality classification of a contract clause by shape.
 /// See docs/spec/contracts-methodology.md for the methodology this implements.
 ///
-/// - `tautological`: the predicate is a boolean constant or references no
-///   program value at all (e.g. `true`, `0 >= 0`) — it constrains nothing.
+/// - `tautological`: the predicate is the constant `true` or references no
+///   program value at all (e.g. `0 >= 0`) — it constrains nothing. A `false`
+///   predicate is a contradiction, not a tautology, so it is left `substantive`
+///   here; flagging it as vacuous is the deferred `false` re-check.
 /// - `weak`: an `ensures` that only bounds `result` by an integer literal on
 ///   one side (e.g. `result >= 0`, `result > 0`, `result <= 3`). Satisfiable by
 ///   almost any implementation — the 354-contract trap #81 was filed over.
@@ -10066,7 +10068,7 @@ fn contract_predicate_text(description: &str) -> &str {
 /// is reported `substantive`, so it never over-flags a meaningful contract.
 fn classify_contract_quality(kind: &str, description: &str) -> &'static str {
     let p = contract_predicate_text(description);
-    if p.is_empty() || p == "true" || p == "false" || !p.chars().any(|c| c.is_ascii_alphabetic()) {
+    if p.is_empty() || p == "true" || !p.chars().any(|c| c.is_ascii_alphabetic()) {
         return "tautological";
     }
     if kind == "ensures" && is_weak_result_bound(p) {

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2809,10 +2809,11 @@ that path produces `Unverified` (exit 0).
       "description": "requires y != 0",
       "blame": "Caller",
       "source": { "file": "divide.vow", "offset": 42 },
-      "status": "not_verified"
+      "status": "not_verified",
+      "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0 }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -2828,10 +2829,11 @@ that path produces `Unverified` (exit 0).
       "description": "requires y != 0",
       "blame": "Caller",
       "source": { "file": "divide.vow", "offset": 42 },
-      "status": "proven"
+      "status": "proven",
+      "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0 }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -2846,6 +2848,7 @@ that path produces `Unverified` (exit 0).
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
 | `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
+| `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
 
 ### Status Values
 
@@ -2859,6 +2862,16 @@ that path produces `Unverified` (exit 0).
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) — use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |
+
+### Quality Values
+
+`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.
+
+| Quality        | Meaning                                                                                      |
+|----------------|----------------------------------------------------------------------------------------------|
+| `weak`         | An `ensures` that only bounds `result` by an integer literal (e.g. `result >= 0`). Satisfied by almost any implementation. |
+| `tautological` | A constant clause that references no program value (e.g. `true`, `0 >= 0`). Constrains nothing. |
+| `substantive`  | Everything else — equality, relational, inverse/round-trip, dispatch-totality, or function-call shapes. The classifier is conservative: anything not provably weak/tautological is reported `substantive`. |
 
 ## Trace Output (stderr, --debug-trace)
 
@@ -4311,7 +4324,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["vow_id", "function", "kind", "description", "blame", "source", "status"],
+        "required": ["vow_id", "function", "kind", "description", "blame", "source", "status", "quality"],
         "properties": {
           "vow_id": {
             "type": "integer",
@@ -4354,6 +4367,11 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
             "type": "string",
             "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
             "description": "Verification status"
+          },
+          "quality": {
+            "type": "string",
+            "enum": ["weak", "tautological", "substantive"],
+            "description": "Static, no-ESBMC classification of the clause shape: weak (an ensures that only bounds result by a constant), tautological (constant clause that says nothing), or substantive (equality/relational/inverse/call). See contracts-methodology.md"
           }
         },
         "additionalProperties": false
@@ -4361,7 +4379,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
     },
     "summary": {
       "type": "object",
-      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
+      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified", "skipped", "quality"],
       "properties": {
         "total": { "type": "integer" },
         "proven": { "type": "integer" },
@@ -4370,7 +4388,18 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
         "timeout": { "type": "integer" },
         "error": { "type": "integer" },
         "not_verified": { "type": "integer" },
-        "skipped": { "type": "integer" }
+        "skipped": { "type": "integer" },
+        "quality": {
+          "type": "object",
+          "description": "Static contract-quality tallies independent of verification status",
+          "required": ["weak", "tautological", "substantive"],
+          "properties": {
+            "weak": { "type": "integer" },
+            "tautological": { "type": "integer" },
+            "substantive": { "type": "integer" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     }
@@ -5924,10 +5953,11 @@ that path produces `Unverified` (exit 0).
       "description": "requires y != 0",
       "blame": "Caller",
       "source": { "file": "divide.vow", "offset": 42 },
-      "status": "not_verified"
+      "status": "not_verified",
+      "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0 }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -5943,10 +5973,11 @@ that path produces `Unverified` (exit 0).
       "description": "requires y != 0",
       "blame": "Caller",
       "source": { "file": "divide.vow", "offset": 42 },
-      "status": "proven"
+      "status": "proven",
+      "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0 }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -5961,6 +5992,7 @@ that path produces `Unverified` (exit 0).
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
 | `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
+| `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
 
 ### Status Values
 
@@ -5974,6 +6006,16 @@ that path produces `Unverified` (exit 0).
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) — use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |
+
+### Quality Values
+
+`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.
+
+| Quality        | Meaning                                                                                      |
+|----------------|----------------------------------------------------------------------------------------------|
+| `weak`         | An `ensures` that only bounds `result` by an integer literal (e.g. `result >= 0`). Satisfied by almost any implementation. |
+| `tautological` | A constant clause that references no program value (e.g. `true`, `0 >= 0`). Constrains nothing. |
+| `substantive`  | Everything else — equality, relational, inverse/round-trip, dispatch-totality, or function-call shapes. The classifier is conservative: anything not provably weak/tautological is reported `substantive`. |
 
 ## Trace Output (stderr, --debug-trace)
 
@@ -7424,7 +7466,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["vow_id", "function", "kind", "description", "blame", "source", "status"],
+        "required": ["vow_id", "function", "kind", "description", "blame", "source", "status", "quality"],
         "properties": {
           "vow_id": {
             "type": "integer",
@@ -7467,6 +7509,11 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
             "type": "string",
             "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
             "description": "Verification status"
+          },
+          "quality": {
+            "type": "string",
+            "enum": ["weak", "tautological", "substantive"],
+            "description": "Static, no-ESBMC classification of the clause shape: weak (an ensures that only bounds result by a constant), tautological (constant clause that says nothing), or substantive (equality/relational/inverse/call). See contracts-methodology.md"
           }
         },
         "additionalProperties": false
@@ -7474,7 +7521,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
     },
     "summary": {
       "type": "object",
-      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
+      "required": ["total", "proven", "failed", "unknown", "timeout", "error", "not_verified", "skipped", "quality"],
       "properties": {
         "total": { "type": "integer" },
         "proven": { "type": "integer" },
@@ -7483,7 +7530,18 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
         "timeout": { "type": "integer" },
         "error": { "type": "integer" },
         "not_verified": { "type": "integer" },
-        "skipped": { "type": "integer" }
+        "skipped": { "type": "integer" },
+        "quality": {
+          "type": "object",
+          "description": "Static contract-quality tallies independent of verification status",
+          "required": ["weak", "tautological", "substantive"],
+          "properties": {
+            "weak": { "type": "integer" },
+            "tautological": { "type": "integer" },
+            "substantive": { "type": "integer" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     }
@@ -8175,6 +8233,12 @@ pub struct ContractEntryJson {
     pub blame: String,
     pub source: ContractSourceJson,
     pub status: String,
+    /// Static quality classification of the clause shape (no ESBMC): one of
+    /// `weak` (an `ensures` that only bounds `result` by a constant),
+    /// `tautological` (constant clause that says nothing about the program),
+    /// or `substantive` (equality / relational / inverse / call). See
+    /// docs/spec/contracts-methodology.md.
+    pub quality: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -8193,6 +8257,15 @@ pub struct ContractsSummaryJson {
     pub error: u32,
     pub not_verified: u32,
     pub skipped: u32,
+    pub quality: ContractsQualityJson,
+}
+
+/// Static contract-quality tallies (independent of verification status).
+#[derive(Debug, Clone, Serialize)]
+pub struct ContractsQualityJson {
+    pub weak: u32,
+    pub tautological: u32,
+    pub substantive: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -9968,6 +10041,85 @@ fn vow_kind_from_description(desc: &str) -> &'static str {
     }
 }
 
+/// Strip the leading `requires`/`ensures`/`invariant` keyword from a clause
+/// description, leaving the predicate text. `clause_description` formats every
+/// vow as `"{kind} {printed_expr}"`, so the predicate is everything after the
+/// first space.
+fn contract_predicate_text(description: &str) -> &str {
+    match description.split_once(' ') {
+        Some((_, rest)) => rest.trim(),
+        None => "",
+    }
+}
+
+/// Static, no-ESBMC quality classification of a contract clause by shape.
+/// See docs/spec/contracts-methodology.md for the methodology this implements.
+///
+/// - `tautological`: the predicate is a boolean constant or references no
+///   program value at all (e.g. `true`, `0 >= 0`) — it constrains nothing.
+/// - `weak`: an `ensures` that only bounds `result` by an integer literal on
+///   one side (e.g. `result >= 0`, `result > 0`, `result <= 3`). Satisfiable by
+///   almost any implementation — the 354-contract trap #81 was filed over.
+/// - `substantive`: everything else (equality, relational, inverse, calls).
+///
+/// The classifier is deliberately conservative: anything it cannot prove weak
+/// is reported `substantive`, so it never over-flags a meaningful contract.
+fn classify_contract_quality(kind: &str, description: &str) -> &'static str {
+    let p = contract_predicate_text(description);
+    if p.is_empty() || p == "true" || p == "false" || !p.chars().any(|c| c.is_ascii_alphabetic())
+    {
+        return "tautological";
+    }
+    if kind == "ensures" && is_weak_result_bound(p) {
+        return "weak";
+    }
+    "substantive"
+}
+
+/// True when `pred` is a single ordering comparison between `result` and an
+/// integer literal — the weak postcondition shape. Compound predicates,
+/// equalities, and calls are excluded (they are potentially substantive).
+fn is_weak_result_bound(pred: &str) -> bool {
+    if pred.contains("&&")
+        || pred.contains("||")
+        || pred.contains("==")
+        || pred.contains("!=")
+        || pred.contains('(')
+    {
+        return false;
+    }
+    for op in ["<=", ">="] {
+        if let Some((lhs, rhs)) = pred.split_once(op) {
+            return is_weak_result_comparison(lhs, rhs);
+        }
+    }
+    for op in ['<', '>'] {
+        if let Some((lhs, rhs)) = pred.split_once(op) {
+            return is_weak_result_comparison(lhs, rhs);
+        }
+    }
+    false
+}
+
+fn is_weak_result_comparison(lhs: &str, rhs: &str) -> bool {
+    let lhs = lhs.trim();
+    let rhs = rhs.trim();
+    // Reject anything with a second comparison operator on either side.
+    if has_ordering_op(lhs) || has_ordering_op(rhs) {
+        return false;
+    }
+    (lhs == "result" && is_int_literal(rhs)) || (rhs == "result" && is_int_literal(lhs))
+}
+
+fn has_ordering_op(s: &str) -> bool {
+    s.contains('<') || s.contains('>')
+}
+
+fn is_int_literal(s: &str) -> bool {
+    let digits = s.strip_prefix('-').unwrap_or(s);
+    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
 fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJson {
     let mut summary = ContractsSummaryJson {
         total: entries.len() as u32,
@@ -9978,6 +10130,11 @@ fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJso
         error: 0,
         not_verified: 0,
         skipped: 0,
+        quality: ContractsQualityJson {
+            weak: 0,
+            tautological: 0,
+            substantive: 0,
+        },
     };
     for e in entries {
         match e.status.as_str() {
@@ -9988,6 +10145,11 @@ fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJso
             "error" => summary.error += 1,
             "skipped" => summary.skipped += 1,
             _ => summary.not_verified += 1,
+        }
+        match e.quality.as_str() {
+            "weak" => summary.quality.weak += 1,
+            "tautological" => summary.quality.tautological += 1,
+            _ => summary.quality.substantive += 1,
         }
     }
     summary
@@ -10138,6 +10300,7 @@ fn run_contracts_command(
                 vow_diag::Blame::Callee => "Callee",
                 vow_diag::Blame::None => "None",
             };
+            let quality = classify_contract_quality(kind, &vow.description);
             entries.push(ContractEntryJson {
                 vow_id: vow.id.0,
                 function: func.name.clone(),
@@ -10150,6 +10313,7 @@ fn run_contracts_command(
                     offset: vow.offset,
                 },
                 status: "not_verified".to_string(),
+                quality: quality.to_string(),
             });
         }
     }
@@ -13836,6 +14000,7 @@ fn main() -> i32 {
             blame: "callee".to_string(),
             source: source.clone(),
             status: status.to_string(),
+            quality: "substantive".to_string(),
         };
         let summary = build_contracts_summary(&[
             entry("proven"),
@@ -13856,6 +14021,70 @@ fn main() -> i32 {
         assert_eq!(summary.error, 1);
         assert_eq!(summary.skipped, 1);
         assert_eq!(summary.not_verified, 1);
+        assert_eq!(summary.quality.substantive, 8);
+        assert_eq!(summary.quality.weak, 0);
+        assert_eq!(summary.quality.tautological, 0);
+    }
+
+    #[test]
+    fn classify_contract_quality_flags_weak_result_bounds() {
+        // The 354-contract trap: an ensures that only bounds result by a constant.
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures result >= 0"),
+            "weak"
+        );
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures result > 0"),
+            "weak"
+        );
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures result <= 3"),
+            "weak"
+        );
+        // result vs negative literal is still a constant bound.
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures result >= -1"),
+            "weak"
+        );
+    }
+
+    #[test]
+    fn classify_contract_quality_keeps_substantive_clauses() {
+        // Equality, relational, inverse, totality, and call shapes are not weak.
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures result == val * 4 + kind"),
+            "substantive"
+        );
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures result != -1"),
+            "substantive"
+        );
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures result >= a"),
+            "substantive"
+        );
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures item_kind(result) == kind"),
+            "substantive"
+        );
+        // A one-sided bound is a legitimate precondition, not a weak postcondition.
+        assert_eq!(
+            classify_contract_quality("requires", "requires v <= 255"),
+            "substantive"
+        );
+    }
+
+    #[test]
+    fn classify_contract_quality_flags_tautologies() {
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures true"),
+            "tautological"
+        );
+        // No reference to any program value — constant comparison.
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures 0 >= 0"),
+            "tautological"
+        );
     }
 
     #[test]

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -10066,8 +10066,7 @@ fn contract_predicate_text(description: &str) -> &str {
 /// is reported `substantive`, so it never over-flags a meaningful contract.
 fn classify_contract_quality(kind: &str, description: &str) -> &'static str {
     let p = contract_predicate_text(description);
-    if p.is_empty() || p == "true" || p == "false" || !p.chars().any(|c| c.is_ascii_alphabetic())
-    {
+    if p.is_empty() || p == "true" || p == "false" || !p.chars().any(|c| c.is_ascii_alphabetic()) {
         return "tautological";
     }
     if kind == "ensures" && is_weak_result_bound(p) {

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2865,7 +2865,7 @@ that path produces `Unverified` (exit 0).
 
 ### Quality Values
 
-`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.
+`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See `docs/spec/contracts-methodology.md` for the full taxonomy.
 
 | Quality        | Meaning                                                                                      |
 |----------------|----------------------------------------------------------------------------------------------|
@@ -6009,7 +6009,7 @@ that path produces `Unverified` (exit 0).
 
 ### Quality Values
 
-`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See [contracts-methodology.md](contracts-methodology.md) for the full taxonomy.
+`quality` is a static classification of each clause's *shape*, computed without ESBMC and independent of `status`. It surfaces the "proven but trivial" problem: a `weak` contract can be `proven` while constraining almost nothing. See `docs/spec/contracts-methodology.md` for the full taxonomy.
 
 | Quality        | Meaning                                                                                      |
 |----------------|----------------------------------------------------------------------------------------------|

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -13997,7 +13997,8 @@ fn main() -> i32 {
             function: "f".to_string(),
             function_id: 0,
             kind: "ensures".to_string(),
-            description: "ensures: true".to_string(),
+            // Description must agree with the hard-coded `quality` below.
+            description: "ensures: result == x".to_string(),
             blame: "callee".to_string(),
             source: source.clone(),
             status: status.to_string(),

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -14048,6 +14048,11 @@ fn main() -> i32 {
             classify_contract_quality("ensures", "ensures result >= -1"),
             "weak"
         );
+        // Strict single-char operator path (`<`, not `<=`).
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures result < 3"),
+            "weak"
+        );
     }
 
     #[test]
@@ -14072,6 +14077,12 @@ fn main() -> i32 {
         // A one-sided bound is a legitimate precondition, not a weak postcondition.
         assert_eq!(
             classify_contract_quality("requires", "requires v <= 255"),
+            "substantive"
+        );
+        // A `false` predicate is a contradiction, not a tautology; the static
+        // classifier leaves it substantive (vacuity detection is a follow-up).
+        assert_eq!(
+            classify_contract_quality("ensures", "ensures false"),
             "substantive"
         );
     }

--- a/vow/tests/contracts.rs
+++ b/vow/tests/contracts.rs
@@ -55,6 +55,7 @@ fn contracts_divide_requires() {
     assert_eq!(c["kind"], "requires");
     assert_eq!(c["blame"], "Caller");
     assert_eq!(c["status"], "not_verified");
+    assert_eq!(c["quality"], "substantive");
     assert!(c["description"].as_str().unwrap().contains("y != 0"));
     assert!(c["source"]["file"].as_str().unwrap().contains("divide.vow"));
     assert_eq!(json["summary"]["total"], 1);
@@ -120,12 +121,10 @@ fn contracts_where_clause() {
     for c in contracts {
         assert_eq!(c["kind"], "requires");
         assert_eq!(c["blame"], "Caller");
-        assert!(
-            c["description"]
-                .as_str()
-                .unwrap()
-                .contains("where on parameter")
-        );
+        assert!(c["description"]
+            .as_str()
+            .unwrap()
+            .contains("where on parameter"));
     }
 }
 
@@ -165,6 +164,10 @@ fn contracts_json_has_all_summary_fields() {
     assert!(summary.get("timeout").is_some());
     assert!(summary.get("error").is_some());
     assert!(summary.get("not_verified").is_some());
+    let quality = &summary["quality"];
+    assert!(quality.get("weak").is_some());
+    assert!(quality.get("tautological").is_some());
+    assert!(quality.get("substantive").is_some());
 }
 
 #[test]
@@ -178,6 +181,51 @@ fn contracts_json_has_all_entry_fields() {
     assert!(c.get("blame").is_some());
     assert!(c.get("source").is_some());
     assert!(c.get("status").is_some());
+    assert!(c.get("quality").is_some());
     assert!(c["source"].get("file").is_some());
     assert!(c["source"].get("offset").is_some());
+}
+
+#[test]
+fn contracts_quality_classifies_clause_shapes() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let src = dir.path().join("quality.vow");
+    std::fs::write(
+        &src,
+        "module Quality\n\
+         fn weak_one(x: i64) -> i64 vow {\n  ensures: result >= 0\n} { 0 }\n\
+         fn strong_one(x: i64) -> i64 vow {\n  requires: x >= 0,\n  ensures: result == x + 1\n} { x + 1 }\n\
+         fn taut_one() -> i64 vow {\n  ensures: true\n} { 0 }\n",
+    )
+    .unwrap();
+    let out = Command::new(vow_bin())
+        .args(["contracts", src.to_str().unwrap()])
+        .output()
+        .expect("failed to run vow");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON from contracts: {e}\nstdout: {stdout}"));
+    let quality_of = |func: &str, kind: &str| -> String {
+        json["contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["function"] == func && c["kind"] == kind)
+            .unwrap_or_else(|| panic!("missing {func}/{kind}"))["quality"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+    // A postcondition that only bounds result by a constant is weak; an equality
+    // postcondition and a domain precondition are substantive; `ensures true` is
+    // tautological. See docs/spec/contracts-methodology.md.
+    assert_eq!(quality_of("weak_one", "ensures"), "weak");
+    assert_eq!(quality_of("strong_one", "requires"), "substantive");
+    assert_eq!(quality_of("strong_one", "ensures"), "substantive");
+    assert_eq!(quality_of("taut_one", "ensures"), "tautological");
+    let q = &json["summary"]["quality"];
+    assert_eq!(q["weak"], 1);
+    assert_eq!(q["substantive"], 2);
+    assert_eq!(q["tautological"], 1);
 }

--- a/vow/tests/contracts.rs
+++ b/vow/tests/contracts.rs
@@ -121,10 +121,12 @@ fn contracts_where_clause() {
     for c in contracts {
         assert_eq!(c["kind"], "requires");
         assert_eq!(c["blame"], "Caller");
-        assert!(c["description"]
-            .as_str()
-            .unwrap()
-            .contains("where on parameter"));
+        assert!(
+            c["description"]
+                .as_str()
+                .unwrap()
+                .contains("where on parameter")
+        );
     }
 }
 


### PR DESCRIPTION
## What

Adds a **static contract-quality classifier** to `vow contracts`. Every clause now carries a `quality` label — `weak`, `tautological`, or `substantive` — and the summary carries a `quality` tally. No ESBMC; this is a pure shape analysis of the clause, independent of verification `status`.

Second slice of #81 (after the methodology doc in #576). It makes the headline problem **visible and measurable**: running it on `compiler/ast.vow` reports **81 weak / 0 tautological / 5 substantive out of 86** — i.e. surfaces the "91% trivial contracts" finding directly in tooling output.

## Classification (see `docs/spec/contracts-methodology.md`)

- **`weak`** — an `ensures` that only bounds `result` by an integer literal (`result >= 0`, `result > 0`, `result <= 3`). Satisfied by almost any implementation — the 354-contract trap #81 was filed over.
- **`tautological`** — a constant clause that references no program value (`true`, `0 >= 0`).
- **`substantive`** — everything else: equality, relational, inverse/round-trip, dispatch-totality (`result != -1`), or function-call shapes.

The classifier is **conservative**: anything it cannot prove weak/tautological is reported `substantive`, so it never over-flags a meaningful contract. A one-sided bound in a `requires` is a legitimate domain precondition, not weak — only `ensures` clauses can be `weak`.

## Output (schema bumped + documented)

```json
{
  "contracts": [{ "...": "...", "status": "not_verified", "quality": "weak" }],
  "summary":   { "...": "...", "quality": { "weak": 1, "tautological": 0, "substantive": 0 } }
}
```

## Changes

- **Both compilers** (per CLAUDE.md): `classify_contract_quality` in `vow/src/main.rs`; `cq_*` helpers in `compiler/main.vow` (reusing `verifier.vow`'s `str_*` utilities — no duplication). Verified to produce **identical** `quality` output (Rust ↔ self-hosted parity).
- `docs/spec/schemas/contracts-result.schema.json` — `quality` added to the contract item (required) and the summary object.
- `docs/spec/cli.md` — documents the field + a Quality Values table; regenerated `--help`/skill in both compilers (`skills/vow/` mirror in sync — drift check passes).
- Tests: 4 Rust unit tests for the classifier + 1 end-to-end integration test in `vow/tests/contracts.rs` (`contracts_quality_classifies_clause_shapes`), plus `quality` assertions in the existing field/divide tests.

## Scope / non-goals

Static shape analysis only. The deeper detectors from the methodology doc — **vacuity** (`ensures:false` re-check) and **mutation-based weakness** — need per-obligation verification / the `vowc mutants` harness and are tracked as follow-ups. This PR deliberately ships the cheap, no-ESBMC signal that requires no verification-pipeline changes.

## Verification

- `cargo test -p vow --test contracts` — 12 passed; classifier unit tests pass; full bootstrap triple test (binary fixed point) green.
- Conservative-by-design: `requires` one-sided bounds and `result != -1` totality contracts both classify `substantive`, not weak.

Refs #81
