### PR TITLE
fix(verify-eval): tighten harness diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,13 @@ jobs:
           rm "/tmp/$ESBMC_ZIP"
       - run: echo "$HOME/esbmc/bin" >> "$GITHUB_PATH"
       - run: cargo build --all
+      - name: Verifier-evaluation unit tests
+        run: python3 scripts/test_verify_eval.py
       - name: Verifier-evaluation suite (#334)
         # Asserts the labelled corpus in tests/verify* against ground-truth
         # blame/vow_id, with false-accepts (incl. vacuous proofs) failing the
         # build under a SOUNDNESS banner. ESBMC is on PATH from the step above.
+        # Reuse the debug binary produced by the preceding `cargo build --all`.
         run: python3 scripts/verify_eval.py --verifier ./target/debug/vow --output-dir /tmp/verify-eval
       - name: Build concatenated self-hosted compiler
         run: |

--- a/docs/verifier-eval.md
+++ b/docs/verifier-eval.md
@@ -74,7 +74,7 @@ extending the same `// TEST:` convention `tests/run_tests.sh` already uses.
 | `// TEST: counterexample-blame <caller\|callee\|none>` | Expected blame; `none` = a memory-safety/builtin failure with no contract attribution. |
 | `// TEST: counterexample-vow-id <N>` | Expected violated `vow_id` (from the `vow verify` counterexample, which is a distinct id space from `vow contracts --verify`). |
 | `// TEST: cex fn="<fn>" blame=<b> vow_id=<N>` | Repeatable form for programs with multiple expected counterexamples. |
-| `// TEST: known-soundness-gap "<reason>" #<issue>` | Marks a documented false-accept the verifier does not yet catch. Reported under the KNOWN SOUNDNESS GAPS banner, non-fatal — until the verifier *starts* catching it, at which point the harness fails and demands promotion to a real verify-fail program. |
+| `// TEST: known-soundness-gap "<reason>" #<issue>` | Marks a documented false-accept in `tests/verify/` that the verifier does not yet catch. Reported under the KNOWN SOUNDNESS GAPS banner, non-fatal — until the verifier *starts* catching it, at which point the harness fails and demands promotion to a real verify-fail program. |
 | `// TEST: status <Status>` / `// TEST: skip "<reason>"` | Override the directory's expected status / exclude a program. |
 
 ## How the harness classifies results
@@ -86,8 +86,10 @@ result is bucketed:
 - **SOUNDNESS** — expected-fail program reported `Verified`, or a should-pass
   program proven vacuously. **Hard failure.**
 - **PRECISION** — should-pass program reported `VerifyFailed`/`Skipped`.
-- **BLAME / VOW_ID** — wrong blame or wrong violated `vow_id`.
-- **STATUS** — any other expected/actual status mismatch.
+- **BLAME / VOW_ID** — wrong blame, wrong violated `vow_id`, or surplus
+  counterexamples.
+- **STATUS** — any other expected/actual status mismatch, including a missing
+  expected counterexample.
 - **KNOWN SOUNDNESS GAPS** — tracked false-accepts (non-fatal).
 - **KNOWN GAP APPEARS FIXED** — a known gap the verifier now catches (**hard
   failure**: promote the label).

--- a/scripts/test_verify_eval.py
+++ b/scripts/test_verify_eval.py
@@ -27,6 +27,23 @@ class ClassifyCounterexamplesTest(unittest.TestCase):
         self.assertEqual(verify_eval.STATUS, verdict)
         self.assertIn("no counterexample matched", detail)
 
+    def test_wrong_function_counterexample_is_a_status_mismatch(self):
+        exp = verify_eval.Expect(
+            "tests/verify-fail/wrong_function.vow", "VerifyFailed"
+        )
+        exp.cex = [{"fn": "expected", "blame": "caller", "vow_id": 1}]
+        verify_json = {
+            "status": "VerifyFailed",
+            "counterexamples": [
+                {"function": "other", "blame": "Callee", "vow_id": 1},
+            ],
+        }
+
+        verdict, detail = verify_eval.classify(exp, verify_json, verifier="/unused/vow")
+
+        self.assertEqual(verify_eval.STATUS, verdict)
+        self.assertIn("no counterexample matched", detail)
+
     def test_wrong_counterexample_blame_stays_a_blame_regression(self):
         exp = verify_eval.Expect("tests/verify-fail/wrong_blame.vow", "VerifyFailed")
         exp.cex = [{"fn": "f", "blame": "caller", "vow_id": 7}]

--- a/scripts/test_verify_eval.py
+++ b/scripts/test_verify_eval.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Behavior tests for scripts/verify_eval.py."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import verify_eval
+
+
+class ClassifyCounterexamplesTest(unittest.TestCase):
+    def test_missing_expected_counterexample_is_a_status_mismatch(self):
+        exp = verify_eval.Expect("tests/verify-fail/two_failures.vow", "VerifyFailed")
+        exp.cex = [
+            {"fn": "first", "blame": "caller", "vow_id": 1},
+            {"fn": "second", "blame": "callee", "vow_id": 2},
+        ]
+        verify_json = {
+            "status": "VerifyFailed",
+            "counterexamples": [
+                {"function": "first", "blame": "Caller", "vow_id": 1},
+            ],
+        }
+
+        verdict, detail = verify_eval.classify(exp, verify_json, verifier="/unused/vow")
+
+        self.assertEqual(verify_eval.STATUS, verdict)
+        self.assertIn("no counterexample matched", detail)
+
+    def test_wrong_counterexample_blame_stays_a_blame_regression(self):
+        exp = verify_eval.Expect("tests/verify-fail/wrong_blame.vow", "VerifyFailed")
+        exp.cex = [{"fn": "f", "blame": "caller", "vow_id": 7}]
+        verify_json = {
+            "status": "VerifyFailed",
+            "counterexamples": [
+                {"function": "f", "blame": "Callee", "vow_id": 7},
+            ],
+        }
+
+        verdict, detail = verify_eval.classify(exp, verify_json, verifier="/unused/vow")
+
+        self.assertEqual(verify_eval.BLAME, verdict)
+        self.assertIn("blame want=caller", detail)
+
+    def test_wrong_counterexample_vow_id_stays_a_blame_regression(self):
+        exp = verify_eval.Expect("tests/verify-fail/wrong_vow_id.vow", "VerifyFailed")
+        exp.cex = [{"fn": "f", "blame": "callee", "vow_id": 7}]
+        verify_json = {
+            "status": "VerifyFailed",
+            "counterexamples": [
+                {"function": "f", "blame": "Callee", "vow_id": 8},
+            ],
+        }
+
+        verdict, detail = verify_eval.classify(exp, verify_json, verifier="/unused/vow")
+
+        self.assertEqual(verify_eval.BLAME, verdict)
+        self.assertIn("vow_id want=7", detail)
+
+
+class ParseDirectivesKnownGapTest(unittest.TestCase):
+    def test_known_soundness_gap_is_accepted_under_tests_verify(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            old_repo_root = verify_eval.REPO_ROOT
+            verify_eval.REPO_ROOT = str(root)
+            try:
+                path = root / "tests" / "verify" / "gap.vow"
+                path.parent.mkdir(parents=True)
+                path.write_text(
+                    '// TEST: known-soundness-gap "documented false accept" #123\n',
+                    encoding="utf-8",
+                )
+
+                exp = verify_eval.parse_directives(str(path), "Verified")
+
+                self.assertEqual("documented false accept", exp.known_gap)
+                self.assertEqual("123", exp.known_gap_issue)
+            finally:
+                verify_eval.REPO_ROOT = old_repo_root
+
+    def test_known_soundness_gap_is_rejected_outside_tests_verify(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            old_repo_root = verify_eval.REPO_ROOT
+            verify_eval.REPO_ROOT = str(root)
+            try:
+                for subdir, status in (
+                    ("verify-fail", "VerifyFailed"),
+                    ("verify-skip", "Skipped"),
+                ):
+                    path = root / "tests" / subdir / "gap.vow"
+                    path.parent.mkdir(parents=True)
+                    path.write_text(
+                        '// TEST: known-soundness-gap "documented false accept" #123\n',
+                        encoding="utf-8",
+                    )
+
+                    with self.subTest(subdir=subdir):
+                        with self.assertRaisesRegex(
+                            ValueError, "known-soundness-gap.*tests/verify"
+                        ):
+                            verify_eval.parse_directives(str(path), status)
+            finally:
+                verify_eval.REPO_ROOT = old_repo_root
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_eval.py
+++ b/scripts/verify_eval.py
@@ -16,8 +16,10 @@ silent soundness regression can never hide in an aggregate pass/fail count:
   * SOUNDNESS  (false-accept) — an expected-fail program was Verified, or a
                  should-pass program was proven only vacuously. Hard failure.
   * PRECISION  (false-reject) — a should-pass program was rejected.
-  * BLAME      — wrong Caller/Callee attribution, or wrong violated vow_id.
-  * STATUS     — any other expected/actual status mismatch (e.g. Skipped).
+  * BLAME      — wrong Caller/Callee attribution, wrong violated vow_id, or a
+                 surplus counterexample.
+  * STATUS     — any other expected/actual status mismatch (e.g. Skipped), or
+                 a missing expected counterexample.
 
 Ground truth lives next to each program as `// TEST:` directives (the same
 comment convention tests/run_tests.sh already uses), extended here with
@@ -117,6 +119,20 @@ def validate_blame(path, blame):
     return blame
 
 
+def validate_known_gap_path(path):
+    """Keep known soundness gaps confined to the should-pass corpus."""
+    allowed_dir = os.path.abspath(os.path.join(REPO_ROOT, "tests", "verify"))
+    actual_path = os.path.abspath(path)
+    try:
+        common = os.path.commonpath([allowed_dir, actual_path])
+    except ValueError:
+        common = None
+    if common != allowed_dir:
+        raise ValueError(
+            f"{path}: known-soundness-gap is only valid under tests/verify/"
+        )
+
+
 def parse_directives(path, default_status):
     """Read `// TEST:` directives from a program into an Expect."""
     exp = Expect(path, default_status)
@@ -156,6 +172,7 @@ def parse_directives(path, default_status):
                         f"{path}: malformed known-soundness-gap directive "
                         f'(expected: known-soundness-gap "<reason>" #<issue>): {body!r}'
                     )
+                validate_known_gap_path(path)
                 exp.known_gap = gm.group(1)
                 exp.known_gap_issue = gm.group(2)
             elif body.startswith("counterexample-fn"):
@@ -290,6 +307,8 @@ def match_cex(want, actuals):
         if "vow_id" in want and want["vow_id"] != got["vow_id"]:
             continue
         return "ok", None, got
+    if not actuals:
+        return "missing", f"no counterexample matched {want}", None
     # No exact match: diagnose the closest cause for the same function.
     same_fn = [g for g in actuals if g["fn"] == want.get("fn")] or actuals
     if "blame" in want and all(want["blame"] != g["blame"] for g in same_fn):
@@ -395,13 +414,15 @@ def classify(exp, verify_json, verifier):
         if not actuals:
             return STATUS, "VerifyFailed but no counterexamples emitted"
         # Enforce the EXACT counterexample set: every expected cex must match a
-        # distinct actual, and no surplus actual may remain. Consuming matches
-        # lets a verifier regression that emits an extra bogus counterexample
-        # (on top of the expected one) surface instead of passing silently.
+        # distinct actual, and no surplus actual may remain. Missing expected
+        # cex entries are STATUS diagnostics; wrong blame/vow_id and surplus
+        # actuals remain BLAME diagnostics.
         remaining = list(actuals)
         for want in exp.cex:
             kind, detail, matched = match_cex(want, remaining)
             if kind != "ok":
+                if kind == "missing":
+                    return STATUS, detail
                 return BLAME, detail
             remaining.remove(matched)
         if remaining:

--- a/scripts/verify_eval.py
+++ b/scripts/verify_eval.py
@@ -296,7 +296,10 @@ def match_cex(want, actuals):
 
     kind is 'ok' (with the matched actual cex as the third element so the
     caller can consume it and detect surplus), or 'blame'/'vow_id'/'missing'
-    (with detail and a None matched).
+    (with detail and a None matched). "missing" covers both an exhausted
+    actual list after earlier expected cex entries consumed matches, and a
+    non-empty actual list with no same-function match or no clean blame/vow_id
+    mismatch cause.
     """
     # An exact match on every specified field is success.
     for got in actuals:
@@ -310,7 +313,12 @@ def match_cex(want, actuals):
     if not actuals:
         return "missing", f"no counterexample matched {want}", None
     # No exact match: diagnose the closest cause for the same function.
-    same_fn = [g for g in actuals if g["fn"] == want.get("fn")] or actuals
+    if "fn" in want:
+        same_fn = [g for g in actuals if g["fn"] == want["fn"]]
+        if not same_fn:
+            return "missing", f"no counterexample matched {want}", None
+    else:
+        same_fn = actuals
     if "blame" in want and all(want["blame"] != g["blame"] for g in same_fn):
         got = ", ".join(sorted({g["blame"] for g in same_fn}))
         return "blame", f"blame want={want['blame']} got={got or 'none'}", None


### PR DESCRIPTION
Summary:
- classify missing expected counterexamples as STATUS while preserving BLAME for wrong blame/vow_id and surplus actual cex
- reject known-soundness-gap directives outside tests/verify/ at load time
- add stdlib verifier-eval unit tests, CI coverage, and docs for the harness invariants

Validation:
- python3 scripts/test_verify_eval.py
- python3 -m py_compile scripts/verify_eval.py scripts/test_verify_eval.py
- cargo build --all
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo build --release --all (to provide libvow_runtime.a for tests)
- cargo test --all
- python3 scripts/verify_eval.py --verifier ./target/debug/vow --output-dir /tmp/verify-eval-769
- git diff --check

Note: scripts/full_test.sh was run and still fails on an unrelated pre-existing lib/math/main.vow Rust/self verifier parity issue (math/verify: abs vs pow), documented on issue #769. The verifier-eval section passed 45/45.

Closes #769

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**