### PR TITLE
fix(sat-bench): tolerate result rows without elapsed_s in summary

### DIFF
--- a/examples/sat/bench.py
+++ b/examples/sat/bench.py
@@ -348,9 +348,11 @@ def print_summary(report: dict) -> None:
 
     print("")
     for row in report["results"]:
+        elapsed = row.get("elapsed_s")
+        elapsed_str = f"{elapsed:8.3f}s" if elapsed is not None else f"{'-':>8} "
         print(
             f"{row['tier']:7s} {row['solver']:8s} {row['classification']:26s} "
-            f"{row['elapsed_s']:8.3f}s {row['benchmark']}"
+            f"{elapsed_str} {row['benchmark']}"
         )
 
 


### PR DESCRIPTION
## Summary

`examples/sat/bench.py run` crashed with `KeyError: 'elapsed_s'` whenever the
result set contained a row that has no timing.

When a benchmark file isn't on disk, `run_benchmarks` appends a "skipped"
result row that omits several keys the normal rows carry — including
`elapsed_s`. `print_summary` then read `row['elapsed_s']` unconditionally for
every row, so the first skipped row threw. This is hit by running `run`
without a prior `download` (or with a missing `.local/benchmarks`).

## Fix

`print_summary` now reads `row.get("elapsed_s")` and renders a `-` placeholder
when there is no timing, instead of assuming the key exists. Completed runs are
unchanged.

## Testing

- Reproduced the crash, then confirmed the summary renders cleanly for both
  skipped (no `elapsed_s`) and completed rows.
- End-to-end: `download` + `run` across all tiers (smoke/core/stretch). The run
  exercises the same formatter via timeout rows and prints without error;
  `minisat` was auto-detected and run as a baseline.
