### PR TITLE
fix(skill): live-toolchain probe must not hard-fail when vow is absent (#582)

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -2340,7 +2340,7 @@ fn skill_entrypoint() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Installed toolchain (live)\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("!`(command -v vow >/dev/null 2>&1 && vow --help 2>/dev/null | head -200) || (command -v build/vowc >/dev/null 2>&1 && build/vowc --help 2>/dev/null | head -200)`\n"));
+    r.push_str(String::from("!`(command -v vow >/dev/null 2>&1 && vow --help 2>/dev/null | head -200) || (command -v build/vowc >/dev/null 2>&1 && build/vowc --help 2>/dev/null | head -200) || echo '(vow toolchain not found on PATH; run scripts/bootstrap.sh to build build/vowc)'`\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("## Core workflow\n"));
     r.push_str(String::from("\n"));

--- a/scripts/generate_help.py
+++ b/scripts/generate_help.py
@@ -866,7 +866,7 @@ def build_skill_entrypoint() -> str:
             "",
             "## Installed toolchain (live)",
             "",
-            "!`(command -v vow >/dev/null 2>&1 && vow --help 2>/dev/null | head -200) || (command -v build/vowc >/dev/null 2>&1 && build/vowc --help 2>/dev/null | head -200)`",
+            "!`(command -v vow >/dev/null 2>&1 && vow --help 2>/dev/null | head -200) || (command -v build/vowc >/dev/null 2>&1 && build/vowc --help 2>/dev/null | head -200) || echo '(vow toolchain not found on PATH; run scripts/bootstrap.sh to build build/vowc)'`",
             "",
             "## Core workflow",
             "",

--- a/skills/vow/SKILL.md
+++ b/skills/vow/SKILL.md
@@ -18,7 +18,7 @@ program or contract, and repeat until the result is `Verified`.
 
 ## Installed toolchain (live)
 
-!`(command -v vow >/dev/null 2>&1 && vow --help 2>/dev/null | head -200) || (command -v build/vowc >/dev/null 2>&1 && build/vowc --help 2>/dev/null | head -200)`
+!`(command -v vow >/dev/null 2>&1 && vow --help 2>/dev/null | head -200) || (command -v build/vowc >/dev/null 2>&1 && build/vowc --help 2>/dev/null | head -200) || echo '(vow toolchain not found on PATH; run scripts/bootstrap.sh to build build/vowc)'`
 
 ## Core workflow
 

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1305,7 +1305,7 @@ program or contract, and repeat until the result is `Verified`.
 
 ## Installed toolchain (live)
 
-!`(command -v vow >/dev/null 2>&1 && vow --help 2>/dev/null | head -200) || (command -v build/vowc >/dev/null 2>&1 && build/vowc --help 2>/dev/null | head -200)`
+!`(command -v vow >/dev/null 2>&1 && vow --help 2>/dev/null | head -200) || (command -v build/vowc >/dev/null 2>&1 && build/vowc --help 2>/dev/null | head -200) || echo '(vow toolchain not found on PATH; run scripts/bootstrap.sh to build build/vowc)'`
 
 ## Core workflow
 


### PR DESCRIPTION
## What
Append a `|| echo '(vow toolchain not found on PATH; run scripts/bootstrap.sh to build build/vowc)'` fallback to the skill's "Installed toolchain (live)" backtick command so it always exits 0.

## Why
When neither `vow` nor the self-hosted compiler is on PATH, the `||`-chain's last clause failed and the whole command exited non-zero, so loading the skill produced:
```
Error: Shell command failed for pattern "!`(command -v vow ...) || (command -v build/vowc ...)`"
```

## How
The string lives in four places kept in lockstep — the `generate_help.py` generator and its three generated copies (`vow/src/main.rs`, `compiler/main.vow`, `skills/vow/SKILL.md`). All four are edited identically, **in place** rather than by re-running `generate_help.py`, to avoid pulling in unrelated skill-doc drift. The fallback uses single quotes so it nests safely inside the Python and Vow double-quoted string literals (precedent: `compiler/mutants_main.vow` already embeds `'` in Vow strings).

## TDD / verification
- With no toolchain on PATH: old command → exit **1**; new command → prints the fallback, exit **0**.
- `ast.parse` of `generate_help.py` OK; `cargo build -p vow` clean; `compiler/main.vow` still parses (string-literal-only change).

Closes #582.
