### PR TITLE
test(full_test): run arena/esbmc verify under the 2 GB ulimit (#546)

### DIFF
--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -877,8 +877,12 @@ echo ""
 # ─── Section 11: Arena Primitive ESBMC Verification ────────────────
 
 section_begin "Section 11: Arena Primitive Verification"
+# Run under the same 2 GB virtual-memory cap as run_self so this also guards
+# against a regression in the verify invocation: with the single-shot
+# --unwind 5 --boolector command (#516) the harness peaks at ~0.5 GB, but
+# --incremental-bmc / Bitwuzla blew past 2 GB and OOM-killed here (#546).
 if command -v esbmc >/dev/null 2>&1; then
-    if (cd vow-runtime/verify && make verify) >"$TMPDIR/arena_verify.log" 2>&1; then
+    if (ulimit -v 2000000; cd vow-runtime/verify && make verify) >"$TMPDIR/arena_verify.log" 2>&1; then
         pass "arena/esbmc"
     else
         fail "arena/esbmc" "$(tail -5 "$TMPDIR/arena_verify.log")"


### PR DESCRIPTION
Stacked on #726 (#422-#426); the bottom of the chain is #721 (#516).

## What
Wrap Section 11's `make verify` in the same `(ulimit -v 2000000; …)` subshell that bounds every `run_self`/`run_self_bin` call.

## Why
Section 11 was the only ESBMC invocation in the suite **not** under the 2 GB virtual-memory cap. Under `--incremental-bmc` / Bitwuzla it OOM-killed when the suite ran inside a 2 GB-capped environment (the failure characterized in this issue). With the single-shot `--unwind 5 --boolector` command from #516, the harness peaks at ~0.5 GB, so the explicit cap:
- makes Section 11 environment-independent, and
- turns it into a **regression guard** — reverting #516 would re-OOM and fail here.

## Verification
Section 11 (`ulimit -v 2000000; cd vow-runtime/verify && make verify`) → `pass arena/esbmc`.

## Out of scope (follow-ups noted in the issue)
- Rec. 2: gate Section 9 (bootstrap triple) behind `--exhaustive` (wall-clock, not memory).
- Rec. 3: re-check the #472 `math/build-no-verify` item.

Closes #546.