### PR TITLE
fix(verifier): remove weak invariant unwind-bound contract

### DIFF
--- a/tests/verify-fail/weak_invariant.vow
+++ b/tests/verify-fail/weak_invariant.vow
@@ -1,22 +1,22 @@
 // TEST: category invariant
-// TEST: counterexample-vow-id 4
+// TEST: counterexample-vow-id 2
 // TEST: counterexample-fn "fill_and_sum"
 // TEST: counterexample-blame callee
 // The loop invariant claims sum == i but the loop
 // adds (i+1) each iteration, so sum grows faster than i.
+// Concrete loop bound (8), not a `requires n <= 8` clause: ESBMC unwind limits
+// must never be encoded as contract bounds (see the contract-authoring rules).
 // ESBMC catches the invariant violation on the second iteration.
 module WeakInvariant
 
-fn fill_and_sum(n: i64) -> i64 vow {
-  requires: n >= 0,
-  requires: n <= 8,
+fn fill_and_sum() -> i64 vow {
   ensures: result >= 0
 } {
   let mut sum: i64 = 0;
   let mut i: i64 = 0;
-  while i < n vow {
+  while i < 8 vow {
     invariant: i >= 0,
-    invariant: i <= n,
+    invariant: i <= 8,
     invariant: sum == i
   } {
     sum = sum + i + 1;
@@ -26,6 +26,6 @@ fn fill_and_sum(n: i64) -> i64 vow {
 }
 
 fn main() -> i32 [io] {
-  print_i64(fill_and_sum(5));
+  print_i64(fill_and_sum());
   0
 }


### PR DESCRIPTION
Summary:
- Remove the non-semantic `requires: n <= 8` verifier-unwind bound from `tests/verify-fail/weak_invariant.vow`.
- Make the fixture use a concrete loop trip count of 8, preserving the intended weak invariant failure.
- Re-derived the verifier-eval ground truth: `fill_and_sum`, callee blame, `vow_id=2`.

Verification:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo build --release --all`
- `cargo test --all`
- `python3 scripts/verify_eval.py --verifier ./target/release/vow --filter weak_invariant --output-dir /tmp/verify-eval-770`
- `scripts/full_test.sh` reached Section 4c/4e successfully (`weak_invariant` passed; verifier-eval 45/45) but exited non-zero in unrelated Section 6: `math/verify` reports `function: abs vs pow` from an existing lib/math verifier-parity issue with ESBMC 8.3 and the sample `abs` function name. Details posted on #770 and preserved in workspace `EVIDENCE.md`.

Closes #770

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**