### PR TITLE
fix(verify): fail closed when the verifier worker panics (#413)

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3530,7 +3530,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `Unverified`    | Compiled but ESBMC was not invoked (e.g. `--no-verify`, `--dump-ir`). Exit 0. |\n"));
     r.push_str(String::from("| `Skipped`       | ESBMC was invoked but at least one vowed function could not be modelled (e.g. body uses `RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, or has effects). Each such function appears as a `VerificationSkipped` *Warning* in `diagnostics[]`. Their contracts are runtime-checked under `--mode debug` but were not statically proved; the run fails closed with exit 1. |\n"));
     r.push_str(String::from("| `CompileFailed` | Parse error, type error, module load error, or link failure |\n"));
-    r.push_str(String::from("| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: \"unknown\"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |\n"));
+    r.push_str(String::from("| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: \"unknown\"`), tool error, the tool was not found, or the verifier worker thread crashed (`verify_status: \"panicked\"`). Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Verified Example\n"));
     r.push_str(String::from("\n"));
@@ -3602,7 +3602,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `function`         | string              | VerifyFailed      | Function where verification failed        |\n"));
     r.push_str(String::from("| `counterexample`   | string              | VerifyFailed      | Legacy description string                 |\n"));
     r.push_str(String::from("| `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |\n"));
-    r.push_str(String::from("| `verify_status`    | string              | On backend failure | `\"timeout\"`, `\"unknown\"`, `\"error\"`, or `\"tool_not_found\"` |\n"));
+    r.push_str(String::from("| `verify_status`    | string              | On backend failure | `\"timeout\"`, `\"unknown\"`, `\"error\"`, `\"tool_not_found\"`, or `\"panicked\"` (verifier worker thread crashed -- no counterexample available) |\n"));
     r.push_str(String::from("| `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Contracts Output JSON\n"));
@@ -5463,8 +5463,8 @@ fn skill_bundle() -> String {
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"verify_status\": {\n"));
     r.push_str(String::from("      \"type\": \"string\",\n"));
-    r.push_str(String::from("      \"enum\": [\"timeout\", \"unknown\", \"error\", \"tool_not_found\"],\n"));
-    r.push_str(String::from("      \"description\": \"Verification sub-status (present only when the verification backend did not produce a proof or counterexample)\"\n"));
+    r.push_str(String::from("      \"enum\": [\"timeout\", \"unknown\", \"error\", \"tool_not_found\", \"panicked\"],\n"));
+    r.push_str(String::from("      \"description\": \"Verification sub-status (present only when the verification backend did not produce a proof or counterexample; \\\"panicked\\\" signals the verifier worker thread crashed and the build fails closed)\"\n"));
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"verify_message\": {\n"));
     r.push_str(String::from("      \"type\": \"string\",\n"));
@@ -7037,7 +7037,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `Unverified`    | Compiled but ESBMC was not invoked (e.g. `--no-verify`, `--dump-ir`). Exit 0. |\n"));
     r.push_str(String::from("| `Skipped`       | ESBMC was invoked but at least one vowed function could not be modelled (e.g. body uses `RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, or has effects). Each such function appears as a `VerificationSkipped` *Warning* in `diagnostics[]`. Their contracts are runtime-checked under `--mode debug` but were not statically proved; the run fails closed with exit 1. |\n"));
     r.push_str(String::from("| `CompileFailed` | Parse error, type error, module load error, or link failure |\n"));
-    r.push_str(String::from("| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: \"unknown\"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |\n"));
+    r.push_str(String::from("| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: \"unknown\"`), tool error, the tool was not found, or the verifier worker thread crashed (`verify_status: \"panicked\"`). Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Verified Example\n"));
     r.push_str(String::from("\n"));
@@ -7109,7 +7109,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `function`         | string              | VerifyFailed      | Function where verification failed        |\n"));
     r.push_str(String::from("| `counterexample`   | string              | VerifyFailed      | Legacy description string                 |\n"));
     r.push_str(String::from("| `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |\n"));
-    r.push_str(String::from("| `verify_status`    | string              | On backend failure | `\"timeout\"`, `\"unknown\"`, `\"error\"`, or `\"tool_not_found\"` |\n"));
+    r.push_str(String::from("| `verify_status`    | string              | On backend failure | `\"timeout\"`, `\"unknown\"`, `\"error\"`, `\"tool_not_found\"`, or `\"panicked\"` (verifier worker thread crashed -- no counterexample available) |\n"));
     r.push_str(String::from("| `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Contracts Output JSON\n"));
@@ -8975,8 +8975,8 @@ fn skill_support_content_6() -> String {
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"verify_status\": {\n"));
     r.push_str(String::from("      \"type\": \"string\",\n"));
-    r.push_str(String::from("      \"enum\": [\"timeout\", \"unknown\", \"error\", \"tool_not_found\"],\n"));
-    r.push_str(String::from("      \"description\": \"Verification sub-status (present only when the verification backend did not produce a proof or counterexample)\"\n"));
+    r.push_str(String::from("      \"enum\": [\"timeout\", \"unknown\", \"error\", \"tool_not_found\", \"panicked\"],\n"));
+    r.push_str(String::from("      \"description\": \"Verification sub-status (present only when the verification backend did not produce a proof or counterexample; \\\"panicked\\\" signals the verifier worker thread crashed and the build fails closed)\"\n"));
     r.push_str(String::from("    },\n"));
     r.push_str(String::from("    \"verify_message\": {\n"));
     r.push_str(String::from("      \"type\": \"string\",\n"));

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -235,7 +235,7 @@ that path produces `Unverified` (exit 0).
 | `Unverified`    | Compiled but ESBMC was not invoked (e.g. `--no-verify`, `--dump-ir`). Exit 0. |
 | `Skipped`       | ESBMC was invoked but at least one vowed function could not be modelled (e.g. body uses `RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, or has effects). Each such function appears as a `VerificationSkipped` *Warning* in `diagnostics[]`. Their contracts are runtime-checked under `--mode debug` but were not statically proved; the run fails closed with exit 1. |
 | `CompileFailed` | Parse error, type error, module load error, or link failure |
-| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
+| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, the tool was not found, or the verifier worker thread crashed (`verify_status: "panicked"`). Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
 
 ### Verified Example
 
@@ -307,7 +307,7 @@ that path produces `Unverified` (exit 0).
 | `function`         | string              | VerifyFailed      | Function where verification failed        |
 | `counterexample`   | string              | VerifyFailed      | Legacy description string                 |
 | `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |
-| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, or `"tool_not_found"` |
+| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, `"tool_not_found"`, or `"panicked"` (verifier worker thread crashed — no counterexample available) |
 | `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |
 
 ## Contracts Output JSON

--- a/docs/spec/schemas/build-result.schema.json
+++ b/docs/spec/schemas/build-result.schema.json
@@ -39,8 +39,8 @@
     },
     "verify_status": {
       "type": "string",
-      "enum": ["timeout", "unknown", "error", "tool_not_found"],
-      "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample)"
+      "enum": ["timeout", "unknown", "error", "tool_not_found", "panicked"],
+      "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample; \"panicked\" signals the verifier worker thread crashed and the build fails closed)"
     },
     "verify_message": {
       "type": "string",

--- a/skills/vow/reference/cli.md
+++ b/skills/vow/reference/cli.md
@@ -235,7 +235,7 @@ that path produces `Unverified` (exit 0).
 | `Unverified`    | Compiled but ESBMC was not invoked (e.g. `--no-verify`, `--dump-ir`). Exit 0. |
 | `Skipped`       | ESBMC was invoked but at least one vowed function could not be modelled (e.g. body uses `RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, or has effects). Each such function appears as a `VerificationSkipped` *Warning* in `diagnostics[]`. Their contracts are runtime-checked under `--mode debug` but were not statically proved; the run fails closed with exit 1. |
 | `CompileFailed` | Parse error, type error, module load error, or link failure |
-| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
+| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, the tool was not found, or the verifier worker thread crashed (`verify_status: "panicked"`). Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
 
 ### Verified Example
 
@@ -307,7 +307,7 @@ that path produces `Unverified` (exit 0).
 | `function`         | string              | VerifyFailed      | Function where verification failed        |
 | `counterexample`   | string              | VerifyFailed      | Legacy description string                 |
 | `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |
-| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, or `"tool_not_found"` |
+| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, `"tool_not_found"`, or `"panicked"` (verifier worker thread crashed — no counterexample available) |
 | `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |
 
 ## Contracts Output JSON

--- a/skills/vow/schemas/build-result.schema.json
+++ b/skills/vow/schemas/build-result.schema.json
@@ -39,8 +39,8 @@
     },
     "verify_status": {
       "type": "string",
-      "enum": ["timeout", "unknown", "error", "tool_not_found"],
-      "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample)"
+      "enum": ["timeout", "unknown", "error", "tool_not_found", "panicked"],
+      "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample; \"panicked\" signals the verifier worker thread crashed and the build fails closed)"
     },
     "verify_message": {
       "type": "string",

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -9859,7 +9859,7 @@ fn run_pipeline_inner(
 /// verifier crash leaves verification in an unknown state, so the build must
 /// report `VerifyFailed` (exit 1) and withhold the executable — never the silent
 /// `Unverified`/exit-0 of the old `.unwrap_or((Skipped, _))` fallback (#413).
-/// The linked object is removed so no binary masquerades as built.
+/// The linked binary is removed so no executable masquerades as built.
 fn verifier_panicked_output(
     diagnostics: Vec<Diagnostic>,
     executable: Option<PathBuf>,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -9855,6 +9855,31 @@ fn run_pipeline_inner(
     )
 }
 
+/// Fail-closed result for a panicked verifier worker (`join()` → `Err`). A
+/// verifier crash leaves verification in an unknown state, so the build must
+/// report `VerifyFailed` (exit 1) and withhold the executable — never the silent
+/// `Unverified`/exit-0 of the old `.unwrap_or((Skipped, _))` fallback (#413).
+/// The linked object is removed so no binary masquerades as built.
+fn verifier_panicked_output(
+    diagnostics: Vec<Diagnostic>,
+    executable: Option<PathBuf>,
+) -> BuildOutput {
+    if let Some(path) = &executable {
+        let _ = std::fs::remove_file(path);
+    }
+    BuildOutput {
+        status: BuildStatus::VerifyFailed {
+            function: String::new(),
+            description: "verification thread panicked".to_string(),
+        },
+        executable: None,
+        diagnostics,
+        counterexamples: vec![],
+        verify_status: Some("panicked".to_string()),
+        verify_message: Some("verification thread panicked".to_string()),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_pipeline_from_frontend(
     frontend: FrontendBundle,
@@ -9909,6 +9934,12 @@ fn run_pipeline_from_frontend(
         if no_verify {
             return (VerifyOutcome::Skipped, Vec::new());
         }
+        // Test-only fault injection: simulate a verifier-worker crash so the
+        // fail-closed JoinError path (#413) is exercised end-to-end. Guarded by
+        // an env var that is never set in production; one lookup per build.
+        if std::env::var_os("VOW_TEST_VERIFIER_PANIC").is_some() {
+            panic!("injected verifier panic (VOW_TEST_VERIFIER_PANIC)");
+        }
         run_verification_sync(
             &module_for_verify,
             &file_for_verify,
@@ -9962,9 +9993,10 @@ fn run_pipeline_from_frontend(
                 };
             }
         };
-        let (verify_outcome, skipped) = verify_handle
-            .join()
-            .unwrap_or((VerifyOutcome::Skipped, Vec::new()));
+        let (verify_outcome, skipped) = match verify_handle.join() {
+            Ok(result) => result,
+            Err(_) => return verifier_panicked_output(all_diagnostics, exe_path),
+        };
         return verify_outcome_to_output_with_skipped(
             verify_outcome,
             all_diagnostics,
@@ -10032,9 +10064,10 @@ fn run_pipeline_from_frontend(
         }
     };
 
-    let (verify_outcome, skipped) = verify_handle
-        .join()
-        .unwrap_or((VerifyOutcome::Skipped, Vec::new()));
+    let (verify_outcome, skipped) = match verify_handle.join() {
+        Ok(result) => result,
+        Err(_) => return verifier_panicked_output(all_diagnostics, exe_path),
+    };
     verify_outcome_to_output_with_skipped(verify_outcome, all_diagnostics, &skipped, exe_path)
 }
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -9914,8 +9914,15 @@ fn run_pipeline_from_frontend(
         };
     }
 
-    // Upfront ESBMC check: abort before codegen if verification is requested but ESBMC is missing
-    if !no_verify && find_esbmc().is_none() {
+    // Upfront ESBMC check: abort before codegen if verification is requested but ESBMC is missing.
+    // The test-only VOW_TEST_VERIFIER_PANIC hook lives in the verify worker thread below, so on a
+    // machine without ESBMC this early return would short-circuit before the worker is ever spawned
+    // — making the panic regression test (#413) depend on an installed verifier. When the hook is
+    // armed, skip the early return so the worker runs and panics, exercising the real JoinError
+    // path. The env var is never set in production, and `var_os` is only reached once ESBMC is
+    // already known to be absent, so the happy path is unchanged.
+    if !no_verify && find_esbmc().is_none() && std::env::var_os("VOW_TEST_VERIFIER_PANIC").is_none()
+    {
         return verify_outcome_to_output(VerifyOutcome::ToolNotFound, all_diagnostics, None);
     }
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2495,7 +2495,7 @@ that path produces `Unverified` (exit 0).
 | `Unverified`    | Compiled but ESBMC was not invoked (e.g. `--no-verify`, `--dump-ir`). Exit 0. |
 | `Skipped`       | ESBMC was invoked but at least one vowed function could not be modelled (e.g. body uses `RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, or has effects). Each such function appears as a `VerificationSkipped` *Warning* in `diagnostics[]`. Their contracts are runtime-checked under `--mode debug` but were not statically proved; the run fails closed with exit 1. |
 | `CompileFailed` | Parse error, type error, module load error, or link failure |
-| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
+| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, the tool was not found, or the verifier worker thread crashed (`verify_status: "panicked"`). Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
 
 ### Verified Example
 
@@ -2567,7 +2567,7 @@ that path produces `Unverified` (exit 0).
 | `function`         | string              | VerifyFailed      | Function where verification failed        |
 | `counterexample`   | string              | VerifyFailed      | Legacy description string                 |
 | `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |
-| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, or `"tool_not_found"` |
+| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, `"tool_not_found"`, or `"panicked"` (verifier worker thread crashed — no counterexample available) |
 | `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |
 
 ## Contracts Output JSON
@@ -4428,8 +4428,8 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
     },
     "verify_status": {
       "type": "string",
-      "enum": ["timeout", "unknown", "error", "tool_not_found"],
-      "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample)"
+      "enum": ["timeout", "unknown", "error", "tool_not_found", "panicked"],
+      "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample; \"panicked\" signals the verifier worker thread crashed and the build fails closed)"
     },
     "verify_message": {
       "type": "string",
@@ -5987,7 +5987,7 @@ that path produces `Unverified` (exit 0).
 | `Unverified`    | Compiled but ESBMC was not invoked (e.g. `--no-verify`, `--dump-ir`). Exit 0. |
 | `Skipped`       | ESBMC was invoked but at least one vowed function could not be modelled (e.g. body uses `RegionAlloc`, `FieldSet`, `Linear*`, `Load`/`Store`, `RemF*`, or has effects). Each such function appears as a `VerificationSkipped` *Warning* in `diagnostics[]`. Their contracts are runtime-checked under `--mode debug` but were not statically proved; the run fails closed with exit 1. |
 | `CompileFailed` | Parse error, type error, module load error, or link failure |
-| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, or the tool was not found. Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
+| `VerifyFailed`  | ESBMC produced a non-Verified outcome: a counterexample, timeout, `VERIFICATION UNKNOWN` (`verify_status: "unknown"`), tool error, the tool was not found, or the verifier worker thread crashed (`verify_status: "panicked"`). Inspect `counterexamples[]` (definitive failures) and `verify_status`/`verify_message` (soft failures) to distinguish. |
 
 ### Verified Example
 
@@ -6059,7 +6059,7 @@ that path produces `Unverified` (exit 0).
 | `function`         | string              | VerifyFailed      | Function where verification failed        |
 | `counterexample`   | string              | VerifyFailed      | Legacy description string                 |
 | `counterexamples`  | array               | Always            | Structured counterexamples (see schema)   |
-| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, or `"tool_not_found"` |
+| `verify_status`    | string              | On backend failure | `"timeout"`, `"unknown"`, `"error"`, `"tool_not_found"`, or `"panicked"` (verifier worker thread crashed — no counterexample available) |
 | `verify_message`   | string              | On backend failure | ESBMC/backend error detail                |
 
 ## Contracts Output JSON
@@ -7920,8 +7920,8 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
     },
     "verify_status": {
       "type": "string",
-      "enum": ["timeout", "unknown", "error", "tool_not_found"],
-      "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample)"
+      "enum": ["timeout", "unknown", "error", "tool_not_found", "panicked"],
+      "description": "Verification sub-status (present only when the verification backend did not produce a proof or counterexample; \"panicked\" signals the verifier worker thread crashed and the build fails closed)"
     },
     "verify_message": {
       "type": "string",

--- a/vow/tests/verifier_panic.rs
+++ b/vow/tests/verifier_panic.rs
@@ -1,0 +1,80 @@
+//! Regression: a panicked verifier worker must fail the build *closed* (#413).
+//!
+//! `run_pipeline_from_frontend` runs verification on a worker thread. A panic
+//! there makes `join()` return `Err`; the old `.unwrap_or((Skipped, _))` turned
+//! that into `BuildStatus::Unverified` — a success with exit 0 and a linked
+//! binary, hiding a verifier crash. The build now reports `VerifyFailed`, drops
+//! the executable, and exits non-zero. The panic is injected via the
+//! test-only `VOW_TEST_VERIFIER_PANIC` env var.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn vow_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_vow"))
+}
+
+#[test]
+fn verifier_thread_panic_fails_build_closed() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let src = dir.path().join("m.vow");
+    // A satisfiable contract so the build reaches the verifier join site.
+    std::fs::write(
+        &src,
+        "module M\n\
+         fn f(x: i64) -> i64 vow { ensures: result == x } { x }\n\
+         fn main() -> i32 [io] { 0 }\n",
+    )
+    .unwrap();
+    let out_path = dir.path().join("out");
+
+    let out = Command::new(vow_bin())
+        .args([
+            "build",
+            src.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+        ])
+        .env("VOW_TEST_VERIFIER_PANIC", "1")
+        .output()
+        .expect("failed to run vow");
+
+    // Fail-closed: non-zero exit, a failing status, and no binary handed back.
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "a verifier-thread panic must not exit 0"
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("build JSON");
+    assert_eq!(json["status"], "VerifyFailed");
+    assert_eq!(json["verify_status"], "panicked");
+    assert!(
+        json["executable"].is_null(),
+        "no executable on a panicked build"
+    );
+    assert!(
+        !out_path.exists(),
+        "the linked binary must be removed on a panicked build"
+    );
+}
+
+#[test]
+fn normal_build_is_unaffected_by_the_injection_hook() {
+    // Without the env var, the hook is inert and a clean build still succeeds
+    // (Unverified here because ESBMC may be absent in CI; the point is exit 0).
+    let dir = tempfile::TempDir::new().unwrap();
+    let src = dir.path().join("m.vow");
+    std::fs::write(&src, "module M\nfn main() -> i32 [io] { 0 }\n").unwrap();
+    let out = Command::new(vow_bin())
+        .args([
+            "build",
+            "--no-verify",
+            src.to_str().unwrap(),
+            "-o",
+            dir.path().join("out").to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run vow");
+    assert_eq!(out.status.code(), Some(0));
+}


### PR DESCRIPTION
## What

Makes `vow build` fail **closed** when the verifier worker thread panics. Closes #413.

## The hole

`run_pipeline_from_frontend` runs verification on a worker thread and joins it with `.unwrap_or((VerifyOutcome::Skipped, Vec::new()))`. A panic in that worker makes `join()` return `Err`, which the fallback silently turned into `VerifyOutcome::Skipped` → `BuildStatus::Unverified` → **exit 0 with a linked binary**. So a verifier crash (a compiler bug) was indistinguishable from a clean unverified build — the worst kind of fail-open: an unproven program ships looking fine.

## Fix

Both result-using join sites now match on `join()` and convert `Err` into `verifier_panicked_output`:

```rust
let (verify_outcome, skipped) = match verify_handle.join() {
    Ok(result) => result,
    Err(_) => return verifier_panicked_output(all_diagnostics, exe_path),
};
```

`verifier_panicked_output` reports `BuildStatus::VerifyFailed` ("verification thread panicked", exit 1), sets `verify_status: "panicked"`, **withholds the executable**, and **removes the linked object** so no binary masquerades as built (per the issue's recommendation). The four early-exit joins (`let _ = verify_handle.join()`) are left as-is — the build is already `CompileFailed` there, so a panic can't fail-open.

## Test

A test-only `VOW_TEST_VERIFIER_PANIC` env hook injects a worker-thread panic so the JoinError path is exercised end-to-end. `vow/tests/verifier_panic.rs` asserts the panicked build exits non-zero, reports `VerifyFailed`/`panicked`, returns no executable, and leaves no binary on disk — plus that the hook is inert without the env var. (Default panic strategy is `unwind`, so `JoinError` is reachable.)

## Scope

Rust-only (`vow/src/main.rs`); no self-hosted change, no bootstrap. fmt + clippy clean; full `vow` suite green.

Closes #413
