### PR TITLE
feat(verify): detect vacuous contracts via ESBMC --error-label (#81 PR-B)

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -1959,7 +1959,7 @@ fn emit_btreemap_op(out: String, inst: IrInst, btreemap_max: i64) {
 }
 
 fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, modelable_fi_set: Vec<i64>, m: IrModule,
-                   vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64) {
+                   vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, reach_label: bool) {
     let vec_vars: Vec<i64> = collect_vec_vars(f);
     let string_vars: Vec<i64> = collect_string_vars(f);
     let hashmap_vars: Vec<i64> = collect_hashmap_vars(f);
@@ -2236,10 +2236,31 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
             }
         }
 
+        // Vacuity detection (#81 PR-B): in reach mode, plant the `vow_reach`
+        // label right after the last `requires` assume in the entry block. The
+        // label is reachable iff the preconditions are satisfiable; ESBMC
+        // `--error-label vow_reach` maps unreachable -> contradictory requires ->
+        // vacuous. Placing it after the requires prefix (not the function end)
+        // keeps body divergence from making the label spuriously unreachable.
+        let mut reach_after_idx: i64 = -1;
+        if reach_label && blk.id == first_block_id {
+            let mut qi: i64 = 0;
+            while qi < insts.len() {
+                let qinst: IrInst = insts[qi];
+                if qinst.op == IOP_VOW_REQ() {
+                    reach_after_idx = qi;
+                }
+                qi = qi + 1;
+            }
+        }
+
         let mut ri: i64 = 0;
         while ri < regular.len() {
             let inst: IrInst = insts[regular[ri]];
             emit_inst(out, inst, f, vec_vars, string_vars, hashmap_vars, btreemap_vars, option_vars, const_fn_indices, modelable_fi_set, m, const_str_ids, const_str_idxs, eq_lo, eq_hi, vec_max, string_max, hashmap_max, btreemap_max);
+            if regular[ri] == reach_after_idx {
+                out.push_str(String::from("vow_reach:;\n"));
+            }
             ri = ri + 1;
         }
 
@@ -2441,7 +2462,7 @@ fn emit_c_module(m: IrModule, vec_max: i64, string_max: i64, hashmap_max: i64, b
     let mut fi: i64 = 0;
     while fi < fns.len() {
         let f: IrFunction = fns[fi];
-        emit_c_function(out, f, const_fn_indices, empty_modelable, m, vec_max, model_string_max, hashmap_max, btreemap_max);
+        emit_c_function(out, f, const_fn_indices, empty_modelable, m, vec_max, model_string_max, hashmap_max, btreemap_max, false);
         out.push_byte(10);
         fi = fi + 1;
     }
@@ -2470,7 +2491,7 @@ fn scan_shift_op_in_module_fns(fns: Vec<IrFunction>, target_fi: i64, callee_fis:
 }
 
 fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>, modelable_fi_set: Vec<i64>,
-                              vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64) -> String {
+                              vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, target_reach_label: bool) -> String {
     let fns: Vec<IrFunction> = m.functions;
     let model_string_max: i64 = string_max_for_literals(m, string_max);
     let need_shl_i64: i64 = scan_shift_op_in_module_fns(fns, target_fi, callee_fis, IOP_SHL_I64());
@@ -2505,7 +2526,7 @@ fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>,
         while fi < fns.len() {
             let callee: IrFunction = fns[fi];
             if callee.id == cfid {
-                emit_c_function(out, callee, const_fn_indices, modelable_fi_set, m, vec_max, model_string_max, hashmap_max, btreemap_max);
+                emit_c_function(out, callee, const_fn_indices, modelable_fi_set, m, vec_max, model_string_max, hashmap_max, btreemap_max, false);
                 out.push_byte(10);
                 fi = fns.len();
             }
@@ -2518,7 +2539,7 @@ fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>,
     while fi < fns.len() {
         let f: IrFunction = fns[fi];
         if f.id == target_fi {
-            emit_c_function(out, f, const_fn_indices, modelable_fi_set, m, vec_max, model_string_max, hashmap_max, btreemap_max);
+            emit_c_function(out, f, const_fn_indices, modelable_fi_set, m, vec_max, model_string_max, hashmap_max, btreemap_max, target_reach_label);
             out.push_byte(10);
             fi = fns.len();
         }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3501,7 +3501,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven -- i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` -- and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)\n"));
+    r.push_str(String::from("**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven -- i.e. any `failed`, `timeout`, `unknown`, `error`, `skipped`, or `vacuous` -- and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.\n"));
     r.push_str(String::from("\n"));
@@ -3766,7 +3766,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"vacuous\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -3786,7 +3786,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"vacuous\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -3800,7 +3800,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `description` | string  | Full contract text                                       |\n"));
     r.push_str(String::from("| `blame`       | string  | `\"Caller\"` (requires) or `\"Callee\"` (ensures/invariant)  |\n"));
     r.push_str(String::from("| `source`      | object  | `{ \"file\": string, \"offset\": integer }`                  |\n"));
-    r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, `\"not_verified\"`, or `\"skipped\"` |\n"));
+    r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, `\"not_verified\"`, `\"skipped\"`, or `\"vacuous\"` |\n"));
     r.push_str(String::from("| `quality`     | string  | Static clause-shape classification (no ESBMC): `\"weak\"`, `\"tautological\"`, or `\"substantive\"` |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Status Values\n"));
@@ -3815,6 +3815,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `timeout`       | ESBMC timed out on the containing function (BV and -- when applicable -- IR fallback both timed out) |\n"));
     r.push_str(String::from("| `error`         | ESBMC error or tool not found                        |\n"));
     r.push_str(String::from("| `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) -- use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |\n"));
+    r.push_str(String::from("| `vacuous`       | The containing function's `requires` clauses are contradictory, so every `ensures` is satisfied vacuously -- ESBMC proved nothing of substance (antecedent failure). Detected by a second ESBMC run with `--error-label`: a `vow_reach` label planted after the `requires` assumes is unreachable. All of the function's clauses are reported `vacuous` (fail-closed, exit 1). See `docs/spec/contracts-methodology.md`. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Quality Values\n"));
     r.push_str(String::from("\n"));
@@ -4560,10 +4561,20 @@ fn skill_bundle() -> String {
     r.push_str(String::from("first runs, and trivial validity *always* indicated a real defect in the design,\n"));
     r.push_str(String::from("spec, or environment.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("**Detection (the `false` re-check):** re-verify each obligation with its `ensures`\n"));
-    r.push_str(String::from("replaced by `ensures: false`. If `assert(false)` still passes, the path is\n"));
-    r.push_str(String::from("unreachable under the preconditions -- the original proof was vacuous. A non-vacuous\n"));
-    r.push_str(String::from("obligation must *fail* this check.\n"));
+    r.push_str(String::from("**Detection (the reachability probe).** `vow contracts --verify` ships this check\n"));
+    r.push_str(String::from("(#81). For any function carrying a `requires`, it re-runs ESBMC over the same\n"));
+    r.push_str(String::from("model with a `vow_reach` label planted immediately after the `requires` assumes,\n"));
+    r.push_str(String::from("under `--error-label vow_reach`. If ESBMC reports the label **unreachable**\n"));
+    r.push_str(String::from("(`VERIFICATION SUCCESSFUL`), the conjoined preconditions are contradictory and\n"));
+    r.push_str(String::from("every `ensures` held only vacuously -- all of the function's clauses are reported\n"));
+    r.push_str(String::from("`status: \"vacuous\"` and the command fails closed. If the label is **reachable**\n"));
+    r.push_str(String::from("(`VERIFICATION FAILED`), the precondition domain is non-empty and the proof is\n"));
+    r.push_str(String::from("live. This is operationally the dual of the classic `ensures: false` re-check --\n"));
+    r.push_str(String::from("asking \"is the post-`requires` point reachable?\" instead of \"does `assert(false)`\n"));
+    r.push_str(String::from("still pass?\" -- but it needs only one extra run per function and is unaffected by\n"));
+    r.push_str(String::from("body divergence, since the label precedes the body. The label sits after the\n"));
+    r.push_str(String::from("requires prefix rather than at the function end precisely so an unbounded loop or\n"));
+    r.push_str(String::from("an `assume(0)` deeper in the body cannot make it spuriously unreachable.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("**Interesting witnesses.** Beer et al. also propose the dual of a counterexample:\n"));
     r.push_str(String::from("for a proof that holds, emit a non-trivial *witness* -- concrete inputs that\n"));
@@ -7197,7 +7208,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `--encoding <bv\\|ir\\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |\n"));
     r.push_str(String::from("| `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven -- i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` -- and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)\n"));
+    r.push_str(String::from("**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven -- i.e. any `failed`, `timeout`, `unknown`, `error`, `skipped`, or `vacuous` -- and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.\n"));
     r.push_str(String::from("\n"));
@@ -7462,7 +7473,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"vacuous\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -7482,7 +7493,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"vacuous\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -7496,7 +7507,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `description` | string  | Full contract text                                       |\n"));
     r.push_str(String::from("| `blame`       | string  | `\"Caller\"` (requires) or `\"Callee\"` (ensures/invariant)  |\n"));
     r.push_str(String::from("| `source`      | object  | `{ \"file\": string, \"offset\": integer }`                  |\n"));
-    r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, `\"not_verified\"`, or `\"skipped\"` |\n"));
+    r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, `\"not_verified\"`, `\"skipped\"`, or `\"vacuous\"` |\n"));
     r.push_str(String::from("| `quality`     | string  | Static clause-shape classification (no ESBMC): `\"weak\"`, `\"tautological\"`, or `\"substantive\"` |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Status Values\n"));
@@ -7511,6 +7522,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `timeout`       | ESBMC timed out on the containing function (BV and -- when applicable -- IR fallback both timed out) |\n"));
     r.push_str(String::from("| `error`         | ESBMC error or tool not found                        |\n"));
     r.push_str(String::from("| `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) -- use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |\n"));
+    r.push_str(String::from("| `vacuous`       | The containing function's `requires` clauses are contradictory, so every `ensures` is satisfied vacuously -- ESBMC proved nothing of substance (antecedent failure). Detected by a second ESBMC run with `--error-label`: a `vow_reach` label planted after the `requires` assumes is unreachable. All of the function's clauses are reported `vacuous` (fail-closed, exit 1). See `docs/spec/contracts-methodology.md`. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Quality Values\n"));
     r.push_str(String::from("\n"));
@@ -8260,10 +8272,20 @@ fn skill_support_content_3() -> String {
     r.push_str(String::from("first runs, and trivial validity *always* indicated a real defect in the design,\n"));
     r.push_str(String::from("spec, or environment.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("**Detection (the `false` re-check):** re-verify each obligation with its `ensures`\n"));
-    r.push_str(String::from("replaced by `ensures: false`. If `assert(false)` still passes, the path is\n"));
-    r.push_str(String::from("unreachable under the preconditions -- the original proof was vacuous. A non-vacuous\n"));
-    r.push_str(String::from("obligation must *fail* this check.\n"));
+    r.push_str(String::from("**Detection (the reachability probe).** `vow contracts --verify` ships this check\n"));
+    r.push_str(String::from("(#81). For any function carrying a `requires`, it re-runs ESBMC over the same\n"));
+    r.push_str(String::from("model with a `vow_reach` label planted immediately after the `requires` assumes,\n"));
+    r.push_str(String::from("under `--error-label vow_reach`. If ESBMC reports the label **unreachable**\n"));
+    r.push_str(String::from("(`VERIFICATION SUCCESSFUL`), the conjoined preconditions are contradictory and\n"));
+    r.push_str(String::from("every `ensures` held only vacuously -- all of the function's clauses are reported\n"));
+    r.push_str(String::from("`status: \"vacuous\"` and the command fails closed. If the label is **reachable**\n"));
+    r.push_str(String::from("(`VERIFICATION FAILED`), the precondition domain is non-empty and the proof is\n"));
+    r.push_str(String::from("live. This is operationally the dual of the classic `ensures: false` re-check --\n"));
+    r.push_str(String::from("asking \"is the post-`requires` point reachable?\" instead of \"does `assert(false)`\n"));
+    r.push_str(String::from("still pass?\" -- but it needs only one extra run per function and is unaffected by\n"));
+    r.push_str(String::from("body divergence, since the label precedes the body. The label sits after the\n"));
+    r.push_str(String::from("requires prefix rather than at the function end precisely so an unbounded loop or\n"));
+    r.push_str(String::from("an `assume(0)` deeper in the body cannot make it spuriously unreachable.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("**Interesting witnesses.** Beer et al. also propose the dual of a counterexample:\n"));
     r.push_str(String::from("for a proof that holds, emit a non-trivial *witness* -- concrete inputs that\n"));
@@ -10291,6 +10313,23 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
                             }
                             ei = ei + 1;
                         }
+
+                        // Vacuity probe (#81 PR-B): if the function's `requires`
+                        // are contradictory, the `ensures` above all passed
+                        // vacuously. Re-run with a `vow_reach` label after the
+                        // requires; if that point is unreachable, override the
+                        // whole contract's clauses with `vacuous`. Only functions
+                        // with a `requires` are eligible.
+                        let vac: i64 = verify_function_vacuity(func, ir_mod, max_k_step, solver, encoding, timeout_secs, vec_max_c, string_max_c, hashmap_max_c, btreemap_max_c);
+                        if vac == 1 {
+                            let mut vi2: i64 = 0;
+                            while vi2 < e_func_ids.len() {
+                                if e_func_ids[vi2] == func.id {
+                                    e_statuses[vi2] = String::from("vacuous");
+                                }
+                                vi2 = vi2 + 1;
+                            }
+                        }
                     }
                 }
                 fi = fi + 1;
@@ -10336,6 +10375,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let n_error: i64 = 0;
     let n_not_verified: i64 = 0;
     let n_skipped: i64 = 0;
+    let n_vacuous: i64 = 0;
     let mut si: i64 = 0;
     while si < total {
         let s: String = e_statuses[si];
@@ -10351,6 +10391,8 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
             n_error = n_error + 1;
         } else if s == String::from("skipped") {
             n_skipped = n_skipped + 1;
+        } else if s == String::from("vacuous") {
+            n_vacuous = n_vacuous + 1;
         } else {
             n_not_verified = n_not_verified + 1;
         }
@@ -10358,8 +10400,9 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     }
 
     // Fail closed: `vow contracts --verify` exits non-zero when any contract is
-    // not proven, matching `vow build --verify` / `vow verify` (#479).
-    if n_failed > 0 || n_timeout > 0 || n_unknown > 0 || n_error > 0 || n_skipped > 0 {
+    // not proven, matching `vow build --verify` / `vow verify` (#479). A vacuous
+    // contract is a hollow proof, so it fails closed too (#81 PR-B).
+    if n_failed > 0 || n_timeout > 0 || n_unknown > 0 || n_error > 0 || n_skipped > 0 || n_vacuous > 0 {
         exit_code = 1;
     }
 
@@ -10396,6 +10439,8 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     json.push_str(i64_to_str(n_not_verified));
     json.push_str(String::from(",\"skipped\":"));
     json.push_str(i64_to_str(n_skipped));
+    json.push_str(String::from(",\"vacuous\":"));
+    json.push_str(i64_to_str(n_vacuous));
     json.push_str(String::from(",\"quality\":{\"weak\":"));
     json.push_str(i64_to_str(n_weak));
     json.push_str(String::from(",\"tautological\":"));

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -202,7 +202,7 @@ fn emit_harness(f: IrFunction) -> String {
     out
 }
 
-fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64) -> String {
+fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, reach_label: bool) -> String {
     let const_fn_indices: Vec<i64> = detect_const_fns(m);
     let callee_fis: Vec<i64> = collect_modelable_callees(f, m, const_fn_indices);
     let model_string_max: i64 = string_max_for_literals(m, string_max);
@@ -215,7 +215,7 @@ fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, 
                 modelable_fi_set.push(callee_fis[ci]);
                 ci = ci + 1;
             }
-            emit_c_module_with_callees(m, f.id, callee_fis, modelable_fi_set, vec_max, model_string_max, hashmap_max, btreemap_max)
+            emit_c_module_with_callees(m, f.id, callee_fis, modelable_fi_set, vec_max, model_string_max, hashmap_max, btreemap_max, reach_label)
         } else {
             let preamble: String = cemit_preamble_with_limits(
                 func_has_shift_op(f, IOP_SHL_I64()),
@@ -225,7 +225,7 @@ fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, 
                 vec_max, model_string_max, hashmap_max, btreemap_max
             );
             let empty_modelable: Vec<i64> = Vec::new();
-            emit_c_function(preamble, f, const_fn_indices, empty_modelable, m, vec_max, model_string_max, hashmap_max, btreemap_max);
+            emit_c_function(preamble, f, const_fn_indices, empty_modelable, m, vec_max, model_string_max, hashmap_max, btreemap_max, reach_label);
             preamble.push_byte(10);
             preamble
         }
@@ -665,7 +665,7 @@ fn verify_function_multi_property(f: IrFunction, m: IrModule, max_k_step: String
     if vows.len() == 0 {
         return MultiPropertyResult { status: VERIFY_PROVEN(), verdict_ids: ids, verdict_proven: proven };
     }
-    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max);
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false);
     let fn_name: String = f.name;
     let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
     let tmp_path: String = verify_tmp_path();
@@ -681,6 +681,63 @@ fn verify_function_multi_property(f: IrFunction, m: IrModule, max_k_step: String
     };
     parse_multi_property_verdicts(combined, ids, proven);
     MultiPropertyResult { status: status, verdict_ids: ids, verdict_proven: proven }
+}
+
+// True when the function carries at least one `requires` clause — the only
+// contracts subject to antecedent-failure vacuity (#81 PR-B). Mirrors
+// function_has_requires in vow-verify/src/esbmc.rs.
+fn function_has_requires(f: IrFunction) -> bool {
+    let blocks: Vec<IrBlock> = f.blocks;
+    let nb: i64 = blocks.len();
+    let mut bi: i64 = 0;
+    while bi < nb {
+        let blk: IrBlock = blocks[bi];
+        let insts: Vec<IrInst> = blk.insts;
+        let ni: i64 = insts.len();
+        let mut ii: i64 = 0;
+        while ii < ni {
+            let inst: IrInst = insts[ii];
+            if inst.op == IOP_VOW_REQ() {
+                return true;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    false
+}
+
+// Vacuity probe (#81 PR-B): re-verify with a `vow_reach` label planted after the
+// requires assumes and ESBMC `--error-label vow_reach`. SUCCESSFUL means the
+// label is unreachable — the `requires` are contradictory and the contract is
+// vacuous; anything else (FAILED/timeout/error) is treated as not-vacuous (never
+// claim vacuity on an undecided probe). Only meaningful for functions with a
+// `requires`. Returns 1 when vacuous, 0 otherwise. Mirrors run_esbmc_reach in
+// vow-verify/src/esbmc.rs.
+fn verify_function_vacuity(f: IrFunction, m: IrModule, max_k_step: String, solver: String, encoding: String, timeout_secs: String,
+                           vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64) -> i64 [io] {
+    if !function_has_requires(f) {
+        return 0;
+    }
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, true);
+    let fn_name: String = f.name;
+    let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
+    let tmp_path: String = verify_tmp_path();
+    let extra: Vec<String> = Vec::new();
+    extra.push(String::from("--error-label"));
+    extra.push(String::from("vow_reach"));
+    let r: EsbmcRun = run_esbmc(c_source, max_k_step, tmp_path, fn_name, solver, encoding, bv_timeout, extra);
+    if r.exit_code == -3 {
+        return 0;
+    }
+    let combined: String = r.combined;
+    let status: i64 = {
+        if r.exit_code == -2 { VERIFY_TIMEOUT() } else { parse_verify_status(combined) }
+    };
+    if status == VERIFY_PROVEN() {
+        return 1;
+    }
+    0
 }
 
 fn parse_assignments(output: String, names: Vec<String>, values: Vec<String>) {
@@ -922,7 +979,7 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
             raw_output: String::from(""),
         };
     }
-    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max);
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false);
     let fn_name: String = f.name;
     let ir_solver: String = String::from("z3");
     let ir_encoding: String = String::from("ir");
@@ -964,7 +1021,7 @@ fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_ca
     if vows.len() == 0 {
         return EsbmcStart { handle: -1, tmp_path: String::from("") };
     }
-    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max);
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false);
     // No cache lookup or write — see the note above resolve_auto_bv_solver.
     // `use_cache` stays on the signature for caller-side symmetry with the
     // Rust toolchain but has no effect.

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -67,7 +67,7 @@ vow contracts [OPTIONS] <source.vow>
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
-**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
+**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, `skipped`, or `vacuous` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
 
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
 
@@ -332,7 +332,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -352,7 +352,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -366,7 +366,7 @@ that path produces `Unverified` (exit 0).
 | `description` | string  | Full contract text                                       |
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
-| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
+| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, `"skipped"`, or `"vacuous"` |
 | `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
 
 ### Status Values
@@ -381,6 +381,7 @@ that path produces `Unverified` (exit 0).
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) — use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |
+| `vacuous`       | The containing function's `requires` clauses are contradictory, so every `ensures` is satisfied vacuously — ESBMC proved nothing of substance (antecedent failure). Detected by a second ESBMC run with `--error-label`: a `vow_reach` label planted after the `requires` assumes is unreachable. All of the function's clauses are reported `vacuous` (fail-closed, exit 1). See `docs/spec/contracts-methodology.md`. |
 
 ### Quality Values
 

--- a/docs/spec/contracts-methodology.md
+++ b/docs/spec/contracts-methodology.md
@@ -255,10 +255,20 @@ years of hardware verification at IBM, ~20% of formulas were trivially valid on
 first runs, and trivial validity *always* indicated a real defect in the design,
 spec, or environment.
 
-**Detection (the `false` re-check):** re-verify each obligation with its `ensures`
-replaced by `ensures: false`. If `assert(false)` still passes, the path is
-unreachable under the preconditions — the original proof was vacuous. A non-vacuous
-obligation must *fail* this check.
+**Detection (the reachability probe).** `vow contracts --verify` ships this check
+(#81). For any function carrying a `requires`, it re-runs ESBMC over the same
+model with a `vow_reach` label planted immediately after the `requires` assumes,
+under `--error-label vow_reach`. If ESBMC reports the label **unreachable**
+(`VERIFICATION SUCCESSFUL`), the conjoined preconditions are contradictory and
+every `ensures` held only vacuously — all of the function's clauses are reported
+`status: "vacuous"` and the command fails closed. If the label is **reachable**
+(`VERIFICATION FAILED`), the precondition domain is non-empty and the proof is
+live. This is operationally the dual of the classic `ensures: false` re-check —
+asking "is the post-`requires` point reachable?" instead of "does `assert(false)`
+still pass?" — but it needs only one extra run per function and is unaffected by
+body divergence, since the label precedes the body. The label sits after the
+requires prefix rather than at the function end precisely so an unbounded loop or
+an `assume(0)` deeper in the body cannot make it spuriously unreachable.
 
 **Interesting witnesses.** Beer et al. also propose the dual of a counterexample:
 for a proof that holds, emit a non-trivial *witness* — concrete inputs that

--- a/skills/vow/reference/cli.md
+++ b/skills/vow/reference/cli.md
@@ -67,7 +67,7 @@ vow contracts [OPTIONS] <source.vow>
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
-**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
+**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, `skipped`, or `vacuous` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
 
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
 
@@ -332,7 +332,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -352,7 +352,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -366,7 +366,7 @@ that path produces `Unverified` (exit 0).
 | `description` | string  | Full contract text                                       |
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
-| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
+| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, `"skipped"`, or `"vacuous"` |
 | `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
 
 ### Status Values
@@ -381,6 +381,7 @@ that path produces `Unverified` (exit 0).
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) — use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |
+| `vacuous`       | The containing function's `requires` clauses are contradictory, so every `ensures` is satisfied vacuously — ESBMC proved nothing of substance (antecedent failure). Detected by a second ESBMC run with `--error-label`: a `vow_reach` label planted after the `requires` assumes is unreachable. All of the function's clauses are reported `vacuous` (fail-closed, exit 1). See `docs/spec/contracts-methodology.md`. |
 
 ### Quality Values
 

--- a/skills/vow/reference/contracts-methodology.md
+++ b/skills/vow/reference/contracts-methodology.md
@@ -255,10 +255,20 @@ years of hardware verification at IBM, ~20% of formulas were trivially valid on
 first runs, and trivial validity *always* indicated a real defect in the design,
 spec, or environment.
 
-**Detection (the `false` re-check):** re-verify each obligation with its `ensures`
-replaced by `ensures: false`. If `assert(false)` still passes, the path is
-unreachable under the preconditions — the original proof was vacuous. A non-vacuous
-obligation must *fail* this check.
+**Detection (the reachability probe).** `vow contracts --verify` ships this check
+(#81). For any function carrying a `requires`, it re-runs ESBMC over the same
+model with a `vow_reach` label planted immediately after the `requires` assumes,
+under `--error-label vow_reach`. If ESBMC reports the label **unreachable**
+(`VERIFICATION SUCCESSFUL`), the conjoined preconditions are contradictory and
+every `ensures` held only vacuously — all of the function's clauses are reported
+`status: "vacuous"` and the command fails closed. If the label is **reachable**
+(`VERIFICATION FAILED`), the precondition domain is non-empty and the proof is
+live. This is operationally the dual of the classic `ensures: false` re-check —
+asking "is the post-`requires` point reachable?" instead of "does `assert(false)`
+still pass?" — but it needs only one extra run per function and is unaffected by
+body divergence, since the label precedes the body. The label sits after the
+requires prefix rather than at the function end precisely so an unbounded loop or
+an `assume(0)` deeper in the body cannot make it spuriously unreachable.
 
 **Interesting witnesses.** Beer et al. also propose the dual of a counterexample:
 for a proof that holds, emit a non-trivial *witness* — concrete inputs that

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -422,6 +422,47 @@ else:
       pass "$name"
     fi
   fi
+
+  name="contracts_vacuity_detected"
+  if matches_filter "$name"; then
+    # PR-B (#81): a function whose `requires` are contradictory makes every
+    # `ensures` pass vacuously. The `--error-label vow_reach` probe finds the
+    # post-requires point unreachable and marks the whole contract `vacuous`
+    # (fail-closed, exit 1). Mirrors the Rust contracts_verify_detects_vacuous.
+    src="$TMPDIR/${name}.vow"
+    cat > "$src" <<'VOWEOF'
+module M
+fn f(x: i64) -> i64 vow {
+  requires: x > 10,
+  requires: x < 5,
+  ensures: result == x
+} { x }
+fn main() -> i32 [io] { 0 }
+VOWEOF
+    set +e
+    vac_json="$(run_vowc contracts --verify "$src" 2>/dev/null)"
+    vac_exit=$?
+    set -e
+    vac_check="$(python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    print('parse_error'); sys.exit(0)
+ss = [e.get('status', '') for e in d.get('contracts', [])]
+if ss and all(s == 'vacuous' for s in ss) and d.get('summary', {}).get('vacuous') == 3:
+    print('ok')
+else:
+    print('statuses=%s vacuous=%s' % (ss, d.get('summary', {}).get('vacuous')))
+" <<< "$vac_json")"
+    if [[ "$vac_exit" -ne 1 ]]; then
+      fail "$name" "exit $vac_exit (expected 1 — fail-closed on vacuous)"
+    elif [[ "$vac_check" != "ok" ]]; then
+      fail "$name" "vacuity not detected ($vac_check)"
+    else
+      pass "$name"
+    fi
+  fi
 fi
 
 # --- Phase 3: verify-fail/ tests ---

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -1781,6 +1781,7 @@ pub fn emit_c_function(
             warnings: vec![],
         },
         limits,
+        false,
     )
 }
 
@@ -1790,8 +1791,27 @@ pub fn emit_c_function_full(
     modelable_fns: &HashSet<FuncId>,
     module: &Module,
     limits: &VerifyLimits,
+    reach_label: bool,
 ) -> String {
     let mut out = String::new();
+
+    // Vacuity detection (#81 PR-B): when `reach_label` is set, emit a `vow_reach`
+    // label immediately after the last `requires` assume in the entry block.
+    // The label is reachable iff the preconditions are satisfiable; ESBMC
+    // `--error-label vow_reach` then maps unreachable -> contradictory requires
+    // -> vacuous contract. Placing it right after the requires prefix (not at the
+    // function end) keeps body divergence — unbounded loops, assume(0) — from
+    // making the label spuriously unreachable.
+    let reach_after: Option<u32> = if reach_label {
+        func.blocks.first().and_then(|b| {
+            b.insts
+                .iter()
+                .rfind(|i| i.opcode == Opcode::VowRequires)
+                .map(|i| i.id.0)
+        })
+    } else {
+        None
+    };
     let vec_vars = collect_typed_vars(func, "__vow_vec_new", "__vow_vec_");
     let string_vars = collect_typed_vars(func, "__vow_string_new", "__vow_string_");
     let hashmap_vars = collect_typed_vars(func, "__vow_map_new", "__vow_map_");
@@ -2042,6 +2062,9 @@ pub fn emit_c_function_full(
                 limits,
                 func.return_ty,
             );
+            if reach_after == Some(inst.id.0) {
+                out.push_str("vow_reach:;\n");
+            }
         }
         // Emit Upsilons: read all sources first, then write all targets.
         if !upsilons.is_empty() {
@@ -2228,6 +2251,7 @@ pub fn emit_c_module_with_callees(
     callee_ids: &[FuncId],
     modelable_fns: &HashSet<FuncId>,
     limits: &VerifyLimits,
+    target_reach_label: bool,
 ) -> String {
     let mut out = String::new();
     let effective_limits = limits_with_literal_string_capacity(module, limits);
@@ -2261,18 +2285,20 @@ pub fn emit_c_module_with_callees(
                 modelable_fns,
                 module,
                 &effective_limits,
+                false,
             ));
             out.push('\n');
         }
     }
 
-    // Target function
+    // Target function — the only one that carries the vacuity `vow_reach` label.
     out.push_str(&emit_c_function_full(
         target,
         const_fns,
         modelable_fns,
         module,
         &effective_limits,
+        target_reach_label,
     ));
     out.push('\n');
     out
@@ -2496,6 +2522,7 @@ mod tests {
             &HashSet::new(),
             &module,
             &VerifyLimits::default(),
+            false,
         );
 
         assert!(
@@ -2561,6 +2588,94 @@ mod tests {
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
         assert!(c.contains("__ESBMC_assume(v3)"), "requires: {c}");
         assert!(!c.contains("__ESBMC_assert"), "no assert for requires: {c}");
+    }
+
+    #[test]
+    fn emit_reach_label_after_requires() {
+        // #81 PR-B: in reach mode the `vow_reach` label is planted immediately
+        // after the last `requires` assume (so body divergence can't make it
+        // spuriously unreachable), and it is absent on the normal verify path.
+        let func = Function {
+            id: FuncId(0),
+            name: "divide".to_string(),
+            params: vec![Ty::I64, Ty::I64],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![VowEntry {
+                id: VowId(0),
+                description: "y != 0".to_string(),
+                blame: Blame::Caller,
+                bindings: vec![],
+                file: String::new(),
+                offset: 0,
+            }],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                    inst(1, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(1)),
+                    inst(2, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(3, Opcode::NeI64, Ty::Bool, vec![1, 2], InstData::None),
+                    Inst {
+                        id: InstId(4),
+                        opcode: Opcode::VowRequires,
+                        ty: Ty::Unit,
+                        args: vec![InstId(3)],
+                        data: InstData::VowId(VowId(0)),
+                        origin: sp(),
+                        region: RegionId::Root,
+                    },
+                    inst(
+                        5,
+                        Opcode::WrappingDivI64,
+                        Ty::I64,
+                        vec![0, 1],
+                        InstData::None,
+                    ),
+                    inst(6, Opcode::Return, Ty::Unit, vec![5], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        let module = Module {
+            name: String::new(),
+            functions: vec![],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+            warnings: vec![],
+        };
+        let c = emit_c_function_full(
+            &func,
+            &HashMap::new(),
+            &HashSet::new(),
+            &module,
+            &VerifyLimits::default(),
+            true,
+        );
+        let assume_pos = c
+            .find("__ESBMC_assume(v3)")
+            .expect("requires assume present");
+        let label_pos = c.find("vow_reach:").expect("reach label present");
+        assert!(
+            label_pos > assume_pos,
+            "label must follow the requires assume:\n{c}"
+        );
+        let c_no = emit_c_function_full(
+            &func,
+            &HashMap::new(),
+            &HashSet::new(),
+            &module,
+            &VerifyLimits::default(),
+            false,
+        );
+        assert!(
+            !c_no.contains("vow_reach"),
+            "no reach label on the normal verify path:\n{c_no}"
+        );
     }
 
     #[test]
@@ -4687,6 +4802,7 @@ mod tests {
             &HashSet::new(),
             &module,
             &VerifyLimits::default(),
+            false,
         );
         assert!(c.contains("__vow_string_t v1;"), "string struct decl: {c}");
         assert!(c.contains("v1.len = 5;"), "literal len from pool: {c}");
@@ -4737,6 +4853,7 @@ mod tests {
             &[],
             &HashSet::new(),
             &limits,
+            false,
         );
         assert!(
             c.contains("typedef struct { int64_t len; int8_t data[5]; } __vow_string_t;"),
@@ -4787,6 +4904,7 @@ mod tests {
             &HashSet::new(),
             &module,
             &VerifyLimits::default(),
+            false,
         );
         assert!(c.contains("__vow_string_t v2;"), "clone decl: {c}");
         assert!(c.contains("v2 = v1;"), "clone preserves source model: {c}");
@@ -4824,6 +4942,7 @@ mod tests {
                 warnings: vec![],
             },
             &VerifyLimits::default(),
+            false,
         );
         assert!(c.contains("__vow_string_t v0;"), "dest param model: {c}");
         assert!(c.contains("__vow_string_t v1;"), "source param model: {c}");

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -311,10 +311,56 @@ pub fn emit_verify_c_source(
     let callee_ids = collect_modelable_callees(func, module, const_fns, &mut modelable_cache);
 
     let modelable_fns: std::collections::HashSet<FuncId> = callee_ids.iter().copied().collect();
-    let mut c_src =
-        emit_c_module_with_callees(func, module, const_fns, &callee_ids, &modelable_fns, limits);
+    let mut c_src = emit_c_module_with_callees(
+        func,
+        module,
+        const_fns,
+        &callee_ids,
+        &modelable_fns,
+        limits,
+        false,
+    );
     c_src.push_str(&emit_harness(func));
     c_src
+}
+
+/// Like [`emit_verify_c_source`] but plants a `vow_reach` label after the
+/// target's `requires` assumes, for ESBMC `--error-label vow_reach` vacuity
+/// detection (#81 PR-B). Returns `None` when the function has no `requires` —
+/// there is no antecedent that could be contradictory, so the vacuity check is
+/// not applicable and the caller skips the extra ESBMC run.
+pub fn emit_reach_c_source(
+    func: &Function,
+    module: &Module,
+    const_fns: &HashMap<FuncId, ConstantValue>,
+    limits: &VerifyLimits,
+) -> Option<String> {
+    if !function_has_requires(func) {
+        return None;
+    }
+    let mut modelable_cache = HashMap::new();
+    let callee_ids = collect_modelable_callees(func, module, const_fns, &mut modelable_cache);
+    let modelable_fns: std::collections::HashSet<FuncId> = callee_ids.iter().copied().collect();
+    let mut c_src = emit_c_module_with_callees(
+        func,
+        module,
+        const_fns,
+        &callee_ids,
+        &modelable_fns,
+        limits,
+        true,
+    );
+    c_src.push_str(&emit_harness(func));
+    Some(c_src)
+}
+
+/// True when the function carries at least one `requires` clause — the only
+/// contracts subject to antecedent-failure vacuity.
+pub fn function_has_requires(func: &Function) -> bool {
+    func.blocks
+        .iter()
+        .flat_map(|b| &b.insts)
+        .any(|i| i.opcode == vow_ir::Opcode::VowRequires)
 }
 
 pub const DEFAULT_MAX_K_STEP: u32 = 50;
@@ -609,6 +655,52 @@ pub fn run_esbmc_multi_property(
             parse_multi_property_verdicts(&combined),
         ),
         Err(r) => (r, std::collections::HashMap::new()),
+    }
+}
+
+/// Outcome of the `--error-label vow_reach` vacuity probe (#81 PR-B).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReachVerdict {
+    /// Label unreachable (ESBMC SUCCESSFUL): the `requires` are contradictory,
+    /// so every `ensures` on the function is vacuously satisfied.
+    Vacuous,
+    /// Label reachable (ESBMC FAILED): the precondition domain is non-empty.
+    Live,
+    /// ESBMC could not decide (timeout, tool error, unexpected output) — never
+    /// claim vacuity on an undecided probe.
+    Inconclusive,
+}
+
+/// Vacuity probe: run ESBMC with `--error-label vow_reach` over a C source that
+/// plants the label after the `requires` assumes (see `emit_reach_c_source`).
+/// SUCCESSFUL means the label is unreachable — the preconditions are
+/// contradictory and the contract is vacuous; FAILED means the label is
+/// reachable (live); anything else is inconclusive (#81 PR-B).
+pub fn run_esbmc_reach(
+    esbmc: &std::path::Path,
+    c_src: &str,
+    max_k_step: u32,
+    func_name: &str,
+    config: &SolverConfig,
+) -> ReachVerdict {
+    match run_esbmc_capture(
+        esbmc,
+        c_src,
+        max_k_step,
+        func_name,
+        config,
+        &["--error-label", "vow_reach"],
+    ) {
+        Ok(combined) => {
+            if combined.contains("VERIFICATION SUCCESSFUL") {
+                ReachVerdict::Vacuous
+            } else if combined.contains("VERIFICATION FAILED") {
+                ReachVerdict::Live
+            } else {
+                ReachVerdict::Inconclusive
+            }
+        }
+        Err(_) => ReachVerdict::Inconclusive,
     }
 }
 

--- a/vow-verify/src/lib.rs
+++ b/vow-verify/src/lib.rs
@@ -7,8 +7,9 @@ pub use c_emitter::{
     non_modelable_reason,
 };
 pub use esbmc::{
-    Counterexample, DEFAULT_MAX_K_STEP, VerificationResult, emit_verify_c_source, find_esbmc,
-    parse_esbmc_output, run_esbmc_k_induction, run_esbmc_multi_property, run_esbmc_with_max_k_step,
+    Counterexample, DEFAULT_MAX_K_STEP, ReachVerdict, VerificationResult, emit_reach_c_source,
+    emit_verify_c_source, find_esbmc, function_has_requires, parse_esbmc_output,
+    run_esbmc_k_induction, run_esbmc_multi_property, run_esbmc_reach, run_esbmc_with_max_k_step,
     verify_function, verify_function_with_const_fns, verify_function_with_module,
     verify_function_with_module_and_const_fns,
     verify_function_with_module_and_const_fns_configured,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -17,10 +17,10 @@ use vow_codegen::linker::{find_runtime_lib, find_shim_lib, link};
 use vow_codegen::{Backend, BuildMode, TraceMode};
 use vow_diag::{Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
 use vow_verify::{
-    ConstantValue, Counterexample, DEFAULT_ESBMC_MEMLIMIT_MB, DEFAULT_MAX_K_STEP, Encoding, Solver,
-    SolverConfig, UNSUPPORTED_OP_VOW_ID, VerificationResult, VerifyLimits,
-    detect_constant_functions, emit_verify_c_source, find_esbmc, non_modelable_reason,
-    run_esbmc_multi_property, run_with_fallback,
+    ConstantValue, Counterexample, DEFAULT_ESBMC_MEMLIMIT_MB, DEFAULT_MAX_K_STEP, Encoding,
+    ReachVerdict, Solver, SolverConfig, UNSUPPORTED_OP_VOW_ID, VerificationResult, VerifyLimits,
+    detect_constant_functions, emit_reach_c_source, emit_verify_c_source, find_esbmc,
+    non_modelable_reason, run_esbmc_multi_property, run_esbmc_reach, run_with_fallback,
     verify_function_with_module_and_const_fns_configured,
 };
 
@@ -2467,7 +2467,7 @@ vow contracts [OPTIONS] <source.vow>
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
-**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
+**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, `skipped`, or `vacuous` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
 
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
 
@@ -2732,7 +2732,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -2752,7 +2752,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -2766,7 +2766,7 @@ that path produces `Unverified` (exit 0).
 | `description` | string  | Full contract text                                       |
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
-| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
+| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, `"skipped"`, or `"vacuous"` |
 | `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
 
 ### Status Values
@@ -2781,6 +2781,7 @@ that path produces `Unverified` (exit 0).
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) — use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |
+| `vacuous`       | The containing function's `requires` clauses are contradictory, so every `ensures` is satisfied vacuously — ESBMC proved nothing of substance (antecedent failure). Detected by a second ESBMC run with `--error-label`: a `vow_reach` label planted after the `requires` assumes is unreachable. All of the function's clauses are reported `vacuous` (fail-closed, exit 1). See `docs/spec/contracts-methodology.md`. |
 
 ### Quality Values
 
@@ -3526,10 +3527,20 @@ years of hardware verification at IBM, ~20% of formulas were trivially valid on
 first runs, and trivial validity *always* indicated a real defect in the design,
 spec, or environment.
 
-**Detection (the `false` re-check):** re-verify each obligation with its `ensures`
-replaced by `ensures: false`. If `assert(false)` still passes, the path is
-unreachable under the preconditions — the original proof was vacuous. A non-vacuous
-obligation must *fail* this check.
+**Detection (the reachability probe).** `vow contracts --verify` ships this check
+(#81). For any function carrying a `requires`, it re-runs ESBMC over the same
+model with a `vow_reach` label planted immediately after the `requires` assumes,
+under `--error-label vow_reach`. If ESBMC reports the label **unreachable**
+(`VERIFICATION SUCCESSFUL`), the conjoined preconditions are contradictory and
+every `ensures` held only vacuously — all of the function's clauses are reported
+`status: "vacuous"` and the command fails closed. If the label is **reachable**
+(`VERIFICATION FAILED`), the precondition domain is non-empty and the proof is
+live. This is operationally the dual of the classic `ensures: false` re-check —
+asking "is the post-`requires` point reachable?" instead of "does `assert(false)`
+still pass?" — but it needs only one extra run per function and is unaffected by
+body divergence, since the label precedes the body. The label sits after the
+requires prefix rather than at the function end precisely so an unbounded loop or
+an `assume(0)` deeper in the body cannot make it spuriously unreachable.
 
 **Interesting witnesses.** Beer et al. also propose the dual of a counterexample:
 for a proof that holds, emit a non-trivial *witness* — concrete inputs that
@@ -6148,7 +6159,7 @@ vow contracts [OPTIONS] <source.vow>
 | `--encoding <bv\|ir\|auto>` | `auto` | ESBMC encoding mode (with --verify); ir requires z3 |
 | `--verify-jobs <N>` | `num_cpus/2` | Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial) |
 
-**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, or `skipped` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
+**Exit code.** With `--verify`, `vow contracts` fails closed exactly like `vow build --verify` and `vow verify`: it exits **1** if any contract's `status` is not proven — i.e. any `failed`, `timeout`, `unknown`, `error`, `skipped`, or `vacuous` — and **0** only when every contract is `proven`/`proven-ir`. Without `--verify` every contract is `not_verified` and the command exits 0. (This is independent of the static `quality` classification, which never affects the exit code.)
 
 When `--verify` is requested but ESBMC is not installed, the command still emits the full contracts-result JSON schema with every entry's `status` set to `error` and exits with code 1 (fail-closed). Install ESBMC, or omit `--verify`, to obtain proven/failed/unknown statuses.
 
@@ -6413,7 +6424,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -6433,7 +6444,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -6447,7 +6458,7 @@ that path produces `Unverified` (exit 0).
 | `description` | string  | Full contract text                                       |
 | `blame`       | string  | `"Caller"` (requires) or `"Callee"` (ensures/invariant)  |
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
-| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, or `"skipped"` |
+| `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, `"skipped"`, or `"vacuous"` |
 | `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
 
 ### Status Values
@@ -6462,6 +6473,7 @@ that path produces `Unverified` (exit 0).
 | `timeout`       | ESBMC timed out on the containing function (BV and — when applicable — IR fallback both timed out) |
 | `error`         | ESBMC error or tool not found                        |
 | `skipped`       | The containing function's body uses opcodes the verifier cannot model (e.g. `RegionAlloc` from struct construction). Contract is documentary; runtime checks still apply under `--mode debug`. Surfaces as a `VerificationSkipped` Warning in the build JSON's `diagnostics[]` and lifts the overall build/verify status to `Skipped` (fail-closed, exit 1) — use `--no-verify` if you want a non-failing path that does not invoke ESBMC at all. |
+| `vacuous`       | The containing function's `requires` clauses are contradictory, so every `ensures` is satisfied vacuously — ESBMC proved nothing of substance (antecedent failure). Detected by a second ESBMC run with `--error-label`: a `vow_reach` label planted after the `requires` assumes is unreachable. All of the function's clauses are reported `vacuous` (fail-closed, exit 1). See `docs/spec/contracts-methodology.md`. |
 
 ### Quality Values
 
@@ -7209,10 +7221,20 @@ years of hardware verification at IBM, ~20% of formulas were trivially valid on
 first runs, and trivial validity *always* indicated a real defect in the design,
 spec, or environment.
 
-**Detection (the `false` re-check):** re-verify each obligation with its `ensures`
-replaced by `ensures: false`. If `assert(false)` still passes, the path is
-unreachable under the preconditions — the original proof was vacuous. A non-vacuous
-obligation must *fail* this check.
+**Detection (the reachability probe).** `vow contracts --verify` ships this check
+(#81). For any function carrying a `requires`, it re-runs ESBMC over the same
+model with a `vow_reach` label planted immediately after the `requires` assumes,
+under `--error-label vow_reach`. If ESBMC reports the label **unreachable**
+(`VERIFICATION SUCCESSFUL`), the conjoined preconditions are contradictory and
+every `ensures` held only vacuously — all of the function's clauses are reported
+`status: "vacuous"` and the command fails closed. If the label is **reachable**
+(`VERIFICATION FAILED`), the precondition domain is non-empty and the proof is
+live. This is operationally the dual of the classic `ensures: false` re-check —
+asking "is the post-`requires` point reachable?" instead of "does `assert(false)`
+still pass?" — but it needs only one extra run per function and is unaffected by
+body divergence, since the label precedes the body. The label sits after the
+requires prefix rather than at the function end precisely so an unbounded loop or
+an `assume(0)` deeper in the body cannot make it spuriously unreachable.
 
 **Interesting witnesses.** Beer et al. also propose the dual of a counterexample:
 for a proof that holds, emit a non-trivial *witness* — concrete inputs that
@@ -9133,6 +9155,7 @@ pub struct ContractsSummaryJson {
     pub error: u32,
     pub not_verified: u32,
     pub skipped: u32,
+    pub vacuous: u32,
     pub quality: ContractsQualityJson,
 }
 
@@ -11036,6 +11059,7 @@ fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJso
         error: 0,
         not_verified: 0,
         skipped: 0,
+        vacuous: 0,
         quality: ContractsQualityJson {
             weak: 0,
             tautological: 0,
@@ -11050,6 +11074,7 @@ fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJso
             "timeout" => summary.timeout += 1,
             "error" => summary.error += 1,
             "skipped" => summary.skipped += 1,
+            "vacuous" => summary.vacuous += 1,
             _ => summary.not_verified += 1,
         }
         match e.quality.as_str() {
@@ -11126,6 +11151,24 @@ fn update_contract_statuses(
             }
             .to_string();
         }
+
+        // Vacuity probe (#81 PR-B): if the function's `requires` are
+        // contradictory, the `ensures` above all passed vacuously. Re-run with a
+        // `vow_reach` label planted after the requires; if that point is
+        // unreachable (ESBMC SUCCESSFUL), the whole contract is vacuous —
+        // override the misleading `proven`s with `vacuous`. Only functions with
+        // a `requires` are eligible (emit_reach_c_source returns None otherwise),
+        // so this adds at most one extra ESBMC run per such function.
+        if let Some(reach_src) = emit_reach_c_source(func, ir_module, &const_fns, limits)
+            && run_esbmc_reach(&esbmc, &reach_src, limits.max_k_step, &func.name, config)
+                == ReachVerdict::Vacuous
+        {
+            for entry in entries.iter_mut() {
+                if entry.function_id == func.id.0 {
+                    entry.status = "vacuous".to_string();
+                }
+            }
+        }
     }
 }
 
@@ -11139,6 +11182,7 @@ fn contracts_summary_has_failure(summary: &ContractsSummaryJson) -> bool {
         || summary.unknown > 0
         || summary.error > 0
         || summary.skipped > 0
+        || summary.vacuous > 0
 }
 
 fn run_contracts_command(
@@ -14918,6 +14962,7 @@ fn main() -> i32 {
             error: 0,
             not_verified: 0,
             skipped: 0,
+            vacuous: 0,
             quality: ContractsQualityJson {
                 weak: 0,
                 tautological: 0,
@@ -14951,6 +14996,10 @@ fn main() -> i32 {
             },
             ContractsSummaryJson {
                 skipped: 1,
+                ..all_proven.clone()
+            },
+            ContractsSummaryJson {
+                vacuous: 1,
                 ..all_proven.clone()
             },
         ] {

--- a/vow/tests/contracts.rs
+++ b/vow/tests/contracts.rs
@@ -110,6 +110,40 @@ fn contracts_verify_per_clause_precise_status() {
 }
 
 #[test]
+fn contracts_verify_detects_vacuous_contract() {
+    // PR-B (#81): a function whose `requires` are contradictory makes every
+    // `ensures` pass vacuously. The `--error-label vow_reach` probe finds the
+    // post-requires point unreachable and marks the whole contract `vacuous`
+    // (fail-closed, exit 1). Requires ESBMC; skips gracefully if absent.
+    let dir = tempfile::TempDir::new().unwrap();
+    let src = dir.path().join("vac.vow");
+    std::fs::write(
+        &src,
+        "module M\n\
+         fn f(x: i64) -> i64 vow {\n  requires: x > 10,\n  requires: x < 5,\n  ensures: result == x\n} { x }\n\
+         fn main() -> i32 [io] { 0 }\n",
+    )
+    .unwrap();
+    let out = Command::new(vow_bin())
+        .args(["contracts", "--verify", src.to_str().unwrap()])
+        .output()
+        .expect("failed to run vow");
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("contracts JSON");
+    let contracts = json["contracts"].as_array().unwrap();
+    if contracts.iter().all(|c| c["status"] == "error") {
+        return; // ESBMC absent
+    }
+    assert!(
+        contracts.iter().all(|c| c["status"] == "vacuous"),
+        "all clauses of a contradictory-requires contract are vacuous: {contracts:?}"
+    );
+    assert_eq!(json["summary"]["vacuous"], 3);
+    assert_eq!(json["summary"]["proven"], 0);
+    assert_eq!(out.status.code(), Some(1), "fail-closed on vacuous");
+}
+
+#[test]
 fn contracts_verify_missing_esbmc_keeps_contracts_schema() {
     let empty_path = tempfile::TempDir::new().unwrap();
     let out = Command::new(vow_bin())


### PR DESCRIPTION
## What

`vow contracts --verify` now detects **vacuous contracts**: a function whose `requires` clauses are contradictory makes every `ensures` provable for free (antecedent failure), so ESBMC reports `proven` while proving nothing. Such clauses are now reported `status: "vacuous"` and fail closed. Part of #81 (contract methodology — distinguishing real proofs from hollow ones).

Stacked on **PR-A (#716)**.

## The technique

For any function carrying a `requires`, a second ESBMC run is made over the same model with a `vow_reach` label planted **immediately after the `requires` assumes**, under `--error-label vow_reach`:

- label **unreachable** (`VERIFICATION SUCCESSFUL`) → the conjoined preconditions are contradictory → the whole contract is **vacuous**;
- label **reachable** (`VERIFICATION FAILED`) → the precondition domain is non-empty → the proof is live.

The label sits after the requires prefix (not at the function end) on purpose: an unbounded loop or an `assume(0)` deeper in the body must not be able to make it spuriously unreachable. This is the operational dual of the classic `ensures: false` re-check (Beer et al., FMSD 2001), but needs only one extra run per function and is immune to body divergence. Functions with no `requires` are skipped — there is no antecedent that could fail.

```
fn f(x: i64) -> i64 vow { requires: x > 10, requires: x < 5, ensures: result == x } { x }
```
→ all three clauses `vacuous`, `summary.vacuous = 3`, exit 1. A satisfiable contract (e.g. `requires: y != 0`) is unaffected.

## Changes (both compilers, in parity)

- **Rust** — `vow-verify/src/c_emitter.rs`: `emit_c_function_full` gains a `reach_label` mode that plants `vow_reach:` after the last `VowRequires` in the entry block; `vow-verify/src/esbmc.rs`: `emit_reach_c_source` (returns `None` when the function has no `requires`), `function_has_requires`, and `run_esbmc_reach` → `ReachVerdict { Vacuous, Live, Inconclusive }`; `vow/src/main.rs`: `update_contract_statuses` runs the probe after the per-clause pass and overrides a vacuous function's clauses with `vacuous`; new `vacuous` summary field, counted and fail-closed.
- **Self-hosted** — mirrored in `compiler/c_emitter.vow` (reach label after the requires prefix), `compiler/verifier.vow` (`function_has_requires`, `verify_function_vacuity` running `--error-label vow_reach`), and `compiler/main.vow` `run_contracts` (per-function override + `vacuous` tally + fail-closed).
- **Spec** — `docs/spec/cli.md` (new `vacuous` status row, status enum, exit-code set, example summaries) and `docs/spec/contracts-methodology.md` (the Detection paragraph now describes the shipped reachability probe). Embedded skill regenerated.

## Tests

- Rust: `emit_reach_label_after_requires` (label placement, absent on the normal path); `contracts_verify_detects_vacuous_contract` (contradictory `requires` → all `vacuous`, exit 1); fail-closed unit test extended with the `vacuous` case.
- Self-hosted: `contracts_vacuity_detected` (tests/run_tests.sh, ESBMC-gated).
- Full verifying bootstrap green; binary fixed point (vowc2 == vowc3); clippy + fmt clean. No false positives — satisfiable contracts (`divide.vow`, the PR-A per-clause case) are unaffected.

Part of #81.
