### PR TITLE
test(verify): verify try_extend frame condition (#431, #432)

### DIFF
--- a/vow-runtime/verify/arena.c
+++ b/vow-runtime/verify/arena.c
@@ -287,6 +287,12 @@ int main(void) {
         void* saved_start = a.last_alloc_start;
         uintptr_t saved_cursor = a.cursor;
         uintptr_t saved_chunk_end = a.chunk_end;
+        /* Snapshot the non-owned header fields for the frame condition
+         * (issues #431/#432): try_extend modifies *only* cursor and, on
+         * success, last_alloc_size. */
+        void* saved_first_chunk = a.first_chunk;
+        void* saved_current_chunk = a.current_chunk;
+        uintptr_t saved_retained = a.retained_bytes;
         /* try_extend must return 1 *exactly* when a valid extension fits
          * (issue #433): p is the last allocation and new_size >= sz, so the
          * sole deciding factor is whether the grow fits before chunk_end.
@@ -307,6 +313,17 @@ int main(void) {
             assert(a.last_alloc_start == saved_start);
             assert(a.cursor == saved_cursor);
         }
+
+        /* Frame condition (#431/#432): regardless of success/failure,
+         * try_extend never touches any field other than cursor and (on
+         * success) last_alloc_size. A regression that corrupted, e.g.,
+         * retained_bytes or current_chunk while preserving cursor would
+         * otherwise pass the branch assertions above. */
+        assert(a.first_chunk == saved_first_chunk);
+        assert(a.current_chunk == saved_current_chunk);
+        assert(a.chunk_end == saved_chunk_end);
+        assert(a.last_alloc_start == saved_start);
+        assert(a.retained_bytes == saved_retained);
 
         /* Negative cases: try_extend must reject mismatched calls (#433) —
          * a wrong pointer, a wrong old_size, or a shrink each return 0. */


### PR DESCRIPTION
Re-opens #725, which was merged into `vow/issue516-arena-unwind` by accident and then reverted (revert commit `3598c05`). GitHub does not allow reopening a merged PR and its head branch was auto-deleted, so this is a fresh PR carrying the identical change.

Opened as a **draft** to keep the stacked-PR merge automation from auto-merging it; mark ready when the stack is settled.

---

Snapshot the full `VowArena` header before `try_extend` and assert the **non-owned** fields are invariant on **both** the success and failure paths:
```c
assert(a.first_chunk == saved_first_chunk);
assert(a.current_chunk == saved_current_chunk);
assert(a.chunk_end == saved_chunk_end);
assert(a.last_alloc_start == saved_start);
assert(a.retained_bytes == saved_retained);
```

## Why
`try_extend`'s contract is that it touches **only** `cursor` and (on success) `last_alloc_size`. The harness only checked `last_alloc_start`/`cursor`/`last_alloc_size`, so a regression that corrupted `retained_bytes` or `current_chunk` while preserving those passed silently.

## TDD
- Mutate `try_extend` to also `a->retained_bytes = 0` on success → harness **FAILS** the frame assert.
- Unmutated harness → **VERIFICATION SUCCESSFUL** (`--unwind 5 --boolector`).

Closes #431, closes #432.