### PR TITLE
fix(region): lift loop-carried values out of refreshed loop arenas, reclaiming small Vec leaks (#400)

### DIFF
--- a/compiler/region.vow
+++ b/compiler/region.vow
@@ -2205,6 +2205,13 @@ fn analyze_function(
     // materializing a must_outlive set for every value: for each heap producer,
     // gather direct-use markers plus Phi/call return-alias users, then compute
     // the cached block-tree LCA when only block markers remain.
+    //
+    // Loop-header blocks (back-edge targets). Computed once per function from
+    // the CFG (not the inferred regions, to avoid circularity). A value carried
+    // into a loop-header Phi must not be placed in the header's refreshed
+    // Block(_) arena; see the Upsilon arm of `direct_markers_collect_regions`.
+    let loop_be: BackEdges = detect_loop_back_edges(f);
+    let loop_headers: Vec<i64> = loop_be.headers;
     let mut rbi: i64 = 0;
     while rbi < n_bks {
         let rb: IrBlock = bks[rbi];
@@ -2214,7 +2221,7 @@ fn analyze_function(
             if is_heap_producing_for_region(rinst, int_kinds) {
                 let mut rgn: i64 = value_lub_region(
                     f, rinst.id, rb.id, fidx, id_to_inst, id_to_block,
-                    block_parent, block_depth,
+                    block_parent, block_depth, loop_headers,
                     is_scalar_ity(f.return_ty),
                     int_kinds, int_auxs, int_aliases_list,
                     int_se_targets, int_se_src_kinds, int_se_src_aux,
@@ -2225,12 +2232,15 @@ fn analyze_function(
                 // them to Root for codegen conservatism, which would otherwise
                 // silence the diagnostic. Mirrors the nested structure at
                 // vow-ir/src/region.rs:1437-1455.
+                // Issue #400: only internal-call results that escape to a
+                // hidden caller arena (Caller(_)) are still collapsed to Root.
+                // Block(_) results are kept local — loop-carried escape (the
+                // hazard the old blanket collapse masked) is handled by the
+                // loop-header Upsilon lifting in direct_markers_collect_regions.
                 if rinst.op == IOP_CALL() && rinst.dk != IDATA_CALL_EXTERN() {
                     let rk: i64 = region_kind(rgn);
                     if rk == REGION_KIND_CALLER() {
                         put_inst_region(note_region_keys[fidx], note_region_vals[fidx], rinst.id, rgn);
-                    }
-                    if rk == REGION_KIND_BLOCK() || rk == REGION_KIND_CALLER() {
                         rgn = region_root();
                     }
                 }
@@ -2452,7 +2462,7 @@ fn lookup_inst_block(id_to_block: Vec<i64>, id: i64) -> i64 {
 fn value_lub_region(
     f: IrFunction, id: i64, defining_block: i64, fi: i64,
     id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>,
-    block_parent: Vec<i64>, block_depth: Vec<i64>,
+    block_parent: Vec<i64>, block_depth: Vec<i64>, loop_headers: Vec<i64>,
     return_is_scalar: bool,
     int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
     int_se_targets: Vec<Vec<i64>>, int_se_src_kinds: Vec<Vec<i64>>, int_se_src_aux: Vec<Vec<i64>>
@@ -2474,6 +2484,8 @@ fn value_lub_region(
             cur,
             id_to_inst,
             id_to_block,
+            block_parent,
+            loop_headers,
             markers,
             return_is_scalar,
             int_kinds,
@@ -2598,6 +2610,7 @@ fn region_lub_from_markers(
 fn direct_markers_collect_regions(
     f: IrFunction, id: i64,
     id_to_inst: Vec<IrInst>, id_to_block: Vec<i64>,
+    block_parent: Vec<i64>, loop_headers: Vec<i64>,
     markers: Vec<i64>,
     return_is_scalar: bool,
     int_kinds: Vec<i64>, int_auxs: Vec<i64>, int_aliases_list: Vec<Vec<i64>>,
@@ -2632,7 +2645,22 @@ fn direct_markers_collect_regions(
                     if inst.op == IOP_UPSILON() && ai == 0 && inst.dk == IDATA_PHI_TARGET() {
                         let phi_block: i64 = lookup_inst_block(id_to_block, inst.dv);
                         if phi_block >= 0 {
-                            linear_insert_i64(markers, region_pack(REGION_KIND_BLOCK(), phi_block));
+                            // Issue #400: a source carried into a loop-header
+                            // Phi is live across the back-edge; Block(header)
+                            // would be freed by the loop-region refresh. Lift it
+                            // to the loop's enclosing block region (Root if the
+                            // loop has no enclosing block). A non-loop Phi keeps
+                            // Block(header).
+                            if region_vec_contains_i64(loop_headers, phi_block) {
+                                let lifted_parent: i64 = block_parent_at(block_parent, phi_block);
+                                if lifted_parent >= 0 {
+                                    linear_insert_i64(markers, region_pack(REGION_KIND_BLOCK(), lifted_parent));
+                                } else {
+                                    linear_insert_i64(markers, region_root());
+                                }
+                            } else {
+                                linear_insert_i64(markers, region_pack(REGION_KIND_BLOCK(), phi_block));
+                            }
                             push_region_work(work, seen, inst.dv);
                         } else {
                             linear_insert_i64(markers, region_root());

--- a/tests/run/issue400_internal_call_root_escape.vow
+++ b/tests/run/issue400_internal_call_root_escape.vow
@@ -1,4 +1,3 @@
-// TEST: skip "issue #400: internal-Call heap result rewritten Block/Caller -> Root in vow-ir/src/region.rs:1511-1528"
 // TEST: stdout "ok"
 // Regression for issue #400 (small Vec/String backings leak into root region).
 //
@@ -9,24 +8,23 @@
 // `Block(_)` — placing the backing in `consume`'s block arena,
 // which closes at function exit and frees every chunk it owns.
 //
-// Today the region pass infers `Block(_)` correctly, but then
-// `analyze_function` in `vow-ir/src/region.rs:1511-1528` unconditionally
-// rewrites any internal-`Call` heap producer with region
-// `Block(_) | Caller(_)` to `RegionId::Root`, citing
-//   "Hidden caller-region codegen is still too shallow for unresolved/
-//    internal aggregate FreshInCaller call results that are immediately
-//    projected and repackaged."
-// (commit 3916da6 "Implement block-tree region LUB").
+// The region pass infers `Block(_)` for this call result. A previous
+// blanket rewrite in `analyze_function` collapsed *every* internal-`Call`
+// heap producer with region `Block(_) | Caller(_)` to `RegionId::Root` —
+// so transient Vec<i64>/Vec<String>/HashMap<K,V> returns were pinned in
+// the root arena and never freed. PR #392 (issue #391) could not reclaim
+// them because the backings are <2048 bytes and live inside shared normal
+// chunks; `arena_try_free_oversized_chunk` only frees single-resident
+// oversized chunks.
 //
-// The rewrite was intended to protect a specific projection-and-
-// repackaging codegen path, but it fires for every internal-Call heap
-// result — so transient Vec<i64>/Vec<String>/HashMap<K,V> returns get
-// pinned in the root arena and never freed. PR #392 (issue #391) cannot
-// reclaim them because the backings are <2048 bytes and live inside
-// shared normal chunks; `arena_try_free_oversized_chunk` only frees
-// single-resident oversized chunks.
+// The collapse now fires only for `Caller(_)`. Genuinely block-local
+// internal-call results (no return, no store, no loop-carry — like the
+// one below) keep their `Block(_)` region and free at block close. The
+// loop-carried escape the blanket collapse used to mask is handled
+// soundly in `must_outlive` by lifting loop-header Upsilon sources out of
+// the refreshed loop arena.
 //
-// Once the over-approximation is fixed, the loop below should leave
+// With the fix in place, the loop below leaves
 // `memory_root_arena_bytes()` essentially unchanged from before the
 // loop (modulo the initial 4112-byte root chunk plus any small
 // per-iteration allocations that genuinely escape — the Vec is not one

--- a/tests/run/issue400_loop_carried_aggregate.vow
+++ b/tests/run/issue400_loop_carried_aggregate.vow
@@ -1,0 +1,86 @@
+// TEST: stdout "ok"
+// Regression for issue #400 (loop-carried struct-wrapped Vec must not be
+// freed by the loop-region refresh).
+//
+// `Box` wraps a `Vec<i64>`. `box_step` takes the box by value, aliases its
+// backing via a FieldGet (`let d = b.data`), mutates it in place, and returns
+// a new box wrapping the SAME backing. The loop reassigns `b = box_step(b, i)`
+// every iteration (loop-carried via an Upsilon into the loop-header Phi) and
+// reads the backing both inside the loop (`box_first`) and after it
+// (`box_sum`), so the backing must stay live across every iteration.
+//
+// If region inference placed the loop-carried backing in the refreshed
+// `Block(loop)` arena, the back-edge close would free it while still live —
+// a use-after-free that corrupts the running read and the final sum. The fix
+// lifts loop-carried Upsilon sources out of the refreshed loop arena into the
+// loop's enclosing block region. This is the heap-MinHeap pattern distilled.
+module Issue400LoopCarriedAggregate
+
+struct Box {
+    data: Vec<i64>,
+    size: i64,
+}
+
+fn box_new() -> Box {
+    let v: Vec<i64> = Vec::new();
+    v.push(7);
+    Box { data: v, size: 1 }
+}
+
+fn box_step(b: Box, val: i64) -> Box {
+    let d: Vec<i64> = b.data;
+    d.push(val);
+    Box { data: d, size: b.size + 1 }
+}
+
+fn box_first(b: Box) -> i64 {
+    let d: Vec<i64> = b.data;
+    d[0]
+}
+
+fn box_size(b: Box) -> i64 {
+    b.size
+}
+
+fn box_sum(b: Box) -> i64 {
+    let d: Vec<i64> = b.data;
+    let mut s: i64 = 0;
+    let mut i: i64 = 0;
+    while i < d.len() {
+        s = s + d[i];
+        i = i + 1;
+    }
+    s
+}
+
+fn main() -> i32 [io] {
+    let mut b: Box = box_new();
+    let mut acc: i64 = 0;
+    let mut i: i64 = 1;
+    // Push 1..=1000; read the carried backing's first element each iteration
+    // (always 7) so an early free would corrupt the running total.
+    while i <= 1000 {
+        acc = acc + box_first(b);
+        b = box_step(b, i);
+        i = i + 1;
+    }
+    // backing = [7, 1, 2, ..., 1000]; sum = 7 + (1000*1001/2) = 500507.
+    // box_sum walks the whole grown backing, so a freed/realloc'd backing
+    // would yield a wrong total.
+    let total: i64 = box_sum(b);
+    let sz: i64 = box_size(b);
+    let running_ok: bool = acc == 7000;
+    let sum_ok: bool = total == 500507;
+    let size_ok: bool = sz == 1001;
+    if running_ok && sum_ok && size_ok {
+        print_str("ok");
+    } else {
+        print_str("running=");
+        print_i64(acc);
+        print_str(" sum=");
+        print_i64(total);
+        print_str(" size=");
+        print_i64(sz);
+    }
+    0
+}

--- a/vow-ir/src/region.rs
+++ b/vow-ir/src/region.rs
@@ -818,6 +818,13 @@ impl BlockTree {
     fn depth_of(&self, block: BlockId) -> u32 {
         self.depth.get(&block).copied().unwrap_or(0)
     }
+
+    /// The block-tree parent of `block` (its enclosing region in the DFS
+    /// spanning tree), or `None` for a DFS root. Used to lift a loop-carried
+    /// value out of a refreshed loop region into the loop's enclosing scope.
+    fn parent_of(&self, block: BlockId) -> Option<BlockId> {
+        self.parent.get(&block).copied().flatten()
+    }
 }
 
 fn emit_live_linear_errors(
@@ -1462,6 +1469,16 @@ fn analyze_function(
     let phi_arms = collect_phi_arms(func);
     let block_tree = BlockTree::from_function(func);
 
+    // Loop-header blocks (back-edge targets). A value loop-carried through
+    // such a Phi must not be placed in the header's own `Block(_)` region:
+    // that arena is refreshed (closed + reopened) on every back-edge, so a
+    // value live across the back-edge would be freed while still reachable.
+    // Computed from the CFG (not the inferred regions) to avoid circularity.
+    let loop_headers: BTreeSet<BlockId> = detect_loop_back_edges(func)
+        .into_iter()
+        .map(|(_, header)| header)
+        .collect();
+
     // Forward sweep collecting use-set contributions.
     for block in &func.blocks {
         for inst in &block.insts {
@@ -1473,6 +1490,8 @@ fn analyze_function(
                 is_scalar_ty(func.return_ty),
                 &mut must_outlive,
                 &mut summary,
+                &loop_headers,
+                &block_tree,
             );
         }
     }
@@ -1511,19 +1530,18 @@ fn analyze_function(
             if inst.opcode == Opcode::Call
                 && !matches!(&inst.data, InstData::CallExtern(sym) if heap_producing_extern(sym))
             {
-                // Hidden caller-region codegen is still too shallow for
-                // unresolved/internal aggregate FreshInCaller call results
-                // that are immediately projected and repackaged. Keep those
-                // materialisations conservative, while allowing recognised
-                // runtime heap producers to route through their explicit
-                // arena-aware ABI.
-                if matches!(region_id, RegionId::Block(_) | RegionId::Caller(_)) {
-                    if matches!(region_id, RegionId::Caller(_)) {
-                        // Stash the pre-rewrite Caller(_) so the note pass can
-                        // see it; only Caller(_) ever fires `RegionRootEscape`,
-                        // so capturing Block(_) would just inflate the map.
-                        note_region_map.insert(inst.id, region_id);
-                    }
+                // Internal `Call` heap results that escape to a hidden caller
+                // arena (`Caller(_)`) are still collapsed to `Root` for codegen
+                // conservatism. `Block(_)` results are now safe to keep local:
+                // loop-carried escape — the hazard the previous blanket collapse
+                // masked (issue #400) — is handled in `must_outlive` via the
+                // loop-header Upsilon lifting above, so a genuinely block-local
+                // internal-call Vec/String/Map is freed at its block's close
+                // instead of leaking into the root arena.
+                if matches!(region_id, RegionId::Caller(_)) {
+                    // Stash the pre-rewrite Caller(_) so the note pass can see
+                    // it; only Caller(_) ever fires `RegionRootEscape`.
+                    note_region_map.insert(inst.id, region_id);
                     region_id = RegionId::Root;
                 }
             }
@@ -1855,6 +1873,8 @@ fn handle_inst(
     return_is_scalar: bool,
     must_outlive: &mut BTreeMap<InstId, BTreeSet<MustOutliveMarker>>,
     summary: &mut InternalSummary,
+    loop_headers: &BTreeSet<BlockId>,
+    block_tree: &BlockTree,
 ) {
     match inst.opcode {
         Opcode::Return => {
@@ -1909,11 +1929,21 @@ fn handle_inst(
                 && let Some(&source_id) = inst.args.first()
                 && let Some((target_block, _)) = inst_lookup.get(&target_phi)
             {
-                add_marker(
-                    must_outlive,
-                    source_id,
-                    MustOutliveMarker::Block(*target_block),
-                );
+                // The source is carried into the Phi at `target_block`. If that
+                // block is a loop header, the source is live across the loop's
+                // back-edge, so it must outlive the refreshed `Block(header)`
+                // arena. Lift it to the loop's enclosing block region (the
+                // header's block-tree parent); fall back to Root when the loop
+                // has no enclosing block. A non-loop Phi keeps `Block(header)`.
+                let marker = if loop_headers.contains(target_block) {
+                    match block_tree.parent_of(*target_block) {
+                        Some(parent) => MustOutliveMarker::Block(parent),
+                        None => MustOutliveMarker::Root,
+                    }
+                } else {
+                    MustOutliveMarker::Block(*target_block)
+                };
+                add_marker(must_outlive, source_id, marker);
             }
         }
         Opcode::Call => {
@@ -6035,7 +6065,13 @@ mod tests {
     }
 
     #[test]
-    fn fresh_in_caller_call_result_used_locally_remains_root_until_aggregate_codegen() {
+    fn fresh_in_caller_call_result_used_locally_stays_block_local() {
+        // Issue #400: an internal `Call` FreshInCaller result that is used
+        // locally and never escapes (no return, no store, no loop-carry) must
+        // resolve to its own `Block(_)` region so it frees at block close,
+        // rather than being collapsed into the never-freed root arena. The old
+        // blanket `Block(_) | Caller(_) -> Root` collapse leaked exactly this
+        // shape; the collapse now fires only for `Caller(_)`.
         let callee = build_returning_alloc();
         let caller_insts = vec![
             inst(
@@ -6054,8 +6090,85 @@ mod tests {
         let call = &m.functions[1].blocks[0].insts[0];
         assert_eq!(
             call.region,
-            RegionId::Root,
-            "FreshInCaller call result materialization remains conservative until aggregate hidden-region codegen is complete"
+            RegionId::Block(BlockId(0)),
+            "non-escaping FreshInCaller call result should be block-local, not collapsed to Root"
+        );
+    }
+
+    #[test]
+    fn loop_carried_alloc_is_lifted_out_of_refreshed_header_region() {
+        // Issue #400: a heap value created inside a loop body and carried
+        // across the back-edge (an Upsilon source feeding the loop-header Phi)
+        // must NOT be placed in the loop header's own Block(_) region — that
+        // arena is refreshed (closed + reopened) on every back-edge, which
+        // would free the value while it is still live in the next iteration.
+        // It is lifted to the loop's enclosing block region instead. Without
+        // the lift its must_outlive set {Block(header), Block(body)} LCAs to
+        // Block(header) (the refreshed arena); the lift replaces the header
+        // marker with the header's parent so the LCA becomes the enclosing
+        // block.
+        let entry_alloc = inst(
+            1,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        let b0 = vec![
+            entry_alloc,
+            inst(
+                2,
+                Opcode::Upsilon,
+                Ty::Unit,
+                vec![1],
+                InstData::PhiTarget(InstId(5)),
+            ),
+            jump_inst(3, 1),
+        ];
+        let b1 = vec![
+            inst(5, Opcode::Phi, Ty::Ptr, vec![], InstData::None),
+            branch_inst(6, 2, 3),
+        ];
+        // The allocation under test: created in the loop body, carried back to
+        // the header Phi across the back-edge (block 2 -> block 1).
+        let body_alloc = inst(
+            7,
+            Opcode::RegionAlloc,
+            Ty::Ptr,
+            vec![],
+            InstData::AllocSize { size: 16, align: 8 },
+        );
+        let b2 = vec![
+            body_alloc,
+            inst(
+                8,
+                Opcode::Upsilon,
+                Ty::Unit,
+                vec![7],
+                InstData::PhiTarget(InstId(5)),
+            ),
+            jump_inst(9, 1),
+        ];
+        let b3 = vec![return_unit_inst(10)];
+        let f = function(
+            0,
+            "loop_carry",
+            vec![],
+            Ty::Unit,
+            vec![block(0, b0), block(1, b1), block(2, b2), block(3, b3)],
+        );
+        let mut m = module(vec![f]);
+        infer_regions(&mut m);
+        let carried = m.functions[0].blocks[2].insts[0].region;
+        assert_ne!(
+            carried,
+            RegionId::Block(BlockId(1)),
+            "loop-carried alloc must not land in the refreshed loop-header region"
+        );
+        assert_eq!(
+            carried,
+            RegionId::Block(BlockId(0)),
+            "loop-carried alloc should be lifted to the loop's enclosing block region"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #400. Small short-lived `Vec`/`String`/`Map` backings returned from helper functions leaked into the never-freed root arena (~90 B/iter; OOMs `vow-lean-kernel` on `init.ndjson`).

The leak came from a blanket rewrite in the region pass: every internal-`Call` FreshInCaller heap result whose inferred region was `Block(_) | Caller(_)` was collapsed to `RegionId::Root`. That collapse was **load-bearing** — it masked a `must_outlive` under-approximation. A value carried across a loop back-edge (an Upsilon feeding the loop-header Phi) was marked `Block(loop_header)`, which is exactly the arena the loop-region *refresh* closes (`__vow_arena_close` frees every chunk) on each back-edge. Naively narrowing the collapse to keep `Block(_)` therefore produced a **use-after-free** (verified firsthand: `lib/heap` drain loops truncate identically in both compilers).

## Fix

Make `must_outlive` escape-sound at the source, then narrow the collapse:

1. **Loop-carried lifting** — when an Upsilon source feeds a loop-header Phi (header detected from the CFG via `detect_loop_back_edges`, not the inferred regions, to avoid circularity), lift its marker to the loop's **enclosing** block region (`block_tree.parent_of(header)`), falling back to `Root` when the loop has no enclosing block. The LUB then resolves the value to a region that outlives the loop instead of `Block(loop_header)`.
2. **Narrow the collapse** — with loop-carried escape handled, the `Block(_)` half of the collapse is dropped; only `Caller(_)` internal-call results are still routed to `Root` (codegen conservatism for hidden-caller-arena results). Genuinely block-local internal-call `Vec`s now free at block close instead of leaking.

Aggregate-field escape (the heap struct wrapping a `Vec`) is carried to the embedded backing by the existing alias-propagation edges (FieldGet / stored-value / FreshInCaller-result→args); the lift on the loop-carried struct flows through them.

Applied **identically** to the Rust bootstrap (`vow-ir/src/region.rs`) and the self-hosted compiler (`compiler/region.vow`). The self-hosted lift reuses `region_pack`/`region_root` (no new marker encoding — avoids colliding with the packed-marker scheme).

## Validation

- **Binary fixed point holds** — self-hosted Stage B == Stage C (`sha256` identical).
- `#400` leak reproducer: 4,465,632 B leaked → `ok` (root-arena delta < 1 MB).
- `lib/heap` drain loops: correct in both compilers (no UAF).
- New distilled regression `tests/run/issue400_loop_carried_aggregate.vow` (struct-wrapped `Vec`, loop-carried, read-after-reassign): `ok`.
- `cargo test --all`: 1073 passed, 0 failed. `cargo clippy --all -- -D warnings`: clean.
- `scripts/full_test.sh`: green.

## Tests

- Unskip `tests/run/issue400_internal_call_root_escape.vow` (leak reproducer).
- Add `tests/run/issue400_loop_carried_aggregate.vow` (the heap UAF distilled — the soundness contract: no leak **and** no UAF together).
- `region.rs` unit tests: add `loop_carried_alloc_is_lifted_out_of_refreshed_header_region`; rename/flip `fresh_in_caller_call_result_used_locally_*` to expect `Block(_)` (block-local) instead of `Root`.

## Notes

- `compiler/tests/test_region.vow` is orphaned infra (no harness references it; doesn't build standalone — its `use` paths resolve under `compiler/tests/`). The self-hosted change is instead covered by the binary fixed point plus `tests/run/` Section 4, which compiles both new tests with the self-hosted compiler. Not extended here to avoid adding to dead code.
- The investigation (5-perspective agent team + an independent Codex review) is captured in the issue-#400 follow-up; this PR implements the recommended inference-side fix.
