### PR TITLE
fix(verify): tighten arena addr bound to strict < (#480)

### DIFF
--- a/vow-runtime/verify/arena.c
+++ b/vow-runtime/verify/arena.c
@@ -54,7 +54,7 @@ struct VowArena {
 /* `addr + align - 1` could wrap uintptr_t for adversarial inputs. Safe here
  * because the harness constrains `align` to {1, 8, 16, 4096} and bounds every
  * chunk to alloc_chunk's non-wrapping low-address model:
- * `total <= ARENA_VERIFY_ADDR_CAP` and
+ * `total < ARENA_VERIFY_ADDR_CAP` and
  * `(uintptr_t)base <= ARENA_VERIFY_ADDR_CAP - total`. Widening either bound
  * (larger symbolic alignments, or removing the chunk-base bound) requires a
  * checked-add guard or explicit __ESBMC_assume on the sum. */
@@ -77,8 +77,12 @@ static void* alloc_chunk(uintptr_t total, int oversized) {
         /* ESBMC models malloc addresses symbolically. Constrain the abstract
          * pointer to the intended non-wrapping low-address model before any
          * base + total arithmetic, matching real hosts that do not map the
-         * top of the address space. */
-        __ESBMC_assume(total <= ARENA_VERIFY_ADDR_CAP);
+         * top of the address space. The bound is strict: addresses must stay
+         * strictly below the flag bit (ARENA_VERIFY_ADDR_CAP aliases
+         * CHUNK_OVERSIZED_FLAG), or `total == CHUNK_OVERSIZED_FLAG` would set
+         * the oversized marker in the size word and `chunk_total()` would mask
+         * the real size to 0. */
+        __ESBMC_assume(total < ARENA_VERIFY_ADDR_CAP);
         __ESBMC_assume(base_addr <= ARENA_VERIFY_ADDR_CAP - total);
         /* Regression assert in derived form: implied by the two assumes above
          * but as a distinct expression, so ESBMC actually exercises it. A


### PR DESCRIPTION
Stacked on #721 (#516).

## What
Change `alloc_chunk`'s first assume from `total <= ARENA_VERIFY_ADDR_CAP` to `total < ARENA_VERIFY_ADDR_CAP`, matching the alias comment ("addresses must stay *strictly* below the flag bit").

## Why
`ARENA_VERIFY_ADDR_CAP` aliases `CHUNK_OVERSIZED_FLAG`. With `<=`, ESBMC could admit `total == CHUNK_OVERSIZED_FLAG`, at which point:
- the non-oversized path writes `word = total = FLAG`, so `chunk_is_oversized()` misreads the chunk as oversized, and
- `chunk_total()` (`word & ~FLAG`) masks the size to 0.

`total` is at most ~8 KB at every callsite, so this edge is unreachable in the harness today — it's a defensive tightening that makes the assume match its prose, as requested in the issue.

## Verification
`( ulimit -v 2000000; make -C vow-runtime/verify verify )` → `VERIFICATION SUCCESSFUL`.

Closes #480.