### PR TITLE
test(verify): assert returned allocation alignment (#430)

### DIFF
--- a/vow-runtime/verify/arena.c
+++ b/vow-runtime/verify/arena.c
@@ -273,6 +273,10 @@ int main(void) {
         /* Allocation pointer lies within the current chunk's usable range. */
         assert((uintptr_t)p >= (uintptr_t)a.current_chunk + CHUNK_LINK_BYTES);
         assert((uintptr_t)p + sz <= a.chunk_end);
+        /* Returned pointer honours the requested alignment (issue #430):
+         * align is part of the allocator contract, so a buggy align_up that
+         * returned an in-bounds but under-aligned pointer must be rejected. */
+        assert(((uintptr_t)p & (align - 1)) == 0);
         /* last_alloc_size is what we just requested. */
         assert(a.last_alloc_size == sz);
 


### PR DESCRIPTION
Reopens #723, which was **accidentally merged** into `vow/issue516-arena-unwind` (merge commit `133ccd8`) and has now been **reverted** (`5a905de`). GitHub does not allow reopening a merged PR, so this PR restores the change for review. Base is now `vow/issue516-arena-unwind` (the original base `vow/issue480-total-strict`/#722 was merged and its branch deleted in the same cascade).

---

## What
Add an alignment postcondition to the symbolic alloc loop:
```c
assert(((uintptr_t)p & (align - 1)) == 0);
```

## Why
`align` is symbolic over `{1, 8, 16, 4096}` and is part of the allocator contract, but the harness only asserted cursor/in-chunk bounds and `last_alloc_size`. A buggy `align_up` returning an in-bounds but under-aligned pointer passed every existing check.

## TDD
- Mutate `align_up` to `return addr;` → harness **FAILS** on the new assert.
- Unmutated harness → **VERIFICATION SUCCESSFUL** (`--unwind 5 --boolector`, ~290 MB).

Closes #430.
