### PR TITLE
test(full_test): check function parity in compare_verify soft-fail (#377)

### DIFF
--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -124,7 +124,13 @@ soft_fail = rs == 'VerifyFailed' and ss == 'VerifyFailed' and rvs and svs
 if soft_fail:
     if rvs != svs:
         errors.append(f'verify_status: {rvs} vs {svs}')
-    # verify_message is not compared — ESBMC-output text varies across runs and would cause brittle parity failures.
+    # For deterministic inputs the same function should trigger the soft fail on
+    # both compilers; a divergence on which function was selected would otherwise
+    # pass silently (verify_message is still skipped — ESBMC text is non-deterministic).
+    rfn = r.get('function') or ''
+    sfn = s.get('function') or ''
+    if rfn != sfn:
+        errors.append(f'function: {rfn} vs {sfn}')
 elif rs == 'VerifyFailed' and ss == 'VerifyFailed':
     if len(rc) == 0:
         errors.append('rust has no counterexamples for VerifyFailed')


### PR DESCRIPTION
## What
Add a `function`-field parity check to `compare_verify`'s `soft_fail` branch in `scripts/full_test.sh`.

## Why
The soft-fail relaxation (for ESBMC `timeout`/`unknown`/`error`/`tool_not_found` outcomes, which produce no counterexample) compared `verify_status` but not the top-level `function`. For deterministic inputs the same function should trigger the soft fail on both the Rust and self-hosted compilers, so a future divergence on which function gets selected would pass silently. `verify_message` stays excluded — ESBMC's text is non-deterministic.

## TDD
Running the extracted comparator on two soft-fail results:
- same `function` → `OK`
- different `function` → `FAIL: function: foo vs bar`

`bash -n scripts/full_test.sh` passes; the embedded comparator `ast.parse`s clean.

Closes #377.
