### PR TITLE
refactor(verify): rename VerifyOutcome::Skipped to NotRun (#385)

### DIFF
--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -8956,7 +8956,9 @@ pub struct CeCallSite {
 
 enum VerifyOutcome {
     /// ESBMC not invoked (`--no-verify`); maps to `BuildStatus::Unverified` (exit 0).
-    Skipped,
+    /// Named `NotRun` (not `Skipped`) to avoid colliding with `SkippedNonModelable`,
+    /// which has the opposite exit code.
+    NotRun,
     /// ESBMC ran but ≥1 vowed function non-modelable; maps to `BuildStatus::Skipped` (exit 1).
     SkippedNonModelable,
     Proven,
@@ -10081,7 +10083,7 @@ fn verify_outcome_to_output_with_skipped(
             Some("error".to_string()),
             Some(message),
         ),
-        VerifyOutcome::Skipped => (BuildStatus::Unverified, vec![], None, None),
+        VerifyOutcome::NotRun => (BuildStatus::Unverified, vec![], None, None),
         VerifyOutcome::SkippedNonModelable => (BuildStatus::Skipped, vec![], None, None),
         VerifyOutcome::Proven => (BuildStatus::Verified, vec![], None, None),
         VerifyOutcome::ToolNotFound => {
@@ -10324,7 +10326,7 @@ fn run_pipeline_from_frontend(
     let verify_config = *config;
     let verify_handle = thread::spawn(move || -> (VerifyOutcome, Vec<SkippedFunction>) {
         if no_verify {
-            return (VerifyOutcome::Skipped, Vec::new());
+            return (VerifyOutcome::NotRun, Vec::new());
         }
         // Test-only fault injection: simulate a verifier-worker crash so the
         // fail-closed JoinError path (#413) is exercised end-to-end. Guarded by


### PR DESCRIPTION
## What
Rename `VerifyOutcome::Skipped` → `VerifyOutcome::NotRun` (definition + both use sites in `vow/src/main.rs`).

## Why
`VerifyOutcome::Skipped` (ESBMC never invoked → `BuildStatus::Unverified`, exit 0) and `VerifyOutcome::SkippedNonModelable` (ESBMC ran, function non-modelable → `BuildStatus::Skipped`, exit 1) were two `Skipped`-themed names in the same enum meaning opposite things w.r.t. exit code — a footgun flagged on #346 (by @claude and the codex P2 review).

The enum is private to `vow/src/main.rs`, so this is purely internal. The JSON `BuildStatus::Unverified → "Unverified"` mapping is unchanged. No spec change required.

## Verification
`cargo build -p vow` clean; no remaining `VerifyOutcome::Skipped` references.

Closes #385.