### PR TITLE
fix(build): prefer release over debug archives in cargo-target lib fallback

### DIFF
--- a/vow-clif-shim/src/lib.rs
+++ b/vow-clif-shim/src/lib.rs
@@ -2759,9 +2759,14 @@ fn cargo_target_dir() -> std::path::PathBuf {
 
 fn find_lib_in_cargo_target(name: &str, target_dir: &std::path::Path) -> Option<String> {
     // Development fallback only: env overrides and installed-prefix libraries
-    // are checked first, so prefer plain cargo build/test artifacts here while
-    // still accepting release bootstrap artifacts.
-    for profile in &["debug", "release"] {
+    // are checked first. Prefer `release` over `debug`: the bootstrap
+    // (`cargo build --release --all`, scripts/bootstrap.sh) produces the
+    // release archives, so a stale pre-existing `target/debug/*.a` (left over
+    // from an earlier `cargo build`/`cargo test`) must not shadow the fresh
+    // release runtime — otherwise a newly added `__vow_*` builtin links against
+    // the older debug archive and fails with undefined references. A
+    // debug-only checkout (no release archive) still resolves to debug.
+    for profile in &["release", "debug"] {
         let p = target_dir.join(profile).join(name);
         if p.exists() {
             return Some(p.to_string_lossy().into_owned());
@@ -3795,7 +3800,11 @@ mod tests {
     }
 
     #[test]
-    fn cargo_target_fallback_prefers_debug_before_release() {
+    fn cargo_target_fallback_prefers_release_before_debug() {
+        // A stale pre-existing target/debug archive must not shadow the fresh
+        // release archive produced by the bootstrap; otherwise a newly added
+        // __vow_* runtime symbol links against the older debug build and fails
+        // with undefined references. See find_lib_in_cargo_target.
         let root = tempfile::TempDir::new().unwrap();
         let debug_dir = root.path().join("debug");
         let release_dir = root.path().join("release");
@@ -3808,7 +3817,21 @@ mod tests {
 
         let found =
             find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, root.path());
-        let expected = debug_lib.to_string_lossy().into_owned();
+        let expected = release_lib.to_string_lossy().into_owned();
+        assert_eq!(found.as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn cargo_target_fallback_accepts_debug_when_release_missing() {
+        let root = tempfile::TempDir::new().unwrap();
+        let debug_dir = root.path().join("debug");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        let lib = debug_dir.join("libvow_runtime.a");
+        std::fs::write(&lib, b"debug").unwrap();
+
+        let found =
+            find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, root.path());
+        let expected = lib.to_string_lossy().into_owned();
         assert_eq!(found.as_deref(), Some(expected.as_str()));
     }
 

--- a/vow-codegen/src/linker.rs
+++ b/vow-codegen/src/linker.rs
@@ -75,9 +75,14 @@ fn cargo_target_dir() -> PathBuf {
 
 fn find_lib_in_cargo_target(name: &str, target_dir: &Path) -> Option<PathBuf> {
     // Development fallback only: env overrides and installed-prefix libraries
-    // are checked first, so prefer plain cargo build/test artifacts here while
-    // still accepting release bootstrap artifacts.
-    ["debug", "release"]
+    // are checked first. Prefer `release` over `debug`: the bootstrap
+    // (`cargo build --release --all`, scripts/bootstrap.sh) produces the
+    // release archives, so a stale pre-existing `target/debug/*.a` (left over
+    // from an earlier `cargo build`/`cargo test`) must not shadow the fresh
+    // release runtime — otherwise a newly added `__vow_*` builtin links against
+    // the older debug archive and fails with undefined references. A
+    // debug-only checkout (no release archive) still resolves to debug.
+    ["release", "debug"]
         .into_iter()
         .map(|profile| target_dir.join(profile).join(name))
         .find(|candidate| candidate.exists())
@@ -211,7 +216,11 @@ mod tests {
     }
 
     #[test]
-    fn cargo_target_fallback_prefers_debug_before_release() {
+    fn cargo_target_fallback_prefers_release_before_debug() {
+        // A stale pre-existing target/debug archive must not shadow the fresh
+        // release archive produced by the bootstrap; otherwise a newly added
+        // __vow_* runtime symbol links against the older debug build and fails
+        // with undefined references. See find_lib_in_cargo_target.
         let dir = tempfile::TempDir::new().unwrap();
         let debug_dir = dir.path().join("debug");
         let release_dir = dir.path().join("release");
@@ -223,7 +232,19 @@ mod tests {
         std::fs::write(&release_lib, b"release").unwrap();
 
         let found = find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, dir.path());
-        assert_eq!(found.as_deref(), Some(debug_lib.as_path()));
+        assert_eq!(found.as_deref(), Some(release_lib.as_path()));
+    }
+
+    #[test]
+    fn cargo_target_fallback_accepts_debug_when_release_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let debug_dir = dir.path().join("debug");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        let lib = debug_dir.join("libvow_runtime.a");
+        std::fs::write(&lib, b"debug").unwrap();
+
+        let found = find_lib_from_parts_with_target_dir("libvow_runtime.a", None, None, dir.path());
+        assert_eq!(found.as_deref(), Some(lib.as_path()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a bootstrap-breaking regression exposed by the recent perfetto/process merges (#784/#789). The self-hosted `build/vowc` and the Rust compiler locate `libvow_runtime.a` / `libvow_clif_shim.a` via `find_lib_in_cargo_target`, which searched `target/debug/` **before** `target/release/`. Those merges added the runtime builtins `__vow_time_micros`, `__vow_proc_sample`, `__vow_gzip_write_file`, `__vow_process_poll_wait`, and the self-hosted tracer references them. On any machine with a leftover **pre-perfetto** `target/debug/*.a` (from a routine `cargo build`/`cargo test`), the stale debug archive shadowed the freshly built release archives and `build/vowc build compiler/main.vow` failed to link:

```
undefined reference to `__vow_time_micros'
undefined reference to `__vow_proc_sample'
undefined reference to `__vow_gzip_write_file'
undefined reference to `__vow_process_poll_wait'
collect2: error: ld returned 1 exit status
```

Clean checkouts (CI, `cargo build --release` first) have no debug archive, so the fixed-point check stayed green and masked the regression.

## Fix

Prefer `release` over `debug` in **both** linker paths (per the dual-compiler rule), since release is the canonical bootstrap profile (`cargo build --release --all`, `scripts/bootstrap.sh`):

- `vow-clif-shim/src/lib.rs` — used by the self-hosted `build/vowc`
- `vow-codegen/src/linker.rs` — used by the Rust compiler

A debug-only checkout (no release archive) still resolves to debug via the fallback. `vow/tests/agent_level1.rs::find_support_lib` is intentionally left debug-first — it `cargo build`s the debug archives fresh immediately before searching.

## Tests

- Flipped `cargo_target_fallback_prefers_debug_before_release` → `..._prefers_release_before_debug` in both crates.
- Added `cargo_target_fallback_accepts_debug_when_release_missing` in both crates to guard the fallback.

## Verification

- Reproduced the failure by planting the stale debug archives into a clean worktree `target/` → build not produced (undefined references).
- After the fix, with the stale debug archives **still present**: re-bootstrap matches the SHA-256 fixed point and `build/vowc build compiler/main.vow` produces the executable.
- `cargo test -p vow-codegen -p vow-clif-shim` green; clippy + fmt clean; examples, both `issue400_*` region tests (`ok`), and ESBMC `verify` (`Verified`) all pass.

## Not implicated

The #788 region change was independently audited (two reviewers, valgrind-clean reproducers per escape vector, full Rust↔self-hosted parity, 0/114 differential divergences) and confirmed **sound** — it is not the cause. perfetto/#785/#780/#776 were also cleared (default-path clean, parity verified, builtin registration complete).

## Follow-up (optional, not in this PR)

Consider having `scripts/bootstrap.sh` proactively guard against stale debug archives (e.g. `cargo clean -p vow-runtime -p vow-clif-shim` or a freshness check) as defense-in-depth.
