### PR TITLE
ci: fix stale Codecov slug, add codecov.yml + coverage badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,9 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: pmatos/vow-lang
+          slug: vow-lang/vow
           files: lcov.info
+          fail_ci_if_error: true
 
   bootstrap:
     # Runs scripts/bootstrap.sh end-to-end so a bootstrap regression

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Vow
 
+[![CI](https://github.com/vow-lang/vow/actions/workflows/ci.yml/badge.svg)](https://github.com/vow-lang/vow/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/vow-lang/vow/graph/badge.svg)](https://codecov.io/gh/vow-lang/vow)
+
 An agent-first programming language with formal verification.
 
 Vow programs carry machine-checked contracts (preconditions, postconditions, loop invariants) that are statically verified by [ESBMC](https://esbmc.org/) bounded model checking. The compiler emits structured JSON output designed for AI agents to consume, enabling a CEGIS (counterexample-guided inductive synthesis) workflow: write code → compile → verify → read counterexamples → fix → iterate.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,36 @@
+# Codecov configuration for vow-lang/vow.
+#
+# Scope: these numbers measure ONLY the Rust crates as exercised by
+# `cargo llvm-cov --all` (cargo unit + integration tests). The large `.vow`
+# end-to-end corpus (tests/, examples/) and the self-hosted bootstrap run the
+# release / self-hosted binaries, which are not Rust-instrumented and therefore
+# contribute nothing here. Crates dominated by that path — notably
+# `vow-clif-shim` (FFI codegen, driven by every bootstrap) and `vow-runtime`
+# (intrinsics called by compiled programs at runtime) — read low despite being
+# heavily exercised end-to-end. Statuses are therefore informational: a
+# structural under-measurement must never block a PR.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true
+
+# Files that are not meaningful coverage *targets*. (`.vow` sources under
+# compiler/ and the benchmark/script trees are not Rust and never appear in
+# lcov; listing them is documentation of intent and harmless.)
+ignore:
+  - "**/tests/**"
+  - "benchmarks"
+  - "bench"
+  - "compiler"
+  - "scripts"


### PR DESCRIPTION
## Summary

Codecov has been wired into CI since `bc3b86d` (2026-02-26), but it has been **silently broken**. The repo moved from `pmatos/vow-lang` to `vow-lang/vow`, yet the upload step still pinned `slug: pmatos/vow-lang`. Because codecov-action v7 defaults to `fail_ci_if_error: false`, the misdirected upload failed quietly — coverage has not actually been tracked since the move.

This PR fixes the slug and hardens the setup.

## Changes

- **`ci.yml`** — correct slug to `vow-lang/vow`; set `fail_ci_if_error: true` so a broken upload fails loudly instead of hiding (this is the failure mode that hid the bug for ~3.5 months).
- **`codecov.yml`** (new) — `project`/`patch` statuses set to **informational** so they never block a PR, an `ignore` list for non-Rust trees, and a header comment documenting scope. Passes the Codecov validator (`Valid!`).
- **`README.md`** — CI + Codecov badges.

## Coverage audit (context)

Reproduced CI's `cargo llvm-cov --all` locally, but with the runtime libs on `VOW_RUNTIME_PATH`/`VOW_CLIF_SHIM_PATH` (so the 8 codegen-and-run e2e tests link) and `--no-fail-fast`:

**TOTAL: 84.3% line · 79.2% region · 85.1% function**

| Crate | line % |
|---|---:|
| vow (driver) | 92.7 |
| vow-verify | 93.0 |
| vow-diag | 93.3 |
| vow-syntax | 87.6 |
| vow-types | 86.1 |
| vow-codegen | 86.0 |
| vow-ir | 84.6 |
| vow-runtime | 59.9 |
| vow-clif-shim | 33.0 |

**Caveat baked into `codecov.yml`:** `cargo llvm-cov` measures only Rust `cargo test`. The 258-file `.vow` corpus (run via the release binary by `scripts/full_test.sh`) and the self-hosted bootstrap are invisible to it, so `vow-clif-shim` (FFI codegen, run by every bootstrap) and `vow-runtime` (`__vow_*` intrinsics) read low despite heavy end-to-end exercise. The percentage is a Rust-unit-test number, not a measure of total compiler exercise.

## Note for reviewer

`fail_ci_if_error: true` makes a Codecov outage redden the required `build-and-test` job. That's the intended trade — silent failure is what caused this — but flip it back to `false` if Codecov flakiness becomes a nuisance; the slug fix alone restores tracking.
