### PR TITLE
feat(test): distinguish contract_skipped from verify_failed (#386)

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -1054,6 +1054,7 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                 let vin_flight_fi: Vec<i64> = Vec::new();
                 let vin_flight_tmp: Vec<String> = Vec::new();
                 let mut verify_failed: bool = false;
+                let mut contract_skipped: bool = false;
                 let t_dctx: DiagCtx = checked.dctx;
                 let t_const_fns: Vec<i64> = detect_const_fns(ir_mod);
                 let mut vfi: i64 = 0;
@@ -1096,8 +1097,11 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                         }
                         if !verify_failed {
                             // Fail closed: a non-modelable contract was not statically proved.
+                            // Reported as contract_skipped (ESBMC never invoked) rather than
+                            // verify_failed (a proved violation); a real violation in any other
+                            // function still sets verify_failed, which takes precedence (#386).
                             if skip_if_non_modelable(vf, ir_mod, t_const_fns, t_dctx) {
-                                verify_failed = true;
+                                contract_skipped = true;
                             } else {
                                 let vstarted: EsbmcStart = verify_start(vf, ir_mod, t_max_k_step, vfi, false, String::from(""), String::from(""), String::from(""), t_vec_max, t_string_max, t_hashmap_max, t_btreemap_max);
                                 vin_flight_h.push(vstarted.handle);
@@ -1143,6 +1147,15 @@ fn run_test(argv: Vec<String>) -> i32 [io] {
                     let duration: i64 = time_unix_ms() - start_time;
                     let diag_vf: String = String::from("[{\"error_code\":\"VerifyFailed\",\"message\":\"contract verification failed\",\"severity\":\"error\"}]");
                     let entry: String = emit_test_entry_json(test_path, short_name, String::from("verify_failed"), -1, String::from(""), String::from(""), duration, diag_vf);
+                    entries_json.push(entry);
+                    failed = failed + 1;
+                    skip_exec = true;
+                } else if contract_skipped {
+                    // Fail closed but distinguishable: ESBMC was never invoked
+                    // because a vowed function is non-modelable (#386).
+                    let duration: i64 = time_unix_ms() - start_time;
+                    let diag_cs: String = String::from("[{\"error_code\":\"VerificationSkipped\",\"message\":\"contract verification skipped: function not modelable\",\"severity\":\"error\"}]");
+                    let entry: String = emit_test_entry_json(test_path, short_name, String::from("contract_skipped"), -1, String::from(""), String::from(""), duration, diag_cs);
                     entries_json.push(entry);
                     failed = failed + 1;
                     skip_exec = true;
@@ -3587,7 +3600,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("| `TestsPassed`  | All tests passed                                  |\n"));
     r.push_str(String::from("| `TestsFailed`  | One or more tests failed                          |\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `skipped`.\n"));
+    r.push_str(String::from("Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow decl`\n"));
     r.push_str(String::from("\n"));
@@ -6027,7 +6040,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("        \"name\": { \"type\": \"string\", \"description\": \"Test name (file stem)\" },\n"));
     r.push_str(String::from("        \"status\": {\n"));
     r.push_str(String::from("          \"type\": \"string\",\n"));
-    r.push_str(String::from("          \"enum\": [\"passed\", \"failed\", \"timeout\", \"skipped\", \"compile_error\", \"verify_failed\"],\n"));
+    r.push_str(String::from("          \"enum\": [\"passed\", \"failed\", \"timeout\", \"skipped\", \"compile_error\", \"verify_failed\", \"contract_skipped\"],\n"));
     r.push_str(String::from("          \"description\": \"Per-test outcome\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        \"exit_code\": {\n"));
@@ -7283,7 +7296,7 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `TestsPassed`  | All tests passed                                  |\n"));
     r.push_str(String::from("| `TestsFailed`  | One or more tests failed                          |\n"));
     r.push_str(String::from("\n"));
-    r.push_str(String::from("Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `skipped`.\n"));
+    r.push_str(String::from("Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow decl`\n"));
     r.push_str(String::from("\n"));
@@ -9728,7 +9741,7 @@ fn skill_support_content_11() -> String {
     r.push_str(String::from("        \"name\": { \"type\": \"string\", \"description\": \"Test name (file stem)\" },\n"));
     r.push_str(String::from("        \"status\": {\n"));
     r.push_str(String::from("          \"type\": \"string\",\n"));
-    r.push_str(String::from("          \"enum\": [\"passed\", \"failed\", \"timeout\", \"skipped\", \"compile_error\", \"verify_failed\"],\n"));
+    r.push_str(String::from("          \"enum\": [\"passed\", \"failed\", \"timeout\", \"skipped\", \"compile_error\", \"verify_failed\", \"contract_skipped\"],\n"));
     r.push_str(String::from("          \"description\": \"Per-test outcome\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        \"exit_code\": {\n"));

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -153,7 +153,9 @@ Test discovery: files matching `test_*.vow` or `*_test.vow` under the given dire
 | `TestsPassed`  | All tests passed                                  |
 | `TestsFailed`  | One or more tests failed                          |
 
-Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `skipped`.
+Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.
+
+`contract_skipped` means ESBMC was never invoked because a vowed function is non-modelable (distinct from `verify_failed`, where ESBMC proved a violation). Both are fail-closed — a `contract_skipped` test counts toward `failed` and yields a `TestsFailed` overall status.
 
 ### `vow decl`
 

--- a/docs/spec/schemas/test-result.schema.json
+++ b/docs/spec/schemas/test-result.schema.json
@@ -46,8 +46,8 @@
         "name": { "type": "string", "description": "Test name (file stem)" },
         "status": {
           "type": "string",
-          "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed"],
-          "description": "Per-test outcome"
+          "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed", "contract_skipped"],
+          "description": "Per-test outcome (`contract_skipped`: ESBMC never invoked because a vowed function is non-modelable; fail-closed, counts toward `failed`)"
         },
         "exit_code": {
           "type": ["integer", "null"],

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2552,7 +2552,7 @@ Test discovery: files matching `test_*.vow` or `*_test.vow` under the given dire
 | `TestsPassed`  | All tests passed                                  |
 | `TestsFailed`  | One or more tests failed                          |
 
-Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `skipped`.
+Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.
 
 ### `vow decl`
 
@@ -4992,7 +4992,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
         "name": { "type": "string", "description": "Test name (file stem)" },
         "status": {
           "type": "string",
-          "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed"],
+          "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed", "contract_skipped"],
           "description": "Per-test outcome"
         },
         "exit_code": {
@@ -6233,7 +6233,7 @@ Test discovery: files matching `test_*.vow` or `*_test.vow` under the given dire
 | `TestsPassed`  | All tests passed                                  |
 | `TestsFailed`  | One or more tests failed                          |
 
-Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `skipped`.
+Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.
 
 ### `vow decl`
 
@@ -8668,7 +8668,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
         "name": { "type": "string", "description": "Test name (file stem)" },
         "status": {
           "type": "string",
-          "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed"],
+          "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed", "contract_skipped"],
           "description": "Per-test outcome"
         },
         "exit_code": {
@@ -10671,10 +10671,19 @@ fn run_test_command(
                 continue;
             }
             BuildStatus::VerifyFailed { .. } | BuildStatus::Skipped => {
+                // `Skipped` (≥1 vowed function non-modelable, ESBMC never run)
+                // is reported as `contract_skipped` so consumers can tell it
+                // apart from `verify_failed` (ESBMC proved a violation). Both
+                // are fail-closed — see the `failed` tally below (#386).
+                let status = if matches!(result.status, BuildStatus::Skipped) {
+                    "contract_skipped"
+                } else {
+                    "verify_failed"
+                };
                 entries.push(TestEntry {
                     file: file_str,
                     name,
-                    status: "verify_failed".to_string(),
+                    status: status.to_string(),
                     exit_code: None,
                     stdout: String::new(),
                     stderr: String::new(),
@@ -10801,7 +10810,7 @@ fn run_test_command(
         .filter(|e| {
             matches!(
                 e.status.as_str(),
-                "failed" | "compile_error" | "verify_failed"
+                "failed" | "compile_error" | "verify_failed" | "contract_skipped"
             )
         })
         .count();


### PR DESCRIPTION
Stacked on #728 (#385).

## What
Introduce a distinct `contract_skipped` per-test status in `vowc test` (both compilers), split out of the `verify_failed` bucket.

## Why
`BuildStatus::Skipped` (ESBMC was never invoked because a vowed function is non-modelable) was reported under `"verify_failed"`, so consumers of `vowc test` JSON — the benchmark harness, CI parsers — could not distinguish it from `"ESBMC proved a violation"`. Both are correct failures, but the signals differ (the gap from #346's review).

## Design decision (fail-closed)
`contract_skipped` **still counts toward `failed`** and yields `TestsFailed` / exit 1 — it is a correct failure, just a distinguishable one. This preserves the security goal of #346. In the self-hosted `cmd_test`, a real violation in any function still sets `verify_failed`, which takes precedence over `contract_skipped`.

(Flagged for reviewer: if you'd prefer `contract_skipped` to be a *separate* counter rather than folded into `failed`, that's a one-line change — but it must still produce a non-zero exit to stay fail-closed.)

## Changes
- `vow/src/main.rs` `run_test_command`: split the `VerifyFailed | Skipped` arm so `Skipped` → `"contract_skipped"`; add `contract_skipped` to the `failed` tally.
- `compiler/main.vow` `cmd_test`: add a `contract_skipped` flag set by `skip_if_non_modelable` (instead of `verify_failed`); emit the new status, still counted as failed.
- `docs/spec/cli.md` Per-test status list + `docs/spec/schemas/test-result.schema.json` enum.
- Embedded `--help`/skill copies of the status list and schema enum in both compilers (edited in place to match the spec, not via `generate_help.py`, to avoid unrelated skill-doc drift).

## Verification
- `cargo build -p vow` clean.
- Self-hosted triple test (`Rust→A→B→C`): **byte-identical fixed point** (B == C).
- Functional, both compilers, on `tests/verify-skip/vec_of_string_skipped.vow` (non-modelable):
  ```
  overall: TestsFailed  failed: 1  passed: 0
    vec_of_string_skipped -> contract_skipped
  ```

Closes #386.
