### PR TITLE
Remove verify-only collection capacity flags (#278)

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -10,10 +10,10 @@ use ir_printer
 // the prover, not about Vow — not language properties and not user-tunable.
 // Swap in an unbounded checker and the same source verifies unchanged.
 // See docs/design/verifier-model-bounds.md.
-fn VOW_VEC_MAX() -> i64 vow { ensures: result >= 0 } { 128 }
-fn VOW_STRING_MAX() -> i64 vow { ensures: result >= 0 } { 256 }
-fn VOW_HASHMAP_MAX() -> i64 vow { ensures: result >= 0 } { 64 }
-fn VOW_BTREEMAP_MAX() -> i64 vow { ensures: result >= 0 } { 64 }
+fn VOW_VEC_MAX() -> i64 vow { ensures: result >= 1 } { 128 }
+fn VOW_STRING_MAX() -> i64 vow { ensures: result >= 1 } { 256 }
+fn VOW_HASHMAP_MAX() -> i64 vow { ensures: result >= 1 } { 64 }
+fn VOW_BTREEMAP_MAX() -> i64 vow { ensures: result >= 1 } { 64 }
 
 fn str3(a: String, b: String, c: String) -> String {
     let r: String = String::from("");

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -4,6 +4,12 @@ use clif
 use ir
 use ir_printer
 
+// Internal verifier-model bounds for bounded model checking. ESBMC models
+// Vec/String/HashMap/BTreeMap as fixed-size C arrays, so the model needs a
+// finite capacity per collection. These are safe defaults that are a fact about
+// the prover, not about Vow — not language properties and not user-tunable.
+// Swap in an unbounded checker and the same source verifies unchanged.
+// See docs/design/verifier-model-bounds.md.
 fn VOW_VEC_MAX() -> i64 vow { ensures: result >= 0 } { 128 }
 fn VOW_STRING_MAX() -> i64 vow { ensures: result >= 0 } { 256 }
 fn VOW_HASHMAP_MAX() -> i64 vow { ensures: result >= 0 } { 64 }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -44,7 +44,7 @@ fn get_source_path(argv: Vec<String>) -> String {
         if first_byte != 45 {
             if i > 1 {
                 let prev: String = argv[i - 1];
-                if prev == "-o" || prev == "--mode" || prev == "--max-k-step" || prev == "--debug-trace" || prev == "--filter" || prev == "--timeout" || prev == "--solver" || prev == "--encoding" || prev == "--vec-max" || prev == "--string-max" || prev == "--hashmap-max" || prev == "--btreemap-max" || prev == "--verify-jobs" || prev == "--module-root" {
+                if prev == "-o" || prev == "--mode" || prev == "--max-k-step" || prev == "--debug-trace" || prev == "--filter" || prev == "--timeout" || prev == "--solver" || prev == "--encoding" || prev == "--verify-jobs" || prev == "--module-root" {
                     i = i - 1;
                 } else {
                     return a;
@@ -67,7 +67,7 @@ fn get_source_path_sub(argv: Vec<String>) -> String {
         if first_byte != 45 {
             if i > 2 {
                 let prev: String = argv[i - 1];
-                if prev == "-o" || prev == "--mode" || prev == "--max-k-step" || prev == "--debug-trace" || prev == "--filter" || prev == "--timeout" || prev == "--solver" || prev == "--encoding" || prev == "--vec-max" || prev == "--string-max" || prev == "--hashmap-max" || prev == "--btreemap-max" || prev == "--verify-jobs" || prev == "--module-root" {
+                if prev == "-o" || prev == "--mode" || prev == "--max-k-step" || prev == "--debug-trace" || prev == "--filter" || prev == "--timeout" || prev == "--solver" || prev == "--encoding" || prev == "--verify-jobs" || prev == "--module-root" {
                     i = i - 1;
                 } else {
                     return a;
@@ -314,13 +314,6 @@ fn emit_ir_warnings(ir_mod: IrModule, dctx: DiagCtx) [io] {
     }
 }
 
-fn validate_limits(vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64) [io] {
-    if vec_max <= 0 || string_max <= 0 || hashmap_max <= 0 || btreemap_max <= 0 {
-        eprintln_str(String::from("error: --vec-max, --string-max, --hashmap-max, and --btreemap-max must be >= 1"));
-        process_exit(1);
-    }
-}
-
 fn resolve_verify_jobs(argv: Vec<String>) -> i64 [io] {
     let raw: String = get_flag_arg(argv, "--verify-jobs");
     if raw.len() == 0 {
@@ -522,15 +515,10 @@ fn run_verify(argv: Vec<String>) -> i32 [io] {
         if max_k_step_str.len() > 0 { max_k_step_str }
         else { String::from("50") }
     };
-    let vec_max_str: String = get_flag_arg(argv, "--vec-max");
-    let vec_max: i64 = { if vec_max_str.len() > 0 { parse_i64(vec_max_str) } else { 128 } };
-    let string_max_str: String = get_flag_arg(argv, "--string-max");
-    let string_max: i64 = { if string_max_str.len() > 0 { parse_i64(string_max_str) } else { 256 } };
-    let hashmap_max_str: String = get_flag_arg(argv, "--hashmap-max");
-    let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
-    let btreemap_max_str: String = get_flag_arg(argv, "--btreemap-max");
-    let btreemap_max: i64 = { if btreemap_max_str.len() > 0 { parse_i64(btreemap_max_str) } else { 64 } };
-    validate_limits(vec_max, string_max, hashmap_max, btreemap_max);
+    let vec_max: i64 = VOW_VEC_MAX();
+    let string_max: i64 = VOW_STRING_MAX();
+    let hashmap_max: i64 = VOW_HASHMAP_MAX();
+    let btreemap_max: i64 = VOW_BTREEMAP_MAX();
     let jobs: i64 = resolve_verify_jobs(argv);
     let use_cache: bool = !has_flag(argv, "--no-cache");
     let mut solver: String = get_flag_arg(argv, "--solver");
@@ -747,15 +735,10 @@ fn run_build(argv: Vec<String>) -> i32 [io] {
             solver = String::from("z3");
         }
     }
-    let vec_max_str: String = get_flag_arg(argv, "--vec-max");
-    let vec_max: i64 = { if vec_max_str.len() > 0 { parse_i64(vec_max_str) } else { 128 } };
-    let string_max_str: String = get_flag_arg(argv, "--string-max");
-    let string_max: i64 = { if string_max_str.len() > 0 { parse_i64(string_max_str) } else { 256 } };
-    let hashmap_max_str: String = get_flag_arg(argv, "--hashmap-max");
-    let hashmap_max: i64 = { if hashmap_max_str.len() > 0 { parse_i64(hashmap_max_str) } else { 64 } };
-    let btreemap_max_str: String = get_flag_arg(argv, "--btreemap-max");
-    let btreemap_max: i64 = { if btreemap_max_str.len() > 0 { parse_i64(btreemap_max_str) } else { 64 } };
-    validate_limits(vec_max, string_max, hashmap_max, btreemap_max);
+    let vec_max: i64 = VOW_VEC_MAX();
+    let string_max: i64 = VOW_STRING_MAX();
+    let hashmap_max: i64 = VOW_HASHMAP_MAX();
+    let btreemap_max: i64 = VOW_BTREEMAP_MAX();
     let jobs: i64 = resolve_verify_jobs(argv);
     let fns: Vec<IrFunction> = ir_mod.functions;
     let ces: Vec<VerifyCE> = Vec::new();
@@ -967,15 +950,10 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
     let do_verify: bool = has_flag(argv, "--verify");
     let t_mks_str: String = get_flag_arg(argv, "--max-k-step");
     let t_max_k_step: String = { if t_mks_str.len() > 0 { t_mks_str } else { String::from("50") } };
-    let t_vm_str: String = get_flag_arg(argv, "--vec-max");
-    let t_vec_max: i64 = { if t_vm_str.len() > 0 { parse_i64(t_vm_str) } else { 128 } };
-    let t_sm_str: String = get_flag_arg(argv, "--string-max");
-    let t_string_max: i64 = { if t_sm_str.len() > 0 { parse_i64(t_sm_str) } else { 256 } };
-    let t_hm_str: String = get_flag_arg(argv, "--hashmap-max");
-    let t_hashmap_max: i64 = { if t_hm_str.len() > 0 { parse_i64(t_hm_str) } else { 64 } };
-    let t_bm_str: String = get_flag_arg(argv, "--btreemap-max");
-    let t_btreemap_max: i64 = { if t_bm_str.len() > 0 { parse_i64(t_bm_str) } else { 64 } };
-    validate_limits(t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
+    let t_vec_max: i64 = VOW_VEC_MAX();
+    let t_string_max: i64 = VOW_STRING_MAX();
+    let t_hashmap_max: i64 = VOW_HASHMAP_MAX();
+    let t_btreemap_max: i64 = VOW_BTREEMAP_MAX();
     let t_jobs: i64 = resolve_verify_jobs(argv);
 
     // Validate path exists
@@ -1312,11 +1290,10 @@ fn run_legacy(argv: Vec<String>) -> i32 [io] {
                 if max_k_step_str.len() > 0 { max_k_step_str }
                 else { String::from("50") }
             };
-            let vec_max_leg: i64 = { let s: String = get_flag_arg(argv, "--vec-max"); if s.len() > 0 { parse_i64(s) } else { 128 } };
-            let string_max_leg: i64 = { let s: String = get_flag_arg(argv, "--string-max"); if s.len() > 0 { parse_i64(s) } else { 256 } };
-            let hashmap_max_leg: i64 = { let s: String = get_flag_arg(argv, "--hashmap-max"); if s.len() > 0 { parse_i64(s) } else { 64 } };
-            let btreemap_max_leg: i64 = { let s: String = get_flag_arg(argv, "--btreemap-max"); if s.len() > 0 { parse_i64(s) } else { 64 } };
-            validate_limits(vec_max_leg, string_max_leg, hashmap_max_leg, btreemap_max_leg);
+            let vec_max_leg: i64 = VOW_VEC_MAX();
+            let string_max_leg: i64 = VOW_STRING_MAX();
+            let hashmap_max_leg: i64 = VOW_HASHMAP_MAX();
+            let btreemap_max_leg: i64 = VOW_BTREEMAP_MAX();
             emit_ir_warnings(ir_mod, dctx);
             let fns: Vec<IrFunction> = ir_mod.functions;
             let ces: Vec<VerifyCE> = Vec::new();
@@ -1542,38 +1519,6 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"default\": \"300 (or 30 when --encoding is auto)\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max Vec capacity for verification model (default: 128)\",\n"));
-    r.push_str(String::from("          \"long\": \"--vec-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 128\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--string-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("          \"long\": \"--string-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 256\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--hashmap-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("          \"long\": \"--hashmap-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 64\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--btreemap-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max BTreeMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("          \"long\": \"--btreemap-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 64\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--verify-jobs <N>\",\n"));
     r.push_str(String::from("          \"description\": \"Max concurrent ESBMC verification jobs (default: num_cpus/2)\",\n"));
     r.push_str(String::from("          \"long\": \"--verify-jobs\",\n"));
@@ -1663,38 +1608,6 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"default\": \"300 (or 30 when --encoding is auto)\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max Vec capacity for verification model (default: 128)\",\n"));
-    r.push_str(String::from("          \"long\": \"--vec-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 128\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--string-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("          \"long\": \"--string-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 256\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--hashmap-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("          \"long\": \"--hashmap-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 64\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--btreemap-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max BTreeMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("          \"long\": \"--btreemap-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 64\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--verify-jobs <N>\",\n"));
     r.push_str(String::from("          \"description\": \"Max concurrent ESBMC verification jobs (default: num_cpus/2)\",\n"));
     r.push_str(String::from("          \"long\": \"--verify-jobs\",\n"));
@@ -1776,38 +1689,6 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"value_name\": \"N\",\n"));
     r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
     r.push_str(String::from("          \"default\": 50\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max Vec capacity for verification model (default: 128)\",\n"));
-    r.push_str(String::from("          \"long\": \"--vec-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 128\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--string-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("          \"long\": \"--string-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 256\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--hashmap-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("          \"long\": \"--hashmap-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 64\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--btreemap-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max BTreeMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("          \"long\": \"--btreemap-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 64\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--verify-jobs <N>\",\n"));
@@ -1919,38 +1800,6 @@ fn skill_json() -> String {
     r.push_str(String::from("          \"default\": \"auto\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--vec-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max Vec capacity for verification model (default: 128)\",\n"));
-    r.push_str(String::from("          \"long\": \"--vec-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 128\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--string-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("          \"long\": \"--string-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 256\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--hashmap-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("          \"long\": \"--hashmap-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 64\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
-    r.push_str(String::from("          \"form\": \"--btreemap-max <N>\",\n"));
-    r.push_str(String::from("          \"description\": \"Max BTreeMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("          \"long\": \"--btreemap-max\",\n"));
-    r.push_str(String::from("          \"value_name\": \"N\",\n"));
-    r.push_str(String::from("          \"value_kind\": \"integer\",\n"));
-    r.push_str(String::from("          \"default\": 64\n"));
-    r.push_str(String::from("        },\n"));
-    r.push_str(String::from("        {\n"));
     r.push_str(String::from("          \"form\": \"--verify-jobs <N>\",\n"));
     r.push_str(String::from("          \"description\": \"Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)\",\n"));
     r.push_str(String::from("          \"long\": \"--verify-jobs\",\n"));
@@ -1980,10 +1829,6 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
     r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit --timeout overrides both. --timeout 0 is honoured as an immediate watchdog kill (default: 300 (or 30 when --encoding is auto))\",\n"));
-    r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
-    r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("    \"--btreemap-max <N>\": \"Max BTreeMap capacity for verification model (default: 64)\",\n"));
     r.push_str(String::from("    \"--verify-jobs <N>\": \"Max concurrent ESBMC verification jobs (default: num_cpus/2)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"verify_options\": {\n"));
@@ -1992,10 +1837,6 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\",\n"));
     r.push_str(String::from("    \"--timeout <N>\": \"ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit --timeout overrides both. --timeout 0 is honoured as an immediate watchdog kill (default: 300 (or 30 when --encoding is auto))\",\n"));
-    r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
-    r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("    \"--btreemap-max <N>\": \"Max BTreeMap capacity for verification model (default: 64)\",\n"));
     r.push_str(String::from("    \"--verify-jobs <N>\": \"Max concurrent ESBMC verification jobs (default: num_cpus/2)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"test_options\": {\n"));
@@ -2005,10 +1846,6 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--mode <debug|release>\": \"Build mode; debug inserts runtime vow checks (default: (default))\",\n"));
     r.push_str(String::from("    \"--timeout <ms>\": \"Per-test execution timeout in milliseconds (default: 30000)\",\n"));
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (with --verify)\",\n"));
-    r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
-    r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("    \"--btreemap-max <N>\": \"Max BTreeMap capacity for verification model (default: 64)\",\n"));
     r.push_str(String::from("    \"--verify-jobs <N>\": \"Max concurrent ESBMC verification jobs (with --verify)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"decl_options\": {\n"));
@@ -2020,10 +1857,6 @@ fn skill_json() -> String {
     r.push_str(String::from("    \"--max-k-step <N>\": \"ESBMC incremental BMC max iterations (default: 50)\",\n"));
     r.push_str(String::from("    \"--solver <boolector|z3|bitwuzla|auto>\": \"ESBMC SMT solver (with --verify)\",\n"));
     r.push_str(String::from("    \"--encoding <bv|ir|auto>\": \"ESBMC encoding mode (with --verify); ir requires z3 (default: auto)\",\n"));
-    r.push_str(String::from("    \"--vec-max <N>\": \"Max Vec capacity for verification model (default: 128)\",\n"));
-    r.push_str(String::from("    \"--string-max <N>\": \"Max String capacity for verification model (default: 256)\",\n"));
-    r.push_str(String::from("    \"--hashmap-max <N>\": \"Max HashMap capacity for verification model (default: 64)\",\n"));
-    r.push_str(String::from("    \"--btreemap-max <N>\": \"Max BTreeMap capacity for verification model (default: 64)\",\n"));
     r.push_str(String::from("    \"--verify-jobs <N>\": \"Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)\"\n"));
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"global_options\": {\n"));
@@ -2361,11 +2194,7 @@ fn skill_json() -> String {
     r.push_str(String::from("  },\n"));
     r.push_str(String::from("  \"verification_defaults\": {\n"));
     r.push_str(String::from("    \"strategy\": \"k-induction-parallel\",\n"));
-    r.push_str(String::from("    \"max_k_step\": 50,\n"));
-    r.push_str(String::from("    \"vec_max\": 128,\n"));
-    r.push_str(String::from("    \"string_max\": 256,\n"));
-    r.push_str(String::from("    \"hashmap_max\": 64,\n"));
-    r.push_str(String::from("    \"btreemap_max\": 64\n"));
+    r.push_str(String::from("    \"max_k_step\": 50\n"));
     r.push_str(String::from("  }\n"));
     r.push_str(String::from("}\n"));
     r
@@ -2397,10 +2226,6 @@ fn skill_human() -> String {
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
     r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit --timeout overrides both. --timeout 0 is honoured as an immediate watchdog kill (default: 300 (or 30 when --encoding is auto))\n"));
-    r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
-    r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
-    r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
-    r.push_str(String::from("  --btreemap-max <N>      Max BTreeMap capacity for verification model (default: 64)\n"));
     r.push_str(String::from("  --verify-jobs <N>       Max concurrent ESBMC verification jobs (default: num_cpus/2)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("VERIFY OPTIONS\n"));
@@ -2409,10 +2234,6 @@ fn skill_human() -> String {
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)\n"));
     r.push_str(String::from("  --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit --timeout overrides both. --timeout 0 is honoured as an immediate watchdog kill (default: 300 (or 30 when --encoding is auto))\n"));
-    r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
-    r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
-    r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
-    r.push_str(String::from("  --btreemap-max <N>      Max BTreeMap capacity for verification model (default: 64)\n"));
     r.push_str(String::from("  --verify-jobs <N>       Max concurrent ESBMC verification jobs (default: num_cpus/2)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("TEST OPTIONS\n"));
@@ -2422,10 +2243,6 @@ fn skill_human() -> String {
     r.push_str(String::from("  --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: (default))\n"));
     r.push_str(String::from("  --timeout <ms>          Per-test execution timeout in milliseconds (default: 30000)\n"));
     r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (with --verify)\n"));
-    r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
-    r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
-    r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
-    r.push_str(String::from("  --btreemap-max <N>      Max BTreeMap capacity for verification model (default: 64)\n"));
     r.push_str(String::from("  --verify-jobs <N>       Max concurrent ESBMC verification jobs (with --verify)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("CONTRACTS OPTIONS\n"));
@@ -2434,10 +2251,6 @@ fn skill_human() -> String {
     r.push_str(String::from("  --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)\n"));
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver (with --verify)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode (with --verify); ir requires z3 (default: auto)\n"));
-    r.push_str(String::from("  --vec-max <N>           Max Vec capacity for verification model (default: 128)\n"));
-    r.push_str(String::from("  --string-max <N>        Max String capacity for verification model (default: 256)\n"));
-    r.push_str(String::from("  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)\n"));
-    r.push_str(String::from("  --btreemap-max <N>      Max BTreeMap capacity for verification model (default: 64)\n"));
     r.push_str(String::from("  --verify-jobs <N>       Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("DECL OPTIONS\n"));
@@ -2491,13 +2304,9 @@ fn skill_human() -> String {
     r.push_str(String::from("            HashMap: HashMap::new/insert/get/contains_key/remove/len   BTreeMap: BTreeMap::new/insert/get/contains/len   Option: unwrap\n"));
     r.push_str(String::from("OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max, --btreemap-max)\n"));
+    r.push_str(String::from("VERIFICATION DEFAULTS (--max-k-step)\n"));
     r.push_str(String::from("  Strategy        : k-induction-parallel (incremental BMC + k-induction)\n"));
     r.push_str(String::from("  Incremental BMC : 50 max iterations (--max-k-step)\n"));
-    r.push_str(String::from("  Vec<T>          : 128 max capacity\n"));
-    r.push_str(String::from("  String          : 256 max capacity\n"));
-    r.push_str(String::from("  HashMap<K, V>   : 64 max capacity\n"));
-    r.push_str(String::from("  BTreeMap<K, V>  : 64 max capacity\n"));
     r
 }
 // GENERATE:SKILL_HUMAN:END
@@ -3508,10 +3317,6 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
     r.push_str(String::from("| `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |\n"));
-    r.push_str(String::from("| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |\n"));
-    r.push_str(String::from("| `--string-max <N>` | `256`    | Max String capacity for verification model   |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |\n"));
-    r.push_str(String::from("| `--btreemap-max <N>` | `64`   | Max BTreeMap capacity for verification model |\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("**Compile-object cache behavior.** The on-disk compile-object cache (`$VOW_CACHE_DIR` or `~/.cache/vow/`, where each entry is a `<key>.o` artifact keyed by a content hash of all dependencies, mode, and trace settings) is automatically disabled whenever ESBMC verification is active. This guarantees the linked binary always comes from the same codegen run whose IR was verified, closing the integrity gap where a stale or attacker-supplied `.o` could be linked against freshly-verified IR. Concretely the cache only activates on `vow build --no-verify` invocations; it is bypassed on the default `vow build` path. `--no-cache` additionally disables the cache for `--no-verify` builds.\n"));
@@ -3533,10 +3338,6 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
     r.push_str(String::from("| `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |\n"));
-    r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
-    r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
-    r.push_str(String::from("| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow contracts`\n"));
@@ -3556,10 +3357,6 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |\n"));
-    r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
-    r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
-    r.push_str(String::from("| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.\n"));
@@ -3605,10 +3402,6 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `--mode release`  | `debug`     | Omit all vow checks for performance       |\n"));
     r.push_str(String::from("| `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |\n"));
     r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations (with --verify) |\n"));
-    r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
-    r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
-    r.push_str(String::from("| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs (with --verify) |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("Test discovery: files matching `test_*.vow` or `*_test.vow` under the given directory **and its subdirectories**, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.\n"));
@@ -4017,15 +3810,37 @@ fn skill_bundle() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Collection Models for Verification\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("ESBMC uses bounded models for collection types. Defaults are shown below; override with `--vec-max`, `--string-max`, `--hashmap-max`:\n"));
+    r.push_str(String::from("ESBMC is a *bounded* model checker, so it models collection types as\n"));
+    r.push_str(String::from("fixed-size arrays and reasons about them up to a finite capacity. These\n"));
+    r.push_str(String::from("capacities are an internal property of the verifier, not of the language:\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("| Type              | Default Max Capacity | CLI Flag | Supported Operations |\n"));
-    r.push_str(String::from("|-------------------|---------------------|----------|----------------------------------------------|\n"));
-    r.push_str(String::from("| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |\n"));
-    r.push_str(String::from("| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |\n"));
-    r.push_str(String::from("| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|\n"));
+    r.push_str(String::from("| Type              | Model Capacity | Supported Operations |\n"));
+    r.push_str(String::from("|-------------------|----------------|----------------------------------------------|\n"));
+    r.push_str(String::from("| `Vec<T>`          | 128            | `new`, `push`, `pop`, `len`, `get`, `set`    |\n"));
+    r.push_str(String::from("| `String`          | 256            | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |\n"));
+    r.push_str(String::from("| `HashMap<K, V>`   | 64             | `new`, `insert`, `get`, `contains_key`, `len`|\n"));
+    r.push_str(String::from("| `BTreeMap<K, V>`  | 64             | `new`, `insert`, `get`, `contains_key`, `len`|\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("These support the same operations as the runtime but with bounded storage. String literals carry their concrete length and bytes in verification, and `String::from` copies that model from its source value. The effective string model capacity is at least the longest static string literal, even when `--string-max` is lower, so literal byte initializers fit the model array. Operations whose bytes are not statically known, such as `String::from_cstr`, produce a nondeterministic length (0 to max-1). `string_matches_literal_at` is modeled against the literal's concrete bytes and byte length; the third argument must be a string literal so the verifier never has to infer static text from a dynamic `String`.\n"));
+    r.push_str(String::from("**These bounds are not a language feature and are not user-tunable.** A `Vec`\n"));
+    r.push_str(String::from("in a Vow program grows dynamically on the heap with no fixed maximum; the\n"));
+    r.push_str(String::from("capacity above only describes how far the *bounded* model checker reasons. The\n"));
+    r.push_str(String::from("language and its contracts are deliberately decoupled from what any particular\n"));
+    r.push_str(String::from("prover can prove: replace ESBMC with a stronger (or unbounded) checker and the\n"));
+    r.push_str(String::from("same source, the same contracts, and the same CLI keep working -- the only\n"));
+    r.push_str(String::from("difference is that proof covers more (or all) of the state space. For this\n"));
+    r.push_str(String::from("reason a `requires`/`ensures` clause must never encode a verifier bound (e.g.\n"));
+    r.push_str(String::from("`requires: v.len() <= 128`); see \"Verification-Driven Bounds (Anti-Pattern)\"\n"));
+    r.push_str(String::from("below and `docs/design/verifier-model-bounds.md`.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("These models support the same operations as the runtime but with bounded\n"));
+    r.push_str(String::from("storage. String literals carry their concrete length and bytes in verification,\n"));
+    r.push_str(String::from("and `String::from` copies that model from its source value. The effective string\n"));
+    r.push_str(String::from("model capacity is automatically at least the longest static string literal, so\n"));
+    r.push_str(String::from("literal byte initializers always fit the model array. Operations whose bytes are\n"));
+    r.push_str(String::from("not statically known, such as `String::from_cstr`, produce a nondeterministic\n"));
+    r.push_str(String::from("length (0 to max-1). `string_matches_literal_at` is modeled against the\n"));
+    r.push_str(String::from("literal's concrete bytes and byte length; the third argument must be a string\n"));
+    r.push_str(String::from("literal so the verifier never has to infer static text from a dynamic `String`.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Blame Model\n"));
     r.push_str(String::from("\n"));
@@ -4268,7 +4083,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("} { ... }\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic) -- if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification.\n"));
+    r.push_str(String::from("Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic, bounded collection models) -- if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification. The same rule is why the verifier's collection model capacities (see \"Collection Models for Verification\") are internal defaults rather than CLI flags or contract clauses: a bound that belongs to the prover must never leak into the language.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Interpreting Counterexamples\n"));
     r.push_str(String::from("\n"));
@@ -6634,10 +6449,6 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
     r.push_str(String::from("| `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |\n"));
-    r.push_str(String::from("| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |\n"));
-    r.push_str(String::from("| `--string-max <N>` | `256`    | Max String capacity for verification model   |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |\n"));
-    r.push_str(String::from("| `--btreemap-max <N>` | `64`   | Max BTreeMap capacity for verification model |\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("**Compile-object cache behavior.** The on-disk compile-object cache (`$VOW_CACHE_DIR` or `~/.cache/vow/`, where each entry is a `<key>.o` artifact keyed by a content hash of all dependencies, mode, and trace settings) is automatically disabled whenever ESBMC verification is active. This guarantees the linked binary always comes from the same codegen run whose IR was verified, closing the integrity gap where a stale or attacker-supplied `.o` could be linked against freshly-verified IR. Concretely the cache only activates on `vow build --no-verify` invocations; it is bypassed on the default `vow build` path. `--no-cache` additionally disables the cache for `--no-verify` builds.\n"));
@@ -6659,10 +6470,6 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |\n"));
     r.push_str(String::from("| `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |\n"));
-    r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
-    r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
-    r.push_str(String::from("| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow contracts`\n"));
@@ -6682,10 +6489,6 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |\n"));
     r.push_str(String::from("| `--solver <boolector\\|z3\\|bitwuzla\\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |\n"));
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |\n"));
-    r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
-    r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
-    r.push_str(String::from("| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.\n"));
@@ -6731,10 +6534,6 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `--mode release`  | `debug`     | Omit all vow checks for performance       |\n"));
     r.push_str(String::from("| `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |\n"));
     r.push_str(String::from("| `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations (with --verify) |\n"));
-    r.push_str(String::from("| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |\n"));
-    r.push_str(String::from("| `--string-max <N>`| `256`       | Max String capacity for verification model |\n"));
-    r.push_str(String::from("| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|\n"));
-    r.push_str(String::from("| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs (with --verify) |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("Test discovery: files matching `test_*.vow` or `*_test.vow` under the given directory **and its subdirectories**, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.\n"));
@@ -7145,15 +6944,37 @@ fn skill_support_content_2() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Collection Models for Verification\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("ESBMC uses bounded models for collection types. Defaults are shown below; override with `--vec-max`, `--string-max`, `--hashmap-max`:\n"));
+    r.push_str(String::from("ESBMC is a *bounded* model checker, so it models collection types as\n"));
+    r.push_str(String::from("fixed-size arrays and reasons about them up to a finite capacity. These\n"));
+    r.push_str(String::from("capacities are an internal property of the verifier, not of the language:\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("| Type              | Default Max Capacity | CLI Flag | Supported Operations |\n"));
-    r.push_str(String::from("|-------------------|---------------------|----------|----------------------------------------------|\n"));
-    r.push_str(String::from("| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |\n"));
-    r.push_str(String::from("| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |\n"));
-    r.push_str(String::from("| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|\n"));
+    r.push_str(String::from("| Type              | Model Capacity | Supported Operations |\n"));
+    r.push_str(String::from("|-------------------|----------------|----------------------------------------------|\n"));
+    r.push_str(String::from("| `Vec<T>`          | 128            | `new`, `push`, `pop`, `len`, `get`, `set`    |\n"));
+    r.push_str(String::from("| `String`          | 256            | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |\n"));
+    r.push_str(String::from("| `HashMap<K, V>`   | 64             | `new`, `insert`, `get`, `contains_key`, `len`|\n"));
+    r.push_str(String::from("| `BTreeMap<K, V>`  | 64             | `new`, `insert`, `get`, `contains_key`, `len`|\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("These support the same operations as the runtime but with bounded storage. String literals carry their concrete length and bytes in verification, and `String::from` copies that model from its source value. The effective string model capacity is at least the longest static string literal, even when `--string-max` is lower, so literal byte initializers fit the model array. Operations whose bytes are not statically known, such as `String::from_cstr`, produce a nondeterministic length (0 to max-1). `string_matches_literal_at` is modeled against the literal's concrete bytes and byte length; the third argument must be a string literal so the verifier never has to infer static text from a dynamic `String`.\n"));
+    r.push_str(String::from("**These bounds are not a language feature and are not user-tunable.** A `Vec`\n"));
+    r.push_str(String::from("in a Vow program grows dynamically on the heap with no fixed maximum; the\n"));
+    r.push_str(String::from("capacity above only describes how far the *bounded* model checker reasons. The\n"));
+    r.push_str(String::from("language and its contracts are deliberately decoupled from what any particular\n"));
+    r.push_str(String::from("prover can prove: replace ESBMC with a stronger (or unbounded) checker and the\n"));
+    r.push_str(String::from("same source, the same contracts, and the same CLI keep working -- the only\n"));
+    r.push_str(String::from("difference is that proof covers more (or all) of the state space. For this\n"));
+    r.push_str(String::from("reason a `requires`/`ensures` clause must never encode a verifier bound (e.g.\n"));
+    r.push_str(String::from("`requires: v.len() <= 128`); see \"Verification-Driven Bounds (Anti-Pattern)\"\n"));
+    r.push_str(String::from("below and `docs/design/verifier-model-bounds.md`.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("These models support the same operations as the runtime but with bounded\n"));
+    r.push_str(String::from("storage. String literals carry their concrete length and bytes in verification,\n"));
+    r.push_str(String::from("and `String::from` copies that model from its source value. The effective string\n"));
+    r.push_str(String::from("model capacity is automatically at least the longest static string literal, so\n"));
+    r.push_str(String::from("literal byte initializers always fit the model array. Operations whose bytes are\n"));
+    r.push_str(String::from("not statically known, such as `String::from_cstr`, produce a nondeterministic\n"));
+    r.push_str(String::from("length (0 to max-1). `string_matches_literal_at` is modeled against the\n"));
+    r.push_str(String::from("literal's concrete bytes and byte length; the third argument must be a string\n"));
+    r.push_str(String::from("literal so the verifier never has to infer static text from a dynamic `String`.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Blame Model\n"));
     r.push_str(String::from("\n"));
@@ -7396,7 +7217,7 @@ fn skill_support_content_2() -> String {
     r.push_str(String::from("} { ... }\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic) -- if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification.\n"));
+    r.push_str(String::from("Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic, bounded collection models) -- if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification. The same rule is why the verifier's collection model capacities (see \"Collection Models for Verification\") are internal defaults rather than CLI flags or contract clauses: a bound that belongs to the prover must never leak into the language.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Interpreting Counterexamples\n"));
     r.push_str(String::from("\n"));
@@ -9097,13 +8918,12 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
             solver = String::from("z3");
         }
     }
-    let vec_max_c: i64 = { let s: String = get_flag_arg(argv, "--vec-max"); if s.len() > 0 { parse_i64(s) } else { 128 } };
-    let string_max_c: i64 = { let s: String = get_flag_arg(argv, "--string-max"); if s.len() > 0 { parse_i64(s) } else { 256 } };
-    let hashmap_max_c: i64 = { let s: String = get_flag_arg(argv, "--hashmap-max"); if s.len() > 0 { parse_i64(s) } else { 64 } };
-    let btreemap_max_c: i64 = { let s: String = get_flag_arg(argv, "--btreemap-max"); if s.len() > 0 { parse_i64(s) } else { 64 } };
-    validate_limits(vec_max_c, string_max_c, hashmap_max_c, btreemap_max_c);
-    // Accepted for CLI parity with build/verify/test; validates a 0 rejection
-    // uniformly, then is discarded because the contracts verify loop is serial.
+    let vec_max_c: i64 = VOW_VEC_MAX();
+    let string_max_c: i64 = VOW_STRING_MAX();
+    let hashmap_max_c: i64 = VOW_HASHMAP_MAX();
+    let btreemap_max_c: i64 = VOW_BTREEMAP_MAX();
+    // Accepted for CLI parity with build/verify/test; resolved via the same
+    // path, then discarded because the contracts verify loop is serial.
     let _cjobs: i64 = resolve_verify_jobs(argv);
 
     // Collect per-contract entries into parallel arrays

--- a/docs/design/verifier-model-bounds.md
+++ b/docs/design/verifier-model-bounds.md
@@ -1,0 +1,149 @@
+# Verifier model bounds are decoupled from the language
+
+**Status:** Normative design specification. Implemented.
+
+This document records the decision and rationale for issue
+[#278](https://github.com/vow-lang/vow/issues/278): the removal of the
+verify-only `--vec-max` / `--string-max` / `--hashmap-max` / `--btreemap-max`
+capacity flags. It is the authoritative statement of how bounded-model-checker
+limits relate to the Vow language. When this document and an implementation
+disagree, this document is normative.
+
+It fulfills roadmap workstream **WS-3.4** ("Stop leaking verifier bounds into
+contracts") of `docs/roadmap-0.3.0-foundations.md`.
+
+## The principle
+
+**The language and its contracts are decoupled from what any particular prover
+can prove.** A property a Vow program asserts (`requires`, `ensures`,
+`invariant`) is a statement about the program, not about the tool that checks
+it. The prover's reach — how much of the state space it can actually discharge —
+is a separate concern that lives entirely inside the verifier.
+
+The test for any verification mechanism is therefore:
+
+> If we replaced the current prover with an infinitely powerful, unbounded model
+> checker, would the source, the contracts, and the CLI keep working unchanged —
+> the only difference being that we now prove the whole state space instead of a
+> bounded slice?
+
+If the answer is "no, something in the language would have to change," that
+something is a leak and does not belong in the language. The bounded model
+checker we use today (ESBMC) must be swappable for a stronger backend with **no
+edits to any `.vow` source, any contract, or any user-facing CLI surface.**
+
+## What was wrong
+
+ESBMC is a *bounded* model checker. Its C model represents each collection as a
+fixed-size array:
+
+```c
+typedef struct { int64_t len; int64_t data[VEC_MAX]; } __vow_vec_t;
+__ESBMC_assert(v.len < VEC_MAX, "vec capacity");
+```
+
+so the model needs a finite capacity per collection type. We had exposed those
+capacities as four CLI flags with per-collection defaults (`--vec-max 128`,
+`--string-max 256`, `--hashmap-max 64`, `--btreemap-max 64`).
+
+This leaked the verifier's implementation into the language surface:
+
+- A user reading `--btreemap-max <N>` reasonably asks "why does my data
+  structure have a maximum?" It does not. A `Vec`/`String`/`HashMap`/`BTreeMap`
+  in a compiled Vow program grows dynamically on the heap with no fixed cap. The
+  flag described ESBMC's model, not the language.
+- It invited the exact anti-pattern `docs/spec/contracts.md` forbids: encoding a
+  verifier bound (`requires: v.len() <= 128`) as if it were a semantic contract.
+- It did not scale: every new collection type (BTreeSet, future trees) would
+  grow yet another `--xxx-max` flag.
+
+An unbounded backend would make all four flags meaningless — proof that they
+were never language properties.
+
+## The decision
+
+1. **Remove all four flags** from both compilers, from every subcommand
+   (`build`, `verify`, `test`, `contracts`, and the legacy bare form), and from
+   all help / skill / capability output.
+2. **Keep a single safe internal default per collection type**, passed to ESBMC
+   by the verifier. These defaults are not user-tunable and are not part of the
+   language. The current values are `Vec` 128, `String` 256, `HashMap` 64,
+   `BTreeMap` 64 — chosen because they verify the entire reference + benchmark
+   corpus and the self-hosted compiler.
+3. **Keep automatic, invisible per-function widening** where the model *must*
+   accommodate static content: a string literal longer than the default
+   `String` capacity transparently raises that function's `String` model size
+   (`limits_with_literal_string_capacity` in Rust, `string_max_for_literals` in
+   the self-hosted compiler). This is the verifier adapting its own model to the
+   program; it is never surfaced and never tunable.
+4. **No escape hatch on the language side.** A program that genuinely cannot be
+   proven within the model is a *prover* limitation, addressed by a stronger or
+   unbounded backend — never by a language knob. See "Failure semantics" below.
+
+## Why not the alternatives
+
+The issue floated several directions. All were rejected in favor of the above
+because they either relocated the leak or contradicted the principle:
+
+- **Per-function annotation** (`vow { capacity: 100, ... }`) moves the verifier
+  bound *into the contract block* — the worst possible place — and adds a new,
+  non-predicate clause axis to the grammar. Directly contradicts WS-3.4.
+- **Auto-size from contracts** (read `requires: m.len() <= 100`) rewards writing
+  a verifier bound as a contract, the precise anti-pattern we forbid, and
+  couples the contract text to the model's array sizing.
+- **Construction-site bound** (`Vec::with_capacity(100)` doubles as the model
+  bound) adds surface syntax to an intentionally small language, does not bound
+  function-parameter collections (the common case has no construction site), and
+  conflates runtime reservation with verification bounding.
+- **Rename to `--verify-*`** only renames the smell; the per-collection-flag
+  proliferation and the conceptual mismatch remain.
+- **Lift to ESBMC heap/SMT arrays** is a large re-architecture of the collection
+  model with high verifier cost and is out of scope for retiring the flags;
+  under BMC, loops still unwind to a bound, so a bound does not actually
+  disappear. It can be revisited independently as a prover-side improvement —
+  and, by this document's principle, doing so would require **no** language
+  change.
+
+Crucially, an unbounded backend (or the ESBMC-SMT-array direction) can be
+adopted later with zero changes to the language, contracts, or CLI. That is the
+whole point of the decoupling.
+
+## Where the bound lives
+
+The bound is defined in exactly one place per compiler and threaded only through
+internal verification code:
+
+- **Rust:** `vow-verify/src/c_emitter.rs` — the `VEC_MODEL_CAP` /
+  `STRING_MODEL_CAP` / `HASHMAP_MODEL_CAP` / `BTREEMAP_MODEL_CAP` constants and
+  `VerifyLimits::default()`. The CLI (`vow/src/main.rs`) constructs
+  `VerifyLimits` from `..VerifyLimits::default()` and only overrides
+  `max_k_step` (a genuine, retained verification-performance knob).
+- **Self-hosted:** `compiler/c_emitter.vow` — `VOW_VEC_MAX()` /
+  `VOW_STRING_MAX()` / `VOW_HASHMAP_MAX()` / `VOW_BTREEMAP_MAX()`. The CLI
+  (`compiler/main.vow`) sources the bounds from these constants instead of
+  parsing flags.
+
+`max_k_step` is **not** in scope for this decision. It is a verification-effort
+control (how far incremental BMC unwinds), not a language-visible property of a
+data type, and it remains a CLI flag.
+
+## Failure semantics (follow-up)
+
+Under this model, exceeding a collection's model capacity is a *verifier
+limitation*, not a contract violation: it means "this prover could not reason
+about this program within its model," not "this program is wrong." The honest
+classification is therefore a verifier-model outcome (a `bug`/unprovable status
+under roadmap §5.3 "No false `FAILED`"), distinct from a real contract `FAILED`
+backed by a counterexample. Today the capacity assertions already carry
+`blame = none` and no `vow_id`, so they are not attributed to any user contract.
+Tightening the *reported status* for a model-capacity hit so it never reads as a
+contract `FAILED` is tracked as follow-up work alongside #552; it does not
+affect the flag removal, which is complete.
+
+## Migration
+
+The flags were verify-only and had no effect on compiled binaries, so removing
+them changes no program's runtime behavior. Any script, CI step, or harness that
+passed `--vec-max` / `--string-max` / `--hashmap-max` / `--btreemap-max` must
+drop those arguments; the defaults they were almost always set to are now the
+built-in behavior. There is no replacement flag — by design.

--- a/docs/design/verifier-model-bounds.md
+++ b/docs/design/verifier-model-bounds.md
@@ -9,8 +9,10 @@ capacity flags. It is the authoritative statement of how bounded-model-checker
 limits relate to the Vow language. When this document and an implementation
 disagree, this document is normative.
 
-It fulfills roadmap workstream **WS-3.4** ("Stop leaking verifier bounds into
-contracts") of `docs/roadmap-0.3.0-foundations.md`.
+It fulfills the 0.3.0 Foundations stabilization plan
+(`docs/roadmap-0.3.0-foundations.md`, tracked in #564), workstream **WS-3**
+("Make verification tractable and meaningful"), item 4 — "Stop leaking verifier
+bounds into contracts" (#278, #552).
 
 ## The principle
 
@@ -133,7 +135,7 @@ Under this model, exceeding a collection's model capacity is a *verifier
 limitation*, not a contract violation: it means "this prover could not reason
 about this program within its model," not "this program is wrong." The honest
 classification is therefore a verifier-model outcome (a `bug`/unprovable status
-under roadmap §5.3 "No false `FAILED`"), distinct from a real contract `FAILED`
+under the roadmap's "No false `FAILED`" engineering guideline), distinct from a real contract `FAILED`
 backed by a counterexample. Today the capacity assertions already carry
 `blame = none` and no `vow_id`, so they are not attributed to any user contract.
 Tightening the *reported status* for a model-capacity hit so it never reads as a

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -25,10 +25,6 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |
-| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
-| `--string-max <N>` | `256`    | Max String capacity for verification model   |
-| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
-| `--btreemap-max <N>` | `64`   | Max BTreeMap capacity for verification model |
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 **Compile-object cache behavior.** The on-disk compile-object cache (`$VOW_CACHE_DIR` or `~/.cache/vow/`, where each entry is a `<key>.o` artifact keyed by a content hash of all dependencies, mode, and trace settings) is automatically disabled whenever ESBMC verification is active. This guarantees the linked binary always comes from the same codegen run whose IR was verified, closing the integrity gap where a stale or attacker-supplied `.o` could be linked against freshly-verified IR. Concretely the cache only activates on `vow build --no-verify` invocations; it is bypassed on the default `vow build` path. `--no-cache` additionally disables the cache for `--no-verify` builds.
@@ -50,10 +46,6 @@ vow verify [OPTIONS] <source.vow>
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 ### `vow contracts`
@@ -73,10 +65,6 @@ vow contracts [OPTIONS] <source.vow>
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
@@ -122,10 +110,6 @@ vow test [OPTIONS] [<path>]
 | `--mode release`  | `debug`     | Omit all vow checks for performance       |
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations (with --verify) |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs (with --verify) |
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` under the given directory **and its subdirectories**, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.

--- a/docs/spec/contracts.md
+++ b/docs/spec/contracts.md
@@ -22,15 +22,37 @@ Contract clauses become IR opcodes. The C emitter translates `requires` to `__ES
 
 ### Collection Models for Verification
 
-ESBMC uses bounded models for collection types. Defaults are shown below; override with `--vec-max`, `--string-max`, `--hashmap-max`:
+ESBMC is a *bounded* model checker, so it models collection types as
+fixed-size arrays and reasons about them up to a finite capacity. These
+capacities are an internal property of the verifier, not of the language:
 
-| Type              | Default Max Capacity | CLI Flag | Supported Operations |
-|-------------------|---------------------|----------|----------------------------------------------|
-| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |
-| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |
-| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|
+| Type              | Model Capacity | Supported Operations |
+|-------------------|----------------|----------------------------------------------|
+| `Vec<T>`          | 128            | `new`, `push`, `pop`, `len`, `get`, `set`    |
+| `String`          | 256            | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |
+| `HashMap<K, V>`   | 64             | `new`, `insert`, `get`, `contains_key`, `len`|
+| `BTreeMap<K, V>`  | 64             | `new`, `insert`, `get`, `contains_key`, `len`|
 
-These support the same operations as the runtime but with bounded storage. String literals carry their concrete length and bytes in verification, and `String::from` copies that model from its source value. The effective string model capacity is at least the longest static string literal, even when `--string-max` is lower, so literal byte initializers fit the model array. Operations whose bytes are not statically known, such as `String::from_cstr`, produce a nondeterministic length (0 to max-1). `string_matches_literal_at` is modeled against the literal's concrete bytes and byte length; the third argument must be a string literal so the verifier never has to infer static text from a dynamic `String`.
+**These bounds are not a language feature and are not user-tunable.** A `Vec`
+in a Vow program grows dynamically on the heap with no fixed maximum; the
+capacity above only describes how far the *bounded* model checker reasons. The
+language and its contracts are deliberately decoupled from what any particular
+prover can prove: replace ESBMC with a stronger (or unbounded) checker and the
+same source, the same contracts, and the same CLI keep working — the only
+difference is that proof covers more (or all) of the state space. For this
+reason a `requires`/`ensures` clause must never encode a verifier bound (e.g.
+`requires: v.len() <= 128`); see "Verification-Driven Bounds (Anti-Pattern)"
+below and `docs/design/verifier-model-bounds.md`.
+
+These models support the same operations as the runtime but with bounded
+storage. String literals carry their concrete length and bytes in verification,
+and `String::from` copies that model from its source value. The effective string
+model capacity is automatically at least the longest static string literal, so
+literal byte initializers always fit the model array. Operations whose bytes are
+not statically known, such as `String::from_cstr`, produce a nondeterministic
+length (0 to max-1). `string_matches_literal_at` is modeled against the
+literal's concrete bytes and byte length; the third argument must be a string
+literal so the verifier never has to infer static text from a dynamic `String`.
 
 ## Blame Model
 
@@ -273,7 +295,7 @@ fn gcd(a: i64, b: i64) -> i64 vow {
 } { ... }
 ```
 
-Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic) — if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification.
+Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic, bounded collection models) — if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification. The same rule is why the verifier's collection model capacities (see "Collection Models for Verification") are internal defaults rather than CLI flags or contract clauses: a bound that belongs to the prover must never leak into the language.
 
 ## Interpreting Counterexamples
 

--- a/lib/heap/max_heap.vow
+++ b/lib/heap/max_heap.vow
@@ -114,8 +114,8 @@ fn max_right_idx(i: i64) -> i64 vow {
 }
 
 // The max_left_idx/max_right_idx overflow guard (i <= 2^62 - 2) is
-// discharged in practice by n <= data.len(), which ESBMC bounds via
-// --vec-max (default 128). The loop invariant only carries i < n; the
+// discharged in practice by n <= data.len(), which ESBMC bounds via the
+// internal Vec model capacity (128). The loop invariant only carries i < n; the
 // stronger formal chain is not stated because it would require a
 // verifier-driven cap on the heap size itself.
 fn max_sift_down(data: Vec<i64>, n: i64, start: i64) vow {

--- a/lib/heap/min_heap.vow
+++ b/lib/heap/min_heap.vow
@@ -114,8 +114,8 @@ fn min_right_idx(i: i64) -> i64 vow {
 }
 
 // The min_left_idx/min_right_idx overflow guard (i <= 2^62 - 2) is
-// discharged in practice by n <= data.len(), which ESBMC bounds via
-// --vec-max (default 128). The loop invariant only carries i < n; the
+// discharged in practice by n <= data.len(), which ESBMC bounds via the
+// internal Vec model capacity (128). The loop invariant only carries i < n; the
 // stronger formal chain is not stated because it would require a
 // verifier-driven cap on the heap size itself.
 fn min_sift_down(data: Vec<i64>, n: i64, start: i64) vow {

--- a/scripts/generate_help.py
+++ b/scripts/generate_help.py
@@ -147,7 +147,7 @@ def normalize_option(
         option["value_kind"] = "enum"
         option["values"] = ["off", "calls", "full"]
         option["default"] = default
-    elif normalized_flag in ("--max-k-step <N>", "--vec-max <N>", "--string-max <N>", "--hashmap-max <N>", "--btreemap-max <N>"):
+    elif normalized_flag == "--max-k-step <N>":
         option["default"] = int(default) if default.isdigit() else default
     elif output_default is not None:
         option["default"] = output_default
@@ -295,14 +295,13 @@ def build_help_json(grammar: str, cli: str, _contracts: str) -> dict:
         contracts_options[key] = value
         contracts_option_entries.append(option)
 
-    # --- Verification defaults (configurable via CLI flags) ---
+    # --- Verification defaults ---
+    # Collection model capacities (Vec/String/HashMap/BTreeMap) are deliberately
+    # absent: they are internal verifier-model bounds, not language properties or
+    # tunable CLI flags. See docs/design/verifier-model-bounds.md.
     verification_defaults: dict[str, str | int] = {
         "strategy": "k-induction-parallel",
         "max_k_step": DEFAULT_MAX_K_STEP,
-        "vec_max": 128,
-        "string_max": 256,
-        "hashmap_max": 64,
-        "btreemap_max": 64,
     }
 
     return {
@@ -739,13 +738,9 @@ def build_help_human(data: dict) -> str:
 
     vdefaults = data.get("verification_defaults", {})
     if vdefaults:
-        lines.append("VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max, --btreemap-max)")
+        lines.append("VERIFICATION DEFAULTS (--max-k-step)")
         lines.append(f"  Strategy        : {vdefaults.get('strategy', 'k-induction-parallel')} (incremental BMC + k-induction)")
         lines.append(f"  Incremental BMC : {vdefaults.get('max_k_step', DEFAULT_MAX_K_STEP)} max iterations (--max-k-step)")
-        lines.append(f"  Vec<T>          : {vdefaults.get('vec_max', 128)} max capacity")
-        lines.append(f"  String          : {vdefaults.get('string_max', 256)} max capacity")
-        lines.append(f"  HashMap<K, V>   : {vdefaults.get('hashmap_max', 64)} max capacity")
-        lines.append(f"  BTreeMap<K, V>  : {vdefaults.get('btreemap_max', 64)} max capacity")
 
     return "\n".join(lines)
 

--- a/skills/vow/reference/cli.md
+++ b/skills/vow/reference/cli.md
@@ -25,10 +25,6 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |
-| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
-| `--string-max <N>` | `256`    | Max String capacity for verification model   |
-| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
-| `--btreemap-max <N>` | `64`   | Max BTreeMap capacity for verification model |
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 **Compile-object cache behavior.** The on-disk compile-object cache (`$VOW_CACHE_DIR` or `~/.cache/vow/`, where each entry is a `<key>.o` artifact keyed by a content hash of all dependencies, mode, and trace settings) is automatically disabled whenever ESBMC verification is active. This guarantees the linked binary always comes from the same codegen run whose IR was verified, closing the integrity gap where a stale or attacker-supplied `.o` could be linked against freshly-verified IR. Concretely the cache only activates on `vow build --no-verify` invocations; it is bypassed on the default `vow build` path. `--no-cache` additionally disables the cache for `--no-verify` builds.
@@ -50,10 +46,6 @@ vow verify [OPTIONS] <source.vow>
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 ### `vow contracts`
@@ -73,10 +65,6 @@ vow contracts [OPTIONS] <source.vow>
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
@@ -122,10 +110,6 @@ vow test [OPTIONS] [<path>]
 | `--mode release`  | `debug`     | Omit all vow checks for performance       |
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations (with --verify) |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs (with --verify) |
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` under the given directory **and its subdirectories**, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.

--- a/skills/vow/reference/contracts.md
+++ b/skills/vow/reference/contracts.md
@@ -22,15 +22,37 @@ Contract clauses become IR opcodes. The C emitter translates `requires` to `__ES
 
 ### Collection Models for Verification
 
-ESBMC uses bounded models for collection types. Defaults are shown below; override with `--vec-max`, `--string-max`, `--hashmap-max`:
+ESBMC is a *bounded* model checker, so it models collection types as
+fixed-size arrays and reasons about them up to a finite capacity. These
+capacities are an internal property of the verifier, not of the language:
 
-| Type              | Default Max Capacity | CLI Flag | Supported Operations |
-|-------------------|---------------------|----------|----------------------------------------------|
-| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |
-| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |
-| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|
+| Type              | Model Capacity | Supported Operations |
+|-------------------|----------------|----------------------------------------------|
+| `Vec<T>`          | 128            | `new`, `push`, `pop`, `len`, `get`, `set`    |
+| `String`          | 256            | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |
+| `HashMap<K, V>`   | 64             | `new`, `insert`, `get`, `contains_key`, `len`|
+| `BTreeMap<K, V>`  | 64             | `new`, `insert`, `get`, `contains_key`, `len`|
 
-These support the same operations as the runtime but with bounded storage. String literals carry their concrete length and bytes in verification, and `String::from` copies that model from its source value. The effective string model capacity is at least the longest static string literal, even when `--string-max` is lower, so literal byte initializers fit the model array. Operations whose bytes are not statically known, such as `String::from_cstr`, produce a nondeterministic length (0 to max-1). `string_matches_literal_at` is modeled against the literal's concrete bytes and byte length; the third argument must be a string literal so the verifier never has to infer static text from a dynamic `String`.
+**These bounds are not a language feature and are not user-tunable.** A `Vec`
+in a Vow program grows dynamically on the heap with no fixed maximum; the
+capacity above only describes how far the *bounded* model checker reasons. The
+language and its contracts are deliberately decoupled from what any particular
+prover can prove: replace ESBMC with a stronger (or unbounded) checker and the
+same source, the same contracts, and the same CLI keep working — the only
+difference is that proof covers more (or all) of the state space. For this
+reason a `requires`/`ensures` clause must never encode a verifier bound (e.g.
+`requires: v.len() <= 128`); see "Verification-Driven Bounds (Anti-Pattern)"
+below and `docs/design/verifier-model-bounds.md`.
+
+These models support the same operations as the runtime but with bounded
+storage. String literals carry their concrete length and bytes in verification,
+and `String::from` copies that model from its source value. The effective string
+model capacity is automatically at least the longest static string literal, so
+literal byte initializers always fit the model array. Operations whose bytes are
+not statically known, such as `String::from_cstr`, produce a nondeterministic
+length (0 to max-1). `string_matches_literal_at` is modeled against the
+literal's concrete bytes and byte length; the third argument must be a string
+literal so the verifier never has to infer static text from a dynamic `String`.
 
 ## Blame Model
 
@@ -273,7 +295,7 @@ fn gcd(a: i64, b: i64) -> i64 vow {
 } { ... }
 ```
 
-Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic) — if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification.
+Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic, bounded collection models) — if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification. The same rule is why the verifier's collection model capacities (see "Collection Models for Verification") are internal defaults rather than CLI flags or contract clauses: a bound that belongs to the prover must never leak into the language.
 
 ## Interpreting Counterexamples
 

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -70,6 +70,14 @@ pub const HASHMAP_MODEL_CAP: usize = 64;
 /// Safe default model capacity for `BTreeMap<K, V>` under bounded model checking.
 pub const BTREEMAP_MODEL_CAP: usize = 64;
 
+// A capacity of zero would emit a zero-length C array and an unsatisfiable
+// `len < CAP` assertion, silently breaking all collection verification. Pin the
+// positivity invariant the (now-removed) CLI `validate_limits` used to enforce.
+const _: () = assert!(
+    VEC_MODEL_CAP > 0 && STRING_MODEL_CAP > 0 && HASHMAP_MODEL_CAP > 0 && BTREEMAP_MODEL_CAP > 0,
+    "collection model capacities must be positive",
+);
+
 #[derive(Debug, Clone, Copy)]
 pub struct VerifyLimits {
     pub max_k_step: u32,

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -48,8 +48,27 @@ pub fn detect_constant_functions(module: &Module) -> HashMap<FuncId, ConstantVal
 }
 
 // ---------------------------------------------------------------------------
-// Verification limits for bounded model checking
+// Verification model bounds for bounded model checking
+//
+// ESBMC models Vec/String/HashMap/BTreeMap as fixed-size C arrays, so the model
+// needs a finite capacity per collection. These are *internal verifier-model*
+// parameters with safe defaults — NOT language properties and NOT user-tunable.
+// The bound is a fact about the prover, not about Vow: a program that needs more
+// proof power is a prover concern (a stronger or unbounded backend), never a
+// language knob. Swap in an unbounded checker and the same source, contracts,
+// and CLI verify unchanged. See docs/design/verifier-model-bounds.md.
 // ---------------------------------------------------------------------------
+
+/// Safe default model capacity for `Vec<T>` under bounded model checking.
+pub const VEC_MODEL_CAP: usize = 128;
+/// Safe default model capacity for `String` under bounded model checking. The
+/// verifier transparently raises this per function when a string literal is
+/// longer (see `limits_with_literal_string_capacity`).
+pub const STRING_MODEL_CAP: usize = 256;
+/// Safe default model capacity for `HashMap<K, V>` under bounded model checking.
+pub const HASHMAP_MODEL_CAP: usize = 64;
+/// Safe default model capacity for `BTreeMap<K, V>` under bounded model checking.
+pub const BTREEMAP_MODEL_CAP: usize = 64;
 
 #[derive(Debug, Clone, Copy)]
 pub struct VerifyLimits {
@@ -64,10 +83,10 @@ impl Default for VerifyLimits {
     fn default() -> Self {
         Self {
             max_k_step: 50,
-            vec_max: 128,
-            string_max: 256,
-            hashmap_max: 64,
-            btreemap_max: 64,
+            vec_max: VEC_MODEL_CAP,
+            string_max: STRING_MODEL_CAP,
+            hashmap_max: HASHMAP_MODEL_CAP,
+            btreemap_max: BTREEMAP_MODEL_CAP,
         }
     }
 }

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -117,14 +117,6 @@ struct Args {
     no_cache: bool,
     #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
     max_k_step: u32,
-    #[arg(long, default_value = "128")]
-    vec_max: usize,
-    #[arg(long, default_value = "256")]
-    string_max: usize,
-    #[arg(long, default_value = "64")]
-    hashmap_max: usize,
-    #[arg(long, default_value = "64")]
-    btreemap_max: usize,
     #[arg(long, value_enum, default_value = "auto")]
     solver: SolverArg,
     #[arg(long, value_enum, default_value = "auto")]
@@ -175,14 +167,6 @@ struct BuildArgs {
     no_cache: bool,
     #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
     max_k_step: u32,
-    #[arg(long, default_value = "128")]
-    vec_max: usize,
-    #[arg(long, default_value = "256")]
-    string_max: usize,
-    #[arg(long, default_value = "64")]
-    hashmap_max: usize,
-    #[arg(long, default_value = "64")]
-    btreemap_max: usize,
     #[arg(long, value_enum, default_value = "auto")]
     solver: SolverArg,
     #[arg(long, value_enum, default_value = "auto")]
@@ -209,14 +193,6 @@ struct VerifyArgs {
     no_cache: bool,
     #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
     max_k_step: u32,
-    #[arg(long, default_value = "128")]
-    vec_max: usize,
-    #[arg(long, default_value = "256")]
-    string_max: usize,
-    #[arg(long, default_value = "64")]
-    hashmap_max: usize,
-    #[arg(long, default_value = "64")]
-    btreemap_max: usize,
     #[arg(long, value_enum, default_value = "auto")]
     solver: SolverArg,
     #[arg(long, value_enum, default_value = "auto")]
@@ -252,14 +228,6 @@ struct TestArgs {
     /// ESBMC max k-induction step (only with --verify)
     #[arg(long, default_value_t = DEFAULT_MAX_K_STEP)]
     max_k_step: u32,
-    #[arg(long, default_value = "128")]
-    vec_max: usize,
-    #[arg(long, default_value = "256")]
-    string_max: usize,
-    #[arg(long, default_value = "64")]
-    hashmap_max: usize,
-    #[arg(long, default_value = "64")]
-    btreemap_max: usize,
     #[arg(long)]
     verify_jobs: Option<u32>,
     #[arg(long)]
@@ -290,14 +258,6 @@ struct ContractsArgs {
     no_cache: bool,
     #[arg(long)]
     max_k_step: Option<u32>,
-    #[arg(long, default_value = "128")]
-    vec_max: usize,
-    #[arg(long, default_value = "256")]
-    string_max: usize,
-    #[arg(long, default_value = "64")]
-    hashmap_max: usize,
-    #[arg(long, default_value = "64")]
-    btreemap_max: usize,
     #[arg(long, value_enum, default_value = "auto")]
     solver: SolverArg,
     #[arg(long, value_enum, default_value = "auto")]
@@ -524,38 +484,6 @@ fn skill_json() -> String {
           "default": "300 (or 30 when --encoding is auto)"
         },
         {
-          "form": "--vec-max <N>",
-          "description": "Max Vec capacity for verification model (default: 128)",
-          "long": "--vec-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 128
-        },
-        {
-          "form": "--string-max <N>",
-          "description": "Max String capacity for verification model (default: 256)",
-          "long": "--string-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 256
-        },
-        {
-          "form": "--hashmap-max <N>",
-          "description": "Max HashMap capacity for verification model (default: 64)",
-          "long": "--hashmap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
-        },
-        {
-          "form": "--btreemap-max <N>",
-          "description": "Max BTreeMap capacity for verification model (default: 64)",
-          "long": "--btreemap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
-        },
-        {
           "form": "--verify-jobs <N>",
           "description": "Max concurrent ESBMC verification jobs (default: num_cpus/2)",
           "long": "--verify-jobs",
@@ -645,38 +573,6 @@ fn skill_json() -> String {
           "default": "300 (or 30 when --encoding is auto)"
         },
         {
-          "form": "--vec-max <N>",
-          "description": "Max Vec capacity for verification model (default: 128)",
-          "long": "--vec-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 128
-        },
-        {
-          "form": "--string-max <N>",
-          "description": "Max String capacity for verification model (default: 256)",
-          "long": "--string-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 256
-        },
-        {
-          "form": "--hashmap-max <N>",
-          "description": "Max HashMap capacity for verification model (default: 64)",
-          "long": "--hashmap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
-        },
-        {
-          "form": "--btreemap-max <N>",
-          "description": "Max BTreeMap capacity for verification model (default: 64)",
-          "long": "--btreemap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
-        },
-        {
           "form": "--verify-jobs <N>",
           "description": "Max concurrent ESBMC verification jobs (default: num_cpus/2)",
           "long": "--verify-jobs",
@@ -758,38 +654,6 @@ fn skill_json() -> String {
           "value_name": "N",
           "value_kind": "integer",
           "default": 50
-        },
-        {
-          "form": "--vec-max <N>",
-          "description": "Max Vec capacity for verification model (default: 128)",
-          "long": "--vec-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 128
-        },
-        {
-          "form": "--string-max <N>",
-          "description": "Max String capacity for verification model (default: 256)",
-          "long": "--string-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 256
-        },
-        {
-          "form": "--hashmap-max <N>",
-          "description": "Max HashMap capacity for verification model (default: 64)",
-          "long": "--hashmap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
-        },
-        {
-          "form": "--btreemap-max <N>",
-          "description": "Max BTreeMap capacity for verification model (default: 64)",
-          "long": "--btreemap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
         },
         {
           "form": "--verify-jobs <N>",
@@ -901,38 +765,6 @@ fn skill_json() -> String {
           "default": "auto"
         },
         {
-          "form": "--vec-max <N>",
-          "description": "Max Vec capacity for verification model (default: 128)",
-          "long": "--vec-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 128
-        },
-        {
-          "form": "--string-max <N>",
-          "description": "Max String capacity for verification model (default: 256)",
-          "long": "--string-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 256
-        },
-        {
-          "form": "--hashmap-max <N>",
-          "description": "Max HashMap capacity for verification model (default: 64)",
-          "long": "--hashmap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
-        },
-        {
-          "form": "--btreemap-max <N>",
-          "description": "Max BTreeMap capacity for verification model (default: 64)",
-          "long": "--btreemap-max",
-          "value_name": "N",
-          "value_kind": "integer",
-          "default": 64
-        },
-        {
           "form": "--verify-jobs <N>",
           "description": "Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)",
           "long": "--verify-jobs",
@@ -962,10 +794,6 @@ fn skill_json() -> String {
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
     "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit --timeout overrides both. --timeout 0 is honoured as an immediate watchdog kill (default: 300 (or 30 when --encoding is auto))",
-    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
-    "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
-    "--btreemap-max <N>": "Max BTreeMap capacity for verification model (default: 64)",
     "--verify-jobs <N>": "Max concurrent ESBMC verification jobs (default: num_cpus/2)"
   },
   "verify_options": {
@@ -974,10 +802,6 @@ fn skill_json() -> String {
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver; auto selects per-function via heuristic (default: auto)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)",
     "--timeout <N>": "ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit --timeout overrides both. --timeout 0 is honoured as an immediate watchdog kill (default: 300 (or 30 when --encoding is auto))",
-    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
-    "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
-    "--btreemap-max <N>": "Max BTreeMap capacity for verification model (default: 64)",
     "--verify-jobs <N>": "Max concurrent ESBMC verification jobs (default: num_cpus/2)"
   },
   "test_options": {
@@ -987,10 +811,6 @@ fn skill_json() -> String {
     "--mode <debug|release>": "Build mode; debug inserts runtime vow checks (default: (default))",
     "--timeout <ms>": "Per-test execution timeout in milliseconds (default: 30000)",
     "--max-k-step <N>": "ESBMC incremental BMC max iterations (with --verify)",
-    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
-    "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
-    "--btreemap-max <N>": "Max BTreeMap capacity for verification model (default: 64)",
     "--verify-jobs <N>": "Max concurrent ESBMC verification jobs (with --verify)"
   },
   "decl_options": {
@@ -1002,10 +822,6 @@ fn skill_json() -> String {
     "--max-k-step <N>": "ESBMC incremental BMC max iterations (default: 50)",
     "--solver <boolector|z3|bitwuzla|auto>": "ESBMC SMT solver (with --verify)",
     "--encoding <bv|ir|auto>": "ESBMC encoding mode (with --verify); ir requires z3 (default: auto)",
-    "--vec-max <N>": "Max Vec capacity for verification model (default: 128)",
-    "--string-max <N>": "Max String capacity for verification model (default: 256)",
-    "--hashmap-max <N>": "Max HashMap capacity for verification model (default: 64)",
-    "--btreemap-max <N>": "Max BTreeMap capacity for verification model (default: 64)",
     "--verify-jobs <N>": "Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)"
   },
   "global_options": {
@@ -1343,11 +1159,7 @@ fn skill_json() -> String {
   },
   "verification_defaults": {
     "strategy": "k-induction-parallel",
-    "max_k_step": 50,
-    "vec_max": 128,
-    "string_max": 256,
-    "hashmap_max": 64,
-    "btreemap_max": 64
+    "max_k_step": 50
   }
 }"##
     .to_string()
@@ -1379,10 +1191,6 @@ BUILD OPTIONS
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
   --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit --timeout overrides both. --timeout 0 is honoured as an immediate watchdog kill (default: 300 (or 30 when --encoding is auto))
-  --vec-max <N>           Max Vec capacity for verification model (default: 128)
-  --string-max <N>        Max String capacity for verification model (default: 256)
-  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
-  --btreemap-max <N>      Max BTreeMap capacity for verification model (default: 64)
   --verify-jobs <N>       Max concurrent ESBMC verification jobs (default: num_cpus/2)
 
 VERIFY OPTIONS
@@ -1391,10 +1199,6 @@ VERIFY OPTIONS
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver; auto selects per-function via heuristic (default: auto)
   --encoding <bv|ir|auto>  ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 (default: auto)
   --timeout <N>           ESBMC per-function timeout in seconds. Under --encoding auto, a 30s default is applied so the BV-timeout fallback to --encoding ir --solver z3 can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit --timeout overrides both. --timeout 0 is honoured as an immediate watchdog kill (default: 300 (or 30 when --encoding is auto))
-  --vec-max <N>           Max Vec capacity for verification model (default: 128)
-  --string-max <N>        Max String capacity for verification model (default: 256)
-  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
-  --btreemap-max <N>      Max BTreeMap capacity for verification model (default: 64)
   --verify-jobs <N>       Max concurrent ESBMC verification jobs (default: num_cpus/2)
 
 TEST OPTIONS
@@ -1404,10 +1208,6 @@ TEST OPTIONS
   --mode <debug|release>  Build mode; debug inserts runtime vow checks (default: (default))
   --timeout <ms>          Per-test execution timeout in milliseconds (default: 30000)
   --max-k-step <N>        ESBMC incremental BMC max iterations (with --verify)
-  --vec-max <N>           Max Vec capacity for verification model (default: 128)
-  --string-max <N>        Max String capacity for verification model (default: 256)
-  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
-  --btreemap-max <N>      Max BTreeMap capacity for verification model (default: 64)
   --verify-jobs <N>       Max concurrent ESBMC verification jobs (with --verify)
 
 CONTRACTS OPTIONS
@@ -1416,10 +1216,6 @@ CONTRACTS OPTIONS
   --max-k-step <N>        ESBMC incremental BMC max iterations (default: 50)
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver (with --verify)
   --encoding <bv|ir|auto>  ESBMC encoding mode (with --verify); ir requires z3 (default: auto)
-  --vec-max <N>           Max Vec capacity for verification model (default: 128)
-  --string-max <N>        Max String capacity for verification model (default: 256)
-  --hashmap-max <N>       Max HashMap capacity for verification model (default: 64)
-  --btreemap-max <N>      Max BTreeMap capacity for verification model (default: 64)
   --verify-jobs <N>       Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)
 
 DECL OPTIONS
@@ -1473,13 +1269,9 @@ METHODS   : Vec: Vec::new/Vec::from_raw_parts_copy/push/pop/len/clear/truncate/v
             HashMap: HashMap::new/insert/get/contains_key/remove/len   BTreeMap: BTreeMap::new/insert/get/contains/len   Option: unwrap
 OPERATORS : + - * / %   +! -! *! /! %! (checked)   == != < <= > >=   && || !   & | ^ << >> (bitwise, integer-only)   unary - ! & ?
 
-VERIFICATION DEFAULTS (configurable via --max-k-step, --vec-max, --string-max, --hashmap-max, --btreemap-max)
+VERIFICATION DEFAULTS (--max-k-step)
   Strategy        : k-induction-parallel (incremental BMC + k-induction)
-  Incremental BMC : 50 max iterations (--max-k-step)
-  Vec<T>          : 128 max capacity
-  String          : 256 max capacity
-  HashMap<K, V>   : 64 max capacity
-  BTreeMap<K, V>  : 64 max capacity"##
+  Incremental BMC : 50 max iterations (--max-k-step)"##
         .to_string()
 }
 // GENERATE:SKILL_HUMAN:END
@@ -2490,10 +2282,6 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |
-| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
-| `--string-max <N>` | `256`    | Max String capacity for verification model   |
-| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
-| `--btreemap-max <N>` | `64`   | Max BTreeMap capacity for verification model |
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 **Compile-object cache behavior.** The on-disk compile-object cache (`$VOW_CACHE_DIR` or `~/.cache/vow/`, where each entry is a `<key>.o` artifact keyed by a content hash of all dependencies, mode, and trace settings) is automatically disabled whenever ESBMC verification is active. This guarantees the linked binary always comes from the same codegen run whose IR was verified, closing the integrity gap where a stale or attacker-supplied `.o` could be linked against freshly-verified IR. Concretely the cache only activates on `vow build --no-verify` invocations; it is bypassed on the default `vow build` path. `--no-cache` additionally disables the cache for `--no-verify` builds.
@@ -2515,10 +2303,6 @@ vow verify [OPTIONS] <source.vow>
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 ### `vow contracts`
@@ -2538,10 +2322,6 @@ vow contracts [OPTIONS] <source.vow>
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
@@ -2587,10 +2367,6 @@ vow test [OPTIONS] [<path>]
 | `--mode release`  | `debug`     | Omit all vow checks for performance       |
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations (with --verify) |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs (with --verify) |
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` under the given directory **and its subdirectories**, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.
@@ -2999,15 +2775,37 @@ Contract clauses become IR opcodes. The C emitter translates `requires` to `__ES
 
 ### Collection Models for Verification
 
-ESBMC uses bounded models for collection types. Defaults are shown below; override with `--vec-max`, `--string-max`, `--hashmap-max`:
+ESBMC is a *bounded* model checker, so it models collection types as
+fixed-size arrays and reasons about them up to a finite capacity. These
+capacities are an internal property of the verifier, not of the language:
 
-| Type              | Default Max Capacity | CLI Flag | Supported Operations |
-|-------------------|---------------------|----------|----------------------------------------------|
-| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |
-| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |
-| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|
+| Type              | Model Capacity | Supported Operations |
+|-------------------|----------------|----------------------------------------------|
+| `Vec<T>`          | 128            | `new`, `push`, `pop`, `len`, `get`, `set`    |
+| `String`          | 256            | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |
+| `HashMap<K, V>`   | 64             | `new`, `insert`, `get`, `contains_key`, `len`|
+| `BTreeMap<K, V>`  | 64             | `new`, `insert`, `get`, `contains_key`, `len`|
 
-These support the same operations as the runtime but with bounded storage. String literals carry their concrete length and bytes in verification, and `String::from` copies that model from its source value. The effective string model capacity is at least the longest static string literal, even when `--string-max` is lower, so literal byte initializers fit the model array. Operations whose bytes are not statically known, such as `String::from_cstr`, produce a nondeterministic length (0 to max-1). `string_matches_literal_at` is modeled against the literal's concrete bytes and byte length; the third argument must be a string literal so the verifier never has to infer static text from a dynamic `String`.
+**These bounds are not a language feature and are not user-tunable.** A `Vec`
+in a Vow program grows dynamically on the heap with no fixed maximum; the
+capacity above only describes how far the *bounded* model checker reasons. The
+language and its contracts are deliberately decoupled from what any particular
+prover can prove: replace ESBMC with a stronger (or unbounded) checker and the
+same source, the same contracts, and the same CLI keep working — the only
+difference is that proof covers more (or all) of the state space. For this
+reason a `requires`/`ensures` clause must never encode a verifier bound (e.g.
+`requires: v.len() <= 128`); see "Verification-Driven Bounds (Anti-Pattern)"
+below and `docs/design/verifier-model-bounds.md`.
+
+These models support the same operations as the runtime but with bounded
+storage. String literals carry their concrete length and bytes in verification,
+and `String::from` copies that model from its source value. The effective string
+model capacity is automatically at least the longest static string literal, so
+literal byte initializers always fit the model array. Operations whose bytes are
+not statically known, such as `String::from_cstr`, produce a nondeterministic
+length (0 to max-1). `string_matches_literal_at` is modeled against the
+literal's concrete bytes and byte length; the third argument must be a string
+literal so the verifier never has to infer static text from a dynamic `String`.
 
 ## Blame Model
 
@@ -3250,7 +3048,7 @@ fn gcd(a: i64, b: i64) -> i64 vow {
 } { ... }
 ```
 
-Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic) — if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification.
+Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic, bounded collection models) — if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification. The same rule is why the verifier's collection model capacities (see "Collection Models for Verification") are internal defaults rather than CLI flags or contract clauses: a bound that belongs to the prover must never leak into the language.
 
 ## Interpreting Counterexamples
 
@@ -5602,10 +5400,6 @@ vow [OPTIONS] <source.vow>          # legacy (equivalent)
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |
-| `--vec-max <N>` | `128`       | Max Vec capacity for verification model      |
-| `--string-max <N>` | `256`    | Max String capacity for verification model   |
-| `--hashmap-max <N>` | `64`    | Max HashMap capacity for verification model  |
-| `--btreemap-max <N>` | `64`   | Max BTreeMap capacity for verification model |
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 **Compile-object cache behavior.** The on-disk compile-object cache (`$VOW_CACHE_DIR` or `~/.cache/vow/`, where each entry is a `<key>.o` artifact keyed by a content hash of all dependencies, mode, and trace settings) is automatically disabled whenever ESBMC verification is active. This guarantees the linked binary always comes from the same codegen run whose IR was verified, closing the integrity gap where a stale or attacker-supplied `.o` could be linked against freshly-verified IR. Concretely the cache only activates on `vow build --no-verify` invocations; it is bypassed on the default `vow build` path. `--no-cache` additionally disables the cache for `--no-verify` builds.
@@ -5627,10 +5421,6 @@ vow verify [OPTIONS] <source.vow>
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver; auto selects per-function via heuristic |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode: bv (bit-vector) or ir (integer/real arithmetic); ir requires z3 |
 | `--timeout <N>` | `300` (or `30` when `--encoding` is `auto`) | ESBMC per-function timeout in seconds. Under `--encoding auto`, a 30s default is applied so the BV-timeout fallback to `--encoding ir --solver z3` can trigger when bit-vector solving takes too long. With explicit encodings, a 300s safety watchdog bounds the run; explicit `--timeout` overrides both. `--timeout 0` is honoured as an immediate watchdog kill |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs |
 
 ### `vow contracts`
@@ -5650,10 +5440,6 @@ vow contracts [OPTIONS] <source.vow>
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations       |
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
@@ -5699,10 +5485,6 @@ vow test [OPTIONS] [<path>]
 | `--mode release`  | `debug`     | Omit all vow checks for performance       |
 | `--timeout <ms>`  | `30000`     | Per-test execution timeout in milliseconds |
 | `--max-k-step <N>` | `50`       | ESBMC incremental BMC max iterations (with --verify) |
-| `--vec-max <N>`   | `128`       | Max Vec capacity for verification model    |
-| `--string-max <N>`| `256`       | Max String capacity for verification model |
-| `--hashmap-max <N>`| `64`      | Max HashMap capacity for verification model|
-| `--btreemap-max <N>`| `64`     | Max BTreeMap capacity for verification model|
 | `--verify-jobs <N>` | `num_cpus/2` | Max concurrent ESBMC verification jobs (with --verify) |
 
 Test discovery: files matching `test_*.vow` or `*_test.vow` under the given directory **and its subdirectories**, sorted alphabetically. Each test must contain `main() -> i32` returning 0 on success.
@@ -6112,15 +5894,37 @@ Contract clauses become IR opcodes. The C emitter translates `requires` to `__ES
 
 ### Collection Models for Verification
 
-ESBMC uses bounded models for collection types. Defaults are shown below; override with `--vec-max`, `--string-max`, `--hashmap-max`:
+ESBMC is a *bounded* model checker, so it models collection types as
+fixed-size arrays and reasons about them up to a finite capacity. These
+capacities are an internal property of the verifier, not of the language:
 
-| Type              | Default Max Capacity | CLI Flag | Supported Operations |
-|-------------------|---------------------|----------|----------------------------------------------|
-| `Vec<T>`          | 128                 | `--vec-max <N>` | `new`, `push`, `pop`, `len`, `get`, `set`    |
-| `String`          | 256                 | `--string-max <N>` | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |
-| `HashMap<K, V>`   | 64                  | `--hashmap-max <N>` | `new`, `insert`, `get`, `contains_key`, `len`|
+| Type              | Model Capacity | Supported Operations |
+|-------------------|----------------|----------------------------------------------|
+| `Vec<T>`          | 128            | `new`, `push`, `pop`, `len`, `get`, `set`    |
+| `String`          | 256            | `from`, `len`, `push_byte`, `push_str`, `byte_at`, `matches_literal_at` |
+| `HashMap<K, V>`   | 64             | `new`, `insert`, `get`, `contains_key`, `len`|
+| `BTreeMap<K, V>`  | 64             | `new`, `insert`, `get`, `contains_key`, `len`|
 
-These support the same operations as the runtime but with bounded storage. String literals carry their concrete length and bytes in verification, and `String::from` copies that model from its source value. The effective string model capacity is at least the longest static string literal, even when `--string-max` is lower, so literal byte initializers fit the model array. Operations whose bytes are not statically known, such as `String::from_cstr`, produce a nondeterministic length (0 to max-1). `string_matches_literal_at` is modeled against the literal's concrete bytes and byte length; the third argument must be a string literal so the verifier never has to infer static text from a dynamic `String`.
+**These bounds are not a language feature and are not user-tunable.** A `Vec`
+in a Vow program grows dynamically on the heap with no fixed maximum; the
+capacity above only describes how far the *bounded* model checker reasons. The
+language and its contracts are deliberately decoupled from what any particular
+prover can prove: replace ESBMC with a stronger (or unbounded) checker and the
+same source, the same contracts, and the same CLI keep working — the only
+difference is that proof covers more (or all) of the state space. For this
+reason a `requires`/`ensures` clause must never encode a verifier bound (e.g.
+`requires: v.len() <= 128`); see "Verification-Driven Bounds (Anti-Pattern)"
+below and `docs/design/verifier-model-bounds.md`.
+
+These models support the same operations as the runtime but with bounded
+storage. String literals carry their concrete length and bytes in verification,
+and `String::from` copies that model from its source value. The effective string
+model capacity is automatically at least the longest static string literal, so
+literal byte initializers always fit the model array. Operations whose bytes are
+not statically known, such as `String::from_cstr`, produce a nondeterministic
+length (0 to max-1). `string_matches_literal_at` is modeled against the
+literal's concrete bytes and byte length; the third argument must be a string
+literal so the verifier never has to infer static text from a dynamic `String`.
 
 ## Blame Model
 
@@ -6363,7 +6167,7 @@ fn gcd(a: i64, b: i64) -> i64 vow {
 } { ... }
 ```
 
-Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic) — if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification.
+Contracts express what is mathematically required for correctness. ESBMC verifies within its capabilities (bounded loops, bounded arithmetic, bounded collection models) — if it cannot fully prove a correct contract, that is acceptable. Partial verification is better than a distorted specification. The same rule is why the verifier's collection model capacities (see "Collection Models for Verification") are internal defaults rather than CLI flags or contract clauses: a bound that belongs to the prover must never leak into the language.
 
 ## Interpreting Counterexamples
 
@@ -9839,17 +9643,6 @@ fn run_test_command(
 // Entry point
 // ---------------------------------------------------------------------------
 
-fn validate_limits(limits: &VerifyLimits) {
-    if limits.vec_max == 0
-        || limits.string_max == 0
-        || limits.hashmap_max == 0
-        || limits.btreemap_max == 0
-    {
-        eprintln!("error: --vec-max, --string-max, --hashmap-max, and --btreemap-max must be >= 1");
-        std::process::exit(1);
-    }
-}
-
 /// User value verbatim; rejects 0 with a clear error. None → num_cpus/2 clamped to ≥1.
 fn resolve_verify_jobs(opt: Option<u32>) -> usize {
     match opt {
@@ -10212,12 +10005,8 @@ fn main() {
             };
             let limits = VerifyLimits {
                 max_k_step: b.max_k_step,
-                vec_max: b.vec_max,
-                string_max: b.string_max,
-                hashmap_max: b.hashmap_max,
-                btreemap_max: b.btreemap_max,
+                ..VerifyLimits::default()
             };
-            validate_limits(&limits);
             let jobs = resolve_verify_jobs(b.verify_jobs);
             let bconfig = make_solver_config(b.solver, b.encoding, b.timeout);
             if let Ok(cwd) = std::env::current_dir() {
@@ -10254,12 +10043,8 @@ fn main() {
             };
             let limits = VerifyLimits {
                 max_k_step: v.max_k_step,
-                vec_max: v.vec_max,
-                string_max: v.string_max,
-                hashmap_max: v.hashmap_max,
-                btreemap_max: v.btreemap_max,
+                ..VerifyLimits::default()
             };
-            validate_limits(&limits);
             let jobs = resolve_verify_jobs(v.verify_jobs);
             let config = make_solver_config(v.solver, v.encoding, v.timeout);
             run_verify_command(&source, v.no_cache, &limits, jobs, &config);
@@ -10285,12 +10070,8 @@ fn main() {
             };
             let limits = VerifyLimits {
                 max_k_step: t.max_k_step,
-                vec_max: t.vec_max,
-                string_max: t.string_max,
-                hashmap_max: t.hashmap_max,
-                btreemap_max: t.btreemap_max,
+                ..VerifyLimits::default()
             };
-            validate_limits(&limits);
             let jobs = resolve_verify_jobs(t.verify_jobs);
             run_test_command(
                 &path,
@@ -10339,14 +10120,10 @@ fn main() {
             };
             let limits = VerifyLimits {
                 max_k_step: c.max_k_step.unwrap_or(DEFAULT_MAX_K_STEP),
-                vec_max: c.vec_max,
-                string_max: c.string_max,
-                hashmap_max: c.hashmap_max,
-                btreemap_max: c.btreemap_max,
+                ..VerifyLimits::default()
             };
-            validate_limits(&limits);
-            // Accepted for CLI parity; validates a 0 rejection via the same path
-            // as build/verify/test, then is discarded because update_contract_statuses
+            // Accepted for CLI parity; resolved via the same path as
+            // build/verify/test, then discarded because update_contract_statuses
             // has no pool wiring today.
             let _ = resolve_verify_jobs(c.verify_jobs);
             let config = make_solver_config(c.solver, c.encoding, c.timeout);
@@ -10415,12 +10192,8 @@ fn main() {
 
             let limits = VerifyLimits {
                 max_k_step: args.max_k_step,
-                vec_max: args.vec_max,
-                string_max: args.string_max,
-                hashmap_max: args.hashmap_max,
-                btreemap_max: args.btreemap_max,
+                ..VerifyLimits::default()
             };
-            validate_limits(&limits);
             let jobs = resolve_verify_jobs(args.verify_jobs);
             let config = make_solver_config(args.solver, args.encoding, args.timeout);
             if let Ok(cwd) = std::env::current_dir() {
@@ -10463,6 +10236,33 @@ mod tests {
             BuildStatus::VerifyFailed { description, .. }
                 if description.contains("ESBMC not found")
         )
+    }
+
+    #[test]
+    fn capacity_flags_are_not_advertised() {
+        // Issue #278: the verify-only --vec-max / --string-max / --hashmap-max /
+        // --btreemap-max flags were removed. The collection model bound is an
+        // internal verifier detail, not a CLI knob, so it must never reappear in
+        // any help or skill surface. (--max-k-step is a real, retained flag.)
+        let surfaces = [
+            skill_json(),
+            skill_human(),
+            skill_entrypoint_markdown(),
+            skill_bundle_markdown(),
+        ];
+        for surface in &surfaces {
+            for flag in [
+                "--vec-max",
+                "--string-max",
+                "--hashmap-max",
+                "--btreemap-max",
+            ] {
+                assert!(
+                    !surface.contains(flag),
+                    "removed capacity flag `{flag}` still advertised in a help/skill surface"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #278.

## What & why

ESBMC modelled `Vec`/`String`/`HashMap`/`BTreeMap` as fixed-size C arrays and exposed their capacities as four CLI flags: `--vec-max` (128), `--string-max` (256), `--hashmap-max` (64), `--btreemap-max` (64). These were **verify-only** — they bounded the verifier's model, never the compiled binary. That leaked an ESBMC implementation detail into the language surface ("why does my data structure have a max?").

Per the design decision in this PR, **the language and its contracts are decoupled from what the prover can prove.** The model capacity is now a single safe internal default per collection type — not user-tunable, absent from every CLI/help/skill surface. Swap in a stronger or unbounded checker later and the same source, contracts, and CLI keep working unchanged; the only difference is proving more (or all) of the state space. This is roadmap **WS-3.4** ("Stop leaking verifier bounds into contracts").

## Changes
- **Rust** (`vow/src/main.rs`): removed the 4 flags from all 5 clap structs; `VerifyLimits` built from `..VerifyLimits::default()`; `validate_limits` deleted.
- **Rust** (`vow-verify/src/c_emitter.rs`): named the defaults `VEC_MODEL_CAP` / `STRING_MODEL_CAP` / `HASHMAP_MODEL_CAP` / `BTREEMAP_MODEL_CAP`; documented them as internal verifier-model bounds.
- **Self-hosted** (`compiler/main.vow`): removed the 4 flags from all 5 verify entry points and both source-path-detection lists; bounds sourced from `VOW_*_MAX()`; `validate_limits` deleted. (`compiler/c_emitter.vow`: documented the constants.)
- **Spec** (`docs/spec/cli.md`): dropped the 4 flag rows from all 4 option tables. (`docs/spec/contracts.md`): reframed the collection-model section as internal verifier bounds, added the missing `BTreeMap` row, dropped the CLI-flag column. (`scripts/generate_help.py`): dropped the flags; help/skill regenerated in both compilers + `skills/vow/`.
- **Design doc** `docs/design/verifier-model-bounds.md`: new, normative — records the decoupling principle, the rejected alternatives, and a failure-semantics follow-up.
- `lib/heap/*.vow`: updated comments that referenced the removed flag.
- New regression test `capacity_flags_are_not_advertised` guards against re-introduction in any help/skill surface.

## Verification
- ✅ `cargo build --all`, `cargo clippy --all -- -D warnings`, `cargo test -p vow -p vow-verify` (incl. new test) green.
- ✅ `scripts/bootstrap.sh --skip-cargo`: bootstrap triple, **SHA-256 fixed point holds** (`vowc2 == vowc3`).
- ✅ Adversarial diff review: no blockers; nits addressed.
- ⏳ `scripts/full_test.sh` delegated to CI (local re-bootstrap didn't fit the session).

Per repo policy, merge via a **merge commit** once CI is green — do not squash/rebase.