### PR TITLE
refactor(contracts): tag families are structural, not contracted (#81 PR-E)

### DIFF
--- a/compiler/ast.vow
+++ b/compiler/ast.vow
@@ -1,93 +1,93 @@
 module Ast
 
-fn EXPR_LIT_INT() -> i64 vow { ensures: result >= 0 } { 0 }
-fn EXPR_LIT_BOOL() -> i64 vow { ensures: result >= 0 } { 1 }
-fn EXPR_LIT_STR() -> i64 vow { ensures: result >= 0 } { 2 }
-fn EXPR_LIT_FLOAT() -> i64 vow { ensures: result >= 0 } { 3 }
-fn EXPR_IDENT() -> i64 vow { ensures: result >= 0 } { 4 }
-fn EXPR_BINOP() -> i64 vow { ensures: result >= 0 } { 5 }
-fn EXPR_UNOP() -> i64 vow { ensures: result >= 0 } { 6 }
-fn EXPR_CALL() -> i64 vow { ensures: result >= 0 } { 7 }
-fn EXPR_METHOD() -> i64 vow { ensures: result >= 0 } { 8 }
-fn EXPR_FIELD() -> i64 vow { ensures: result >= 0 } { 9 }
-fn EXPR_INDEX() -> i64 vow { ensures: result >= 0 } { 10 }
-fn EXPR_IF() -> i64 vow { ensures: result >= 0 } { 11 }
-fn EXPR_WHILE() -> i64 vow { ensures: result >= 0 } { 12 }
-fn EXPR_MATCH() -> i64 vow { ensures: result >= 0 } { 13 }
-fn EXPR_RETURN() -> i64 vow { ensures: result >= 0 } { 14 }
-fn EXPR_BREAK() -> i64 vow { ensures: result >= 0 } { 15 }
-fn EXPR_BLOCK() -> i64 vow { ensures: result >= 0 } { 16 }
-fn EXPR_ASSIGN() -> i64 vow { ensures: result >= 0 } { 17 }
-fn EXPR_SLIT() -> i64 vow { ensures: result >= 0 } { 18 }
-fn EXPR_ECTOR() -> i64 vow { ensures: result >= 0 } { 19 }
-fn EXPR_QUESTION() -> i64 vow { ensures: result >= 0 } { 20 }
-fn EXPR_TUPLE() -> i64 vow { ensures: result >= 0 } { 21 }
-fn EXPR_RESULT() -> i64 vow { ensures: result >= 0 } { 22 }
-fn EXPR_CAST() -> i64 vow { ensures: result >= 0 } { 23 }
-fn EXPR_LOOP() -> i64 vow { ensures: result >= 0 } { 24 }
-fn EXPR_FOR() -> i64 vow { ensures: result >= 0 } { 25 }
-fn EXPR_CONTINUE() -> i64 vow { ensures: result >= 0 } { 26 }
+fn EXPR_LIT_INT() -> i64 { 0 }
+fn EXPR_LIT_BOOL() -> i64 { 1 }
+fn EXPR_LIT_STR() -> i64 { 2 }
+fn EXPR_LIT_FLOAT() -> i64 { 3 }
+fn EXPR_IDENT() -> i64 { 4 }
+fn EXPR_BINOP() -> i64 { 5 }
+fn EXPR_UNOP() -> i64 { 6 }
+fn EXPR_CALL() -> i64 { 7 }
+fn EXPR_METHOD() -> i64 { 8 }
+fn EXPR_FIELD() -> i64 { 9 }
+fn EXPR_INDEX() -> i64 { 10 }
+fn EXPR_IF() -> i64 { 11 }
+fn EXPR_WHILE() -> i64 { 12 }
+fn EXPR_MATCH() -> i64 { 13 }
+fn EXPR_RETURN() -> i64 { 14 }
+fn EXPR_BREAK() -> i64 { 15 }
+fn EXPR_BLOCK() -> i64 { 16 }
+fn EXPR_ASSIGN() -> i64 { 17 }
+fn EXPR_SLIT() -> i64 { 18 }
+fn EXPR_ECTOR() -> i64 { 19 }
+fn EXPR_QUESTION() -> i64 { 20 }
+fn EXPR_TUPLE() -> i64 { 21 }
+fn EXPR_RESULT() -> i64 { 22 }
+fn EXPR_CAST() -> i64 { 23 }
+fn EXPR_LOOP() -> i64 { 24 }
+fn EXPR_FOR() -> i64 { 25 }
+fn EXPR_CONTINUE() -> i64 { 26 }
 
-fn CLAUSE_REQUIRES() -> i64 vow { ensures: result >= 0 } { 0 }
-fn CLAUSE_ENSURES() -> i64 vow { ensures: result >= 0 } { 1 }
-fn CLAUSE_INVARIANT() -> i64 vow { ensures: result >= 0 } { 2 }
+fn CLAUSE_REQUIRES() -> i64 { 0 }
+fn CLAUSE_ENSURES() -> i64 { 1 }
+fn CLAUSE_INVARIANT() -> i64 { 2 }
 
-fn BINOP_ADD() -> i64 vow { ensures: result >= 0 } { 0 }
-fn BINOP_SUB() -> i64 vow { ensures: result >= 0 } { 1 }
-fn BINOP_MUL() -> i64 vow { ensures: result >= 0 } { 2 }
-fn BINOP_DIV() -> i64 vow { ensures: result >= 0 } { 3 }
-fn BINOP_REM() -> i64 vow { ensures: result >= 0 } { 4 }
-fn BINOP_ADD_CHK() -> i64 vow { ensures: result >= 0 } { 5 }
-fn BINOP_SUB_CHK() -> i64 vow { ensures: result >= 0 } { 6 }
-fn BINOP_MUL_CHK() -> i64 vow { ensures: result >= 0 } { 7 }
-fn BINOP_DIV_CHK() -> i64 vow { ensures: result >= 0 } { 8 }
-fn BINOP_REM_CHK() -> i64 vow { ensures: result >= 0 } { 9 }
-fn BINOP_EQ() -> i64 vow { ensures: result >= 0 } { 10 }
-fn BINOP_NE() -> i64 vow { ensures: result >= 0 } { 11 }
-fn BINOP_LT() -> i64 vow { ensures: result >= 0 } { 12 }
-fn BINOP_LE() -> i64 vow { ensures: result >= 0 } { 13 }
-fn BINOP_GT() -> i64 vow { ensures: result >= 0 } { 14 }
-fn BINOP_GE() -> i64 vow { ensures: result >= 0 } { 15 }
-fn BINOP_AND() -> i64 vow { ensures: result >= 0 } { 16 }
-fn BINOP_OR() -> i64 vow { ensures: result >= 0 } { 17 }
-fn BINOP_XOR() -> i64 vow { ensures: result >= 0 } { 18 }
-fn BINOP_BITAND() -> i64 vow { ensures: result >= 0 } { 19 }
-fn BINOP_BITOR() -> i64 vow { ensures: result >= 0 } { 20 }
-fn BINOP_SHL() -> i64 vow { ensures: result >= 0 } { 21 }
-fn BINOP_SHR() -> i64 vow { ensures: result >= 0 } { 22 }
+fn BINOP_ADD() -> i64 { 0 }
+fn BINOP_SUB() -> i64 { 1 }
+fn BINOP_MUL() -> i64 { 2 }
+fn BINOP_DIV() -> i64 { 3 }
+fn BINOP_REM() -> i64 { 4 }
+fn BINOP_ADD_CHK() -> i64 { 5 }
+fn BINOP_SUB_CHK() -> i64 { 6 }
+fn BINOP_MUL_CHK() -> i64 { 7 }
+fn BINOP_DIV_CHK() -> i64 { 8 }
+fn BINOP_REM_CHK() -> i64 { 9 }
+fn BINOP_EQ() -> i64 { 10 }
+fn BINOP_NE() -> i64 { 11 }
+fn BINOP_LT() -> i64 { 12 }
+fn BINOP_LE() -> i64 { 13 }
+fn BINOP_GT() -> i64 { 14 }
+fn BINOP_GE() -> i64 { 15 }
+fn BINOP_AND() -> i64 { 16 }
+fn BINOP_OR() -> i64 { 17 }
+fn BINOP_XOR() -> i64 { 18 }
+fn BINOP_BITAND() -> i64 { 19 }
+fn BINOP_BITOR() -> i64 { 20 }
+fn BINOP_SHL() -> i64 { 21 }
+fn BINOP_SHR() -> i64 { 22 }
 
-fn UNOP_NEG() -> i64 vow { ensures: result >= 0 } { 0 }
-fn UNOP_NOT() -> i64 vow { ensures: result >= 0 } { 1 }
+fn UNOP_NEG() -> i64 { 0 }
+fn UNOP_NOT() -> i64 { 1 }
 
-fn TY_NAMED() -> i64 vow { ensures: result >= 0 } { 0 }
-fn TY_GENERIC() -> i64 vow { ensures: result >= 0 } { 1 }
-fn TY_UNIT() -> i64 vow { ensures: result >= 0 } { 2 }
-fn TY_NEVER() -> i64 vow { ensures: result >= 0 } { 3 }
-fn TY_REF() -> i64 vow { ensures: result >= 0 } { 4 }
-fn TY_SLICE() -> i64 vow { ensures: result >= 0 } { 5 }
-fn TY_TUPLE() -> i64 vow { ensures: result >= 0 } { 6 }
+fn TY_NAMED() -> i64 { 0 }
+fn TY_GENERIC() -> i64 { 1 }
+fn TY_UNIT() -> i64 { 2 }
+fn TY_NEVER() -> i64 { 3 }
+fn TY_REF() -> i64 { 4 }
+fn TY_SLICE() -> i64 { 5 }
+fn TY_TUPLE() -> i64 { 6 }
 
-fn STMT_LET() -> i64 vow { ensures: result >= 0 } { 0 }
-fn STMT_EXPR() -> i64 vow { ensures: result >= 0 } { 1 }
+fn STMT_LET() -> i64 { 0 }
+fn STMT_EXPR() -> i64 { 1 }
 
-fn PAT_WILD() -> i64 vow { ensures: result >= 0 } { 0 }
-fn PAT_IDENT() -> i64 vow { ensures: result >= 0 } { 1 }
-fn PAT_LIT() -> i64 vow { ensures: result >= 0 } { 2 }
-fn PAT_ENUM() -> i64 vow { ensures: result >= 0 } { 3 }
-fn PAT_STRUCT() -> i64 vow { ensures: result >= 0 } { 4 }
-fn PAT_TUPLE() -> i64 vow { ensures: result >= 0 } { 5 }
-fn PAT_OR() -> i64 vow { ensures: result >= 0 } { 6 }
+fn PAT_WILD() -> i64 { 0 }
+fn PAT_IDENT() -> i64 { 1 }
+fn PAT_LIT() -> i64 { 2 }
+fn PAT_ENUM() -> i64 { 3 }
+fn PAT_STRUCT() -> i64 { 4 }
+fn PAT_TUPLE() -> i64 { 5 }
+fn PAT_OR() -> i64 { 6 }
 
-fn ITEM_FN() -> i64 vow { ensures: result >= 0 } { 0 }
-fn ITEM_STRUCT() -> i64 vow { ensures: result >= 0 } { 1 }
-fn ITEM_ENUM() -> i64 vow { ensures: result >= 0 } { 2 }
-fn ITEM_CONST() -> i64 vow { ensures: result >= 0 } { 3 }
+fn ITEM_FN() -> i64 { 0 }
+fn ITEM_STRUCT() -> i64 { 1 }
+fn ITEM_ENUM() -> i64 { 2 }
+fn ITEM_CONST() -> i64 { 3 }
 
-fn EFF_IO() -> i64 vow { ensures: result > 0 } { 1 }
-fn EFF_PANIC() -> i64 vow { ensures: result > 0 } { 2 }
-fn EFF_READ() -> i64 vow { ensures: result > 0 } { 4 }
-fn EFF_UNSAFE() -> i64 vow { ensures: result > 0 } { 8 }
-fn EFF_WRITE() -> i64 vow { ensures: result > 0 } { 16 }
+fn EFF_IO() -> i64 { 1 }
+fn EFF_PANIC() -> i64 { 2 }
+fn EFF_READ() -> i64 { 4 }
+fn EFF_UNSAFE() -> i64 { 8 }
+fn EFF_WRITE() -> i64 { 16 }
 
 struct AstArena {
     expr_data: Vec<i64>,

--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -10,10 +10,10 @@ use ir_printer
 // the prover, not about Vow — not language properties and not user-tunable.
 // Swap in an unbounded checker and the same source verifies unchanged.
 // See docs/design/verifier-model-bounds.md.
-fn VOW_VEC_MAX() -> i64 vow { ensures: result >= 1 } { 128 }
-fn VOW_STRING_MAX() -> i64 vow { ensures: result >= 1 } { 256 }
-fn VOW_HASHMAP_MAX() -> i64 vow { ensures: result >= 1 } { 64 }
-fn VOW_BTREEMAP_MAX() -> i64 vow { ensures: result >= 1 } { 64 }
+fn VOW_VEC_MAX() -> i64 { 128 }
+fn VOW_STRING_MAX() -> i64 { 256 }
+fn VOW_HASHMAP_MAX() -> i64 { 64 }
+fn VOW_BTREEMAP_MAX() -> i64 { 64 }
 
 fn str3(a: String, b: String, c: String) -> String {
     let r: String = String::from("");

--- a/compiler/diag.vow
+++ b/compiler/diag.vow
@@ -1,42 +1,42 @@
 module Diag
 
-fn SEV_ERROR() -> i64 vow { ensures: result >= 0 } { 0 }
-fn SEV_WARNING() -> i64 vow { ensures: result >= 0 } { 1 }
-fn SEV_NOTE() -> i64 vow { ensures: result >= 0 } { 2 }
+fn SEV_ERROR() -> i64 { 0 }
+fn SEV_WARNING() -> i64 { 1 }
+fn SEV_NOTE() -> i64 { 2 }
 
-fn DIAG_BLAME_CALLER() -> i64 vow { ensures: result >= 0 } { 0 }
-fn DIAG_BLAME_CALLEE() -> i64 vow { ensures: result >= 0 } { 1 }
-fn DIAG_BLAME_NONE() -> i64 vow { ensures: result >= 0 } { 2 }
+fn DIAG_BLAME_CALLER() -> i64 { 0 }
+fn DIAG_BLAME_CALLEE() -> i64 { 1 }
+fn DIAG_BLAME_NONE() -> i64 { 2 }
 
-fn EC_UNTERMINATED_STRING() -> i64 vow { ensures: result >= 0 } { 0 }
-fn EC_INVALID_CHARACTER() -> i64 vow { ensures: result >= 0 } { 1 }
-fn EC_UNEXPECTED_TOKEN() -> i64 vow { ensures: result >= 0 } { 2 }
-fn EC_MISSING_DELIMITER() -> i64 vow { ensures: result >= 0 } { 3 }
-fn EC_TYPE_MISMATCH() -> i64 vow { ensures: result >= 0 } { 4 }
-fn EC_EFFECT_VIOLATION() -> i64 vow { ensures: result >= 0 } { 5 }
-fn EC_LINEAR_TYPE_VIOLATION() -> i64 vow { ensures: result >= 0 } { 6 }
-fn EC_NON_EXHAUSTIVE_MATCH() -> i64 vow { ensures: result >= 0 } { 7 }
-fn EC_VOW_REQUIRES_VIOLATED() -> i64 vow { ensures: result >= 0 } { 8 }
-fn EC_VOW_ENSURES_VIOLATED() -> i64 vow { ensures: result >= 0 } { 9 }
-fn EC_VOW_INVARIANT_VIOLATED() -> i64 vow { ensures: result >= 0 } { 10 }
-fn EC_UNKNOWN_METHOD() -> i64 vow { ensures: result >= 0 } { 12 }
-fn EC_UNSUPPORTED_FEATURE() -> i64 vow { ensures: result >= 0 } { 13 }
-fn EC_LOWERING_WARNING() -> i64 vow { ensures: result >= 0 } { 14 }
-fn EC_IO_ERROR() -> i64 vow { ensures: result >= 0 } { 11 }
-fn EC_MISSING_CONTRACT() -> i64 vow { ensures: result >= 0 } { 15 }
-fn EC_CONTRACT_TYPE_MISMATCH() -> i64 vow { ensures: result >= 0 } { 16 }
-fn EC_ESBMC_NOT_FOUND() -> i64 vow { ensures: result >= 0 } { 17 }
-fn EC_REGION_CONFLICT() -> i64 vow { ensures: result >= 0 } { 18 }
-fn EC_REGION_LINEAR() -> i64 vow { ensures: result >= 0 } { 19 }
+fn EC_UNTERMINATED_STRING() -> i64 { 0 }
+fn EC_INVALID_CHARACTER() -> i64 { 1 }
+fn EC_UNEXPECTED_TOKEN() -> i64 { 2 }
+fn EC_MISSING_DELIMITER() -> i64 { 3 }
+fn EC_TYPE_MISMATCH() -> i64 { 4 }
+fn EC_EFFECT_VIOLATION() -> i64 { 5 }
+fn EC_LINEAR_TYPE_VIOLATION() -> i64 { 6 }
+fn EC_NON_EXHAUSTIVE_MATCH() -> i64 { 7 }
+fn EC_VOW_REQUIRES_VIOLATED() -> i64 { 8 }
+fn EC_VOW_ENSURES_VIOLATED() -> i64 { 9 }
+fn EC_VOW_INVARIANT_VIOLATED() -> i64 { 10 }
+fn EC_UNKNOWN_METHOD() -> i64 { 12 }
+fn EC_UNSUPPORTED_FEATURE() -> i64 { 13 }
+fn EC_LOWERING_WARNING() -> i64 { 14 }
+fn EC_IO_ERROR() -> i64 { 11 }
+fn EC_MISSING_CONTRACT() -> i64 { 15 }
+fn EC_CONTRACT_TYPE_MISMATCH() -> i64 { 16 }
+fn EC_ESBMC_NOT_FOUND() -> i64 { 17 }
+fn EC_REGION_CONFLICT() -> i64 { 18 }
+fn EC_REGION_LINEAR() -> i64 { 19 }
 // Emitted as a Warning when a vowed function's body cannot be modeled by
 // the verifier. Mirrors `vow_diag::ErrorCode::VerificationSkipped`.
-fn EC_VERIFICATION_SKIPPED() -> i64 vow { ensures: result >= 0 } { 20 }
-fn EC_BTREEMAP_KEY_TYPE_MUST_BE_I64() -> i64 vow { ensures: result >= 0 } { 21 }
-fn EC_BTREEMAP_VALUE_MUST_BE_NON_LINEAR() -> i64 vow { ensures: result >= 0 } { 22 }
+fn EC_VERIFICATION_SKIPPED() -> i64 { 20 }
+fn EC_BTREEMAP_KEY_TYPE_MUST_BE_I64() -> i64 { 21 }
+fn EC_BTREEMAP_VALUE_MUST_BE_NON_LINEAR() -> i64 { 22 }
 // Note: program-lifetime root-arena placement. See arena_memory.md §4.4.
-fn EC_REGION_ROOT_ESCAPE() -> i64 vow { ensures: result >= 0 } { 23 }
-fn EC_STATIC_LITERAL_REQUIRED() -> i64 vow { ensures: result >= 0 } { 24 }
-fn EC_REGION_LITERAL_MUTATION() -> i64 vow { ensures: result >= 0 } { 25 }
+fn EC_REGION_ROOT_ESCAPE() -> i64 { 23 }
+fn EC_STATIC_LITERAL_REQUIRED() -> i64 { 24 }
+fn EC_REGION_LITERAL_MUTATION() -> i64 { 25 }
 
 struct Diagnostic {
     severity: i64,

--- a/compiler/ir.vow
+++ b/compiler/ir.vow
@@ -1,142 +1,142 @@
 module Ir
 
-fn IOP_CONST_I32() -> i64 vow { ensures: result >= 0 } { 0 }
-fn IOP_CONST_I64() -> i64 vow { ensures: result >= 0 } { 1 }
-fn IOP_CONST_F32() -> i64 vow { ensures: result >= 0 } { 2 }
-fn IOP_CONST_F64() -> i64 vow { ensures: result >= 0 } { 3 }
-fn IOP_CONST_BOOL() -> i64 vow { ensures: result >= 0 } { 4 }
-fn IOP_CONST_STR() -> i64 vow { ensures: result >= 0 } { 5 }
-fn IOP_CONST_UNIT() -> i64 vow { ensures: result >= 0 } { 6 }
+fn IOP_CONST_I32() -> i64 { 0 }
+fn IOP_CONST_I64() -> i64 { 1 }
+fn IOP_CONST_F32() -> i64 { 2 }
+fn IOP_CONST_F64() -> i64 { 3 }
+fn IOP_CONST_BOOL() -> i64 { 4 }
+fn IOP_CONST_STR() -> i64 { 5 }
+fn IOP_CONST_UNIT() -> i64 { 6 }
 
-fn IOP_GET_ARG() -> i64 vow { ensures: result >= 0 } { 7 }
+fn IOP_GET_ARG() -> i64 { 7 }
 
-fn IOP_WADD_I32() -> i64 vow { ensures: result >= 0 } { 8 }
-fn IOP_WSUB_I32() -> i64 vow { ensures: result >= 0 } { 9 }
-fn IOP_WMUL_I32() -> i64 vow { ensures: result >= 0 } { 10 }
-fn IOP_WDIV_I32() -> i64 vow { ensures: result >= 0 } { 11 }
-fn IOP_WREM_I32() -> i64 vow { ensures: result >= 0 } { 12 }
-fn IOP_CADD_I32() -> i64 vow { ensures: result >= 0 } { 13 }
-fn IOP_CSUB_I32() -> i64 vow { ensures: result >= 0 } { 14 }
-fn IOP_CMUL_I32() -> i64 vow { ensures: result >= 0 } { 15 }
-fn IOP_CDIV_I32() -> i64 vow { ensures: result >= 0 } { 16 }
-fn IOP_CREM_I32() -> i64 vow { ensures: result >= 0 } { 17 }
-fn IOP_EQ_I32() -> i64 vow { ensures: result >= 0 } { 18 }
-fn IOP_NE_I32() -> i64 vow { ensures: result >= 0 } { 19 }
-fn IOP_LT_I32() -> i64 vow { ensures: result >= 0 } { 20 }
-fn IOP_LE_I32() -> i64 vow { ensures: result >= 0 } { 21 }
-fn IOP_GT_I32() -> i64 vow { ensures: result >= 0 } { 22 }
-fn IOP_GE_I32() -> i64 vow { ensures: result >= 0 } { 23 }
+fn IOP_WADD_I32() -> i64 { 8 }
+fn IOP_WSUB_I32() -> i64 { 9 }
+fn IOP_WMUL_I32() -> i64 { 10 }
+fn IOP_WDIV_I32() -> i64 { 11 }
+fn IOP_WREM_I32() -> i64 { 12 }
+fn IOP_CADD_I32() -> i64 { 13 }
+fn IOP_CSUB_I32() -> i64 { 14 }
+fn IOP_CMUL_I32() -> i64 { 15 }
+fn IOP_CDIV_I32() -> i64 { 16 }
+fn IOP_CREM_I32() -> i64 { 17 }
+fn IOP_EQ_I32() -> i64 { 18 }
+fn IOP_NE_I32() -> i64 { 19 }
+fn IOP_LT_I32() -> i64 { 20 }
+fn IOP_LE_I32() -> i64 { 21 }
+fn IOP_GT_I32() -> i64 { 22 }
+fn IOP_GE_I32() -> i64 { 23 }
 
-fn IOP_WADD_I64() -> i64 vow { ensures: result >= 0 } { 24 }
-fn IOP_WSUB_I64() -> i64 vow { ensures: result >= 0 } { 25 }
-fn IOP_WMUL_I64() -> i64 vow { ensures: result >= 0 } { 26 }
-fn IOP_WDIV_I64() -> i64 vow { ensures: result >= 0 } { 27 }
-fn IOP_WREM_I64() -> i64 vow { ensures: result >= 0 } { 28 }
-fn IOP_CADD_I64() -> i64 vow { ensures: result >= 0 } { 29 }
-fn IOP_CSUB_I64() -> i64 vow { ensures: result >= 0 } { 30 }
-fn IOP_CMUL_I64() -> i64 vow { ensures: result >= 0 } { 31 }
-fn IOP_CDIV_I64() -> i64 vow { ensures: result >= 0 } { 32 }
-fn IOP_CREM_I64() -> i64 vow { ensures: result >= 0 } { 33 }
-fn IOP_EQ_I64() -> i64 vow { ensures: result >= 0 } { 34 }
-fn IOP_NE_I64() -> i64 vow { ensures: result >= 0 } { 35 }
-fn IOP_LT_I64() -> i64 vow { ensures: result >= 0 } { 36 }
-fn IOP_LE_I64() -> i64 vow { ensures: result >= 0 } { 37 }
-fn IOP_GT_I64() -> i64 vow { ensures: result >= 0 } { 38 }
-fn IOP_GE_I64() -> i64 vow { ensures: result >= 0 } { 39 }
+fn IOP_WADD_I64() -> i64 { 24 }
+fn IOP_WSUB_I64() -> i64 { 25 }
+fn IOP_WMUL_I64() -> i64 { 26 }
+fn IOP_WDIV_I64() -> i64 { 27 }
+fn IOP_WREM_I64() -> i64 { 28 }
+fn IOP_CADD_I64() -> i64 { 29 }
+fn IOP_CSUB_I64() -> i64 { 30 }
+fn IOP_CMUL_I64() -> i64 { 31 }
+fn IOP_CDIV_I64() -> i64 { 32 }
+fn IOP_CREM_I64() -> i64 { 33 }
+fn IOP_EQ_I64() -> i64 { 34 }
+fn IOP_NE_I64() -> i64 { 35 }
+fn IOP_LT_I64() -> i64 { 36 }
+fn IOP_LE_I64() -> i64 { 37 }
+fn IOP_GT_I64() -> i64 { 38 }
+fn IOP_GE_I64() -> i64 { 39 }
 
-fn IOP_ADD_F32() -> i64 vow { ensures: result >= 0 } { 40 }
-fn IOP_SUB_F32() -> i64 vow { ensures: result >= 0 } { 41 }
-fn IOP_MUL_F32() -> i64 vow { ensures: result >= 0 } { 42 }
-fn IOP_DIV_F32() -> i64 vow { ensures: result >= 0 } { 43 }
-fn IOP_REM_F32() -> i64 vow { ensures: result >= 0 } { 44 }
-fn IOP_EQ_F32() -> i64 vow { ensures: result >= 0 } { 45 }
-fn IOP_NE_F32() -> i64 vow { ensures: result >= 0 } { 46 }
-fn IOP_LT_F32() -> i64 vow { ensures: result >= 0 } { 47 }
-fn IOP_LE_F32() -> i64 vow { ensures: result >= 0 } { 48 }
-fn IOP_GT_F32() -> i64 vow { ensures: result >= 0 } { 49 }
-fn IOP_GE_F32() -> i64 vow { ensures: result >= 0 } { 50 }
+fn IOP_ADD_F32() -> i64 { 40 }
+fn IOP_SUB_F32() -> i64 { 41 }
+fn IOP_MUL_F32() -> i64 { 42 }
+fn IOP_DIV_F32() -> i64 { 43 }
+fn IOP_REM_F32() -> i64 { 44 }
+fn IOP_EQ_F32() -> i64 { 45 }
+fn IOP_NE_F32() -> i64 { 46 }
+fn IOP_LT_F32() -> i64 { 47 }
+fn IOP_LE_F32() -> i64 { 48 }
+fn IOP_GT_F32() -> i64 { 49 }
+fn IOP_GE_F32() -> i64 { 50 }
 
-fn IOP_ADD_F64() -> i64 vow { ensures: result >= 0 } { 51 }
-fn IOP_SUB_F64() -> i64 vow { ensures: result >= 0 } { 52 }
-fn IOP_MUL_F64() -> i64 vow { ensures: result >= 0 } { 53 }
-fn IOP_DIV_F64() -> i64 vow { ensures: result >= 0 } { 54 }
-fn IOP_REM_F64() -> i64 vow { ensures: result >= 0 } { 55 }
-fn IOP_EQ_F64() -> i64 vow { ensures: result >= 0 } { 56 }
-fn IOP_NE_F64() -> i64 vow { ensures: result >= 0 } { 57 }
-fn IOP_LT_F64() -> i64 vow { ensures: result >= 0 } { 58 }
-fn IOP_LE_F64() -> i64 vow { ensures: result >= 0 } { 59 }
-fn IOP_GT_F64() -> i64 vow { ensures: result >= 0 } { 60 }
-fn IOP_GE_F64() -> i64 vow { ensures: result >= 0 } { 61 }
+fn IOP_ADD_F64() -> i64 { 51 }
+fn IOP_SUB_F64() -> i64 { 52 }
+fn IOP_MUL_F64() -> i64 { 53 }
+fn IOP_DIV_F64() -> i64 { 54 }
+fn IOP_REM_F64() -> i64 { 55 }
+fn IOP_EQ_F64() -> i64 { 56 }
+fn IOP_NE_F64() -> i64 { 57 }
+fn IOP_LT_F64() -> i64 { 58 }
+fn IOP_LE_F64() -> i64 { 59 }
+fn IOP_GT_F64() -> i64 { 60 }
+fn IOP_GE_F64() -> i64 { 61 }
 
-fn IOP_NOT() -> i64 vow { ensures: result >= 0 } { 62 }
-fn IOP_AND() -> i64 vow { ensures: result >= 0 } { 63 }
-fn IOP_OR() -> i64 vow { ensures: result >= 0 } { 64 }
+fn IOP_NOT() -> i64 { 62 }
+fn IOP_AND() -> i64 { 63 }
+fn IOP_OR() -> i64 { 64 }
 
-fn IOP_LOAD() -> i64 vow { ensures: result >= 0 } { 65 }
-fn IOP_STORE() -> i64 vow { ensures: result >= 0 } { 66 }
+fn IOP_LOAD() -> i64 { 65 }
+fn IOP_STORE() -> i64 { 66 }
 
-fn IOP_BRANCH() -> i64 vow { ensures: result >= 0 } { 67 }
-fn IOP_JUMP() -> i64 vow { ensures: result >= 0 } { 68 }
-fn IOP_RETURN() -> i64 vow { ensures: result >= 0 } { 69 }
-fn IOP_UNREACHABLE() -> i64 vow { ensures: result >= 0 } { 70 }
+fn IOP_BRANCH() -> i64 { 67 }
+fn IOP_JUMP() -> i64 { 68 }
+fn IOP_RETURN() -> i64 { 69 }
+fn IOP_UNREACHABLE() -> i64 { 70 }
 
-fn IOP_PHI() -> i64 vow { ensures: result >= 0 } { 71 }
-fn IOP_UPSILON() -> i64 vow { ensures: result >= 0 } { 72 }
+fn IOP_PHI() -> i64 { 71 }
+fn IOP_UPSILON() -> i64 { 72 }
 
-fn IOP_VOW_REQ() -> i64 vow { ensures: result >= 0 } { 73 }
-fn IOP_VOW_ENS() -> i64 vow { ensures: result >= 0 } { 74 }
-fn IOP_VOW_INV() -> i64 vow { ensures: result >= 0 } { 75 }
+fn IOP_VOW_REQ() -> i64 { 73 }
+fn IOP_VOW_ENS() -> i64 { 74 }
+fn IOP_VOW_INV() -> i64 { 75 }
 
-fn IOP_CALL() -> i64 vow { ensures: result >= 0 } { 76 }
+fn IOP_CALL() -> i64 { 76 }
 
-fn IOP_REGION_ALLOC() -> i64 vow { ensures: result >= 0 } { 77 }
+fn IOP_REGION_ALLOC() -> i64 { 77 }
 
-fn IOP_LINEAR_CONSUME() -> i64 vow { ensures: result >= 0 } { 79 }
-fn IOP_LINEAR_BORROW() -> i64 vow { ensures: result >= 0 } { 80 }
+fn IOP_LINEAR_CONSUME() -> i64 { 79 }
+fn IOP_LINEAR_BORROW() -> i64 { 80 }
 
-fn IOP_FIELD_GET() -> i64 vow { ensures: result >= 0 } { 81 }
-fn IOP_FIELD_SET() -> i64 vow { ensures: result >= 0 } { 82 }
+fn IOP_FIELD_GET() -> i64 { 81 }
+fn IOP_FIELD_SET() -> i64 { 82 }
 
-fn IOP_XOR_I32() -> i64 vow { ensures: result >= 0 } { 83 }
-fn IOP_XOR_I64() -> i64 vow { ensures: result >= 0 } { 84 }
+fn IOP_XOR_I32() -> i64 { 83 }
+fn IOP_XOR_I64() -> i64 { 84 }
 
-fn IOP_WADD_U64() -> i64 vow { ensures: result >= 0 } { 85 }
-fn IOP_WSUB_U64() -> i64 vow { ensures: result >= 0 } { 86 }
-fn IOP_WMUL_U64() -> i64 vow { ensures: result >= 0 } { 87 }
-fn IOP_WDIV_U64() -> i64 vow { ensures: result >= 0 } { 88 }
-fn IOP_WREM_U64() -> i64 vow { ensures: result >= 0 } { 89 }
-fn IOP_CADD_U64() -> i64 vow { ensures: result >= 0 } { 90 }
-fn IOP_CSUB_U64() -> i64 vow { ensures: result >= 0 } { 91 }
-fn IOP_CMUL_U64() -> i64 vow { ensures: result >= 0 } { 92 }
-fn IOP_CDIV_U64() -> i64 vow { ensures: result >= 0 } { 93 }
-fn IOP_CREM_U64() -> i64 vow { ensures: result >= 0 } { 94 }
-fn IOP_EQ_U64() -> i64 vow { ensures: result >= 0 } { 95 }
-fn IOP_NE_U64() -> i64 vow { ensures: result >= 0 } { 96 }
-fn IOP_LT_U64() -> i64 vow { ensures: result >= 0 } { 97 }
-fn IOP_LE_U64() -> i64 vow { ensures: result >= 0 } { 98 }
-fn IOP_GT_U64() -> i64 vow { ensures: result >= 0 } { 99 }
-fn IOP_GE_U64() -> i64 vow { ensures: result >= 0 } { 100 }
-fn IOP_XOR_U64() -> i64 vow { ensures: result >= 0 } { 101 }
-fn IOP_CONST_U64() -> i64 vow { ensures: result >= 0 } { 102 }
-fn IOP_CAST_I64_TO_U64() -> i64 vow { ensures: result >= 0 } { 103 }
-fn IOP_CAST_U64_TO_I64() -> i64 vow { ensures: result >= 0 } { 104 }
-fn IOP_DEBUG_CALL() -> i64 vow { ensures: result >= 0 } { 105 }
-fn IOP_BITAND_I64() -> i64 vow { ensures: result >= 0 } { 106 }
-fn IOP_BITOR_I64() -> i64 vow { ensures: result >= 0 } { 107 }
-fn IOP_SHL_I64() -> i64 vow { ensures: result >= 0 } { 108 }
-fn IOP_SHR_I64() -> i64 vow { ensures: result >= 0 } { 109 }
-fn IOP_BITAND_U64() -> i64 vow { ensures: result >= 0 } { 110 }
-fn IOP_BITOR_U64() -> i64 vow { ensures: result >= 0 } { 111 }
-fn IOP_SHL_U64() -> i64 vow { ensures: result >= 0 } { 112 }
-fn IOP_SHR_U64() -> i64 vow { ensures: result >= 0 } { 113 }
+fn IOP_WADD_U64() -> i64 { 85 }
+fn IOP_WSUB_U64() -> i64 { 86 }
+fn IOP_WMUL_U64() -> i64 { 87 }
+fn IOP_WDIV_U64() -> i64 { 88 }
+fn IOP_WREM_U64() -> i64 { 89 }
+fn IOP_CADD_U64() -> i64 { 90 }
+fn IOP_CSUB_U64() -> i64 { 91 }
+fn IOP_CMUL_U64() -> i64 { 92 }
+fn IOP_CDIV_U64() -> i64 { 93 }
+fn IOP_CREM_U64() -> i64 { 94 }
+fn IOP_EQ_U64() -> i64 { 95 }
+fn IOP_NE_U64() -> i64 { 96 }
+fn IOP_LT_U64() -> i64 { 97 }
+fn IOP_LE_U64() -> i64 { 98 }
+fn IOP_GT_U64() -> i64 { 99 }
+fn IOP_GE_U64() -> i64 { 100 }
+fn IOP_XOR_U64() -> i64 { 101 }
+fn IOP_CONST_U64() -> i64 { 102 }
+fn IOP_CAST_I64_TO_U64() -> i64 { 103 }
+fn IOP_CAST_U64_TO_I64() -> i64 { 104 }
+fn IOP_DEBUG_CALL() -> i64 { 105 }
+fn IOP_BITAND_I64() -> i64 { 106 }
+fn IOP_BITOR_I64() -> i64 { 107 }
+fn IOP_SHL_I64() -> i64 { 108 }
+fn IOP_SHR_I64() -> i64 { 109 }
+fn IOP_BITAND_U64() -> i64 { 110 }
+fn IOP_BITOR_U64() -> i64 { 111 }
+fn IOP_SHL_U64() -> i64 { 112 }
+fn IOP_SHR_U64() -> i64 { 113 }
 
-fn IOP_REGION_OPEN() -> i64 vow { ensures: result >= 0 } { 114 }
-fn IOP_REGION_CLOSE() -> i64 vow { ensures: result >= 0 } { 115 }
+fn IOP_REGION_OPEN() -> i64 { 114 }
+fn IOP_REGION_CLOSE() -> i64 { 115 }
 
-fn REGION_KIND_BLOCK()  -> i64 vow { ensures: result >= 0 } { 0 }
-fn REGION_KIND_CALLER() -> i64 vow { ensures: result >= 0 } { 1 }
-fn REGION_KIND_ROOT()   -> i64 vow { ensures: result >= 0 } { 2 }
-fn REGION_KIND_RODATA() -> i64 vow { ensures: result >= 0 } { 3 }
+fn REGION_KIND_BLOCK()  -> i64 { 0 }
+fn REGION_KIND_CALLER() -> i64 { 1 }
+fn REGION_KIND_ROOT()   -> i64 { 2 }
+fn REGION_KIND_RODATA() -> i64 { 3 }
 
 fn region_pack(kind: i64, val: i64) -> i64 vow {
     requires: kind >= 0,
@@ -165,7 +165,7 @@ fn region_rodata() -> i64 { region_pack(REGION_KIND_RODATA(), 0) }
 // Skips 2 because `tests/multi/vmod_decode_bad_version/main.vow` pins the
 // literal byte 2 as its bad-version probe — kept synchronized with the
 // Rust `MODULE_VERSION` constant in `vow-ir/src/serialize.rs`.
-fn MODULE_VERSION() -> i64 vow { ensures: result > 0 } { 3 }
+fn MODULE_VERSION() -> i64 { 3 }
 
 fn iop_is_terminal(op: i64) -> bool vow {
     requires: op >= 0
@@ -173,15 +173,15 @@ fn iop_is_terminal(op: i64) -> bool vow {
     op == IOP_BRANCH() || op == IOP_JUMP() || op == IOP_RETURN() || op == IOP_UNREACHABLE()
 }
 
-fn ITY_I32() -> i64 vow { ensures: result >= 0 } { 0 }
-fn ITY_I64() -> i64 vow { ensures: result >= 0 } { 1 }
-fn ITY_F32() -> i64 vow { ensures: result >= 0 } { 2 }
-fn ITY_F64() -> i64 vow { ensures: result >= 0 } { 3 }
-fn ITY_BOOL() -> i64 vow { ensures: result >= 0 } { 4 }
-fn ITY_UNIT() -> i64 vow { ensures: result >= 0 } { 5 }
-fn ITY_PTR() -> i64 vow { ensures: result >= 0 } { 6 }
-fn ITY_LPTR() -> i64 vow { ensures: result >= 0 } { 7 }
-fn ITY_U64() -> i64 vow { ensures: result >= 0 } { 8 }
+fn ITY_I32() -> i64 { 0 }
+fn ITY_I64() -> i64 { 1 }
+fn ITY_F32() -> i64 { 2 }
+fn ITY_F64() -> i64 { 3 }
+fn ITY_BOOL() -> i64 { 4 }
+fn ITY_UNIT() -> i64 { 5 }
+fn ITY_PTR() -> i64 { 6 }
+fn ITY_LPTR() -> i64 { 7 }
+fn ITY_U64() -> i64 { 8 }
 
 // IDATA_* are the **in-memory** data-kind tags for the self-hosted IR
 // (`IrInst.dk`). They are a separate numbering space from the on-disk
@@ -201,29 +201,29 @@ fn ITY_U64() -> i64 vow { ensures: result >= 0 } { 8 }
 // `IDATA_*` → fixed byte, not via any `dk + offset` formula. That
 // keeps the mapping visible in one place and fails loudly if either
 // numbering space shifts.
-fn IDATA_NONE() -> i64 vow { ensures: result >= 0 } { 0 }
-fn IDATA_CONST_I32() -> i64 vow { ensures: result >= 0 } { 1 }
-fn IDATA_CONST_I64() -> i64 vow { ensures: result >= 0 } { 2 }
-fn IDATA_CONST_F32() -> i64 vow { ensures: result >= 0 } { 3 }
-fn IDATA_CONST_F64() -> i64 vow { ensures: result >= 0 } { 4 }
-fn IDATA_CONST_BOOL() -> i64 vow { ensures: result >= 0 } { 5 }
-fn IDATA_ARG_INDEX() -> i64 vow { ensures: result >= 0 } { 6 }
-fn IDATA_PHI_TARGET() -> i64 vow { ensures: result >= 0 } { 7 }
-fn IDATA_CONST_STR() -> i64 vow { ensures: result >= 0 } { 8 }
-fn IDATA_CALL_TARGET() -> i64 vow { ensures: result >= 0 } { 9 }
-fn IDATA_CALL_EXTERN() -> i64 vow { ensures: result >= 0 } { 10 }
-fn IDATA_BRANCH_TARGETS() -> i64 vow { ensures: result >= 0 } { 11 }
-fn IDATA_JUMP_TARGET() -> i64 vow { ensures: result >= 0 } { 12 }
+fn IDATA_NONE() -> i64 { 0 }
+fn IDATA_CONST_I32() -> i64 { 1 }
+fn IDATA_CONST_I64() -> i64 { 2 }
+fn IDATA_CONST_F32() -> i64 { 3 }
+fn IDATA_CONST_F64() -> i64 { 4 }
+fn IDATA_CONST_BOOL() -> i64 { 5 }
+fn IDATA_ARG_INDEX() -> i64 { 6 }
+fn IDATA_PHI_TARGET() -> i64 { 7 }
+fn IDATA_CONST_STR() -> i64 { 8 }
+fn IDATA_CALL_TARGET() -> i64 { 9 }
+fn IDATA_CALL_EXTERN() -> i64 { 10 }
+fn IDATA_BRANCH_TARGETS() -> i64 { 11 }
+fn IDATA_JUMP_TARGET() -> i64 { 12 }
 // Slot 13 (IDATA_REGION_ID) was retired in Phase 2 alongside the Rust
 // `InstData::RegionId` variant; the shim keeps the numeric slot reserved
 // under `#[allow(dead_code)]` for numbering alignment. Do not reuse.
-fn IDATA_VOW_ID() -> i64 vow { ensures: result >= 0 } { 14 }
-fn IDATA_ALLOC_SIZE() -> i64 vow { ensures: result >= 0 } { 15 }
-fn IDATA_FIELD() -> i64 vow { ensures: result >= 0 } { 16 }
-fn IDATA_CONST_U64() -> i64 vow { ensures: result >= 0 } { 17 }
+fn IDATA_VOW_ID() -> i64 { 14 }
+fn IDATA_ALLOC_SIZE() -> i64 { 15 }
+fn IDATA_FIELD() -> i64 { 16 }
+fn IDATA_CONST_U64() -> i64 { 17 }
 
-fn BLAME_CALLER() -> i64 vow { ensures: result >= 0 } { 0 }
-fn BLAME_CALLEE() -> i64 vow { ensures: result >= 0 } { 1 }
+fn BLAME_CALLER() -> i64 { 0 }
+fn BLAME_CALLEE() -> i64 { 1 }
 
 struct IrInst {
     id: i64,
@@ -254,10 +254,10 @@ struct IrVowEntry {
     offset: i64,
 }
 
-fn RSUM_KIND_FRESH_IN_CALLER() -> i64 vow { ensures: result >= 0 } { 0 }
-fn RSUM_KIND_ALIAS_OF()        -> i64 vow { ensures: result >= 0 } { 1 }
-fn RSUM_KIND_ALIAS_OF_ANY()    -> i64 vow { ensures: result >= 0 } { 2 }
-fn RSUM_KIND_CONSTANT_GLOBAL() -> i64 vow { ensures: result >= 0 } { 3 }
+fn RSUM_KIND_FRESH_IN_CALLER() -> i64 { 0 }
+fn RSUM_KIND_ALIAS_OF()        -> i64 { 1 }
+fn RSUM_KIND_ALIAS_OF_ANY()    -> i64 { 2 }
+fn RSUM_KIND_CONSTANT_GLOBAL() -> i64 { 3 }
 
 struct IrFunction {
     id: i64,

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -133,13 +133,13 @@ fn default_output(path: String) -> String {
     r
 }
 
-fn CMD_NONE() -> i64 vow { ensures: result >= 0 } { 0 }
-fn CMD_BUILD() -> i64 vow { ensures: result >= 0 } { 1 }
-fn CMD_VERIFY() -> i64 vow { ensures: result >= 0 } { 2 }
-fn CMD_TEST() -> i64 vow { ensures: result >= 0 } { 3 }
-fn CMD_CONTRACTS() -> i64 vow { ensures: result >= 0 } { 4 }
-fn CMD_SKILL() -> i64 vow { ensures: result >= 0 } { 5 }
-fn CMD_MUTANTS() -> i64 vow { ensures: result >= 0 } { 6 }
+fn CMD_NONE() -> i64 { 0 }
+fn CMD_BUILD() -> i64 { 1 }
+fn CMD_VERIFY() -> i64 { 2 }
+fn CMD_TEST() -> i64 { 3 }
+fn CMD_CONTRACTS() -> i64 { 4 }
+fn CMD_SKILL() -> i64 { 5 }
+fn CMD_MUTANTS() -> i64 { 6 }
 
 fn get_subcommand(argv: Vec<String>) -> i64 {
     if argv.len() < 2 {
@@ -4678,11 +4678,24 @@ fn skill_bundle() -> String {
     r.push_str(String::from("`vow contracts compiler/main.vow` and fails if the `weak` or `tautological` count\n"));
     r.push_str(String::from("exceeds a committed baseline, so a new `ensures result >= 0` cannot slip in\n"));
     r.push_str(String::from("unnoticed. It runs in `scripts/full_test.sh`. The baseline is an upper bound to\n"));
-    r.push_str(String::from("ratchet down as contracts harden -- most of the current `weak` count is the\n"));
-    r.push_str(String::from("constant tag-family functions the structural refactor (#81 follow-up) dissolves.\n"));
-    r.push_str(String::from("The dispatch-totality example above (`binop_opcode`, `ensures: result != -1`) and\n"));
-    r.push_str(String::from("`binop_result_ty` (`ensures: result == ITY_BOOL() || result == ITY_U64() ||\n"));
-    r.push_str(String::from("result == ITY_I64()`) are enforced in `compiler/lower.vow` today.\n"));
+    r.push_str(String::from("ratchet down as contracts harden. The dispatch-totality example above\n"));
+    r.push_str(String::from("(`binop_opcode`, `ensures: result != -1`) and `binop_result_ty`\n"));
+    r.push_str(String::from("(`ensures: result == ITY_BOOL() || result == ITY_U64() || result == ITY_I64()`)\n"));
+    r.push_str(String::from("are enforced in `compiler/lower.vow` today.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Tag families are structural, not contracted.** The bulk of the old `weak`\n"));
+    r.push_str(String::from("count was nullary tag constants -- `fn IOP_VOW_REQ() -> i64 { 73 }`, the `ITY_*`,\n"));
+    r.push_str(String::from("`EXPR_*`, `BINOP_*`, `RSUM_KIND_*`, … enum families. A per-constant `ensures\n"));
+    r.push_str(String::from("result >= 0` proves nothing: a constant's value is the only fact about it, and\n"));
+    r.push_str(String::from("that fact is structural (each is a distinct literal). So these carry **no**\n"));
+    r.push_str(String::from("contract. Their correctness is established where it matters -- at use sites: the\n"));
+    r.push_str(String::from("dispatch-totality contracts above prove every valid tag is handled, the IR\n"));
+    r.push_str(String::from("validator and serializer round-trips exercise every kind, and the binary\n"));
+    r.push_str(String::from("fixed-point bootstrap miscompiles if any two tags collide. Removing the\n"));
+    r.push_str(String::from("contracts cut the compiler's `weak` count from 408 to 11 (#81). The remaining 11\n"));
+    r.push_str(String::from("are genuine parametric functions (the region/span bit-packers and friends) whose\n"));
+    r.push_str(String::from("right contract is a round-trip or enumerated postcondition -- the next hardening\n"));
+    r.push_str(String::from("target, not noise.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## References\n"));
     r.push_str(String::from("\n"));
@@ -8421,11 +8434,24 @@ fn skill_support_content_3() -> String {
     r.push_str(String::from("`vow contracts compiler/main.vow` and fails if the `weak` or `tautological` count\n"));
     r.push_str(String::from("exceeds a committed baseline, so a new `ensures result >= 0` cannot slip in\n"));
     r.push_str(String::from("unnoticed. It runs in `scripts/full_test.sh`. The baseline is an upper bound to\n"));
-    r.push_str(String::from("ratchet down as contracts harden -- most of the current `weak` count is the\n"));
-    r.push_str(String::from("constant tag-family functions the structural refactor (#81 follow-up) dissolves.\n"));
-    r.push_str(String::from("The dispatch-totality example above (`binop_opcode`, `ensures: result != -1`) and\n"));
-    r.push_str(String::from("`binop_result_ty` (`ensures: result == ITY_BOOL() || result == ITY_U64() ||\n"));
-    r.push_str(String::from("result == ITY_I64()`) are enforced in `compiler/lower.vow` today.\n"));
+    r.push_str(String::from("ratchet down as contracts harden. The dispatch-totality example above\n"));
+    r.push_str(String::from("(`binop_opcode`, `ensures: result != -1`) and `binop_result_ty`\n"));
+    r.push_str(String::from("(`ensures: result == ITY_BOOL() || result == ITY_U64() || result == ITY_I64()`)\n"));
+    r.push_str(String::from("are enforced in `compiler/lower.vow` today.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("**Tag families are structural, not contracted.** The bulk of the old `weak`\n"));
+    r.push_str(String::from("count was nullary tag constants -- `fn IOP_VOW_REQ() -> i64 { 73 }`, the `ITY_*`,\n"));
+    r.push_str(String::from("`EXPR_*`, `BINOP_*`, `RSUM_KIND_*`, … enum families. A per-constant `ensures\n"));
+    r.push_str(String::from("result >= 0` proves nothing: a constant's value is the only fact about it, and\n"));
+    r.push_str(String::from("that fact is structural (each is a distinct literal). So these carry **no**\n"));
+    r.push_str(String::from("contract. Their correctness is established where it matters -- at use sites: the\n"));
+    r.push_str(String::from("dispatch-totality contracts above prove every valid tag is handled, the IR\n"));
+    r.push_str(String::from("validator and serializer round-trips exercise every kind, and the binary\n"));
+    r.push_str(String::from("fixed-point bootstrap miscompiles if any two tags collide. Removing the\n"));
+    r.push_str(String::from("contracts cut the compiler's `weak` count from 408 to 11 (#81). The remaining 11\n"));
+    r.push_str(String::from("are genuine parametric functions (the region/span bit-packers and friends) whose\n"));
+    r.push_str(String::from("right contract is a round-trip or enumerated postcondition -- the next hardening\n"));
+    r.push_str(String::from("target, not noise.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## References\n"));
     r.push_str(String::from("\n"));

--- a/compiler/module_io.vow
+++ b/compiler/module_io.vow
@@ -10,18 +10,18 @@ module ModuleIo
 
 use ir
 
-fn MODULE_MAGIC_0() -> i64 vow { ensures: result >= 0 } { 86 }   // 'V'
-fn MODULE_MAGIC_1() -> i64 vow { ensures: result >= 0 } { 77 }   // 'M'
-fn MODULE_MAGIC_2() -> i64 vow { ensures: result >= 0 } { 79 }   // 'O'
-fn MODULE_MAGIC_3() -> i64 vow { ensures: result >= 0 } { 68 }   // 'D'
+fn MODULE_MAGIC_0() -> i64 { 86 }   // 'V'
+fn MODULE_MAGIC_1() -> i64 { 77 }   // 'M'
+fn MODULE_MAGIC_2() -> i64 { 79 }   // 'O'
+fn MODULE_MAGIC_3() -> i64 { 68 }   // 'D'
 
-fn BLAME_NONE() -> i64 vow { ensures: result >= 0 } { 2 }
+fn BLAME_NONE() -> i64 { 2 }
 
-fn EFFECT_IO() -> i64 vow { ensures: result >= 0 } { 1 }
-fn EFFECT_PANIC() -> i64 vow { ensures: result >= 0 } { 2 }
-fn EFFECT_READ() -> i64 vow { ensures: result >= 0 } { 4 }
-fn EFFECT_UNSAFE() -> i64 vow { ensures: result >= 0 } { 8 }
-fn EFFECT_WRITE() -> i64 vow { ensures: result >= 0 } { 16 }
+fn EFFECT_IO() -> i64 { 1 }
+fn EFFECT_PANIC() -> i64 { 2 }
+fn EFFECT_READ() -> i64 { 4 }
+fn EFFECT_UNSAFE() -> i64 { 8 }
+fn EFFECT_WRITE() -> i64 { 16 }
 
 struct ModuleReader {
     buf: Vec<i64>,

--- a/compiler/token.vow
+++ b/compiler/token.vow
@@ -9,100 +9,100 @@ struct Token {
     span_len: i64,
 }
 
-fn tok_kw_fn() -> i64 vow { ensures: result >= 0 } { 0 }
-fn tok_kw_let() -> i64 vow { ensures: result >= 0 } { 1 }
-fn tok_kw_mut() -> i64 vow { ensures: result >= 0 } { 2 }
-fn tok_kw_struct() -> i64 vow { ensures: result >= 0 } { 3 }
-fn tok_kw_enum() -> i64 vow { ensures: result >= 0 } { 4 }
-fn tok_kw_match() -> i64 vow { ensures: result >= 0 } { 5 }
-fn tok_kw_if() -> i64 vow { ensures: result >= 0 } { 6 }
-fn tok_kw_else() -> i64 vow { ensures: result >= 0 } { 7 }
-fn tok_kw_while() -> i64 vow { ensures: result >= 0 } { 8 }
-fn tok_kw_loop() -> i64 vow { ensures: result >= 0 } { 9 }
-fn tok_kw_break() -> i64 vow { ensures: result >= 0 } { 10 }
-fn tok_kw_return() -> i64 vow { ensures: result >= 0 } { 11 }
-fn tok_kw_pub() -> i64 vow { ensures: result >= 0 } { 12 }
-fn tok_kw_use() -> i64 vow { ensures: result >= 0 } { 13 }
-fn tok_kw_module() -> i64 vow { ensures: result >= 0 } { 14 }
-fn tok_kw_vow() -> i64 vow { ensures: result >= 0 } { 15 }
-fn tok_kw_requires() -> i64 vow { ensures: result >= 0 } { 16 }
-fn tok_kw_ensures() -> i64 vow { ensures: result >= 0 } { 17 }
-fn tok_kw_invariant() -> i64 vow { ensures: result >= 0 } { 18 }
-fn tok_kw_where() -> i64 vow { ensures: result >= 0 } { 19 }
-fn tok_kw_region() -> i64 vow { ensures: result >= 0 } { 20 }
-fn tok_kw_linear() -> i64 vow { ensures: result >= 0 } { 21 }
-fn tok_kw_extern() -> i64 vow { ensures: result >= 0 } { 22 }
-fn tok_kw_impl() -> i64 vow { ensures: result >= 0 } { 23 }
-fn tok_kw_trait() -> i64 vow { ensures: result >= 0 } { 24 }
-fn tok_kw_type() -> i64 vow { ensures: result >= 0 } { 25 }
-fn tok_kw_for() -> i64 vow { ensures: result >= 0 } { 26 }
-fn tok_kw_in() -> i64 vow { ensures: result >= 0 } { 27 }
-fn tok_kw_as() -> i64 vow { ensures: result >= 0 } { 28 }
-fn tok_kw_read() -> i64 vow { ensures: result >= 0 } { 29 }
-fn tok_kw_write() -> i64 vow { ensures: result >= 0 } { 30 }
-fn tok_kw_io() -> i64 vow { ensures: result >= 0 } { 31 }
-fn tok_kw_panic() -> i64 vow { ensures: result >= 0 } { 32 }
-fn tok_kw_unsafe() -> i64 vow { ensures: result >= 0 } { 33 }
-fn tok_lit_int() -> i64 vow { ensures: result >= 0 } { 34 }
-fn tok_lit_bool() -> i64 vow { ensures: result >= 0 } { 35 }
-fn tok_lit_string() -> i64 vow { ensures: result >= 0 } { 36 }
-fn tok_lit_int_suffixed() -> i64 vow { ensures: result >= 0 } { 37 }
-fn tok_ident() -> i64 vow { ensures: result >= 0 } { 38 }
-fn tok_plus() -> i64 vow { ensures: result >= 0 } { 39 }
-fn tok_minus() -> i64 vow { ensures: result >= 0 } { 40 }
-fn tok_star() -> i64 vow { ensures: result >= 0 } { 41 }
-fn tok_slash() -> i64 vow { ensures: result >= 0 } { 42 }
-fn tok_percent() -> i64 vow { ensures: result >= 0 } { 43 }
-fn tok_plus_checked() -> i64 vow { ensures: result >= 0 } { 44 }
-fn tok_minus_checked() -> i64 vow { ensures: result >= 0 } { 45 }
-fn tok_star_checked() -> i64 vow { ensures: result >= 0 } { 46 }
-fn tok_slash_checked() -> i64 vow { ensures: result >= 0 } { 47 }
-fn tok_percent_checked() -> i64 vow { ensures: result >= 0 } { 48 }
-fn tok_eq_eq() -> i64 vow { ensures: result >= 0 } { 49 }
-fn tok_bang_eq() -> i64 vow { ensures: result >= 0 } { 50 }
-fn tok_lt() -> i64 vow { ensures: result >= 0 } { 51 }
-fn tok_gt() -> i64 vow { ensures: result >= 0 } { 52 }
-fn tok_lt_eq() -> i64 vow { ensures: result >= 0 } { 53 }
-fn tok_gt_eq() -> i64 vow { ensures: result >= 0 } { 54 }
-fn tok_amp_amp() -> i64 vow { ensures: result >= 0 } { 55 }
-fn tok_pipe_pipe() -> i64 vow { ensures: result >= 0 } { 56 }
-fn tok_bang() -> i64 vow { ensures: result >= 0 } { 57 }
-fn tok_amp() -> i64 vow { ensures: result >= 0 } { 58 }
-fn tok_question() -> i64 vow { ensures: result >= 0 } { 59 }
-fn tok_fat_arrow() -> i64 vow { ensures: result >= 0 } { 60 }
-fn tok_thin_arrow() -> i64 vow { ensures: result >= 0 } { 61 }
-fn tok_eq() -> i64 vow { ensures: result >= 0 } { 62 }
-fn tok_lbrace() -> i64 vow { ensures: result >= 0 } { 63 }
-fn tok_rbrace() -> i64 vow { ensures: result >= 0 } { 64 }
-fn tok_lparen() -> i64 vow { ensures: result >= 0 } { 65 }
-fn tok_rparen() -> i64 vow { ensures: result >= 0 } { 66 }
-fn tok_lbracket() -> i64 vow { ensures: result >= 0 } { 67 }
-fn tok_rbracket() -> i64 vow { ensures: result >= 0 } { 68 }
-fn tok_comma() -> i64 vow { ensures: result >= 0 } { 69 }
-fn tok_colon() -> i64 vow { ensures: result >= 0 } { 70 }
-fn tok_semicolon() -> i64 vow { ensures: result >= 0 } { 71 }
-fn tok_dot() -> i64 vow { ensures: result >= 0 } { 72 }
-fn tok_colon_colon() -> i64 vow { ensures: result >= 0 } { 73 }
-fn tok_dot_dot() -> i64 vow { ensures: result >= 0 } { 74 }
-fn tok_underscore() -> i64 vow { ensures: result >= 0 } { 75 }
-fn tok_eof() -> i64 vow { ensures: result >= 0 } { 76 }
-fn tok_kw_const() -> i64 vow { ensures: result >= 0 } { 77 }
-fn tok_caret() -> i64 vow { ensures: result >= 0 } { 78 }
-fn tok_kw_continue() -> i64 vow { ensures: result >= 0 } { 79 }
-fn tok_pipe() -> i64 vow { ensures: result >= 0 } { 80 }
+fn tok_kw_fn() -> i64 { 0 }
+fn tok_kw_let() -> i64 { 1 }
+fn tok_kw_mut() -> i64 { 2 }
+fn tok_kw_struct() -> i64 { 3 }
+fn tok_kw_enum() -> i64 { 4 }
+fn tok_kw_match() -> i64 { 5 }
+fn tok_kw_if() -> i64 { 6 }
+fn tok_kw_else() -> i64 { 7 }
+fn tok_kw_while() -> i64 { 8 }
+fn tok_kw_loop() -> i64 { 9 }
+fn tok_kw_break() -> i64 { 10 }
+fn tok_kw_return() -> i64 { 11 }
+fn tok_kw_pub() -> i64 { 12 }
+fn tok_kw_use() -> i64 { 13 }
+fn tok_kw_module() -> i64 { 14 }
+fn tok_kw_vow() -> i64 { 15 }
+fn tok_kw_requires() -> i64 { 16 }
+fn tok_kw_ensures() -> i64 { 17 }
+fn tok_kw_invariant() -> i64 { 18 }
+fn tok_kw_where() -> i64 { 19 }
+fn tok_kw_region() -> i64 { 20 }
+fn tok_kw_linear() -> i64 { 21 }
+fn tok_kw_extern() -> i64 { 22 }
+fn tok_kw_impl() -> i64 { 23 }
+fn tok_kw_trait() -> i64 { 24 }
+fn tok_kw_type() -> i64 { 25 }
+fn tok_kw_for() -> i64 { 26 }
+fn tok_kw_in() -> i64 { 27 }
+fn tok_kw_as() -> i64 { 28 }
+fn tok_kw_read() -> i64 { 29 }
+fn tok_kw_write() -> i64 { 30 }
+fn tok_kw_io() -> i64 { 31 }
+fn tok_kw_panic() -> i64 { 32 }
+fn tok_kw_unsafe() -> i64 { 33 }
+fn tok_lit_int() -> i64 { 34 }
+fn tok_lit_bool() -> i64 { 35 }
+fn tok_lit_string() -> i64 { 36 }
+fn tok_lit_int_suffixed() -> i64 { 37 }
+fn tok_ident() -> i64 { 38 }
+fn tok_plus() -> i64 { 39 }
+fn tok_minus() -> i64 { 40 }
+fn tok_star() -> i64 { 41 }
+fn tok_slash() -> i64 { 42 }
+fn tok_percent() -> i64 { 43 }
+fn tok_plus_checked() -> i64 { 44 }
+fn tok_minus_checked() -> i64 { 45 }
+fn tok_star_checked() -> i64 { 46 }
+fn tok_slash_checked() -> i64 { 47 }
+fn tok_percent_checked() -> i64 { 48 }
+fn tok_eq_eq() -> i64 { 49 }
+fn tok_bang_eq() -> i64 { 50 }
+fn tok_lt() -> i64 { 51 }
+fn tok_gt() -> i64 { 52 }
+fn tok_lt_eq() -> i64 { 53 }
+fn tok_gt_eq() -> i64 { 54 }
+fn tok_amp_amp() -> i64 { 55 }
+fn tok_pipe_pipe() -> i64 { 56 }
+fn tok_bang() -> i64 { 57 }
+fn tok_amp() -> i64 { 58 }
+fn tok_question() -> i64 { 59 }
+fn tok_fat_arrow() -> i64 { 60 }
+fn tok_thin_arrow() -> i64 { 61 }
+fn tok_eq() -> i64 { 62 }
+fn tok_lbrace() -> i64 { 63 }
+fn tok_rbrace() -> i64 { 64 }
+fn tok_lparen() -> i64 { 65 }
+fn tok_rparen() -> i64 { 66 }
+fn tok_lbracket() -> i64 { 67 }
+fn tok_rbracket() -> i64 { 68 }
+fn tok_comma() -> i64 { 69 }
+fn tok_colon() -> i64 { 70 }
+fn tok_semicolon() -> i64 { 71 }
+fn tok_dot() -> i64 { 72 }
+fn tok_colon_colon() -> i64 { 73 }
+fn tok_dot_dot() -> i64 { 74 }
+fn tok_underscore() -> i64 { 75 }
+fn tok_eof() -> i64 { 76 }
+fn tok_kw_const() -> i64 { 77 }
+fn tok_caret() -> i64 { 78 }
+fn tok_kw_continue() -> i64 { 79 }
+fn tok_pipe() -> i64 { 80 }
 
-fn tok_suffix_i8() -> i64 vow { ensures: result >= 0 } { 0 }
-fn tok_suffix_i16() -> i64 vow { ensures: result >= 0 } { 1 }
-fn tok_suffix_i32() -> i64 vow { ensures: result >= 0 } { 2 }
-fn tok_suffix_i64() -> i64 vow { ensures: result >= 0 } { 3 }
-fn tok_suffix_i128() -> i64 vow { ensures: result >= 0 } { 4 }
-fn tok_suffix_u8() -> i64 vow { ensures: result >= 0 } { 5 }
-fn tok_suffix_u16() -> i64 vow { ensures: result >= 0 } { 6 }
-fn tok_suffix_u32() -> i64 vow { ensures: result >= 0 } { 7 }
-fn tok_suffix_u64() -> i64 vow { ensures: result >= 0 } { 8 }
-fn tok_suffix_u128() -> i64 vow { ensures: result >= 0 } { 9 }
-fn tok_suffix_usize() -> i64 vow { ensures: result >= 0 } { 10 }
-fn tok_suffix_isize() -> i64 vow { ensures: result >= 0 } { 11 }
+fn tok_suffix_i8() -> i64 { 0 }
+fn tok_suffix_i16() -> i64 { 1 }
+fn tok_suffix_i32() -> i64 { 2 }
+fn tok_suffix_i64() -> i64 { 3 }
+fn tok_suffix_i128() -> i64 { 4 }
+fn tok_suffix_u8() -> i64 { 5 }
+fn tok_suffix_u16() -> i64 { 6 }
+fn tok_suffix_u32() -> i64 { 7 }
+fn tok_suffix_u64() -> i64 { 8 }
+fn tok_suffix_u128() -> i64 { 9 }
+fn tok_suffix_usize() -> i64 { 10 }
+fn tok_suffix_isize() -> i64 { 11 }
 
 fn make_token(tag: i64, int_val: i64, int_val2: i64, str_val: String, span_start: i64, span_len: i64) -> Token {
     Token {

--- a/compiler/types.vow
+++ b/compiler/types.vow
@@ -1,27 +1,27 @@
 module Types
 
-fn CTY_I8() -> i64 vow { ensures: result >= 0 } { 0 }
-fn CTY_I16() -> i64 vow { ensures: result >= 0 } { 1 }
-fn CTY_I32() -> i64 vow { ensures: result >= 0 } { 2 }
-fn CTY_I64() -> i64 vow { ensures: result >= 0 } { 3 }
-fn CTY_I128() -> i64 vow { ensures: result >= 0 } { 4 }
-fn CTY_U8() -> i64 vow { ensures: result >= 0 } { 5 }
-fn CTY_U16() -> i64 vow { ensures: result >= 0 } { 6 }
-fn CTY_U32() -> i64 vow { ensures: result >= 0 } { 7 }
-fn CTY_U64() -> i64 vow { ensures: result >= 0 } { 8 }
-fn CTY_U128() -> i64 vow { ensures: result >= 0 } { 9 }
-fn CTY_F32() -> i64 vow { ensures: result >= 0 } { 10 }
-fn CTY_F64() -> i64 vow { ensures: result >= 0 } { 11 }
-fn CTY_BOOL() -> i64 vow { ensures: result >= 0 } { 12 }
-fn CTY_STR() -> i64 vow { ensures: result >= 0 } { 13 }
-fn CTY_UNIT() -> i64 vow { ensures: result >= 0 } { 14 }
-fn CTY_NEVER() -> i64 vow { ensures: result >= 0 } { 15 }
-fn CTY_STRUCT() -> i64 vow { ensures: result >= 0 } { 16 }
-fn CTY_ENUM() -> i64 vow { ensures: result >= 0 } { 17 }
-fn CTY_APPLIED() -> i64 vow { ensures: result >= 0 } { 18 }
-fn CTY_REF() -> i64 vow { ensures: result >= 0 } { 19 }
-fn CTY_TUPLE() -> i64 vow { ensures: result >= 0 } { 20 }
-fn CTY_UNKNOWN() -> i64 vow { ensures: result >= 0 } { 21 }
+fn CTY_I8() -> i64 { 0 }
+fn CTY_I16() -> i64 { 1 }
+fn CTY_I32() -> i64 { 2 }
+fn CTY_I64() -> i64 { 3 }
+fn CTY_I128() -> i64 { 4 }
+fn CTY_U8() -> i64 { 5 }
+fn CTY_U16() -> i64 { 6 }
+fn CTY_U32() -> i64 { 7 }
+fn CTY_U64() -> i64 { 8 }
+fn CTY_U128() -> i64 { 9 }
+fn CTY_F32() -> i64 { 10 }
+fn CTY_F64() -> i64 { 11 }
+fn CTY_BOOL() -> i64 { 12 }
+fn CTY_STR() -> i64 { 13 }
+fn CTY_UNIT() -> i64 { 14 }
+fn CTY_NEVER() -> i64 { 15 }
+fn CTY_STRUCT() -> i64 { 16 }
+fn CTY_ENUM() -> i64 { 17 }
+fn CTY_APPLIED() -> i64 { 18 }
+fn CTY_REF() -> i64 { 19 }
+fn CTY_TUPLE() -> i64 { 20 }
+fn CTY_UNKNOWN() -> i64 { 21 }
 
 struct TyStore {
     data: Vec<i64>,

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -5,13 +5,13 @@ use clif
 use ir
 use ir_printer
 
-fn VERIFY_PROVEN() -> i64 vow { ensures: result >= 0 } { 0 }
-fn VERIFY_FAILED() -> i64 vow { ensures: result >= 0 } { 1 }
-fn VERIFY_TIMEOUT() -> i64 vow { ensures: result >= 0 } { 2 }
-fn VERIFY_ERROR() -> i64 vow { ensures: result >= 0 } { 3 }
-fn VERIFY_NOT_FOUND() -> i64 vow { ensures: result >= 0 } { 4 }
-fn VERIFY_PROVEN_IR() -> i64 vow { ensures: result >= 0 } { 5 }
-fn VERIFY_UNKNOWN() -> i64 vow { ensures: result >= 0 } { 6 }
+fn VERIFY_PROVEN() -> i64 { 0 }
+fn VERIFY_FAILED() -> i64 { 1 }
+fn VERIFY_TIMEOUT() -> i64 { 2 }
+fn VERIFY_ERROR() -> i64 { 3 }
+fn VERIFY_NOT_FOUND() -> i64 { 4 }
+fn VERIFY_PROVEN_IR() -> i64 { 5 }
+fn VERIFY_UNKNOWN() -> i64 { 6 }
 
 struct VerifyResult {
     status: i64,

--- a/docs/spec/contracts-methodology.md
+++ b/docs/spec/contracts-methodology.md
@@ -371,11 +371,24 @@ quality of the self-hosted compiler's own contracts: it reads
 `vow contracts compiler/main.vow` and fails if the `weak` or `tautological` count
 exceeds a committed baseline, so a new `ensures result >= 0` cannot slip in
 unnoticed. It runs in `scripts/full_test.sh`. The baseline is an upper bound to
-ratchet down as contracts harden — most of the current `weak` count is the
-constant tag-family functions the structural refactor (#81 follow-up) dissolves.
-The dispatch-totality example above (`binop_opcode`, `ensures: result != -1`) and
-`binop_result_ty` (`ensures: result == ITY_BOOL() || result == ITY_U64() ||
-result == ITY_I64()`) are enforced in `compiler/lower.vow` today.
+ratchet down as contracts harden. The dispatch-totality example above
+(`binop_opcode`, `ensures: result != -1`) and `binop_result_ty`
+(`ensures: result == ITY_BOOL() || result == ITY_U64() || result == ITY_I64()`)
+are enforced in `compiler/lower.vow` today.
+
+**Tag families are structural, not contracted.** The bulk of the old `weak`
+count was nullary tag constants — `fn IOP_VOW_REQ() -> i64 { 73 }`, the `ITY_*`,
+`EXPR_*`, `BINOP_*`, `RSUM_KIND_*`, … enum families. A per-constant `ensures
+result >= 0` proves nothing: a constant's value is the only fact about it, and
+that fact is structural (each is a distinct literal). So these carry **no**
+contract. Their correctness is established where it matters — at use sites: the
+dispatch-totality contracts above prove every valid tag is handled, the IR
+validator and serializer round-trips exercise every kind, and the binary
+fixed-point bootstrap miscompiles if any two tags collide. Removing the
+contracts cut the compiler's `weak` count from 408 to 11 (#81). The remaining 11
+are genuine parametric functions (the region/span bit-packers and friends) whose
+right contract is a round-trip or enumerated postcondition — the next hardening
+target, not noise.
 
 ## References
 

--- a/scripts/check_contract_quality.py
+++ b/scripts/check_contract_quality.py
@@ -19,7 +19,11 @@ import json
 import sys
 
 # The count must not EXCEED these. Ratchet DOWN as contracts harden; never up.
-WEAK_MAX = 408
+# 408 -> 11 once #81 PR-E removed the meaningless `ensures result >= 0` from the
+# tag-constant families (IOP_*, ITY_*, EXPR_*, …). The remaining 11 are real
+# parametric functions (region/span bit-packers and friends) that want a proper
+# round-trip or enumerated postcondition — ratchet down as those are hardened.
+WEAK_MAX = 11
 TAUTOLOGICAL_MAX = 0
 
 try:

--- a/skills/vow/reference/contracts-methodology.md
+++ b/skills/vow/reference/contracts-methodology.md
@@ -371,11 +371,24 @@ quality of the self-hosted compiler's own contracts: it reads
 `vow contracts compiler/main.vow` and fails if the `weak` or `tautological` count
 exceeds a committed baseline, so a new `ensures result >= 0` cannot slip in
 unnoticed. It runs in `scripts/full_test.sh`. The baseline is an upper bound to
-ratchet down as contracts harden — most of the current `weak` count is the
-constant tag-family functions the structural refactor (#81 follow-up) dissolves.
-The dispatch-totality example above (`binop_opcode`, `ensures: result != -1`) and
-`binop_result_ty` (`ensures: result == ITY_BOOL() || result == ITY_U64() ||
-result == ITY_I64()`) are enforced in `compiler/lower.vow` today.
+ratchet down as contracts harden. The dispatch-totality example above
+(`binop_opcode`, `ensures: result != -1`) and `binop_result_ty`
+(`ensures: result == ITY_BOOL() || result == ITY_U64() || result == ITY_I64()`)
+are enforced in `compiler/lower.vow` today.
+
+**Tag families are structural, not contracted.** The bulk of the old `weak`
+count was nullary tag constants — `fn IOP_VOW_REQ() -> i64 { 73 }`, the `ITY_*`,
+`EXPR_*`, `BINOP_*`, `RSUM_KIND_*`, … enum families. A per-constant `ensures
+result >= 0` proves nothing: a constant's value is the only fact about it, and
+that fact is structural (each is a distinct literal). So these carry **no**
+contract. Their correctness is established where it matters — at use sites: the
+dispatch-totality contracts above prove every valid tag is handled, the IR
+validator and serializer round-trips exercise every kind, and the binary
+fixed-point bootstrap miscompiles if any two tags collide. Removing the
+contracts cut the compiler's `weak` count from 408 to 11 (#81). The remaining 11
+are genuine parametric functions (the region/span bit-packers and friends) whose
+right contract is a round-trip or enumerated postcondition — the next hardening
+target, not noise.
 
 ## References
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -3645,11 +3645,24 @@ quality of the self-hosted compiler's own contracts: it reads
 `vow contracts compiler/main.vow` and fails if the `weak` or `tautological` count
 exceeds a committed baseline, so a new `ensures result >= 0` cannot slip in
 unnoticed. It runs in `scripts/full_test.sh`. The baseline is an upper bound to
-ratchet down as contracts harden — most of the current `weak` count is the
-constant tag-family functions the structural refactor (#81 follow-up) dissolves.
-The dispatch-totality example above (`binop_opcode`, `ensures: result != -1`) and
-`binop_result_ty` (`ensures: result == ITY_BOOL() || result == ITY_U64() ||
-result == ITY_I64()`) are enforced in `compiler/lower.vow` today.
+ratchet down as contracts harden. The dispatch-totality example above
+(`binop_opcode`, `ensures: result != -1`) and `binop_result_ty`
+(`ensures: result == ITY_BOOL() || result == ITY_U64() || result == ITY_I64()`)
+are enforced in `compiler/lower.vow` today.
+
+**Tag families are structural, not contracted.** The bulk of the old `weak`
+count was nullary tag constants — `fn IOP_VOW_REQ() -> i64 { 73 }`, the `ITY_*`,
+`EXPR_*`, `BINOP_*`, `RSUM_KIND_*`, … enum families. A per-constant `ensures
+result >= 0` proves nothing: a constant's value is the only fact about it, and
+that fact is structural (each is a distinct literal). So these carry **no**
+contract. Their correctness is established where it matters — at use sites: the
+dispatch-totality contracts above prove every valid tag is handled, the IR
+validator and serializer round-trips exercise every kind, and the binary
+fixed-point bootstrap miscompiles if any two tags collide. Removing the
+contracts cut the compiler's `weak` count from 408 to 11 (#81). The remaining 11
+are genuine parametric functions (the region/span bit-packers and friends) whose
+right contract is a round-trip or enumerated postcondition — the next hardening
+target, not noise.
 
 ## References
 
@@ -7371,11 +7384,24 @@ quality of the self-hosted compiler's own contracts: it reads
 `vow contracts compiler/main.vow` and fails if the `weak` or `tautological` count
 exceeds a committed baseline, so a new `ensures result >= 0` cannot slip in
 unnoticed. It runs in `scripts/full_test.sh`. The baseline is an upper bound to
-ratchet down as contracts harden — most of the current `weak` count is the
-constant tag-family functions the structural refactor (#81 follow-up) dissolves.
-The dispatch-totality example above (`binop_opcode`, `ensures: result != -1`) and
-`binop_result_ty` (`ensures: result == ITY_BOOL() || result == ITY_U64() ||
-result == ITY_I64()`) are enforced in `compiler/lower.vow` today.
+ratchet down as contracts harden. The dispatch-totality example above
+(`binop_opcode`, `ensures: result != -1`) and `binop_result_ty`
+(`ensures: result == ITY_BOOL() || result == ITY_U64() || result == ITY_I64()`)
+are enforced in `compiler/lower.vow` today.
+
+**Tag families are structural, not contracted.** The bulk of the old `weak`
+count was nullary tag constants — `fn IOP_VOW_REQ() -> i64 { 73 }`, the `ITY_*`,
+`EXPR_*`, `BINOP_*`, `RSUM_KIND_*`, … enum families. A per-constant `ensures
+result >= 0` proves nothing: a constant's value is the only fact about it, and
+that fact is structural (each is a distinct literal). So these carry **no**
+contract. Their correctness is established where it matters — at use sites: the
+dispatch-totality contracts above prove every valid tag is handled, the IR
+validator and serializer round-trips exercise every kind, and the binary
+fixed-point bootstrap miscompiles if any two tags collide. Removing the
+contracts cut the compiler's `weak` count from 408 to 11 (#81). The remaining 11
+are genuine parametric functions (the region/span bit-packers and friends) whose
+right contract is a round-trip or enumerated postcondition — the next hardening
+target, not noise.
 
 ## References
 


### PR DESCRIPTION
## What

The structural answer to #81's headline finding — **91% of the self-hosted compiler's contracts were trivial `ensures result >= 0` clauses**. This PR removes the meaningless per-constant contracts from the nullary tag-constant families, cutting the compiler's `weak` contract count from **408 to 11** and ratcheting the CI weak-gate down to lock it in. Stacked on **PR-D (#719)**.

## The idea: tag correctness is structural, not contracted

The bulk of the weak count was nullary enum-tag constants:

```
fn IOP_VOW_REQ() -> i64 vow { ensures: result >= 0 } { 73 }
fn EXPR_LIT_INT() -> i64 vow { ensures: result >= 0 } { 0 }
fn ITY_BOOL()    -> i64 vow { ensures: result >= 0 } { 1 }
```

A per-constant `ensures result >= 0` proves nothing: a constant's value *is* the only fact about it, and that fact is already structural — each is a distinct literal. So these now carry **no** contract:

```
fn IOP_VOW_REQ() -> i64 { 73 }
```

Their correctness is established where it actually matters — at **use sites**, not on the constants:
- the dispatch-totality contracts from PR-D (`binop_opcode: ensures result != -1`) prove every valid tag is handled;
- the IR validator and the `.vmod` serializer round-trips exercise every kind;
- the **binary fixed-point bootstrap** miscompiles (and fails) if any two tags collide.

Removing the contracts is behaviour-preserving (the literal values are untouched, and the verifier already inlines constant functions, so dependent proofs like `binop_opcode` still verify — checked directly). The bootstrap reaches the same fixed point.

## Scope

~400 nullary `fn NAME() -> i64 vow { ensures: result >=? <0|1> } { <literal> }` definitions across `compiler/{ast,diag,ir,module_io,types,token,c_emitter,verifier,main}.vow` — the `IOP_*`, `ITY_*`, `EXPR_*`, `BINOP_*`, `RSUM_KIND_*`, `REGION_KIND_*`, `tok_kw_*`, `CMD_*`, `MODULE_*`, `VOW_*_MAX`, `VERIFY_*` families. Parametric functions are untouched: the **11 remaining** weak contracts are genuine functions (the region/span bit-packers `region_pack`/`span_pack`/…) whose right contract is a round-trip or enumerated postcondition — the next hardening target, documented as such.

## Changes

- **`compiler/*.vow`**: removed the trivial `ensures` from the tag-constant families (values unchanged).
- **`scripts/check_contract_quality.py`**: ratcheted `WEAK_MAX` 408 → 11.
- **`docs/spec/contracts-methodology.md`**: new "Tag families are structural, not contracted" note; embedded skill regenerated.

## Validation

- `vow contracts compiler/main.vow`: weak **11**, tautological 0 (was weak 408). Weak-gate passes at the new baseline; fails if it regresses.
- Self-hosted compiler type-checks (0 errors); full **verifying** bootstrap green; binary **fixed point** (vowc2 == vowc3) — proving the removals changed no behaviour and every surviving contract still verifies.
- Self-hosted only: the tags are Vow functions in the self-hosted compiler; the Rust bootstrap compiler models opcodes as Rust enums (nothing to mirror).

Part of #81.
