### PR TITLE
test(verify): clarify non-gating stress fixture comment

### DIFF
--- a/tests/verify-stress/unwind_loop.vow
+++ b/tests/verify-stress/unwind_loop.vow
@@ -1,4 +1,5 @@
-// CATEGORY: unverifiable (stress; non-gating)
+// Non-gating stress fixture; this prose comment is intentionally not a `// TEST:`
+// directive read by scripts/verify_eval.py.
 //
 // A loop with no invariant whose trip count (100000, passed from `main`) ESBMC
 // must unwind to discharge its postcondition; at the configured unwind budget


### PR DESCRIPTION
Summary:
- Replace the directive-like `// CATEGORY:` header in `tests/verify-stress/unwind_loop.vow` with prose.
- Make clear the stress fixture is non-gating and intentionally not a `// TEST:` harness directive.

Validation:
- `if rg -n "^// CATEGORY:" tests/verify-stress; then exit 1; fi`
- `if rg -n "^// TEST: category" tests/verify-stress; then exit 1; fi`
- `git diff --check`
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo build --release --all` (needed before the Rust test suite so `libvow_runtime.a` exists)
- `cargo test --all`
- `scripts/full_test.sh` exits nonzero on unrelated existing Section 6 parity: `math/verify - FAIL: function: abs vs pow`; verifier-eval itself passed `45/45`. See issue comment for targeted repro details.

Closes #768

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
