### PR TITLE
fix(verify): namespace verifier C user functions

### DIFF
--- a/compiler/c_emitter.vow
+++ b/compiler/c_emitter.vow
@@ -168,6 +168,10 @@ fn is_reserved_verifier_symbol(name: String) -> bool {
     || str_starts_with(name, String::from("__VERIFIER_"))
 }
 
+fn verifier_c_func_name(f: IrFunction) -> String {
+    str2(String::from("vow_user_fn_"), i64_to_str(f.id))
+}
+
 // Returns the args[] index of the value stored into __vow_vec_t::data[] for
 // vec store-ops. Returns -1 when the op is __vow_vec_get_val (the relevant id
 // is then inst.id, not an arg) or when the op is not one of these.
@@ -1234,10 +1238,10 @@ fn emit_inst(out: String, inst: IrInst, f: IrFunction, vec_vars: Vec<i64>, strin
                         }
                         if ty != ITY_UNIT() {
                             out.push_str(str6(String::from("  v"), i64_to_str(id),
-                                String::from(" = "), callee.name,
+                                String::from(" = "), verifier_c_func_name(callee),
                                 String::from("("), str2(args_str, String::from(");\n"))));
                         } else {
-                            out.push_str(str4(String::from("  "), callee.name,
+                            out.push_str(str4(String::from("  "), verifier_c_func_name(callee),
                                 String::from("("), str2(args_str, String::from(");\n"))));
                         }
                         fi = fns.len();
@@ -2028,7 +2032,7 @@ fn emit_c_function(out: String, f: IrFunction, const_fn_indices: Vec<i64>, model
     }
 
     let param_str: String = if cl_idx == 0 { String::from("void") } else { params_list };
-    out.push_str(str5(ret_c, String::from(" "), f.name, String::from("("), str3(param_str, String::from(") {\n"), String::from(""))));
+    out.push_str(str5(ret_c, String::from(" "), verifier_c_func_name(f), String::from("("), str3(param_str, String::from(") {\n"), String::from(""))));
 
     let blocks: Vec<IrBlock> = f.blocks;
     let n_blocks: i64 = blocks.len();
@@ -2502,7 +2506,7 @@ fn emit_forward_declaration(out: String, f: IrFunction) {
         pi = pi + 1;
     }
     let param_str: String = if cl_idx == 0 { String::from("void") } else { params_list };
-    out.push_str(str5(ret_c, String::from(" "), f.name, String::from("("), str2(param_str, String::from(");\n"))));
+    out.push_str(str5(ret_c, String::from(" "), verifier_c_func_name(f), String::from("("), str2(param_str, String::from(");\n"))));
 }
 
 fn emit_c_module(m: IrModule, vec_max: i64, string_max: i64, hashmap_max: i64, btreemap_max: i64) -> String {

--- a/compiler/verifier.vow
+++ b/compiler/verifier.vow
@@ -183,7 +183,7 @@ fn esbmc_nondet_call(ty: i64) -> String {
 
 fn emit_harness(f: IrFunction) -> String {
     let out: String = String::from("int main(void) { ");
-    out.push_str(f.name);
+    out.push_str(verifier_c_func_name(f));
     out.push_byte(40);
     let params: Vec<i64> = f.params;
     let np: i64 = params.len();

--- a/tests/fixtures/complexity/contracts.vow
+++ b/tests/fixtures/complexity/contracts.vow
@@ -11,7 +11,7 @@ fn bounded(lo: i64, hi: i64) -> i64 vow {
     requires: hi >= lo
 } {
     let mut lo: i64 = lo;
-    let mut hi: i64 = hi;
+    let hi: i64 = hi;
     while lo + 1 < hi vow {
         invariant: hi - lo >= 0
     } {

--- a/tests/verify/libc_name_collision.vow
+++ b/tests/verify/libc_name_collision.vow
@@ -1,0 +1,31 @@
+// TEST: category model-drift
+module LibcNameCollision
+
+fn abs(x: i64) -> i64 vow {
+  ensures: result == x
+} {
+  x
+}
+
+fn div(x: i64) -> i64 vow {
+  ensures: result == x
+} {
+  x
+}
+
+fn exit(x: i64) -> i64 vow {
+  ensures: result == x
+} {
+  x
+}
+
+fn round_trip(x: i64) -> i64 vow {
+  ensures: result == x
+} {
+  exit(div(abs(x)))
+}
+
+fn main() -> i32 [io] {
+  print_i64(round_trip(3));
+  0
+}

--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -471,6 +471,10 @@ fn is_reserved_verifier_symbol(name: &str) -> bool {
     name.starts_with("__ESBMC_") || name.starts_with("__VERIFIER_")
 }
 
+pub(crate) fn verifier_c_func_name(func: &Function) -> String {
+    format!("vow_user_fn_{}", func.id.0)
+}
+
 /// Check whether a function can be precisely modeled in the C emitter.
 /// Modelable functions are pure (no effects) and use only opcodes that the
 /// C emitter handles without resorting to `__VERIFIER_nondet`.
@@ -1596,11 +1600,15 @@ fn emit_inst(
                     out.push_str(&format!(
                         "  v{} = {}({});\n",
                         id,
-                        callee.name,
+                        verifier_c_func_name(callee),
                         args_str.join(", ")
                     ));
                 } else {
-                    out.push_str(&format!("  {}({});\n", callee.name, args_str.join(", ")));
+                    out.push_str(&format!(
+                        "  {}({});\n",
+                        verifier_c_func_name(callee),
+                        args_str.join(", ")
+                    ));
                 }
             }
         }
@@ -1903,7 +1911,12 @@ pub fn emit_c_function_full(
         params.join(", ")
     };
 
-    out.push_str(&format!("{} {}({}) {{\n", ret_c, func.name, param_str));
+    out.push_str(&format!(
+        "{} {}({}) {{\n",
+        ret_c,
+        verifier_c_func_name(func),
+        param_str
+    ));
 
     // Map arg index to parameter name at the top of the function
     // GetArg(idx) refers to p{cl_idx} where cl_idx skips Unit params
@@ -2279,7 +2292,12 @@ fn emit_forward_declaration(func: &Function, out: &mut String) {
     } else {
         params.join(", ")
     };
-    out.push_str(&format!("{} {}({});\n", ret_c, func.name, param_str));
+    out.push_str(&format!(
+        "{} {}({});\n",
+        ret_c,
+        verifier_c_func_name(func),
+        param_str
+    ));
 }
 
 pub fn emit_c_module(
@@ -2537,9 +2555,31 @@ mod tests {
             source_file: String::new(),
         };
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
-        assert!(c.contains("int64_t add("), "signature: {c}");
+        assert!(c.contains("int64_t vow_user_fn_0("), "signature: {c}");
         assert!(c.contains("v2 = v0 + v1"), "add: {c}");
         assert!(c.contains("return v2"), "return: {c}");
+    }
+
+    #[test]
+    fn emit_function_uses_verifier_private_symbol_for_source_name() {
+        let mut func = make_func(
+            "abs",
+            vec![Ty::I64],
+            Ty::I64,
+            vec![
+                inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+            ],
+        );
+        func.id = FuncId(7);
+
+        let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
+
+        assert!(
+            c.contains("int64_t vow_user_fn_7("),
+            "mangled signature: {c}"
+        );
+        assert!(!c.contains("int64_t abs("), "raw libc name leaked: {c}");
     }
 
     #[test]
@@ -2960,7 +3000,7 @@ mod tests {
             ],
         );
         let c = emit_c_function(&func, &HashMap::new(), &VerifyLimits::default());
-        assert!(c.contains("void void_fn("), "void signature: {c}");
+        assert!(c.contains("void vow_user_fn_0("), "void signature: {c}");
         assert!(c.contains("  return;\n"), "bare return: {c}");
         assert!(!c.contains("return v0;"), "no value returned: {c}");
         assert!(!c.contains("return 0;"), "no value returned: {c}");
@@ -3415,13 +3455,14 @@ mod tests {
 
     #[test]
     fn emit_c_module_wraps_multiple_functions() {
-        let f1 = make_func(
+        let mut f1 = make_func(
             "f1",
             vec![],
             Ty::Unit,
             vec![inst(0, Opcode::Return, Ty::Unit, vec![], InstData::None)],
         );
-        let f2 = make_func(
+        f1.id = FuncId(1);
+        let mut f2 = make_func(
             "f2",
             vec![Ty::I64],
             Ty::I64,
@@ -3430,11 +3471,15 @@ mod tests {
                 inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
             ],
         );
+        f2.id = FuncId(2);
         let out = emit_c_module(&[&f1, &f2], &HashMap::new(), &VerifyLimits::default());
         assert!(out.contains("#include <stdint.h>"), "includes: {out}");
         assert!(out.contains("__ESBMC_assume"), "esbmc assume: {out}");
-        assert!(out.contains("void f1(void)"), "f1 signature: {out}");
-        assert!(out.contains("f2("), "f2 signature: {out}");
+        assert!(
+            out.contains("void vow_user_fn_1(void)"),
+            "f1 signature: {out}"
+        );
+        assert!(out.contains("vow_user_fn_2("), "f2 signature: {out}");
     }
 
     #[test]

--- a/vow-verify/src/esbmc.rs
+++ b/vow-verify/src/esbmc.rs
@@ -13,7 +13,7 @@ use crate::solver_strategy::{
 
 use crate::c_emitter::{
     ConstantValue, VerifyLimits, collect_modelable_callees, detect_constant_functions,
-    emit_c_module, emit_c_module_with_callees, non_modelable_reason,
+    emit_c_module, emit_c_module_with_callees, non_modelable_reason, verifier_c_func_name,
 };
 
 // ---------------------------------------------------------------------------
@@ -94,7 +94,7 @@ fn emit_harness(func: &Function) -> String {
         .collect();
     format!(
         "int main(void) {{ {}({}); return 0; }}\n",
-        func.name,
+        verifier_c_func_name(func),
         args.join(", ")
     )
 }
@@ -1074,6 +1074,78 @@ mod tests {
         let c = emit_verify_c_source(&func, &module, &HashMap::new(), &VerifyLimits::default());
 
         assert!(c.contains("v1.len = 5;"), "literal len from pool: {c}");
+    }
+
+    #[test]
+    fn emit_verify_c_source_uses_private_symbols_for_target_and_callees() {
+        let callee = Function {
+            id: FuncId(5),
+            name: "div".to_string(),
+            params: vec![Ty::I64],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                    inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        let target = Function {
+            id: FuncId(2),
+            name: "abs".to_string(),
+            params: vec![Ty::I64],
+            param_names: vec![],
+            return_ty: Ty::I64,
+            effects: vec![],
+            vows: vec![],
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                insts: vec![
+                    inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                    inst(
+                        1,
+                        Opcode::Call,
+                        Ty::I64,
+                        vec![0],
+                        InstData::CallTarget(FuncId(5)),
+                    ),
+                    inst(2, Opcode::Return, Ty::Unit, vec![1], InstData::None),
+                ],
+            }],
+            local_names: std::collections::HashMap::new(),
+            summary: RegionSummary::default(),
+            source_file: String::new(),
+        };
+        let module = Module {
+            name: String::new(),
+            functions: vec![target.clone(), callee],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+            warnings: vec![],
+        };
+
+        let c = emit_verify_c_source(&target, &module, &HashMap::new(), &VerifyLimits::default());
+
+        assert!(
+            c.contains("int64_t vow_user_fn_5("),
+            "callee definition: {c}"
+        );
+        assert!(c.contains("v1 = vow_user_fn_5(v0);"), "callee call: {c}");
+        assert!(
+            c.contains("int main(void) { vow_user_fn_2(__VERIFIER_nondet_long()); return 0; }"),
+            "harness target call: {c}"
+        );
+        assert!(!c.contains("int64_t div("), "raw callee definition: {c}");
+        assert!(!c.contains(" div(v0)"), "raw callee call: {c}");
+        assert!(!c.contains(" abs("), "raw target call: {c}");
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Namespace verifier-emitted C symbols for Vow user functions as `vow_user_fn_<id>` in both the Rust and self-hosted compilers.
- Add a verifier regression covering libc-name user functions (`abs`, `div`, `exit`) so `<stdlib.h>` declarations cannot collide with emitted verification C.
- Keep the complexity contracts fixture type-checkable by removing an unused `mut`; the complexity golden output remains unchanged.

Implementation note
- The required full local gate exposed an existing Section 13 blocker in `tests/fixtures/complexity/contracts.vow`: both compilers reject `let mut hi` as `UnusedMut` before the complexity JSON comparison runs. I chose the minimal fixture correction (`let hi`) rather than changing the harness or weakening diagnostics.

Tests
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`
- `scripts/full_test.sh` (486 passed, 0 failed, 2 skipped)

Closes #774

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**