### PR TITLE
fix(skill): resync embedded + mirror skill docs after #386 contract_skipped

### DIFF
--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -3602,6 +3602,8 @@ fn skill_bundle() -> String {
     r.push_str(String::from("\n"));
     r.push_str(String::from("Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.\n"));
     r.push_str(String::from("\n"));
+    r.push_str(String::from("`contract_skipped` means ESBMC was never invoked because a vowed function is non-modelable (distinct from `verify_failed`, where ESBMC proved a violation). Both are fail-closed -- a `contract_skipped` test counts toward `failed` and yields a `TestsFailed` overall status.\n"));
+    r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow decl`\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("Emit declaration file output only.\n"));
@@ -6118,7 +6120,7 @@ fn skill_bundle() -> String {
     r.push_str(String::from("        \"status\": {\n"));
     r.push_str(String::from("          \"type\": \"string\",\n"));
     r.push_str(String::from("          \"enum\": [\"passed\", \"failed\", \"timeout\", \"skipped\", \"compile_error\", \"verify_failed\", \"contract_skipped\"],\n"));
-    r.push_str(String::from("          \"description\": \"Per-test outcome\"\n"));
+    r.push_str(String::from("          \"description\": \"Per-test outcome (`contract_skipped`: ESBMC never invoked because a vowed function is non-modelable; fail-closed, counts toward `failed`)\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        \"exit_code\": {\n"));
     r.push_str(String::from("          \"type\": [\"integer\", \"null\"],\n"));
@@ -7374,6 +7376,8 @@ fn skill_support_content_1() -> String {
     r.push_str(String::from("| `TestsFailed`  | One or more tests failed                          |\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("`contract_skipped` means ESBMC was never invoked because a vowed function is non-modelable (distinct from `verify_failed`, where ESBMC proved a violation). Both are fail-closed -- a `contract_skipped` test counts toward `failed` and yields a `TestsFailed` overall status.\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("### `vow decl`\n"));
     r.push_str(String::from("\n"));
@@ -9896,7 +9900,7 @@ fn skill_support_content_11() -> String {
     r.push_str(String::from("        \"status\": {\n"));
     r.push_str(String::from("          \"type\": \"string\",\n"));
     r.push_str(String::from("          \"enum\": [\"passed\", \"failed\", \"timeout\", \"skipped\", \"compile_error\", \"verify_failed\", \"contract_skipped\"],\n"));
-    r.push_str(String::from("          \"description\": \"Per-test outcome\"\n"));
+    r.push_str(String::from("          \"description\": \"Per-test outcome (`contract_skipped`: ESBMC never invoked because a vowed function is non-modelable; fail-closed, counts toward `failed`)\"\n"));
     r.push_str(String::from("        },\n"));
     r.push_str(String::from("        \"exit_code\": {\n"));
     r.push_str(String::from("          \"type\": [\"integer\", \"null\"],\n"));

--- a/skills/vow/reference/cli.md
+++ b/skills/vow/reference/cli.md
@@ -153,7 +153,9 @@ Test discovery: files matching `test_*.vow` or `*_test.vow` under the given dire
 | `TestsPassed`  | All tests passed                                  |
 | `TestsFailed`  | One or more tests failed                          |
 
-Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `skipped`.
+Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.
+
+`contract_skipped` means ESBMC was never invoked because a vowed function is non-modelable (distinct from `verify_failed`, where ESBMC proved a violation). Both are fail-closed — a `contract_skipped` test counts toward `failed` and yields a `TestsFailed` overall status.
 
 ### `vow decl`
 

--- a/skills/vow/schemas/test-result.schema.json
+++ b/skills/vow/schemas/test-result.schema.json
@@ -46,8 +46,8 @@
         "name": { "type": "string", "description": "Test name (file stem)" },
         "status": {
           "type": "string",
-          "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed"],
-          "description": "Per-test outcome"
+          "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed", "contract_skipped"],
+          "description": "Per-test outcome (`contract_skipped`: ESBMC never invoked because a vowed function is non-modelable; fail-closed, counts toward `failed`)"
         },
         "exit_code": {
           "type": ["integer", "null"],

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -2556,6 +2556,8 @@ Test discovery: files matching `test_*.vow` or `*_test.vow` under the given dire
 
 Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.
 
+`contract_skipped` means ESBMC was never invoked because a vowed function is non-modelable (distinct from `verify_failed`, where ESBMC proved a violation). Both are fail-closed — a `contract_skipped` test counts toward `failed` and yields a `TestsFailed` overall status.
+
 ### `vow decl`
 
 Emit declaration file output only.
@@ -5072,7 +5074,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
         "status": {
           "type": "string",
           "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed", "contract_skipped"],
-          "description": "Per-test outcome"
+          "description": "Per-test outcome (`contract_skipped`: ESBMC never invoked because a vowed function is non-modelable; fail-closed, counts toward `failed`)"
         },
         "exit_code": {
           "type": ["integer", "null"],
@@ -6313,6 +6315,8 @@ Test discovery: files matching `test_*.vow` or `*_test.vow` under the given dire
 | `TestsFailed`  | One or more tests failed                          |
 
 Per-test status: `passed`, `failed`, `timeout`, `compile_error`, `verify_failed`, `contract_skipped`, `skipped`.
+
+`contract_skipped` means ESBMC was never invoked because a vowed function is non-modelable (distinct from `verify_failed`, where ESBMC proved a violation). Both are fail-closed — a `contract_skipped` test counts toward `failed` and yields a `TestsFailed` overall status.
 
 ### `vow decl`
 
@@ -8825,7 +8829,7 @@ Note that `.insert` returns `Option<V>` (the previous value, if any), and `.get`
         "status": {
           "type": "string",
           "enum": ["passed", "failed", "timeout", "skipped", "compile_error", "verify_failed", "contract_skipped"],
-          "description": "Per-test outcome"
+          "description": "Per-test outcome (`contract_skipped`: ESBMC never invoked because a vowed function is non-modelable; fail-closed, counts toward `failed`)"
         },
         "exit_code": {
           "type": ["integer", "null"],


### PR DESCRIPTION
## What

#386 (PR #733) added the `contract_skipped` test status to `docs/spec` (the `test-result.schema.json` `status` enum and `cli.md`) but did **not** run `scripts/generate_help.py`. As a result the compiler-embedded skill copies and the checked-in `skills/vow/` mirror drifted from the spec.

## Symptom

`checked_in_skills_vow_matches_install_output` fails on `main` (`build-and-test` + `build-and-test-macos` red, e.g. on `cfe0fcc`), which also blocks CI on every open PR whose CI builds against main's tip (e.g. #734).

## Fix

Regenerate with the sanctioned tool, `scripts/generate_help.py` (per `scripts/full_test.sh`):

- `vow/src/main.rs`, `compiler/main.vow` — embedded skill copies pick up the `contract_skipped` enum value, its description, and the `cli.md` paragraph.
- `skills/vow/schemas/test-result.schema.json`, `skills/vow/reference/cli.md` — mirror resynced to match the embedded install output.

Minimal, topical diff (4 files, +17/−7); no unrelated embed drift.

## Verification

`cargo test -p vow checked_in_skills_vow_matches_install_output` passes locally. Unblocks CI on `main` and on #734.