### PR TITLE
region: refresh handle_inst Return-arm comment for CallerReturn (#372)

### DIFF
--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -1858,9 +1858,12 @@ fn handle_inst(
 ) {
     match inst.opcode {
         Opcode::Return => {
-            // The returned value escapes to the virtual caller. Mark it so
-            // the inst.region populate pass tags any RegionAlloc that flows
-            // into the return as Caller(0).
+            // The returned value escapes to the caller via the return path.
+            // Mark it `CallerReturn` so `lub_to_region_id` resolves it through
+            // the function's return summary (`return_escape_slots`): the
+            // param store-target slot for an `AliasOf(p)` return, slot 0 for
+            // `FreshInCaller`, or the slot-less caller fallback when the
+            // return pins no hidden slot.
             if !return_is_scalar && let Some(&arg_id) = inst.args.first() {
                 add_marker(must_outlive, arg_id, MustOutliveMarker::CallerReturn);
             }


### PR DESCRIPTION
Closes #372.

### Context
Issue #372 asked to flip `handle_inst`'s Return arm from `VirtualCaller` to `CallerReturn` (plus comment/doc updates) so the alias-aware LUB fires in production. The **substantive change already landed in #342** (merged 2026-05-12):

- `vow-ir/src/region.rs:1865` already emits `MustOutliveMarker::CallerReturn`.
- The `VirtualCaller` enum doc already records the migration.
- `lub_to_region_id` already resolves `CallerReturn` via `return_escape_slots()` (slot-aware, with slot-less fallback).
- The self-hosted `compiler/region.vow` was mirrored (val==0 caller marker + `collect_return_escape_slots`) and its comments are already accurate.

#372 was triaged into the 0.3.0 milestone on 2026-06-05 — after #342 merged — so the only un-done item on the issue's checklist was the **stale leading comment** in the Return arm, which still described the pre-#342 "virtual caller" / "Caller(0)" behavior.

### Change
- `vow-ir/src/region.rs:1861-1866`: replace the stale comment with text describing the actual `CallerReturn` / `return_escape_slots` slot-resolution semantics. **Comment-only; no behavioral change.**

### Why no self-hosted change / no new test
- `compiler/region.vow` is untouched and already consistent (its encoding doc at `region.vow:3030-3034` is accurate), so the self-hosted compiler and the bootstrap fixed-point are unaffected.
- The production path (`handle_inst` → `CallerReturn` → LUB, incl. non-zero-slot routing) is already covered end-to-end by `field_return_alias_of_param_collapses_with_store_target_marker` and `slot_aware_inference_routes_allocs_to_distinct_hidden_slots` (vow-ir unit tests run via `infer_regions`) and by `tests/run/region_caller_return_alias_of_param.vow`. A comment-only edit warrants no new test.

### Verification
- `cargo test --all` (after a full release build): vow-ir 172, vow bin 113, vow integration 15 — all green.
- `cargo clippy --all -- -D warnings`: clean.
