### PR TITLE
fix(contracts): vow contracts --verify fails closed on unproven contracts (#479)

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3501,6 +3501,8 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |\n"));
     r.push_str(String::from("\n"));
+    r.push_str(String::from("**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven -- i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` -- and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)\n"));
+    r.push_str(String::from("\n"));
     r.push_str(String::from("When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow skill`\n"));
@@ -7195,6 +7197,8 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |\n"));
     r.push_str(String::from("\n"));
+    r.push_str(String::from("**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven -- i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` -- and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)\n"));
+    r.push_str(String::from("\n"));
     r.push_str(String::from("When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow skill`\n"));
@@ -10337,6 +10341,12 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
             n_not_verified = n_not_verified + 1;
         }
         si = si + 1;
+    }
+
+    // Fail closed: `vow contracts --verify` exits non-zero when any contract is
+    // not proven, matching `vow build --verify` / `vow verify` (#479).
+    if n_failed > 0 || n_timeout > 0 || n_unknown > 0 || n_error > 0 || n_skipped > 0 {
+        exit_code = 1;
     }
 
     // Static contract-quality tallies (independent of verification status).

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -67,6 +67,8 @@ vow contracts [OPTIONS] <source.vow>
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
+**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
+
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
 
 ### `vow skill`

--- a/skills/vow/reference/cli.md
+++ b/skills/vow/reference/cli.md
@@ -67,6 +67,8 @@ vow contracts [OPTIONS] <source.vow>
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
+**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
+
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
 
 ### `vow skill`

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2466,6 +2466,8 @@ vow contracts [OPTIONS] <source.vow>
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
+**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
+
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
 
 ### `vow skill`
@@ -6144,6 +6146,8 @@ vow contracts [OPTIONS] <source.vow>
 | `--solver <boolector\|z3\|bitwuzla\|auto>` | `auto` | ESBMC SMT solver (with --verify)           |
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
+
+**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
 
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
 
@@ -11134,6 +11138,18 @@ fn update_contract_statuses(
     }
 }
 
+/// `vow contracts --verify` fails closed when any contract is not proven —
+/// the same fail-closed set as `vow build --verify` / `vow verify` (#479).
+/// `proven` / `proven-ir` / `not_verified` pass; failed/timeout/unknown/error/
+/// skipped fail.
+fn contracts_summary_has_failure(summary: &ContractsSummaryJson) -> bool {
+    summary.failed > 0
+        || summary.timeout > 0
+        || summary.unknown > 0
+        || summary.error > 0
+        || summary.skipped > 0
+}
+
 fn run_contracts_command(
     source: &Path,
     verify: bool,
@@ -11199,6 +11215,11 @@ fn run_contracts_command(
     }
 
     let summary = build_contracts_summary(&entries);
+    // Fail closed: `vow contracts --verify` exits non-zero when any contract is
+    // not proven, matching `vow build --verify` / `vow verify` (#479).
+    if contracts_summary_has_failure(&summary) {
+        exit_code = 1;
+    }
     let result = ContractsResultJson {
         contracts: entries,
         summary,
@@ -14893,6 +14914,57 @@ fn main() -> i32 {
         assert_eq!(summary.quality.substantive, 8);
         assert_eq!(summary.quality.weak, 0);
         assert_eq!(summary.quality.tautological, 0);
+    }
+
+    #[test]
+    fn contracts_fail_closed_on_unproven_statuses() {
+        let all_proven = ContractsSummaryJson {
+            total: 1,
+            proven: 1,
+            failed: 0,
+            unknown: 0,
+            timeout: 0,
+            error: 0,
+            not_verified: 0,
+            skipped: 0,
+            quality: ContractsQualityJson {
+                weak: 0,
+                tautological: 0,
+                substantive: 1,
+            },
+        };
+        // All proven, or unverified (no --verify) → pass (exit 0).
+        assert!(!contracts_summary_has_failure(&all_proven));
+        assert!(!contracts_summary_has_failure(&ContractsSummaryJson {
+            proven: 0,
+            not_verified: 1,
+            ..all_proven.clone()
+        }));
+        // Every not-proven status fails closed (matches `vow build --verify`).
+        for failing in [
+            ContractsSummaryJson {
+                failed: 1,
+                ..all_proven.clone()
+            },
+            ContractsSummaryJson {
+                timeout: 1,
+                ..all_proven.clone()
+            },
+            ContractsSummaryJson {
+                unknown: 1,
+                ..all_proven.clone()
+            },
+            ContractsSummaryJson {
+                error: 1,
+                ..all_proven.clone()
+            },
+            ContractsSummaryJson {
+                skipped: 1,
+                ..all_proven.clone()
+            },
+        ] {
+            assert!(contracts_summary_has_failure(&failing));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Makes `vow contracts --verify` **fail closed**: it now exits **1** when any contract is not proven, matching `vow build --verify` and `vow verify`. Closes #479.

## The hole

`vow contracts --verify` ran ESBMC and reported per-contract `status` (`failed`, `timeout`, `unknown`, …) but only set a non-zero exit code in the ESBMC-absent branch. So an agent could run it, get JSON containing `"status": "failed"`, and still see **exit 0** — every other verify command fails closed, this one didn't, making it unsafe as a CI/agent gate.

## Policy (per maintainer decision)

Fail closed on the **same set** as `build --verify` / `verify`: exit 1 if any contract is `failed`/`timeout`/`unknown`/`error`/`skipped`; exit 0 only when every contract is `proven`/`proven-ir`. Without `--verify`, all are `not_verified` → exit 0. The static `quality` classification never affects the exit code. Unconditional (no flag) for cross-command consistency.

## Changes

- **Rust** (`vow/src/main.rs`): `contracts_summary_has_failure(summary)` decides fail-close from the summary tallies; `run_contracts_command` sets `exit_code = 1` accordingly. Unit test `contracts_fail_closed_on_unproven_statuses`.
- **Self-hosted** (`compiler/main.vow`): the same check mirrored in `run_contracts`.
- `docs/spec/cli.md`: documents the exit-code semantics; `--help`/skill regenerated (the `cli.md`-only delta).

## Stacking

Stacked on the skill/`--help` resync PR (regenerating ADR 0001 / #522 drift) so this PR's diff is just the ~15-line fail-close logic + `cli.md` + test, not the pre-existing drift. Merge the resync PR first; GitHub will retarget this to `main`.

## Tests

- Unit test covers the decision (all-proven / not_verified → pass; each not-proven status → fail).
- End-to-end with ESBMC: false `ensures` → `failed` → **exit 1**; true `ensures` → `proven` → **exit 0**; ESBMC-absent path still exits 1. Both compilers verified at parity; bootstrap fixed point green; fmt + clippy clean.

Closes #479
