### PR TITLE
fix(checker): enforce vow-clause purity in the self-hosted compiler (#586)

### DIFF
--- a/compiler/checker.vow
+++ b/compiler/checker.vow
@@ -607,6 +607,37 @@ fn register_enum(e: CheckEnv, m: Module, eid: i64) [io] {
     env_update_enum(e, name, vnames, vpayloads);
 }
 
+// Contract clauses must be pure: a requires/ensures/invariant predicate may not
+// call an effectful function (mirrors the Rust frontend's check_vow_purity in
+// vow-types/src/effects.rs). Without this the production self-hosted compiler
+// admits e.g. `requires: read_file(p).len() > 0` into a contract — an effectful,
+// possibly-failing predicate the verifier model cannot faithfully represent
+// (issue #586). `__unwrap__` panic sites are out of scope here (issue #601),
+// matching the Rust check which also does not flag them.
+fn check_clause_purity(e: CheckEnv, m: Module, clause_eid: i64) [io] {
+    let a: AstArena = m.arena;
+    let calls: Vec<String> = Vec::new();
+    collect_calls_in_expr(e, m, clause_eid, calls);
+    let n: i64 = calls.len();
+    let mut i: i64 = 0;
+    while i < n {
+        let cname: String = calls[i];
+        if cname != String::from("__unwrap__") {
+            let fidx: i64 = env_lookup_fn(e, cname);
+            if fidx != -1 {
+                let callee_eff: i64 = e.fn_effects[fidx];
+                if callee_eff != 0 {
+                    let msg: String = String::from("vow predicate must be pure but calls effectful function `");
+                    msg.push_str(cname);
+                    msg.push_str(String::from("`"));
+                    env_emit_error_code(e, EC_EFFECT_VIOLATION(), msg, expr_span(a, clause_eid));
+                }
+            }
+        }
+        i = i + 1;
+    }
+}
+
 fn check_vow_clause(e: CheckEnv, m: Module, vow_lid: i64, kind: i64, context: String) [io] {
     let a: AstArena = m.arena;
     let n: i64 = list_len(a, vow_lid);
@@ -629,6 +660,7 @@ fn check_vow_clause(e: CheckEnv, m: Module, vow_lid: i64, kind: i64, context: St
                 msg.push_str(String::from("` clause must be `bool`"));
                 env_emit_error_code(e, EC_CONTRACT_TYPE_MISMATCH(), msg, expr_span(a, clause_eid));
             }
+            check_clause_purity(e, m, clause_eid);
         }
         i = i + 1;
     }

--- a/tests/error/contract_impure_predicate.vow
+++ b/tests/error/contract_impure_predicate.vow
@@ -1,0 +1,17 @@
+// TEST: error-code EffectViolation
+module ContractImpurePredicate
+
+fn side_effect() -> i64 [io] {
+    print_i64(0);
+    0
+}
+
+fn f(x: i64) -> i64 vow {
+    requires: side_effect() == 0
+} {
+    x
+}
+
+fn main() -> () [io] {
+    print_i64(f(1));
+}


### PR DESCRIPTION
## What

Ports the Rust frontend's `check_vow_purity` into the self-hosted compiler (`compiler/checker.vow`), so the production `build/vowc` rejects contract clauses (`requires`/`ensures`/`invariant`) that call effectful functions.

Fixes **#586** (critical, audit 2026-06-10). Part of the #81 verification-soundness prerequisites: the contract methodology and quality classifier both *assume* clauses are pure; the production compiler didn't enforce it.

## The hole

`check_vow_clause` validated only that a clause is `bool`-typed; `check_effects_fn` scanned the function body but never the clause expressions. So on `build/vowc` (the primary compiler) an agent could write `fn f(...) -> bool vow { requires: read_file(p).len() > 0 }` and it compiled clean — an effectful, possibly-failing predicate admitted into a contract. Worse, the verifier model is restricted to pure functions, so such a contract is still handed to ESBMC with an obligation it cannot faithfully model, silently weakening the proof. The Rust bootstrap already enforced this (`vow-types/src/effects.rs:check_vow_purity`); only the self-hosted compiler was missing it.

## Fix

`check_clause_purity` runs `collect_calls_in_expr` over each clause and emits `EffectViolation` for any callee whose effect set is non-empty. It's called from inside `check_vow_clause`, which is the single chokepoint for **all** clause kinds — so function `requires`/`ensures` and `while`/`loop`/`for-each` invariants are all covered in one place. Mirrors the Rust check exactly; `__unwrap__` panic sites are deliberately out of scope (issue #601, which covers both compilers) — the Rust check also does not flag them, keeping the compilers in lockstep.

**Bootstrap-safe:** the Rust compiler already enforces clause purity and successfully compiles `compiler/*.vow`, so the compiler's own ~388 contracts are already pure — confirmed by a stage-2 dry run (self-hosted-with-check compiles the compiler clean) and a corpus scan (0 newly-rejected files across `examples/`, `tests/run/`, `tests/verify/`).

## Discovered (separate, pre-existing — not fixed here)

The **Rust** compiler emits the error-severity `EffectViolation` but exits **0** with status `Unverified` — it does not fail the build on the error. The self-hosted compiler now correctly fails (`CompileFailed`, exit 1). This is a latent Rust fail-open on effect errors, distinct from #586 (which is about the self-hosted *missing the check entirely*); fixing it requires understanding the Rust error-gating and risks broader fallout, so it belongs in its own issue. No test harness compares Rust↔self-hosted on `tests/error/` fixtures, so the divergence is not masked or breaking.

## Testing

- `tests/error/contract_impure_predicate.vow` — `// TEST: error-code EffectViolation` (Phase 5, self-hosted).
- Manual: impure contract → `CompileFailed`/`EffectViolation`/exit 1; valid pure contract (`divide.vow`) unaffected.
- Bootstrap triple test (binary fixed point) green.

Closes #586
