### PR TITLE
test(verify): remove ESBMC unwind/SMT bounds from contract fixtures (#552)

### DIFF
--- a/tests/verify/bounds_correct.vow
+++ b/tests/verify/bounds_correct.vow
@@ -1,24 +1,24 @@
-// Fixed version of off_by_one_bounds: access v[n-1] instead of v[n].
+// Fixed version of off_by_one_bounds: access v[len-1] instead of v[len].
+// Concrete loop bound (8), not a `requires n <= 8` clause: ESBMC unwind limits
+// must never be encoded as contract bounds (see the contract-authoring rules).
 module BoundsCorrect
 
-fn last_element(n: i64) -> i64 vow {
-  requires: n >= 1,
-  requires: n <= 8,
-  ensures: result == n
+fn last_element() -> i64 vow {
+  ensures: result == 8
 } {
   let v: Vec<i64> = Vec::new();
   let mut i: i64 = 0;
-  while i < n vow {
+  while i < 8 vow {
     invariant: i >= 0,
-    invariant: i <= n
+    invariant: i <= 8
   } {
     v.push(i + 1);
     i = i + 1;
   }
-  v[n - 1]
+  v[7]
 }
 
 fn main() -> i32 [io] {
-  print_i64(last_element(3));
+  print_i64(last_element());
   0
 }

--- a/tests/verify/modulo_safe.vow
+++ b/tests/verify/modulo_safe.vow
@@ -1,3 +1,4 @@
+// Fixed version of negative_modulo: requires x >= 0 for non-negative remainder.
 module ModuloSafe
 
 fn mod_positive(x: i64, m: i64) -> i64 vow {

--- a/tests/verify/modulo_safe.vow
+++ b/tests/verify/modulo_safe.vow
@@ -1,12 +1,8 @@
-// Fixed version of negative_modulo: requires x >= 0 for non-negative remainder.
-// Bounded inputs keep verification tractable for SMT.
 module ModuloSafe
 
 fn mod_positive(x: i64, m: i64) -> i64 vow {
   requires: x >= 0,
-  requires: x <= 1000,
   requires: m > 0,
-  requires: m <= 100,
   ensures: result >= 0
 } {
   x - (x / m) * m

--- a/tests/verify/overflow_safe.vow
+++ b/tests/verify/overflow_safe.vow
@@ -1,9 +1,8 @@
-// Fixed version of overflow_ensures: bounds on x prevent wrapping.
 module OverflowSafe
 
 fn twice(x: i64) -> i64 vow {
   requires: x > 0,
-  requires: x <= 4000000000000000000,
+  requires: x <= 4611686018427387903,
   ensures: result > x
 } {
   x + x

--- a/tests/verify/strong_invariant.vow
+++ b/tests/verify/strong_invariant.vow
@@ -1,17 +1,17 @@
 // Fixed version of weak_invariant: invariant correctly relates sum to i.
-// sum == i*(i+1)/2 holds because we add (i+1) each iteration.
+// sum == i*(i+1)/2 holds because we add (i+1) each iteration. Concrete loop
+// bound (8), not a `requires n <= 8` clause (contract-authoring rules: ESBMC
+// unwind limits are not contract bounds).
 module StrongInvariant
 
-fn fill_and_sum(n: i64) -> i64 vow {
-  requires: n >= 0,
-  requires: n <= 8,
+fn fill_and_sum() -> i64 vow {
   ensures: result >= 0
 } {
   let mut sum: i64 = 0;
   let mut i: i64 = 0;
-  while i < n vow {
+  while i < 8 vow {
     invariant: i >= 0,
-    invariant: i <= n,
+    invariant: i <= 8,
     invariant: sum == i * (i + 1) / 2
   } {
     sum = sum + i + 1;
@@ -21,6 +21,6 @@ fn fill_and_sum(n: i64) -> i64 vow {
 }
 
 fn main() -> i32 [io] {
-  print_i64(fill_and_sum(5));
+  print_i64(fill_and_sum());
   0
 }

--- a/tests/verify/vec_fill.vow
+++ b/tests/verify/vec_fill.vow
@@ -1,15 +1,15 @@
+// Concrete loop bound (8), not a `requires n <= 8` clause: ESBMC unwind limits
+// must never be encoded as contract bounds (see the contract-authoring rules).
 module VecFill
 
-fn fill_vec(n: i64) -> Vec<i64> vow {
-  requires: n >= 0,
-  requires: n <= 8,
-  ensures: result.len() == n
+fn fill_vec() -> Vec<i64> vow {
+  ensures: result.len() == 8
 } {
   let v: Vec<i64> = Vec::new();
   let mut i: i64 = 0;
-  while i < n vow {
+  while i < 8 vow {
     invariant: i >= 0,
-    invariant: i <= n
+    invariant: i <= 8
   } {
     v.push(i);
     i = i + 1;
@@ -18,7 +18,7 @@ fn fill_vec(n: i64) -> Vec<i64> vow {
 }
 
 fn main() -> i32 [io] {
-  let v: Vec<i64> = fill_vec(5);
+  let v: Vec<i64> = fill_vec();
   print_i64(v.len());
   0
 }

--- a/tests/verify/where_clamp.vow
+++ b/tests/verify/where_clamp.vow
@@ -1,10 +1,9 @@
 module WhereClamp
 
 fn bounded_add(a: i64 where a >= 0, b: i64 where b >= 0) -> i64 vow {
-  requires: a <= 100,
-  requires: b <= 100,
-  ensures: result >= 0,
-  ensures: result <= 200
+  requires: a <= 9223372036854775807 - b,
+  ensures: result == a + b,
+  ensures: result >= 0
 } {
   a + b
 }


### PR DESCRIPTION
## What
Audit `tests/verify/*.vow` and remove ESBMC unwind / SMT-tractability limits that were encoded as `requires`/`ensures` clauses, per the contract-authoring rules (`CLAUDE.md`: *"ESBMC bounds are not contracts"*).

## Changes
| Fixture | Before | After |
|---|---|---|
| `bounds_correct` | `fn last_element(n) requires n>=1, n<=8` | concrete `while i < 8`; `ensures result == 8` |
| `vec_fill` | `fn fill_vec(n) requires n>=0, n<=8` | concrete `while i < 8`; `ensures result.len() == 8` |
| `strong_invariant` | `fn fill_and_sum(n) requires n>=0, n<=8` | concrete `while i < 8`; `ensures result >= 0` |
| `modulo_safe` | `requires x<=1000, m<=100` (+ x>=0, m>0) | drop the two SMT artifacts; keep `x>=0, m>0` |
| `where_clamp` | `requires a<=100, b<=100; ensures result<=200` | genuine overflow guard `a <= i64::MAX - b`; tight `result == a + b`, `result >= 0` |
| `overflow_safe` | `requires x <= 4000000000000000000` | tighten to the exact `x + x` overflow boundary `x <= 4611686018427387903` (i64::MAX/2) |

`n <= 8` is a pure `--unwind` artifact; `x <= 1000`/`m <= 100` are SMT-tractability artifacts; `a <= 100`/`b <= 100`/`result <= 200` are a contrived bounded example, not an overflow guard. Reshaping the loop fixtures to a concrete bound removes the need for the symbolic-parameter contract entirely.

## Kept (genuine semantic bounds)
- `u64_verify`, `verify_jobs_pool`: real overflow guards.
- `lexer_is_whitespace` `b <= 255`: byte domain.
- `bitwise_mask` `ensures result <= 255`: a true mask postcondition.
- `void_loop_invariant`: already uses a concrete bound.

(`string_push_str_in_bounds`'s `a.len()+b.len() <= 256` was left as-is — whether it is a model bound vs an artifact is unclear; flagging for a follow-up rather than risk weakening it.)

## Verification
All six rewritten fixtures report **Verified** on both compilers (Rust `vow verify` and the self-hosted binary), so `full_test.sh` Section 2 parity is preserved.

Closes #552.
