### PR TITLE
fix(verify): declare unsigned long nondet extern

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -2393,6 +2393,7 @@ fn cemit_preamble_with_limits(need_shl_i64: i64, need_shr_i64: i64, need_shl_u64
     out.push_str(String::from("extern void __ESBMC_assert(_Bool, const char*);\n"));
     out.push_str(String::from("extern int __VERIFIER_nondet_int(void);\n"));
     out.push_str(String::from("extern long __VERIFIER_nondet_long(void);\n"));
+    out.push_str(String::from("extern unsigned long __VERIFIER_nondet_unsigned_long(void);\n"));
     out.push_str(String::from("extern float __VERIFIER_nondet_float(void);\n"));
     out.push_str(String::from("extern double __VERIFIER_nondet_double(void);\n"));
     out.push_str(String::from("extern _Bool __VERIFIER_nondet_bool(void);\n\n"));

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -379,6 +379,80 @@ for vow_file in examples/*.vow; do
 done
 echo ""
 
+# ─── Section 2b: Verifier C Preamble ──────────────────────────────
+
+section_begin "Section 2b: Verifier C Preamble"
+
+fake_esbmc_dir="$TMPDIR/fake-esbmc"
+mkdir -p "$fake_esbmc_dir"
+cat > "$fake_esbmc_dir/esbmc" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+capture_dir="${VOW_ESBMC_CAPTURE_DIR:?}"
+mkdir -p "$capture_dir"
+
+for arg in "$@"; do
+    if [ -f "$arg" ] && [ "${arg##*.}" = "c" ]; then
+        dest=$(mktemp "$capture_dir/esbmc.XXXXXX.c")
+        cp "$arg" "$dest"
+        break
+    fi
+done
+
+echo "VERIFICATION SUCCESSFUL"
+SH
+chmod +x "$fake_esbmc_dir/esbmc"
+
+u64_preamble_fixture="$TMPDIR/u64_nondet_preamble.vow"
+cat > "$u64_preamble_fixture" <<'VOW'
+module U64NondetPreamble
+
+fn keep_u64(x: u64) -> u64 vow {
+    ensures: result == x
+} {
+    x
+}
+
+fn main() -> i32 {
+    0
+}
+VOW
+
+check_unsigned_long_preamble_capture() {
+    local label="$1" capture_dir="$2" json="$3" exit_code="$4"
+    if grep -R -q 'extern unsigned long __VERIFIER_nondet_unsigned_long(void);' "$capture_dir" 2>/dev/null; then
+        pass "$label"
+    else
+        local verify_status=""
+        verify_status=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('status',''))" "$json" 2>/dev/null) || verify_status=""
+        fail "$label" "missing unsigned-long nondet extern in captured C (verify_status=${verify_status:-unknown}, exit=$exit_code)"
+    fi
+}
+
+rust_capture="$TMPDIR/rust-esbmc-capture"
+self_capture="$TMPDIR/self-esbmc-capture"
+mkdir -p "$rust_capture" "$self_capture"
+
+rust_json="" self_json="" rust_exit=0 self_exit=0
+rust_json=$(PATH="$fake_esbmc_dir:$PATH" VOW_ESBMC_CAPTURE_DIR="$rust_capture" \
+    "$RUST" verify --no-cache --verify-jobs 1 "$u64_preamble_fixture" 2>/dev/null) || rust_exit=$?
+self_json=$(PATH="$fake_esbmc_dir:$PATH" VOW_ESBMC_CAPTURE_DIR="$self_capture" \
+    run_self verify --no-cache --verify-jobs 1 "$u64_preamble_fixture" 2>/dev/null) || self_exit=$?
+
+if [ -z "$rust_json" ]; then
+    fail "verifier-preamble/rust" "empty output (exit=$rust_exit)"
+else
+    check_unsigned_long_preamble_capture "verifier-preamble/rust" "$rust_capture" "$rust_json" "$rust_exit"
+fi
+
+if [ -z "$self_json" ]; then
+    fail "verifier-preamble/self" "empty output (exit=$self_exit)"
+else
+    check_unsigned_long_preamble_capture "verifier-preamble/self" "$self_capture" "$self_json" "$self_exit"
+fi
+echo ""
+
 # ─── Section 3: Runtime Execution ──────────────────────────────────
 
 section_begin "Section 3: Runtime Execution"

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -2189,6 +2189,7 @@ fn emit_c_preamble(out: &mut String, shifts: &ShiftNeeds, limits: &VerifyLimits)
     out.push_str("extern void __ESBMC_assert(_Bool, const char*);\n");
     out.push_str("extern int __VERIFIER_nondet_int(void);\n");
     out.push_str("extern long __VERIFIER_nondet_long(void);\n");
+    out.push_str("extern unsigned long __VERIFIER_nondet_unsigned_long(void);\n");
     out.push_str("extern float __VERIFIER_nondet_float(void);\n");
     out.push_str("extern double __VERIFIER_nondet_double(void);\n");
     out.push_str("extern _Bool __VERIFIER_nondet_bool(void);\n\n");
@@ -2393,6 +2394,15 @@ mod tests {
             origin: sp(),
             region: RegionId::Root,
         }
+    }
+
+    #[test]
+    fn emit_c_module_declares_unsigned_long_nondet() {
+        let c = emit_c_module(&[], &HashMap::new(), &VerifyLimits::default());
+        assert!(
+            c.contains("extern unsigned long __VERIFIER_nondet_unsigned_long(void);"),
+            "generated C preamble must declare the u64 nondet intrinsic:\n{c}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Declare `extern unsigned long __VERIFIER_nondet_unsigned_long(void);` in both verifier C preambles.
- Add a Rust emitter regression for the generated preamble.
- Add a full-test fake-ESBMC regression that captures generated C from both Rust and self-hosted `verify` paths.

Validation:
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `scripts/bootstrap.sh --skip-cargo`
- `build/vowc test compiler/`
- `target/release/vow verify tests/verify-fail/u64_wrap_ensures.vow` -> VerifyFailed
- `build/vowc verify tests/verify-fail/u64_wrap_ensures.vow` -> VerifyFailed
- `scripts/full_test.sh` reached and passed the new Section 2b preamble check for both compilers, then failed on unrelated existing issues documented on #772: `math/verify` (`abs` C stdlib name collision) and Section 13 complexity fixture `UnusedMut`.

Closes #772

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**