### PR TITLE
feat(verify): detect trivially-satisfiable (weak) ensures via body-replace (#81 PR-C)

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -2215,10 +2215,15 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
             let mut rii: i64 = 0;
             while rii < rinsts.len() {
                 let rinst: IrInst = rinsts[rii];
+                // Match Rust's `.find()` (vow-verify/src/c_emitter.rs): take the
+                // FIRST `Return`, then stop. A trailing scan keeps the LAST
+                // return's value, diverging from Rust for multi-return IR.
                 if rinst.op == IOP_RETURN() {
                     let rargs: Vec<i64> = rinst.args;
                     if rargs.len() > 0 {
                         result_after = rargs[0];
+                        rii = rinsts.len();
+                        rbi = n_blocks;
                     }
                 }
                 rii = rii + 1;

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -1959,7 +1959,7 @@ fn emit_btreemap_op(out: String, inst: IrInst, btreemap_max: i64) {
 }
 
 fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, modelable_fi_set: Vec<i64>, m: IrModule,
-                   vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, reach_label: bool) {
+                   vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, reach_label: bool, body_replace: bool) {
     let vec_vars: Vec<i64> = collect_vec_vars(f);
     let string_vars: Vec<i64> = collect_string_vars(f);
     let hashmap_vars: Vec<i64> = collect_hashmap_vars(f);
@@ -2200,6 +2200,33 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
         }
     };
 
+    // Weakness detection (#81 PR-C): in body-replace mode, `result_after` is the
+    // id of the value the `Return` yields (which the `ensures` predicate also
+    // references). After that instruction is emitted, the result is overwritten
+    // with the type-default, so each `ensures` is checked against a trivial
+    // `return 0` body. Callers only set `body_replace` when this value is a
+    // regular scalar instruction (see verifier.vow eligibility).
+    let mut result_after: i64 = -1;
+    if body_replace {
+        let mut rbi: i64 = 0;
+        while rbi < n_blocks {
+            let rblk: IrBlock = blocks[rbi];
+            let rinsts: Vec<IrInst> = rblk.insts;
+            let mut rii: i64 = 0;
+            while rii < rinsts.len() {
+                let rinst: IrInst = rinsts[rii];
+                if rinst.op == IOP_RETURN() {
+                    let rargs: Vec<i64> = rinst.args;
+                    if rargs.len() > 0 {
+                        result_after = rargs[0];
+                    }
+                }
+                rii = rii + 1;
+            }
+            rbi = rbi + 1;
+        }
+    }
+
     bi = 0;
     while bi < n_blocks {
         let blk: IrBlock = blocks[bi];
@@ -2260,6 +2287,9 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
             emit_inst(out, inst, f, vec_vars, string_vars, hashmap_vars, btreemap_vars, option_vars, const_fn_indices, modelable_fi_set, m, const_str_ids, const_str_idxs, eq_lo, eq_hi, vec_max, string_max, hashmap_max, btreemap_max);
             if regular[ri] == reach_after_idx {
                 out.push_str(String::from("vow_reach:;\n"));
+            }
+            if body_replace && inst.id == result_after {
+                out.push_str(str3(String::from("  v"), i64_to_str(result_after), String::from(" = 0;\n")));
             }
             ri = ri + 1;
         }
@@ -2462,7 +2492,7 @@ fn emit_c_module(m: IrModule, vec_max: i64, string_max: i64, hashmap_max: i64, b
     let mut fi: i64 = 0;
     while fi < fns.len() {
         let f: IrFunction = fns[fi];
-        emit_c_function(out, f, const_fn_indices, empty_modelable, m, vec_max, model_string_max, hashmap_max, btreemap_max, false);
+        emit_c_function(out, f, const_fn_indices, empty_modelable, m, vec_max, model_string_max, hashmap_max, btreemap_max, false, false);
         out.push_byte(10);
         fi = fi + 1;
     }
@@ -2491,7 +2521,7 @@ fn scan_shift_op_in_module_fns(fns: Vec<IrFunction>, target_fi: i64, callee_fis:
 }
 
 fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>, modelable_fi_set: Vec<i64>,
-                              vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, target_reach_label: bool) -> String {
+                              vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, target_reach_label: bool, target_body_replace: bool) -> String {
     let fns: Vec<IrFunction> = m.functions;
     let model_string_max: i64 = string_max_for_literals(m, string_max);
     let need_shl_i64: i64 = scan_shift_op_in_module_fns(fns, target_fi, callee_fis, IOP_SHL_I64());
@@ -2526,7 +2556,7 @@ fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>,
         while fi < fns.len() {
             let callee: IrFunction = fns[fi];
             if callee.id == cfid {
-                emit_c_function(out, callee, const_fn_indices, modelable_fi_set, m, vec_max, model_string_max, hashmap_max, btreemap_max, false);
+                emit_c_function(out, callee, const_fn_indices, modelable_fi_set, m, vec_max, model_string_max, hashmap_max, btreemap_max, false, false);
                 out.push_byte(10);
                 fi = fns.len();
             }
@@ -2539,7 +2569,7 @@ fn emit_c_module_with_callees(m: IrModule, target_fi: i64, callee_fis: Vec<i64>,
     while fi < fns.len() {
         let f: IrFunction = fns[fi];
         if f.id == target_fi {
-            emit_c_function(out, f, const_fn_indices, modelable_fi_set, m, vec_max, model_string_max, hashmap_max, btreemap_max, target_reach_label);
+            emit_c_function(out, f, const_fn_indices, modelable_fi_set, m, vec_max, model_string_max, hashmap_max, btreemap_max, target_reach_label, target_body_replace);
             out.push_byte(10);
             fi = fns.len();
         }

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3766,7 +3766,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"vacuous\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"vacuous\": 0, \"trivially_satisfiable\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -3786,7 +3786,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"vacuous\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"vacuous\": 0, \"trivially_satisfiable\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -3802,6 +3802,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `source`      | object  | `{ \"file\": string, \"offset\": integer }`                  |\n"));
     r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, `\"not_verified\"`, `\"skipped\"`, or `\"vacuous\"` |\n"));
     r.push_str(String::from("| `quality`     | string  | Static clause-shape classification (no ESBMC): `\"weak\"`, `\"tautological\"`, or `\"substantive\"` |\n"));
+    r.push_str(String::from("| `trivially_satisfiable` | bool | `--verify` only: true when a trivial `return <default>` body still satisfies this `ensures` (verification-confirmed weakness). Always false for `requires`/`invariant` and without `--verify`. Informational -- never affects the exit code. See `docs/spec/contracts-methodology.md`. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Status Values\n"));
     r.push_str(String::from("\n"));
@@ -4533,11 +4534,25 @@ fn skill_bundle() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("The clause is satisfiable and true, but so loose that an incorrect\n"));
     r.push_str(String::from("implementation also satisfies it (`ensures: result >= 0` on a computed value).\n"));
-    r.push_str(String::from("This is the 354-contract problem. **Detection (mutation-based):** mutate the\n"));
-    r.push_str(String::from("implementation -- flip a constant, swap an operator -- and re-verify. If the\n"));
-    r.push_str(String::from("contract still proves against the *mutated* body, it does not constrain that\n"));
-    r.push_str(String::from("behavior and is too weak. Vow already has the machinery for this in\n"));
-    r.push_str(String::from("`vowc mutants`; a weak contract is one whose function's mutants survive.\n"));
+    r.push_str(String::from("This is the 354-contract problem.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Detection (the body-replace probe).** `vow contracts --verify` ships this check\n"));
+    r.push_str(String::from("(#81). It mutates the implementation in the strongest possible way -- replaces the\n"));
+    r.push_str(String::from("whole body with a trivial `return <type-default>` -- and re-verifies the\n"));
+    r.push_str(String::from("`ensures`. If the contract still proves against that body, a constant-returning\n"));
+    r.push_str(String::from("implementation satisfies it, so it does not constrain the real computation: each\n"));
+    r.push_str(String::from("such `ensures` is reported `trivially_satisfiable: true`. This is exactly the\n"));
+    r.push_str(String::from("`body-replace` mutation of `vowc mutants` with ESBMC as the oracle.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("The signal is **one-sided (sound, not complete)**: a `true` verdict is a proof of\n"));
+    r.push_str(String::from("weakness (a specific trivial body satisfies the contract), but a `false` verdict\n"));
+    r.push_str(String::from("does not prove strength -- the probe uses a single default value and skips\n"));
+    r.push_str(String::from("non-scalar returns, returned parameters, and φ-merged/branchy results, so it can\n"));
+    r.push_str(String::from("miss weak contracts it cannot witness this way. It is informational and never\n"));
+    r.push_str(String::from("changes the exit code; pair it with the static `quality` field. The one known\n"));
+    r.push_str(String::from("false positive is a function whose correct result genuinely *is* the type default\n"));
+    r.push_str(String::from("(e.g. a constant `ensures result == 0` on a `{ 0 }` body) -- an equivalent mutant,\n"));
+    r.push_str(String::from("the standard caveat of mutation testing.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Tautology\n"));
     r.push_str(String::from("\n"));
@@ -4643,14 +4658,20 @@ fn skill_bundle() -> String {
     r.push_str(String::from("blocked at the *modelable* axis, not the expressible one; classify such gaps as\n"));
     r.push_str(String::from("model limitations, not contract-language limitations.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("## Tooling (planned)\n"));
+    r.push_str(String::from("## Tooling\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("`vow contracts --verify` lists contracts and verifies them per function today. The\n"));
-    r.push_str(String::from("quality work tracked in #81 / roadmap WS-3.2 extends it to a **per-obligation**\n"));
-    r.push_str(String::from("check that emits a quality signal per clause -- flagging tautologies (cheap, no\n"));
-    r.push_str(String::from("ESBMC), vacuous obligations (the `false` re-check), and, via the `vowc mutants`\n"));
-    r.push_str(String::from("harness, weak obligations whose function's mutants survive. Until that ships, the\n"));
-    r.push_str(String::from("three detections above are checks an author can run by hand.\n"));
+    r.push_str(String::from("`vow contracts --verify` performs the **per-obligation** quality analysis tracked\n"));
+    r.push_str(String::from("in #81 / roadmap WS-3.2. Each clause gets an individual verification verdict (via\n"));
+    r.push_str(String::from("ESBMC `--multi-property`), plus the three quality signals above:\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("- **Tautology** -- the static `quality` field flags constant clauses (no ESBMC).\n"));
+    r.push_str(String::from("- **Vacuity** -- a contradictory `requires` is caught by the `--error-label`\n"));
+    r.push_str(String::from("  reachability probe and reported `status: \"vacuous\"` (fail-closed).\n"));
+    r.push_str(String::from("- **Weakness** -- the body-replace probe reports `trivially_satisfiable: true` for\n"));
+    r.push_str(String::from("  an `ensures` a trivial `return <default>` body satisfies (informational).\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("The `summary` carries `vacuous` and `trivially_satisfiable` counts alongside the\n"));
+    r.push_str(String::from("status and quality tallies, so an author or CI can gate on hollow proofs.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## References\n"));
     r.push_str(String::from("\n"));
@@ -7473,7 +7494,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"vacuous\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 0, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 1, \"skipped\": 0, \"vacuous\": 0, \"trivially_satisfiable\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -7493,7 +7514,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("      \"quality\": \"substantive\"\n"));
     r.push_str(String::from("    }\n"));
     r.push_str(String::from("  ],\n"));
-    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"vacuous\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
+    r.push_str(String::from("  \"summary\": { \"total\": 1, \"proven\": 1, \"failed\": 0, \"timeout\": 0, \"error\": 0, \"not_verified\": 0, \"skipped\": 0, \"vacuous\": 0, \"trivially_satisfiable\": 0, \"quality\": { \"weak\": 0, \"tautological\": 0, \"substantive\": 1 } }\n"));
     r.push_str(String::from("}\n"));
     r.push_str(String::from("```\n"));
     r.push_str(String::from("\n"));
@@ -7509,6 +7530,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `source`      | object  | `{ \"file\": string, \"offset\": integer }`                  |\n"));
     r.push_str(String::from("| `status`      | string  | `\"proven\"`, `\"proven-ir\"`, `\"failed\"`, `\"unknown\"`, `\"timeout\"`, `\"error\"`, `\"not_verified\"`, `\"skipped\"`, or `\"vacuous\"` |\n"));
     r.push_str(String::from("| `quality`     | string  | Static clause-shape classification (no ESBMC): `\"weak\"`, `\"tautological\"`, or `\"substantive\"` |\n"));
+    r.push_str(String::from("| `trivially_satisfiable` | bool | `--verify` only: true when a trivial `return <default>` body still satisfies this `ensures` (verification-confirmed weakness). Always false for `requires`/`invariant` and without `--verify`. Informational -- never affects the exit code. See `docs/spec/contracts-methodology.md`. |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Status Values\n"));
     r.push_str(String::from("\n"));
@@ -8244,11 +8266,25 @@ fn skill_support_content_3() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("The clause is satisfiable and true, but so loose that an incorrect\n"));
     r.push_str(String::from("implementation also satisfies it (`ensures: result >= 0` on a computed value).\n"));
-    r.push_str(String::from("This is the 354-contract problem. **Detection (mutation-based):** mutate the\n"));
-    r.push_str(String::from("implementation -- flip a constant, swap an operator -- and re-verify. If the\n"));
-    r.push_str(String::from("contract still proves against the *mutated* body, it does not constrain that\n"));
-    r.push_str(String::from("behavior and is too weak. Vow already has the machinery for this in\n"));
-    r.push_str(String::from("`vowc mutants`; a weak contract is one whose function's mutants survive.\n"));
+    r.push_str(String::from("This is the 354-contract problem.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Detection (the body-replace probe).** `vow contracts --verify` ships this check\n"));
+    r.push_str(String::from("(#81). It mutates the implementation in the strongest possible way -- replaces the\n"));
+    r.push_str(String::from("whole body with a trivial `return <type-default>` -- and re-verifies the\n"));
+    r.push_str(String::from("`ensures`. If the contract still proves against that body, a constant-returning\n"));
+    r.push_str(String::from("implementation satisfies it, so it does not constrain the real computation: each\n"));
+    r.push_str(String::from("such `ensures` is reported `trivially_satisfiable: true`. This is exactly the\n"));
+    r.push_str(String::from("`body-replace` mutation of `vowc mutants` with ESBMC as the oracle.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("The signal is **one-sided (sound, not complete)**: a `true` verdict is a proof of\n"));
+    r.push_str(String::from("weakness (a specific trivial body satisfies the contract), but a `false` verdict\n"));
+    r.push_str(String::from("does not prove strength -- the probe uses a single default value and skips\n"));
+    r.push_str(String::from("non-scalar returns, returned parameters, and φ-merged/branchy results, so it can\n"));
+    r.push_str(String::from("miss weak contracts it cannot witness this way. It is informational and never\n"));
+    r.push_str(String::from("changes the exit code; pair it with the static `quality` field. The one known\n"));
+    r.push_str(String::from("false positive is a function whose correct result genuinely *is* the type default\n"));
+    r.push_str(String::from("(e.g. a constant `ensures result == 0` on a `{ 0 }` body) -- an equivalent mutant,\n"));
+    r.push_str(String::from("the standard caveat of mutation testing.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### Tautology\n"));
     r.push_str(String::from("\n"));
@@ -8354,14 +8390,20 @@ fn skill_support_content_3() -> String {
     r.push_str(String::from("blocked at the *modelable* axis, not the expressible one; classify such gaps as\n"));
     r.push_str(String::from("model limitations, not contract-language limitations.\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("## Tooling (planned)\n"));
+    r.push_str(String::from("## Tooling\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("`vow contracts --verify` lists contracts and verifies them per function today. The\n"));
-    r.push_str(String::from("quality work tracked in #81 / roadmap WS-3.2 extends it to a **per-obligation**\n"));
-    r.push_str(String::from("check that emits a quality signal per clause -- flagging tautologies (cheap, no\n"));
-    r.push_str(String::from("ESBMC), vacuous obligations (the `false` re-check), and, via the `vowc mutants`\n"));
-    r.push_str(String::from("harness, weak obligations whose function's mutants survive. Until that ships, the\n"));
-    r.push_str(String::from("three detections above are checks an author can run by hand.\n"));
+    r.push_str(String::from("`vow contracts --verify` performs the **per-obligation** quality analysis tracked\n"));
+    r.push_str(String::from("in #81 / roadmap WS-3.2. Each clause gets an individual verification verdict (via\n"));
+    r.push_str(String::from("ESBMC `--multi-property`), plus the three quality signals above:\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("- **Tautology** -- the static `quality` field flags constant clauses (no ESBMC).\n"));
+    r.push_str(String::from("- **Vacuity** -- a contradictory `requires` is caught by the `--error-label`\n"));
+    r.push_str(String::from("  reachability probe and reported `status: \"vacuous\"` (fail-closed).\n"));
+    r.push_str(String::from("- **Weakness** -- the body-replace probe reports `trivially_satisfiable: true` for\n"));
+    r.push_str(String::from("  an `ensures` a trivial `return <default>` body satisfies (informational).\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("The `summary` carries `vacuous` and `trivially_satisfiable` counts alongside the\n"));
+    r.push_str(String::from("status and quality tallies, so an author or CI can gate on hollow proofs.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## References\n"));
     r.push_str(String::from("\n"));
@@ -10218,6 +10260,8 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let e_offsets: Vec<i64> = Vec::new();
     let e_statuses: Vec<String> = Vec::new();
     let e_qualities: Vec<String> = Vec::new();
+    // 1 when a trivial `return <default>` body satisfies this ensures (#81 PR-C).
+    let e_trivial: Vec<i64> = Vec::new();
 
     let nf: i64 = ir_mod.functions.len();
     let mut fi: i64 = 0;
@@ -10243,6 +10287,7 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
             e_files.push(ve.file);
             e_offsets.push(ve.offset);
             e_statuses.push(String::from("not_verified"));
+            e_trivial.push(0);
             vi = vi + 1;
         }
         fi = fi + 1;
@@ -10330,6 +10375,20 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
                                 vi2 = vi2 + 1;
                             }
                         }
+
+                        // Weakness probe (#81 PR-C): if a trivial `return
+                        // <default>` body still satisfies the ensures, mark each
+                        // ensures clause trivially_satisfiable (informational).
+                        let triv: i64 = verify_function_trivial(func, ir_mod, max_k_step, solver, encoding, timeout_secs, vec_max_c, string_max_c, hashmap_max_c, btreemap_max_c);
+                        if triv == 1 {
+                            let mut ti: i64 = 0;
+                            while ti < e_func_ids.len() {
+                                if e_func_ids[ti] == func.id && e_kinds[ti] == String::from("ensures") {
+                                    e_trivial[ti] = 1;
+                                }
+                                ti = ti + 1;
+                            }
+                        }
                     }
                 }
                 fi = fi + 1;
@@ -10363,7 +10422,13 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
         json.push_str(e_statuses[ci]);
         json.push_str(String::from("\",\"quality\":\""));
         json.push_str(e_qualities[ci]);
-        json.push_str(String::from("\"}"));
+        json.push_str(String::from("\",\"trivially_satisfiable\":"));
+        if e_trivial[ci] == 1 {
+            json.push_str(String::from("true"));
+        } else {
+            json.push_str(String::from("false"));
+        }
+        json.push_str(String::from("}"));
         ci = ci + 1;
     }
 
@@ -10376,9 +10441,13 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     let n_not_verified: i64 = 0;
     let n_skipped: i64 = 0;
     let n_vacuous: i64 = 0;
+    let n_trivial: i64 = 0;
     let mut si: i64 = 0;
     while si < total {
         let s: String = e_statuses[si];
+        if e_trivial[si] == 1 {
+            n_trivial = n_trivial + 1;
+        }
         if s == String::from("proven") || s == String::from("proven-ir") {
             n_proven = n_proven + 1;
         } else if s == String::from("failed") {
@@ -10441,6 +10510,8 @@ fn run_contracts(argv: Vec<String>) -> i32 [io] {
     json.push_str(i64_to_str(n_skipped));
     json.push_str(String::from(",\"vacuous\":"));
     json.push_str(i64_to_str(n_vacuous));
+    json.push_str(String::from(",\"trivially_satisfiable\":"));
+    json.push_str(i64_to_str(n_trivial));
     json.push_str(String::from(",\"quality\":{\"weak\":"));
     json.push_str(i64_to_str(n_weak));
     json.push_str(String::from(",\"tautological\":"));

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -777,6 +777,7 @@ fn body_replaceable_result(f: IrFunction) -> bool {
     let blocks: Vec<IrBlock> = f.blocks;
     let nb: i64 = blocks.len();
     let mut result_id: i64 = -1;
+    let mut n_returns: i64 = 0;
     let mut bi: i64 = 0;
     while bi < nb {
         let blk: IrBlock = blocks[bi];
@@ -785,20 +786,24 @@ fn body_replaceable_result(f: IrFunction) -> bool {
         let mut ii: i64 = 0;
         while ii < ni {
             let inst: IrInst = insts[ii];
-            // Match Rust's `.find()` (vow-verify/src/esbmc.rs): take the FIRST
-            // `Return`, then stop. A trailing scan keeps the LAST return's value,
-            // diverging from Rust for multi-return IR (any if/else or early return).
             if inst.op == IOP_RETURN() {
+                n_returns = n_returns + 1;
                 let rargs: Vec<i64> = inst.args;
                 if rargs.len() > 0 {
                     result_id = rargs[0];
-                    ii = ni;
-                    bi = nb;
                 }
             }
             ii = ii + 1;
         }
         bi = bi + 1;
+    }
+    // The body-replace rewrite zeroes exactly one return site, so the probe is
+    // only sound for single-exit functions. A function with multiple `Return`s
+    // (any early return / if-else) would leave the other paths running the real
+    // body, which can falsely "prove" a substantive `ensures` — a false weakness
+    // claim. Skip those (mirrors vow-verify/src/esbmc.rs).
+    if n_returns != 1 {
+        return false;
     }
     if result_id < 0 {
         return false;

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -785,10 +785,15 @@ fn body_replaceable_result(f: IrFunction) -> bool {
         let mut ii: i64 = 0;
         while ii < ni {
             let inst: IrInst = insts[ii];
+            // Match Rust's `.find()` (vow-verify/src/esbmc.rs): take the FIRST
+            // `Return`, then stop. A trailing scan keeps the LAST return's value,
+            // diverging from Rust for multi-return IR (any if/else or early return).
             if inst.op == IOP_RETURN() {
                 let rargs: Vec<i64> = inst.args;
                 if rargs.len() > 0 {
                     result_id = rargs[0];
+                    ii = ni;
+                    bi = nb;
                 }
             }
             ii = ii + 1;

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -202,7 +202,7 @@ fn emit_harness(f: IrFunction) -> String {
     out
 }
 
-fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, reach_label: bool) -> String {
+fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64, reach_label: bool, body_replace: bool) -> String {
     let const_fn_indices: Vec<i64> = detect_const_fns(m);
     let callee_fis: Vec<i64> = collect_modelable_callees(f, m, const_fn_indices);
     let model_string_max: i64 = string_max_for_literals(m, string_max);
@@ -215,7 +215,7 @@ fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, 
                 modelable_fi_set.push(callee_fis[ci]);
                 ci = ci + 1;
             }
-            emit_c_module_with_callees(m, f.id, callee_fis, modelable_fi_set, vec_max, model_string_max, hashmap_max, btreemap_max, reach_label)
+            emit_c_module_with_callees(m, f.id, callee_fis, modelable_fi_set, vec_max, model_string_max, hashmap_max, btreemap_max, reach_label, body_replace)
         } else {
             let preamble: String = cemit_preamble_with_limits(
                 func_has_shift_op(f, IOP_SHL_I64()),
@@ -225,7 +225,7 @@ fn emit_c_for_verify(f: IrFunction, m: IrModule, vec_max: i64, string_max: i64, 
                 vec_max, model_string_max, hashmap_max, btreemap_max
             );
             let empty_modelable: Vec<i64> = Vec::new();
-            emit_c_function(preamble, f, const_fn_indices, empty_modelable, m, vec_max, model_string_max, hashmap_max, btreemap_max, reach_label);
+            emit_c_function(preamble, f, const_fn_indices, empty_modelable, m, vec_max, model_string_max, hashmap_max, btreemap_max, reach_label, body_replace);
             preamble.push_byte(10);
             preamble
         }
@@ -665,7 +665,7 @@ fn verify_function_multi_property(f: IrFunction, m: IrModule, max_k_step: String
     if vows.len() == 0 {
         return MultiPropertyResult { status: VERIFY_PROVEN(), verdict_ids: ids, verdict_proven: proven };
     }
-    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false);
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false, false);
     let fn_name: String = f.name;
     let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
     let tmp_path: String = verify_tmp_path();
@@ -719,7 +719,7 @@ fn verify_function_vacuity(f: IrFunction, m: IrModule, max_k_step: String, solve
     if !function_has_requires(f) {
         return 0;
     }
-    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, true);
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, true, false);
     let fn_name: String = f.name;
     let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
     let tmp_path: String = verify_tmp_path();
@@ -735,6 +735,118 @@ fn verify_function_vacuity(f: IrFunction, m: IrModule, max_k_step: String, solve
         if r.exit_code == -2 { VERIFY_TIMEOUT() } else { parse_verify_status(combined) }
     };
     if status == VERIFY_PROVEN() {
+        return 1;
+    }
+    0
+}
+
+// True when the function carries at least one `ensures` clause. Mirrors
+// function_has_ensures in vow-verify/src/esbmc.rs (#81 PR-C).
+fn function_has_ensures(f: IrFunction) -> bool {
+    let blocks: Vec<IrBlock> = f.blocks;
+    let nb: i64 = blocks.len();
+    let mut bi: i64 = 0;
+    while bi < nb {
+        let blk: IrBlock = blocks[bi];
+        let insts: Vec<IrInst> = blk.insts;
+        let ni: i64 = insts.len();
+        let mut ii: i64 = 0;
+        while ii < ni {
+            let inst: IrInst = insts[ii];
+            if inst.op == IOP_VOW_ENS() {
+                return true;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    false
+}
+
+// True when the return type is a scalar integer/bool/float, so the trivial
+// `return 0` body-replace is well-typed (#81 PR-C).
+fn returns_scalar(f: IrFunction) -> bool {
+    let rt: i64 = f.return_ty;
+    rt != ITY_UNIT() && rt != ITY_PTR() && rt != ITY_LPTR()
+}
+
+// True when the value the `Return` yields is produced by a regular (non-GetArg)
+// body instruction, so the body-replace rewrite has an overwrite site. Returned
+// parameters and empty returns are skipped — sound but incomplete (#81 PR-C).
+fn body_replaceable_result(f: IrFunction) -> bool {
+    let blocks: Vec<IrBlock> = f.blocks;
+    let nb: i64 = blocks.len();
+    let mut result_id: i64 = -1;
+    let mut bi: i64 = 0;
+    while bi < nb {
+        let blk: IrBlock = blocks[bi];
+        let insts: Vec<IrInst> = blk.insts;
+        let ni: i64 = insts.len();
+        let mut ii: i64 = 0;
+        while ii < ni {
+            let inst: IrInst = insts[ii];
+            if inst.op == IOP_RETURN() {
+                let rargs: Vec<i64> = inst.args;
+                if rargs.len() > 0 {
+                    result_id = rargs[0];
+                }
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    if result_id < 0 {
+        return false;
+    }
+    bi = 0;
+    while bi < nb {
+        let blk: IrBlock = blocks[bi];
+        let insts: Vec<IrInst> = blk.insts;
+        let ni: i64 = insts.len();
+        let mut ii: i64 = 0;
+        while ii < ni {
+            let inst: IrInst = insts[ii];
+            if inst.id == result_id && inst.op != IOP_GET_ARG() {
+                return true;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    false
+}
+
+// Weakness probe (#81 PR-C): verify a body-replaced model where the returned
+// value is forced to the type-default. SUCCESSFUL means a trivial
+// `return <default>` body satisfies the `ensures` — the contract is too weak to
+// pin down the implementation. Returns 1 then, 0 otherwise. One-sided: an
+// inconclusive probe is reported as not trivially satisfiable. Mirrors
+// run_esbmc_bodyreplace in vow-verify/src/esbmc.rs.
+fn verify_function_trivial(f: IrFunction, m: IrModule, max_k_step: String, solver: String, encoding: String, timeout_secs: String,
+                           vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64) -> i64 [io] {
+    if !function_has_ensures(f) {
+        return 0;
+    }
+    if !returns_scalar(f) {
+        return 0;
+    }
+    if !body_replaceable_result(f) {
+        return 0;
+    }
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false, true);
+    let fn_name: String = f.name;
+    let bv_timeout: String = effective_timeout_for(encoding, solver, timeout_secs);
+    let tmp_path: String = verify_tmp_path();
+    let no_extra: Vec<String> = Vec::new();
+    let r: EsbmcRun = run_esbmc(c_source, max_k_step, tmp_path, fn_name, solver, encoding, bv_timeout, no_extra);
+    if r.exit_code == -3 {
+        return 0;
+    }
+    let combined: String = r.combined;
+    let status: i64 = {
+        if r.exit_code == -2 { VERIFY_TIMEOUT() } else { parse_verify_status(combined) }
+    };
+    if status == VERIFY_PROVEN() || status == VERIFY_PROVEN_IR() {
         return 1;
     }
     0
@@ -979,7 +1091,7 @@ fn verify_function_ir_fallback(f: IrFunction, m: IrModule, max_k_step: String, u
             raw_output: String::from(""),
         };
     }
-    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false);
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false, false);
     let fn_name: String = f.name;
     let ir_solver: String = String::from("z3");
     let ir_encoding: String = String::from("ir");
@@ -1021,7 +1133,7 @@ fn verify_start(f: IrFunction, m: IrModule, max_k_step: String, idx: i64, use_ca
     if vows.len() == 0 {
         return EsbmcStart { handle: -1, tmp_path: String::from("") };
     }
-    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false);
+    let c_source: String = emit_c_for_verify(f, m, vec_max, string_max, hashmap_max, btreemap_max, false, false);
     // No cache lookup or write — see the note above resolve_auto_bv_solver.
     // `use_cache` stays on the signature for caller-side symmetry with the
     // Rust toolchain but has no effect.

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -332,7 +332,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "trivially_satisfiable": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -352,7 +352,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "trivially_satisfiable": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -368,6 +368,7 @@ that path produces `Unverified` (exit 0).
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
 | `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, `"skipped"`, or `"vacuous"` |
 | `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
+| `trivially_satisfiable` | bool | `--verify` only: true when a trivial `return <default>` body still satisfies this `ensures` (verification-confirmed weakness). Always false for `requires`/`invariant` and without `--verify`. Informational — never affects the exit code. See `docs/spec/contracts-methodology.md`. |
 
 ### Status Values
 

--- a/docs/spec/contracts-methodology.md
+++ b/docs/spec/contracts-methodology.md
@@ -227,11 +227,25 @@ ways this happens; a contract-quality tool should distinguish them.
 
 The clause is satisfiable and true, but so loose that an incorrect
 implementation also satisfies it (`ensures: result >= 0` on a computed value).
-This is the 354-contract problem. **Detection (mutation-based):** mutate the
-implementation — flip a constant, swap an operator — and re-verify. If the
-contract still proves against the *mutated* body, it does not constrain that
-behavior and is too weak. Vow already has the machinery for this in
-`vowc mutants`; a weak contract is one whose function's mutants survive.
+This is the 354-contract problem.
+
+**Detection (the body-replace probe).** `vow contracts --verify` ships this check
+(#81). It mutates the implementation in the strongest possible way — replaces the
+whole body with a trivial `return <type-default>` — and re-verifies the
+`ensures`. If the contract still proves against that body, a constant-returning
+implementation satisfies it, so it does not constrain the real computation: each
+such `ensures` is reported `trivially_satisfiable: true`. This is exactly the
+`body-replace` mutation of `vowc mutants` with ESBMC as the oracle.
+
+The signal is **one-sided (sound, not complete)**: a `true` verdict is a proof of
+weakness (a specific trivial body satisfies the contract), but a `false` verdict
+does not prove strength — the probe uses a single default value and skips
+non-scalar returns, returned parameters, and φ-merged/branchy results, so it can
+miss weak contracts it cannot witness this way. It is informational and never
+changes the exit code; pair it with the static `quality` field. The one known
+false positive is a function whose correct result genuinely *is* the type default
+(e.g. a constant `ensures result == 0` on a `{ 0 }` body) — an equivalent mutant,
+the standard caveat of mutation testing.
 
 ### Tautology
 
@@ -337,14 +351,20 @@ Contract expressions must be **pure** — they cannot call effectful functions
 blocked at the *modelable* axis, not the expressible one; classify such gaps as
 model limitations, not contract-language limitations.
 
-## Tooling (planned)
+## Tooling
 
-`vow contracts --verify` lists contracts and verifies them per function today. The
-quality work tracked in #81 / roadmap WS-3.2 extends it to a **per-obligation**
-check that emits a quality signal per clause — flagging tautologies (cheap, no
-ESBMC), vacuous obligations (the `false` re-check), and, via the `vowc mutants`
-harness, weak obligations whose function's mutants survive. Until that ships, the
-three detections above are checks an author can run by hand.
+`vow contracts --verify` performs the **per-obligation** quality analysis tracked
+in #81 / roadmap WS-3.2. Each clause gets an individual verification verdict (via
+ESBMC `--multi-property`), plus the three quality signals above:
+
+- **Tautology** — the static `quality` field flags constant clauses (no ESBMC).
+- **Vacuity** — a contradictory `requires` is caught by the `--error-label`
+  reachability probe and reported `status: "vacuous"` (fail-closed).
+- **Weakness** — the body-replace probe reports `trivially_satisfiable: true` for
+  an `ensures` a trivial `return <default>` body satisfies (informational).
+
+The `summary` carries `vacuous` and `trivially_satisfiable` counts alongside the
+status and quality tallies, so an author or CI can gate on hollow proofs.
 
 ## References
 

--- a/docs/spec/schemas/contracts-result.schema.json
+++ b/docs/spec/schemas/contracts-result.schema.json
@@ -51,13 +51,17 @@
           },
           "status": {
             "type": "string",
-            "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
+            "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified", "skipped", "vacuous"],
             "description": "Verification status"
           },
           "quality": {
             "type": "string",
             "enum": ["weak", "tautological", "substantive"],
             "description": "Static, no-ESBMC classification of the clause shape: weak (an ensures that only bounds result by a constant), tautological (constant clause that says nothing), or substantive (equality/relational/inverse/call). See contracts-methodology.md"
+          },
+          "trivially_satisfiable": {
+            "type": "boolean",
+            "description": "`--verify` only: true when a trivial `return <default>` body still satisfies this `ensures` (verification-confirmed weakness). Always false for `requires`/`invariant` and without `--verify`. Informational; never affects the exit code. See contracts-methodology.md"
           }
         },
         "additionalProperties": false
@@ -75,6 +79,8 @@
         "error": { "type": "integer" },
         "not_verified": { "type": "integer" },
         "skipped": { "type": "integer" },
+        "vacuous": { "type": "integer" },
+        "trivially_satisfiable": { "type": "integer" },
         "quality": {
           "type": "object",
           "description": "Static contract-quality tallies independent of verification status",

--- a/skills/vow/reference/cli.md
+++ b/skills/vow/reference/cli.md
@@ -332,7 +332,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "trivially_satisfiable": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -352,7 +352,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "trivially_satisfiable": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -368,6 +368,7 @@ that path produces `Unverified` (exit 0).
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
 | `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, `"skipped"`, or `"vacuous"` |
 | `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
+| `trivially_satisfiable` | bool | `--verify` only: true when a trivial `return <default>` body still satisfies this `ensures` (verification-confirmed weakness). Always false for `requires`/`invariant` and without `--verify`. Informational — never affects the exit code. See `docs/spec/contracts-methodology.md`. |
 
 ### Status Values
 

--- a/skills/vow/reference/contracts-methodology.md
+++ b/skills/vow/reference/contracts-methodology.md
@@ -227,11 +227,25 @@ ways this happens; a contract-quality tool should distinguish them.
 
 The clause is satisfiable and true, but so loose that an incorrect
 implementation also satisfies it (`ensures: result >= 0` on a computed value).
-This is the 354-contract problem. **Detection (mutation-based):** mutate the
-implementation — flip a constant, swap an operator — and re-verify. If the
-contract still proves against the *mutated* body, it does not constrain that
-behavior and is too weak. Vow already has the machinery for this in
-`vowc mutants`; a weak contract is one whose function's mutants survive.
+This is the 354-contract problem.
+
+**Detection (the body-replace probe).** `vow contracts --verify` ships this check
+(#81). It mutates the implementation in the strongest possible way — replaces the
+whole body with a trivial `return <type-default>` — and re-verifies the
+`ensures`. If the contract still proves against that body, a constant-returning
+implementation satisfies it, so it does not constrain the real computation: each
+such `ensures` is reported `trivially_satisfiable: true`. This is exactly the
+`body-replace` mutation of `vowc mutants` with ESBMC as the oracle.
+
+The signal is **one-sided (sound, not complete)**: a `true` verdict is a proof of
+weakness (a specific trivial body satisfies the contract), but a `false` verdict
+does not prove strength — the probe uses a single default value and skips
+non-scalar returns, returned parameters, and φ-merged/branchy results, so it can
+miss weak contracts it cannot witness this way. It is informational and never
+changes the exit code; pair it with the static `quality` field. The one known
+false positive is a function whose correct result genuinely *is* the type default
+(e.g. a constant `ensures result == 0` on a `{ 0 }` body) — an equivalent mutant,
+the standard caveat of mutation testing.
 
 ### Tautology
 
@@ -337,14 +351,20 @@ Contract expressions must be **pure** — they cannot call effectful functions
 blocked at the *modelable* axis, not the expressible one; classify such gaps as
 model limitations, not contract-language limitations.
 
-## Tooling (planned)
+## Tooling
 
-`vow contracts --verify` lists contracts and verifies them per function today. The
-quality work tracked in #81 / roadmap WS-3.2 extends it to a **per-obligation**
-check that emits a quality signal per clause — flagging tautologies (cheap, no
-ESBMC), vacuous obligations (the `false` re-check), and, via the `vowc mutants`
-harness, weak obligations whose function's mutants survive. Until that ships, the
-three detections above are checks an author can run by hand.
+`vow contracts --verify` performs the **per-obligation** quality analysis tracked
+in #81 / roadmap WS-3.2. Each clause gets an individual verification verdict (via
+ESBMC `--multi-property`), plus the three quality signals above:
+
+- **Tautology** — the static `quality` field flags constant clauses (no ESBMC).
+- **Vacuity** — a contradictory `requires` is caught by the `--error-label`
+  reachability probe and reported `status: "vacuous"` (fail-closed).
+- **Weakness** — the body-replace probe reports `trivially_satisfiable: true` for
+  an `ensures` a trivial `return <default>` body satisfies (informational).
+
+The `summary` carries `vacuous` and `trivially_satisfiable` counts alongside the
+status and quality tallies, so an author or CI can gate on hollow proofs.
 
 ## References
 

--- a/skills/vow/schemas/contracts-result.schema.json
+++ b/skills/vow/schemas/contracts-result.schema.json
@@ -51,13 +51,17 @@
           },
           "status": {
             "type": "string",
-            "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified", "skipped"],
+            "enum": ["proven", "proven-ir", "failed", "unknown", "timeout", "error", "not_verified", "skipped", "vacuous"],
             "description": "Verification status"
           },
           "quality": {
             "type": "string",
             "enum": ["weak", "tautological", "substantive"],
             "description": "Static, no-ESBMC classification of the clause shape: weak (an ensures that only bounds result by a constant), tautological (constant clause that says nothing), or substantive (equality/relational/inverse/call). See contracts-methodology.md"
+          },
+          "trivially_satisfiable": {
+            "type": "boolean",
+            "description": "`--verify` only: true when a trivial `return <default>` body still satisfies this `ensures` (verification-confirmed weakness). Always false for `requires`/`invariant` and without `--verify`. Informational; never affects the exit code. See contracts-methodology.md"
           }
         },
         "additionalProperties": false
@@ -75,6 +79,8 @@
         "error": { "type": "integer" },
         "not_verified": { "type": "integer" },
         "skipped": { "type": "integer" },
+        "vacuous": { "type": "integer" },
+        "trivially_satisfiable": { "type": "integer" },
         "quality": {
           "type": "object",
           "description": "Static contract-quality tallies independent of verification status",

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -463,6 +463,49 @@ else:
       pass "$name"
     fi
   fi
+
+  name="contracts_weakness_trivially_satisfiable"
+  if matches_filter "$name"; then
+    # PR-C (#81): a weak postcondition (`result >= 0`) is satisfied by a trivial
+    # `return 0` body, so the body-replace probe flags it trivially_satisfiable;
+    # a tight one (`result == x + 1`) is not. Informational (no exit-code change).
+    # Mirrors the Rust contracts_verify_flags_trivially_satisfiable_ensures test.
+    src="$TMPDIR/${name}.vow"
+    cat > "$src" <<'VOWEOF'
+module M
+fn weak(x: i64) -> i64 vow {
+  requires: x >= 0,
+  ensures: result >= 0
+} { x + 1 }
+fn tight(x: i64) -> i64 vow {
+  ensures: result == x + 1
+} { x + 1 }
+fn main() -> i32 [io] { 0 }
+VOWEOF
+    set +e
+    wk_json="$(run_vowc contracts --verify "$src" 2>/dev/null)"
+    set -e
+    wk_check="$(python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    print('parse_error'); sys.exit(0)
+t = {}
+for e in d.get('contracts', []):
+    if e.get('kind') == 'ensures':
+        t[e.get('function', '')] = e.get('trivially_satisfiable')
+if t.get('weak') is True and t.get('tight') is False and d.get('summary', {}).get('trivially_satisfiable') == 1:
+    print('ok')
+else:
+    print('weak=%s tight=%s n=%s' % (t.get('weak'), t.get('tight'), d.get('summary', {}).get('trivially_satisfiable')))
+" <<< "$wk_json")"
+    if [[ "$wk_check" != "ok" ]]; then
+      fail "$name" "weakness probe mismatch ($wk_check)"
+    else
+      pass "$name"
+    fi
+  fi
 fi
 
 # --- Phase 3: verify-fail/ tests ---

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -1782,9 +1782,11 @@ pub fn emit_c_function(
         },
         limits,
         false,
+        false,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn emit_c_function_full(
     func: &Function,
     const_fns: &HashMap<FuncId, ConstantValue>,
@@ -1792,6 +1794,7 @@ pub fn emit_c_function_full(
     module: &Module,
     limits: &VerifyLimits,
     reach_label: bool,
+    body_replace: bool,
 ) -> String {
     let mut out = String::new();
 
@@ -1809,6 +1812,24 @@ pub fn emit_c_function_full(
                 .rfind(|i| i.opcode == Opcode::VowRequires)
                 .map(|i| i.id.0)
         })
+    } else {
+        None
+    };
+
+    // Weakness detection (#81 PR-C): when `body_replace` is set, overwrite the
+    // returned value with the type-default right after it is computed, so each
+    // `ensures` is checked against a trivial `return <default>` implementation.
+    // If ESBMC still proves the ensures, a constant-returning body satisfies the
+    // contract — it is too weak to pin down the implementation. `result_after`
+    // is the id of the value the `Return` yields (which the `ensures` predicate
+    // references). Callers only set `body_replace` when this id names a regular
+    // body instruction of scalar type (see `emit_bodyreplace_c_source`).
+    let result_after: Option<u32> = if body_replace {
+        func.blocks
+            .iter()
+            .flat_map(|b| &b.insts)
+            .find(|i| i.opcode == Opcode::Return)
+            .and_then(|ret| ret.args.first().map(|a| a.0))
     } else {
         None
     };
@@ -2065,6 +2086,9 @@ pub fn emit_c_function_full(
             if reach_after == Some(inst.id.0) {
                 out.push_str("vow_reach:;\n");
             }
+            if result_after == Some(inst.id.0) {
+                out.push_str(&format!("  v{} = 0;\n", inst.id.0));
+            }
         }
         // Emit Upsilons: read all sources first, then write all targets.
         if !upsilons.is_empty() {
@@ -2244,6 +2268,7 @@ pub fn emit_c_module(
 
 /// Emit C code for a target function and its modelable callees.
 /// Callee functions are emitted in topological order (callees first).
+#[allow(clippy::too_many_arguments)]
 pub fn emit_c_module_with_callees(
     target: &Function,
     module: &Module,
@@ -2252,6 +2277,7 @@ pub fn emit_c_module_with_callees(
     modelable_fns: &HashSet<FuncId>,
     limits: &VerifyLimits,
     target_reach_label: bool,
+    target_body_replace: bool,
 ) -> String {
     let mut out = String::new();
     let effective_limits = limits_with_literal_string_capacity(module, limits);
@@ -2286,12 +2312,14 @@ pub fn emit_c_module_with_callees(
                 module,
                 &effective_limits,
                 false,
+                false,
             ));
             out.push('\n');
         }
     }
 
-    // Target function — the only one that carries the vacuity `vow_reach` label.
+    // Target function — the only one that carries the vacuity `vow_reach` label
+    // or the weakness body-replace rewrite.
     out.push_str(&emit_c_function_full(
         target,
         const_fns,
@@ -2299,6 +2327,7 @@ pub fn emit_c_module_with_callees(
         module,
         &effective_limits,
         target_reach_label,
+        target_body_replace,
     ));
     out.push('\n');
     out
@@ -2523,6 +2552,7 @@ mod tests {
             &module,
             &VerifyLimits::default(),
             false,
+            false,
         );
 
         assert!(
@@ -2655,6 +2685,7 @@ mod tests {
             &module,
             &VerifyLimits::default(),
             true,
+            false,
         );
         let assume_pos = c
             .find("__ESBMC_assume(v3)")
@@ -2671,10 +2702,101 @@ mod tests {
             &module,
             &VerifyLimits::default(),
             false,
+            false,
         );
         assert!(
             !c_no.contains("vow_reach"),
             "no reach label on the normal verify path:\n{c_no}"
+        );
+    }
+
+    #[test]
+    fn emit_body_replace_overwrites_result_with_default() {
+        // #81 PR-C: in body-replace mode the returned value is overwritten with
+        // the type-default right after it is computed, so the `ensures` is
+        // checked against a trivial `return 0` body; absent on the normal path.
+        // g(x) { x + 1 }: result is %5 (WrappingAddI64), referenced by the
+        // ensures and the Return.
+        let func = Function {
+            id: FuncId(0),
+            name: "g".to_string(),
+            params: vec![Ty::I64],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![VowEntry {
+                id: VowId(1),
+                description: "result >= 0".to_string(),
+                blame: Blame::Callee,
+                bindings: vec![],
+                file: String::new(),
+                offset: 0,
+            }],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                    inst(4, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(1)),
+                    inst(
+                        5,
+                        Opcode::WrappingAddI64,
+                        Ty::I64,
+                        vec![0, 4],
+                        InstData::None,
+                    ),
+                    inst(6, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(0)),
+                    inst(7, Opcode::GeI64, Ty::Bool, vec![5, 6], InstData::None),
+                    Inst {
+                        id: InstId(8),
+                        opcode: Opcode::VowEnsures,
+                        ty: Ty::Unit,
+                        args: vec![InstId(7)],
+                        data: InstData::VowId(VowId(1)),
+                        origin: sp(),
+                        region: RegionId::Root,
+                    },
+                    inst(9, Opcode::Return, Ty::Unit, vec![5], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        let module = Module {
+            name: String::new(),
+            functions: vec![],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+            warnings: vec![],
+        };
+        let c = emit_c_function_full(
+            &func,
+            &HashMap::new(),
+            &HashSet::new(),
+            &module,
+            &VerifyLimits::default(),
+            false,
+            true,
+        );
+        let add_pos = c.find("v5 = v0 + v4").expect("body computes the result");
+        let zero_pos = c.find("v5 = 0;").expect("result overwritten with default");
+        assert!(
+            zero_pos > add_pos,
+            "default overwrite must follow the body's result computation:\n{c}"
+        );
+        let c_no = emit_c_function_full(
+            &func,
+            &HashMap::new(),
+            &HashSet::new(),
+            &module,
+            &VerifyLimits::default(),
+            false,
+            false,
+        );
+        assert!(
+            !c_no.contains("v5 = 0;"),
+            "no result overwrite on the normal verify path:\n{c_no}"
         );
     }
 
@@ -4803,6 +4925,7 @@ mod tests {
             &module,
             &VerifyLimits::default(),
             false,
+            false,
         );
         assert!(c.contains("__vow_string_t v1;"), "string struct decl: {c}");
         assert!(c.contains("v1.len = 5;"), "literal len from pool: {c}");
@@ -4853,6 +4976,7 @@ mod tests {
             &[],
             &HashSet::new(),
             &limits,
+            false,
             false,
         );
         assert!(
@@ -4905,6 +5029,7 @@ mod tests {
             &module,
             &VerifyLimits::default(),
             false,
+            false,
         );
         assert!(c.contains("__vow_string_t v2;"), "clone decl: {c}");
         assert!(c.contains("v2 = v1;"), "clone preserves source model: {c}");
@@ -4942,6 +5067,7 @@ mod tests {
                 warnings: vec![],
             },
             &VerifyLimits::default(),
+            false,
             false,
         );
         assert!(c.contains("__vow_string_t v0;"), "dest param model: {c}");

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -415,20 +415,28 @@ fn returns_scalar(func: &Function) -> bool {
     )
 }
 
-/// True when the value the `Return` yields is produced by a regular body
-/// instruction (one that `emit_c_function_full` emits in its per-instruction
-/// loop). The body-replace rewrite overwrites that value right after it is
-/// emitted; if the result is a bare `GetArg` (returned parameter) the overwrite
-/// site does not exist, so the probe is skipped rather than emitted incorrectly.
+/// True when the function is single-exit and the value its sole `Return` yields
+/// is produced by a regular body instruction (one that `emit_c_function_full`
+/// emits in its per-instruction loop). The body-replace rewrite overwrites that
+/// one value right after it is emitted; if the result is a bare `GetArg`
+/// (returned parameter) the overwrite site does not exist, so the probe is
+/// skipped. Multi-return functions (any early return / if-else) are also
+/// skipped: the rewrite zeroes only a single return site, so the other return
+/// paths would still run the real body and could falsely "prove" a substantive
+/// `ensures` — a false weakness claim. Requiring exactly one `Return` keeps the
+/// probe one-sided (sound). Self-hosted mirror: `compiler/verifier.vow`.
 fn body_replaceable_result(func: &Function) -> bool {
-    let Some(ret) = func
+    let mut returns = func
         .blocks
         .iter()
         .flat_map(|b| &b.insts)
-        .find(|i| i.opcode == vow_ir::Opcode::Return)
-    else {
+        .filter(|i| i.opcode == vow_ir::Opcode::Return);
+    let Some(ret) = returns.next() else {
         return false;
     };
+    if returns.next().is_some() {
+        return false;
+    }
     let Some(result_id) = ret.args.first().map(|a| a.0) else {
         return false;
     };
@@ -2259,20 +2267,18 @@ VERIFICATION FAILED";
         }
     }
 
-    // #81 PR-C parity: `body_replaceable_result` must inspect the FIRST `Return`
-    // instruction (via `.find()`), and the self-hosted compiler
-    // (compiler/verifier.vow) must match. For multi-return IR the first and last
-    // `Return` can name different values, so a last-return scan would pick a
-    // different result id, diverging between the two compilers. This pins the
-    // canonical first-return semantics with a function whose two returns yield
-    // different eligibility verdicts.
+    // #81 PR-C soundness: the body-replace rewrite zeroes exactly one return
+    // site, so the probe is only sound for single-exit functions. A multi-return
+    // function (any early return / if-else) must be SKIPPED — otherwise the
+    // un-overwritten return paths run the real body and a substantive `ensures`
+    // is falsely flagged `trivially_satisfiable` (a false weakness claim). Both
+    // compilers (here + compiler/verifier.vow) must agree.
     #[test]
-    fn body_replaceable_result_uses_first_return_for_multi_return() {
-        // first Return -> %2 (a regular WrappingAddI64, eligible)
-        // last  Return -> %0 (a bare GetArg / returned parameter, ineligible)
-        // First-return semantics => eligible (true); a last-return scan would
-        // inspect the GetArg and wrongly report ineligible (false).
-        let func = Function {
+    fn body_replaceable_result_skips_multi_return_functions() {
+        // Two `Return`s: block 0 returns %2 (a regular add), block 1 returns %0.
+        // This is `if x == 0 { return 0; } x`-shaped IR. The probe could only
+        // zero one return, so eligibility must be false.
+        let multi = Function {
             id: FuncId(0),
             name: "two_returns".to_string(),
             params: vec![Ty::I64],
@@ -2281,7 +2287,7 @@ VERIFICATION FAILED";
             effects: vec![],
             vows: vec![VowEntry {
                 id: VowId(0),
-                description: "result >= 0".to_string(),
+                description: "result == x".to_string(),
                 blame: Blame::Callee,
                 bindings: vec![],
                 file: String::new(),
@@ -2313,9 +2319,50 @@ VERIFICATION FAILED";
             source_file: String::new(),
         };
         assert!(
-            body_replaceable_result(&func),
-            "must inspect the FIRST Return (%2, a regular inst) and report eligible; \
-             a last-return scan would pick %0 (GetArg) and wrongly report ineligible"
+            !body_replaceable_result(&multi),
+            "multi-return functions must be skipped: the probe overwrites only one \
+             return site, so leaving others live would yield a false weakness claim"
+        );
+
+        // A single-return function whose result is a regular instruction stays
+        // eligible — the common case the probe is designed for.
+        let single = Function {
+            id: FuncId(0),
+            name: "one_return".to_string(),
+            params: vec![Ty::I64],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![VowEntry {
+                id: VowId(0),
+                description: "result >= 0".to_string(),
+                blame: Blame::Callee,
+                bindings: vec![],
+                file: String::new(),
+                offset: 0,
+            }],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                    inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(1)),
+                    inst(
+                        2,
+                        Opcode::WrappingAddI64,
+                        Ty::I64,
+                        vec![0, 1],
+                        InstData::None,
+                    ),
+                    inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        assert!(
+            body_replaceable_result(&single),
+            "single-return function with a regular result instruction is eligible"
         );
     }
 }

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -319,6 +319,7 @@ pub fn emit_verify_c_source(
         &modelable_fns,
         limits,
         false,
+        false,
     );
     c_src.push_str(&emit_harness(func));
     c_src
@@ -349,6 +350,40 @@ pub fn emit_reach_c_source(
         &modelable_fns,
         limits,
         true,
+        false,
+    );
+    c_src.push_str(&emit_harness(func));
+    Some(c_src)
+}
+
+/// Like [`emit_verify_c_source`] but overwrites the target's returned value with
+/// the type-default right after it is computed, so each `ensures` is checked
+/// against a trivial `return <default>` body for weakness detection (#81 PR-C).
+/// Returns `None` when the probe does not apply: no `ensures`, a non-scalar
+/// return type, or a returned value that is not a regular body instruction
+/// (a bare parameter or a φ-merged/branchy result). Skipping those is sound but
+/// incomplete — it never produces a false "weak" verdict, only misses some.
+pub fn emit_bodyreplace_c_source(
+    func: &Function,
+    module: &Module,
+    const_fns: &HashMap<FuncId, ConstantValue>,
+    limits: &VerifyLimits,
+) -> Option<String> {
+    if !function_has_ensures(func) || !returns_scalar(func) || !body_replaceable_result(func) {
+        return None;
+    }
+    let mut modelable_cache = HashMap::new();
+    let callee_ids = collect_modelable_callees(func, module, const_fns, &mut modelable_cache);
+    let modelable_fns: std::collections::HashSet<FuncId> = callee_ids.iter().copied().collect();
+    let mut c_src = emit_c_module_with_callees(
+        func,
+        module,
+        const_fns,
+        &callee_ids,
+        &modelable_fns,
+        limits,
+        false,
+        true,
     );
     c_src.push_str(&emit_harness(func));
     Some(c_src)
@@ -361,6 +396,46 @@ pub fn function_has_requires(func: &Function) -> bool {
         .iter()
         .flat_map(|b| &b.insts)
         .any(|i| i.opcode == vow_ir::Opcode::VowRequires)
+}
+
+/// True when the function carries at least one `ensures` clause.
+pub fn function_has_ensures(func: &Function) -> bool {
+    func.blocks
+        .iter()
+        .flat_map(|b| &b.insts)
+        .any(|i| i.opcode == vow_ir::Opcode::VowEnsures)
+}
+
+/// True when the return type is a scalar integer/bool/float, so the trivial
+/// `return 0` body-replace is well-typed. Pointer/struct returns are skipped.
+fn returns_scalar(func: &Function) -> bool {
+    !matches!(
+        func.return_ty,
+        vow_ir::Ty::Unit | vow_ir::Ty::Ptr | vow_ir::Ty::LinearPtr
+    )
+}
+
+/// True when the value the `Return` yields is produced by a regular body
+/// instruction (one that `emit_c_function_full` emits in its per-instruction
+/// loop). The body-replace rewrite overwrites that value right after it is
+/// emitted; if the result is a bare `GetArg` (returned parameter) the overwrite
+/// site does not exist, so the probe is skipped rather than emitted incorrectly.
+fn body_replaceable_result(func: &Function) -> bool {
+    let Some(ret) = func
+        .blocks
+        .iter()
+        .flat_map(|b| &b.insts)
+        .find(|i| i.opcode == vow_ir::Opcode::Return)
+    else {
+        return false;
+    };
+    let Some(result_id) = ret.args.first().map(|a| a.0) else {
+        return false;
+    };
+    func.blocks
+        .iter()
+        .flat_map(|b| &b.insts)
+        .any(|i| i.id.0 == result_id && i.opcode != vow_ir::Opcode::GetArg)
 }
 
 pub const DEFAULT_MAX_K_STEP: u32 = 50;
@@ -702,6 +777,26 @@ pub fn run_esbmc_reach(
         }
         Err(_) => ReachVerdict::Inconclusive,
     }
+}
+
+/// Weakness probe (#81 PR-C): verify a body-replaced model (see
+/// `emit_bodyreplace_c_source`) where the returned value is forced to the
+/// type-default. `true` (ESBMC SUCCESSFUL) means a trivial `return <default>`
+/// implementation satisfies the `ensures` — the contract is too weak to pin down
+/// the implementation. Any other outcome returns `false`; this is a one-sided
+/// signal, never a soundness claim, so an inconclusive probe is reported as
+/// "not trivially satisfiable".
+pub fn run_esbmc_bodyreplace(
+    esbmc: &std::path::Path,
+    c_src: &str,
+    max_k_step: u32,
+    func_name: &str,
+    config: &SolverConfig,
+) -> bool {
+    matches!(
+        run_esbmc_with_max_k_step(esbmc, c_src, max_k_step, func_name, config),
+        VerificationResult::Proven | VerificationResult::ProvenIr
+    )
 }
 
 pub(crate) fn memory_limit_reason() -> String {

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -2258,4 +2258,64 @@ VERIFICATION FAILED";
             other => panic!("expected Skipped (gate must run before find_esbmc), got {other:?}"),
         }
     }
+
+    // #81 PR-C parity: `body_replaceable_result` must inspect the FIRST `Return`
+    // instruction (via `.find()`), and the self-hosted compiler
+    // (compiler/verifier.vow) must match. For multi-return IR the first and last
+    // `Return` can name different values, so a last-return scan would pick a
+    // different result id, diverging between the two compilers. This pins the
+    // canonical first-return semantics with a function whose two returns yield
+    // different eligibility verdicts.
+    #[test]
+    fn body_replaceable_result_uses_first_return_for_multi_return() {
+        // first Return -> %2 (a regular WrappingAddI64, eligible)
+        // last  Return -> %0 (a bare GetArg / returned parameter, ineligible)
+        // First-return semantics => eligible (true); a last-return scan would
+        // inspect the GetArg and wrongly report ineligible (false).
+        let func = Function {
+            id: FuncId(0),
+            name: "two_returns".to_string(),
+            params: vec![Ty::I64],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![VowEntry {
+                id: VowId(0),
+                description: "result >= 0".to_string(),
+                blame: Blame::Callee,
+                bindings: vec![],
+                file: String::new(),
+                offset: 0,
+            }],
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    insts: vec![
+                        inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                        inst(1, Opcode::ConstI64, Ty::I64, vec![], InstData::ConstI64(1)),
+                        inst(
+                            2,
+                            Opcode::WrappingAddI64,
+                            Ty::I64,
+                            vec![0, 1],
+                            InstData::None,
+                        ),
+                        inst(3, Opcode::Return, Ty::Unit, vec![2], InstData::None),
+                    ],
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    insts: vec![inst(4, Opcode::Return, Ty::Unit, vec![0], InstData::None)],
+                },
+            ],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        assert!(
+            body_replaceable_result(&func),
+            "must inspect the FIRST Return (%2, a regular inst) and report eligible; \
+             a last-return scan would pick %0 (GetArg) and wrongly report ineligible"
+        );
+    }
 }

--- a/vow-verify/src/lib.rs
+++ b/vow-verify/src/lib.rs
@@ -7,8 +7,9 @@ pub use c_emitter::{
     non_modelable_reason,
 };
 pub use esbmc::{
-    Counterexample, DEFAULT_MAX_K_STEP, ReachVerdict, VerificationResult, emit_reach_c_source,
-    emit_verify_c_source, find_esbmc, function_has_requires, parse_esbmc_output,
+    Counterexample, DEFAULT_MAX_K_STEP, ReachVerdict, VerificationResult,
+    emit_bodyreplace_c_source, emit_reach_c_source, emit_verify_c_source, find_esbmc,
+    function_has_ensures, function_has_requires, parse_esbmc_output, run_esbmc_bodyreplace,
     run_esbmc_k_induction, run_esbmc_multi_property, run_esbmc_reach, run_esbmc_with_max_k_step,
     verify_function, verify_function_with_const_fns, verify_function_with_module,
     verify_function_with_module_and_const_fns,

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -19,8 +19,9 @@ use vow_diag::{Diagnostic, DiagnosticEmitter, HumanEmitter, Severity};
 use vow_verify::{
     ConstantValue, Counterexample, DEFAULT_ESBMC_MEMLIMIT_MB, DEFAULT_MAX_K_STEP, Encoding,
     ReachVerdict, Solver, SolverConfig, UNSUPPORTED_OP_VOW_ID, VerificationResult, VerifyLimits,
-    detect_constant_functions, emit_reach_c_source, emit_verify_c_source, find_esbmc,
-    non_modelable_reason, run_esbmc_multi_property, run_esbmc_reach, run_with_fallback,
+    detect_constant_functions, emit_bodyreplace_c_source, emit_reach_c_source,
+    emit_verify_c_source, find_esbmc, non_modelable_reason, run_esbmc_bodyreplace,
+    run_esbmc_multi_property, run_esbmc_reach, run_with_fallback,
     verify_function_with_module_and_const_fns_configured,
 };
 
@@ -2732,7 +2733,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "trivially_satisfiable": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -2752,7 +2753,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "trivially_satisfiable": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -2768,6 +2769,7 @@ that path produces `Unverified` (exit 0).
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
 | `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, `"skipped"`, or `"vacuous"` |
 | `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
+| `trivially_satisfiable` | bool | `--verify` only: true when a trivial `return <default>` body still satisfies this `ensures` (verification-confirmed weakness). Always false for `requires`/`invariant` and without `--verify`. Informational — never affects the exit code. See `docs/spec/contracts-methodology.md`. |
 
 ### Status Values
 
@@ -3499,11 +3501,25 @@ ways this happens; a contract-quality tool should distinguish them.
 
 The clause is satisfiable and true, but so loose that an incorrect
 implementation also satisfies it (`ensures: result >= 0` on a computed value).
-This is the 354-contract problem. **Detection (mutation-based):** mutate the
-implementation — flip a constant, swap an operator — and re-verify. If the
-contract still proves against the *mutated* body, it does not constrain that
-behavior and is too weak. Vow already has the machinery for this in
-`vowc mutants`; a weak contract is one whose function's mutants survive.
+This is the 354-contract problem.
+
+**Detection (the body-replace probe).** `vow contracts --verify` ships this check
+(#81). It mutates the implementation in the strongest possible way — replaces the
+whole body with a trivial `return <type-default>` — and re-verifies the
+`ensures`. If the contract still proves against that body, a constant-returning
+implementation satisfies it, so it does not constrain the real computation: each
+such `ensures` is reported `trivially_satisfiable: true`. This is exactly the
+`body-replace` mutation of `vowc mutants` with ESBMC as the oracle.
+
+The signal is **one-sided (sound, not complete)**: a `true` verdict is a proof of
+weakness (a specific trivial body satisfies the contract), but a `false` verdict
+does not prove strength — the probe uses a single default value and skips
+non-scalar returns, returned parameters, and φ-merged/branchy results, so it can
+miss weak contracts it cannot witness this way. It is informational and never
+changes the exit code; pair it with the static `quality` field. The one known
+false positive is a function whose correct result genuinely *is* the type default
+(e.g. a constant `ensures result == 0` on a `{ 0 }` body) — an equivalent mutant,
+the standard caveat of mutation testing.
 
 ### Tautology
 
@@ -3609,14 +3625,20 @@ Contract expressions must be **pure** — they cannot call effectful functions
 blocked at the *modelable* axis, not the expressible one; classify such gaps as
 model limitations, not contract-language limitations.
 
-## Tooling (planned)
+## Tooling
 
-`vow contracts --verify` lists contracts and verifies them per function today. The
-quality work tracked in #81 / roadmap WS-3.2 extends it to a **per-obligation**
-check that emits a quality signal per clause — flagging tautologies (cheap, no
-ESBMC), vacuous obligations (the `false` re-check), and, via the `vowc mutants`
-harness, weak obligations whose function's mutants survive. Until that ships, the
-three detections above are checks an author can run by hand.
+`vow contracts --verify` performs the **per-obligation** quality analysis tracked
+in #81 / roadmap WS-3.2. Each clause gets an individual verification verdict (via
+ESBMC `--multi-property`), plus the three quality signals above:
+
+- **Tautology** — the static `quality` field flags constant clauses (no ESBMC).
+- **Vacuity** — a contradictory `requires` is caught by the `--error-label`
+  reachability probe and reported `status: "vacuous"` (fail-closed).
+- **Weakness** — the body-replace probe reports `trivially_satisfiable: true` for
+  an `ensures` a trivial `return <default>` body satisfies (informational).
+
+The `summary` carries `vacuous` and `trivially_satisfiable` counts alongside the
+status and quality tallies, so an author or CI can gate on hollow proofs.
 
 ## References
 
@@ -6424,7 +6446,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 0, "failed": 0, "timeout": 0, "error": 0, "not_verified": 1, "skipped": 0, "vacuous": 0, "trivially_satisfiable": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -6444,7 +6466,7 @@ that path produces `Unverified` (exit 0).
       "quality": "substantive"
     }
   ],
-  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
+  "summary": { "total": 1, "proven": 1, "failed": 0, "timeout": 0, "error": 0, "not_verified": 0, "skipped": 0, "vacuous": 0, "trivially_satisfiable": 0, "quality": { "weak": 0, "tautological": 0, "substantive": 1 } }
 }
 ```
 
@@ -6460,6 +6482,7 @@ that path produces `Unverified` (exit 0).
 | `source`      | object  | `{ "file": string, "offset": integer }`                  |
 | `status`      | string  | `"proven"`, `"proven-ir"`, `"failed"`, `"unknown"`, `"timeout"`, `"error"`, `"not_verified"`, `"skipped"`, or `"vacuous"` |
 | `quality`     | string  | Static clause-shape classification (no ESBMC): `"weak"`, `"tautological"`, or `"substantive"` |
+| `trivially_satisfiable` | bool | `--verify` only: true when a trivial `return <default>` body still satisfies this `ensures` (verification-confirmed weakness). Always false for `requires`/`invariant` and without `--verify`. Informational — never affects the exit code. See `docs/spec/contracts-methodology.md`. |
 
 ### Status Values
 
@@ -7193,11 +7216,25 @@ ways this happens; a contract-quality tool should distinguish them.
 
 The clause is satisfiable and true, but so loose that an incorrect
 implementation also satisfies it (`ensures: result >= 0` on a computed value).
-This is the 354-contract problem. **Detection (mutation-based):** mutate the
-implementation — flip a constant, swap an operator — and re-verify. If the
-contract still proves against the *mutated* body, it does not constrain that
-behavior and is too weak. Vow already has the machinery for this in
-`vowc mutants`; a weak contract is one whose function's mutants survive.
+This is the 354-contract problem.
+
+**Detection (the body-replace probe).** `vow contracts --verify` ships this check
+(#81). It mutates the implementation in the strongest possible way — replaces the
+whole body with a trivial `return <type-default>` — and re-verifies the
+`ensures`. If the contract still proves against that body, a constant-returning
+implementation satisfies it, so it does not constrain the real computation: each
+such `ensures` is reported `trivially_satisfiable: true`. This is exactly the
+`body-replace` mutation of `vowc mutants` with ESBMC as the oracle.
+
+The signal is **one-sided (sound, not complete)**: a `true` verdict is a proof of
+weakness (a specific trivial body satisfies the contract), but a `false` verdict
+does not prove strength — the probe uses a single default value and skips
+non-scalar returns, returned parameters, and φ-merged/branchy results, so it can
+miss weak contracts it cannot witness this way. It is informational and never
+changes the exit code; pair it with the static `quality` field. The one known
+false positive is a function whose correct result genuinely *is* the type default
+(e.g. a constant `ensures result == 0` on a `{ 0 }` body) — an equivalent mutant,
+the standard caveat of mutation testing.
 
 ### Tautology
 
@@ -7303,14 +7340,20 @@ Contract expressions must be **pure** — they cannot call effectful functions
 blocked at the *modelable* axis, not the expressible one; classify such gaps as
 model limitations, not contract-language limitations.
 
-## Tooling (planned)
+## Tooling
 
-`vow contracts --verify` lists contracts and verifies them per function today. The
-quality work tracked in #81 / roadmap WS-3.2 extends it to a **per-obligation**
-check that emits a quality signal per clause — flagging tautologies (cheap, no
-ESBMC), vacuous obligations (the `false` re-check), and, via the `vowc mutants`
-harness, weak obligations whose function's mutants survive. Until that ships, the
-three detections above are checks an author can run by hand.
+`vow contracts --verify` performs the **per-obligation** quality analysis tracked
+in #81 / roadmap WS-3.2. Each clause gets an individual verification verdict (via
+ESBMC `--multi-property`), plus the three quality signals above:
+
+- **Tautology** — the static `quality` field flags constant clauses (no ESBMC).
+- **Vacuity** — a contradictory `requires` is caught by the `--error-label`
+  reachability probe and reported `status: "vacuous"` (fail-closed).
+- **Weakness** — the body-replace probe reports `trivially_satisfiable: true` for
+  an `ensures` a trivial `return <default>` body satisfies (informational).
+
+The `summary` carries `vacuous` and `trivially_satisfiable` counts alongside the
+status and quality tallies, so an author or CI can gate on hollow proofs.
 
 ## References
 
@@ -9137,6 +9180,12 @@ pub struct ContractEntryJson {
     /// or `substantive` (equality / relational / inverse / call). See
     /// docs/spec/contracts-methodology.md.
     pub quality: String,
+    /// Verification-based weakness signal (#81 PR-C): true when a trivial
+    /// `return <default>` body still satisfies this `ensures` — the contract is
+    /// too weak to pin down the implementation. Only computed for `ensures`
+    /// clauses under `--verify`; always false for `requires`/`invariant` and
+    /// when `--verify` is off. Informational: it does not affect the exit code.
+    pub trivially_satisfiable: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -9156,6 +9205,9 @@ pub struct ContractsSummaryJson {
     pub not_verified: u32,
     pub skipped: u32,
     pub vacuous: u32,
+    /// Count of `ensures` clauses a trivial `return <default>` body satisfies
+    /// (#81 PR-C). Informational, like `quality`; does not affect the exit code.
+    pub trivially_satisfiable: u32,
     pub quality: ContractsQualityJson,
 }
 
@@ -11060,6 +11112,7 @@ fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJso
         not_verified: 0,
         skipped: 0,
         vacuous: 0,
+        trivially_satisfiable: 0,
         quality: ContractsQualityJson {
             weak: 0,
             tautological: 0,
@@ -11067,6 +11120,9 @@ fn build_contracts_summary(entries: &[ContractEntryJson]) -> ContractsSummaryJso
         },
     };
     for e in entries {
+        if e.trivially_satisfiable {
+            summary.trivially_satisfiable += 1;
+        }
         match e.status.as_str() {
             "proven" | "proven-ir" => summary.proven += 1,
             "failed" => summary.failed += 1,
@@ -11169,6 +11225,23 @@ fn update_contract_statuses(
                 }
             }
         }
+
+        // Weakness probe (#81 PR-C): re-verify a body-replaced model where the
+        // returned value is forced to the type-default. If the `ensures` still
+        // holds, a trivial `return <default>` body satisfies the contract — it
+        // is too weak to pin down the implementation. Marks each `ensures` clause
+        // `trivially_satisfiable` (informational; never changes the exit code).
+        // Skipped for non-scalar returns / returned-parameter results, which
+        // keeps the signal one-sided — it never claims weakness it cannot show.
+        if let Some(br_src) = emit_bodyreplace_c_source(func, ir_module, &const_fns, limits)
+            && run_esbmc_bodyreplace(&esbmc, &br_src, limits.max_k_step, &func.name, config)
+        {
+            for entry in entries.iter_mut() {
+                if entry.function_id == func.id.0 && entry.kind == "ensures" {
+                    entry.trivially_satisfiable = true;
+                }
+            }
+        }
     }
 }
 
@@ -11226,6 +11299,7 @@ fn run_contracts_command(
                 },
                 status: "not_verified".to_string(),
                 quality: quality.to_string(),
+                trivially_satisfiable: false,
             });
         }
     }
@@ -14926,6 +15000,7 @@ fn main() -> i32 {
             source: source.clone(),
             status: status.to_string(),
             quality: "substantive".to_string(),
+            trivially_satisfiable: false,
         };
         let summary = build_contracts_summary(&[
             entry("proven"),
@@ -14963,6 +15038,7 @@ fn main() -> i32 {
             not_verified: 0,
             skipped: 0,
             vacuous: 0,
+            trivially_satisfiable: 0,
             quality: ContractsQualityJson {
                 weak: 0,
                 tautological: 0,

--- a/vow/tests/contracts.rs
+++ b/vow/tests/contracts.rs
@@ -144,6 +144,51 @@ fn contracts_verify_detects_vacuous_contract() {
 }
 
 #[test]
+fn contracts_verify_flags_trivially_satisfiable_ensures() {
+    // PR-C (#81): a weak postcondition like `result >= 0` is satisfied by a
+    // trivial `return 0` body, so the body-replace probe flags it
+    // `trivially_satisfiable`. A tight postcondition (`result == x + 1`) is not.
+    // Informational — it does not change the exit code. Requires ESBMC.
+    let dir = tempfile::TempDir::new().unwrap();
+    let src = dir.path().join("w.vow");
+    std::fs::write(
+        &src,
+        "module M\n\
+         fn weak(x: i64) -> i64 vow {\n  requires: x >= 0,\n  ensures: result >= 0\n} { x + 1 }\n\
+         fn tight(x: i64) -> i64 vow {\n  ensures: result == x + 1\n} { x + 1 }\n\
+         fn main() -> i32 [io] { 0 }\n",
+    )
+    .unwrap();
+    let out = Command::new(vow_bin())
+        .args(["contracts", "--verify", src.to_str().unwrap()])
+        .output()
+        .expect("failed to run vow");
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("contracts JSON");
+    let contracts = json["contracts"].as_array().unwrap();
+    if contracts.iter().all(|c| c["status"] == "error") {
+        return; // ESBMC absent
+    }
+    let trivial_of = |func: &str| -> bool {
+        contracts
+            .iter()
+            .find(|c| c["function"] == func && c["kind"] == "ensures")
+            .unwrap_or_else(|| panic!("missing ensures for {func}"))["trivially_satisfiable"]
+            .as_bool()
+            .unwrap()
+    };
+    assert!(
+        trivial_of("weak"),
+        "`ensures result >= 0` is satisfied by a trivial body"
+    );
+    assert!(
+        !trivial_of("tight"),
+        "`ensures result == x + 1` pins the implementation"
+    );
+    assert_eq!(json["summary"]["trivially_satisfiable"], 1);
+}
+
+#[test]
 fn contracts_verify_missing_esbmc_keeps_contracts_schema() {
     let empty_path = tempfile::TempDir::new().unwrap();
     let out = Command::new(vow_bin())


### PR DESCRIPTION
## What

`vow contracts --verify` now flags **trivially-satisfiable** postconditions: an `ensures` that a trivial `return <default>` body still satisfies, i.e. one too weak to pin down the implementation. This is the verification-confirmed detector for the "354-contract problem" — the `ensures result >= 0` clauses that ESBMC rubber-stamps. Part of #81 (contract methodology). Stacked on **PR-B (#717)**.

## The technique (`vowc mutants`' body-replace, with ESBMC as oracle)

For each modelable, `ensures`-bearing, scalar-returning function, a second ESBMC run is made over a **body-replaced** model: the returned value is overwritten with the type-default (`0`) right after it is computed, so each `ensures` is checked against a trivial `return 0` implementation. If ESBMC still proves the `ensures`, a constant-returning body satisfies the contract → it is too weak; every `ensures` clause of that function is reported `trivially_satisfiable: true`, with a `summary.trivially_satisfiable` count.

```
fn weak(x: i64) -> i64 vow { requires: x >= 0, ensures: result >= 0 } { x + 1 }   // trivially_satisfiable: true
fn tight(x: i64) -> i64 vow { ensures: result == x + 1 } { x + 1 }                 // trivially_satisfiable: false
```

The overwrite is planted right after the result instruction — the same post-instruction injection as PR-B's reach-label — so the `ensures` predicate (which references the result) recomputes against the default.

**One-sided (sound, not complete).** A `true` verdict is a proof of weakness; a `false` verdict does not prove strength. The probe uses a single default and skips non-scalar returns, returned parameters, and φ-merged/branchy results (eligibility gated in `emit_bodyreplace_c_source` / `verify_function_trivial`), so it can miss weak contracts it cannot witness — never a false "weak" claim. It is **informational and never changes the exit code** (pair it with the static `quality` field). The one documented false positive is a function whose correct result genuinely is the type-default (`ensures result == 0` on `{ 0 }`) — an equivalent mutant, the standard mutation-testing caveat.

## Changes (both compilers, in parity)

- **Rust** — `vow-verify/src/c_emitter.rs`: `body_replace` mode on `emit_c_function_full` overwrites the `Return`'s value with `0`; `esbmc.rs`: `emit_bodyreplace_c_source` (with `function_has_ensures` / `returns_scalar` / `body_replaceable_result` eligibility) and `run_esbmc_bodyreplace`; `vow/src/main.rs`: `update_contract_statuses` runs the probe and sets `trivially_satisfiable` on `ensures` clauses; new field + summary tally.
- **Self-hosted** — mirrored in `compiler/c_emitter.vow` (`body_replace` + result overwrite), `compiler/verifier.vow` (`function_has_ensures`, `returns_scalar`, `body_replaceable_result`, `verify_function_trivial`), and `compiler/main.vow` `run_contracts`.
- **Spec** — `docs/spec/cli.md` (field + summary) and `docs/spec/contracts-methodology.md` (the Weakness section now describes the shipped body-replace probe; the Tooling section reflects all three shipped detections). Embedded skill regenerated.

## Tests

- Rust: `emit_body_replace_overwrites_result_with_default` (emission) + `contracts_verify_flags_trivially_satisfiable_ensures` (weak→true, tight→false).
- Self-hosted: `contracts_weakness_trivially_satisfiable` (tests/run_tests.sh, ESBMC-gated).
- Rust/self-hosted output parity confirmed byte-for-byte. Full verifying bootstrap green; binary fixed point (vowc2 == vowc3); clippy + fmt clean.

Part of #81.
