### PR TITLE
fix(json): share analysis string escaping

### DIFF
--- a/compiler/complexity_main.vow
+++ b/compiler/complexity_main.vow
@@ -6,26 +6,6 @@ use frontend
 use diag
 use ir
 
-// Minimal JSON string escaper (function names/paths rarely need it, but be
-// safe). Kept local to avoid cross-module coupling with mutants_main.
-fn cx_json_escape(s: String) -> String {
-    let r: String = String::from("");
-    let n: i64 = s.len();
-    let mut i: i64 = 0;
-    while i < n {
-        let b: i64 = s.byte_at(i);
-        if b == 34 { r.push_byte(92); r.push_byte(34); }
-        else if b == 92 { r.push_byte(92); r.push_byte(92); }
-        else if b == 10 { r.push_byte(92); r.push_byte(110); }
-        else if b == 13 { r.push_byte(92); r.push_byte(114); }
-        else if b == 9  { r.push_byte(92); r.push_byte(116); }
-        else if b < 32  { r.push_byte(63); }
-        else { r.push_byte(b); }
-        i = i + 1;
-    }
-    r
-}
-
 fn cx_int_flag(argv: Vec<String>, name: String, dflt: i64) -> i64 {
     let v: String = get_flag_arg(argv, name);
     if v.len() == 0 { return dflt; }
@@ -113,7 +93,7 @@ fn cx_emit_effects(out: String, eff: i64) {
 fn cx_emit_fn(out: String, rec: CxFn, sc: CxScore, thr: i64, ex: CxExtra) {
     out.push_str(String::from("{\"name\":\""));
     let rn: String = rec.name;
-    out.push_str(cx_json_escape(rn));
+    out.push_str(diag_json_escape_str(rn));
     out.push_str(String::from("\",\"line\":"));
     out.push_str(i64_to_string(rec.line));
     out.push_str(String::from(",\"complexity_score\":"));
@@ -373,7 +353,7 @@ fn run_complexity(argv: Vec<String>) -> i32 [io] {
 
     // Pass 2: emit.
     let out: String = String::from("{\"schema_version\":\"1\",\"kind\":\"complexity_report\",\"tool\":\"vow\",\"files\":[{\"file\":\"");
-    out.push_str(cx_json_escape(path));
+    out.push_str(diag_json_escape_str(path));
     out.push_str(String::from("\",\"complexity_score\":"));
     out.push_str(i64_to_string(file_max));
     out.push_str(String::from(",\"functions_over_threshold\":"));
@@ -414,7 +394,7 @@ fn run_complexity(argv: Vec<String>) -> i32 [io] {
             if emitted > 0 { out.push_str(String::from(",")); }
             out.push_str(String::from("\""));
             let r: CxFn = rowe.rec;
-            out.push_str(cx_json_escape(r.name));
+            out.push_str(diag_json_escape_str(r.name));
             out.push_str(String::from("\""));
             emitted = emitted + 1;
         }

--- a/compiler/diag.vow
+++ b/compiler/diag.vow
@@ -282,9 +282,20 @@ fn diag_json_escape_str(s: String) -> String {
         } else if b == 10 {
             r.push_byte(92);
             r.push_byte(110);
+        } else if b == 13 {
+            r.push_byte(92);
+            r.push_byte(114);
         } else if b == 9 {
             r.push_byte(92);
             r.push_byte(116);
+        } else if b == 8 {
+            r.push_byte(92);
+            r.push_byte(98);
+        } else if b == 12 {
+            r.push_byte(92);
+            r.push_byte(102);
+        } else if b < 32 {
+            r.push_byte(63);
         } else {
             r.push_byte(b);
         }

--- a/compiler/mutants_main.vow
+++ b/compiler/mutants_main.vow
@@ -3,6 +3,7 @@ module MutantsMain
 use mutants_sites
 use mutants_patch
 use mutants_oracle
+use diag
 
 fn mutants_print_usage() [io] {
     eprintln_str("usage: vowc mutants <subcommand> [flags]");
@@ -161,37 +162,11 @@ fn join_path(dir: String, name: String) -> String {
     r
 }
 
-// Escape a string for inclusion inside a JSON `"..."` literal.
-// Handles the cases that occur in vow-mutants output: `"`, `\`, newlines,
-// carriage returns, tabs, and other control bytes (rendered as `?`).
-// Raw `"` is the practical concern — `String::from("")` and `Vec::new()`
-// body-replacement defaults plus contract clauses that reference string
-// literals would otherwise produce malformed JSON.
-fn json_escape_str(s: String) -> String {
-    let r: String = String::from("");
-    let n: i64 = s.len();
-    let mut i: i64 = 0;
-    while i < n {
-        let b: i64 = s.byte_at(i);
-        if b == 34 { r.push_byte(92); r.push_byte(34); }
-        else if b == 92 { r.push_byte(92); r.push_byte(92); }
-        else if b == 10 { r.push_byte(92); r.push_byte(110); }
-        else if b == 13 { r.push_byte(92); r.push_byte(114); }
-        else if b == 9  { r.push_byte(92); r.push_byte(116); }
-        else if b == 8  { r.push_byte(92); r.push_byte(98);  }
-        else if b == 12 { r.push_byte(92); r.push_byte(102); }
-        else if b < 32  { r.push_byte(63); }
-        else { r.push_byte(b); }
-        i = i + 1;
-    }
-    r
-}
-
 fn site_to_json(s: Site) -> String {
     let r: String = String::from("{\"name\":\"");
-    r.push_str(json_escape_str(mutant_name(s.file, s.line, s.col, s.label)));
+    r.push_str(diag_json_escape_str(mutant_name(s.file, s.line, s.col, s.label)));
     r.push_str(String::from("\",\"file\":\""));
-    r.push_str(json_escape_str(s.file));
+    r.push_str(diag_json_escape_str(s.file));
     r.push_str(String::from("\",\"line\":"));
     r.push_str(i64_to_string(s.line));
     r.push_str(String::from(",\"col\":"));
@@ -201,13 +176,13 @@ fn site_to_json(s: Site) -> String {
     r.push_str(String::from(",\"len\":"));
     r.push_str(i64_to_string(s.len));
     r.push_str(String::from(",\"kind\":\""));
-    r.push_str(json_escape_str(s.kind));
+    r.push_str(diag_json_escape_str(s.kind));
     r.push_str(String::from("\",\"from\":\""));
-    r.push_str(json_escape_str(s.from_text));
+    r.push_str(diag_json_escape_str(s.from_text));
     r.push_str(String::from("\",\"to\":\""));
-    r.push_str(json_escape_str(s.replacement));
+    r.push_str(diag_json_escape_str(s.replacement));
     r.push_str(String::from("\",\"label\":\""));
-    r.push_str(json_escape_str(s.label));
+    r.push_str(diag_json_escape_str(s.label));
     r.push_str(String::from("\",\"clause_index\":"));
     r.push_str(i64_to_string(s.clause_index));
     r.push_str(String::from("}"));
@@ -387,9 +362,9 @@ fn outcome_record_json(id: i64, s: Site, status: i64, tier: i64, oracle_ms: i64)
     let r: String = String::from("{\"id\":");
     r.push_str(i64_to_string(id));
     r.push_str(String::from(",\"name\":\""));
-    r.push_str(json_escape_str(mutant_name(s.file, s.line, s.col, s.label)));
+    r.push_str(diag_json_escape_str(mutant_name(s.file, s.line, s.col, s.label)));
     r.push_str(String::from("\",\"status\":\""));
-    r.push_str(json_escape_str(status_str(status)));
+    r.push_str(diag_json_escape_str(status_str(status)));
     r.push_str(String::from("\",\"tier\":"));
     r.push_str(i64_to_string(tier));
     r.push_str(String::from(",\"oracle_ms\":"));

--- a/compiler/tests/test_json_escape.vow
+++ b/compiler/tests/test_json_escape.vow
@@ -1,0 +1,49 @@
+module TestJsonEscape
+
+use diag
+
+fn sample_json_string() -> String {
+    let s: String = String::from("");
+    s.push_byte(34);
+    s.push_byte(92);
+    s.push_byte(10);
+    s.push_byte(13);
+    s.push_byte(9);
+    s.push_byte(8);
+    s.push_byte(12);
+    s.push_byte(1);
+    s.push_byte(65);
+    s.push_byte(195);
+    s.push_byte(169);
+    s
+}
+
+fn expected_json_escape() -> String {
+    let s: String = String::from("");
+    s.push_byte(92);
+    s.push_byte(34);
+    s.push_byte(92);
+    s.push_byte(92);
+    s.push_byte(92);
+    s.push_byte(110);
+    s.push_byte(92);
+    s.push_byte(114);
+    s.push_byte(92);
+    s.push_byte(116);
+    s.push_byte(92);
+    s.push_byte(98);
+    s.push_byte(92);
+    s.push_byte(102);
+    s.push_byte(63);
+    s.push_byte(65);
+    s.push_byte(195);
+    s.push_byte(169);
+    s
+}
+
+fn main() -> i32 {
+    let got: String = diag_json_escape_str(sample_json_string());
+    let want: String = expected_json_escape();
+    if got != want { return 1; }
+    0
+}

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -1071,6 +1071,21 @@ else
     fail "complexity/utf8-path-parity" "non-ASCII path JSON diverges between compilers"
 fi
 rm -rf "$utf8dir"
+# JSON named-control escapes in source paths must be byte-identical and must
+# round-trip through a parser. Backspace/form-feed are control bytes that remain
+# shell-log friendly but distinguish `\b`/`\f` from generic `?` escaping.
+escape_dir=$(mktemp -d)
+escape_name=$'quote"backslash\\backspace\bformfeed\f.vow'
+escape_path="$escape_dir/$escape_name"
+cp tests/fixtures/complexity/params_basic.vow "$escape_path"
+rust_escape_json=$("$RUST" complexity "$escape_path" 2>/dev/null)
+self_escape_json=$(run_self complexity "$escape_path" 2>/dev/null)
+if [ "$rust_escape_json" = "$self_escape_json" ] && COMPLEXITY_EXPECT_PATH="$escape_path" python3 -c 'import json, os, sys; d=json.load(sys.stdin); sys.exit(0 if d["files"][0]["file"] == os.environ["COMPLEXITY_EXPECT_PATH"] else 1)' <<< "$rust_escape_json"; then
+    pass "complexity/control-path-parity (quote/backslash/backspace/form-feed round-trip)"
+else
+    fail "complexity/control-path-parity" "escaped control-byte path did not stay byte-identical and round-trip"
+fi
+rm -rf "$escape_dir"
 echo ""
 
 # ─── Section 6: Perfetto Trace (--perfetto, #784) ───────────────────

--- a/tests/mutants/tests.sh
+++ b/tests/mutants/tests.sh
@@ -514,6 +514,56 @@ V
     fi
 }
 
+t27_json_escapes_control_bytes_in_paths() {
+    # Protect JSON escaping for file/name fields beyond the common quote case:
+    # quote, backslash, backspace, and form-feed must parse and round-trip.
+    local escaped_dir=$'json_escape_quote"backslash\\backspace\bformfeed\f'
+    local fix="$TMP/$escaped_dir"
+    mkdir -p "$fix"
+    local escaped_file="$fix/sample.vow"
+    cat > "$escaped_file" <<'V'
+module JsonEscapePath
+
+fn add(a: i64, b: i64) -> i64 { a + b }
+V
+    local out rc list_jsonl
+    list_jsonl="$TMP/t27_list.jsonl"
+    set +e
+    run_vowm list --root "$fix" > "$list_jsonl" 2>&1
+    rc=$?
+    set -e
+    assert_eq "T27: list with JSON-escaped path exits 0" "0" "$rc"
+    if MUTANTS_EXPECT_FILE="$escaped_file" python3 - "$list_jsonl" <<'PY'
+import json
+import os
+import sys
+
+expected = os.environ["MUTANTS_EXPECT_FILE"]
+with open(sys.argv[1], encoding="utf-8") as f:
+    rows = [json.loads(line) for line in f if line.strip()]
+
+mutants = [row for row in rows if "file" in row]
+if not mutants:
+    raise SystemExit("no mutants emitted")
+
+if not any(m.get("file") == expected and expected in m.get("name", "") for m in mutants):
+    raise SystemExit("list JSON did not round-trip escaped file/name")
+
+for m in mutants:
+    for key in ("name", "file", "from", "to", "label"):
+        if not isinstance(m.get(key), str):
+            raise SystemExit(f"mutant field {key} is not a string")
+PY
+    then
+        printf "  ${GREEN}PASS${RESET} T27: list JSON escaped path fields parse and round-trip\n"
+        PASS=$((PASS + 1))
+    else
+        printf "  ${RED}FAIL${RESET} T27: escaped path fields did not parse or round-trip\n    list:\n%s\n" "$(head -c 400 "$list_jsonl" 2>/dev/null)"
+        FAIL=$((FAIL + 1))
+        FAILURES+=("T27")
+    fi
+}
+
 t13_records_carry_line_col_and_name() {
     local out
     set +e
@@ -832,6 +882,7 @@ t23_workdir_with_spaces_is_shell_quoted
 t24_invalid_shard_warns_to_stderr
 t25_body_replace_label_has_no_double_space
 t26_modulo_paired_with_division
+t27_json_escapes_control_bytes_in_paths
 
 echo ""
 if [ "$FAIL" -eq 0 ]; then

--- a/vow/src/complexity.rs
+++ b/vow/src/complexity.rs
@@ -1502,6 +1502,8 @@ fn cx_json_escape(s: &str) -> String {
             '\n' => r.push_str("\\n"),
             '\r' => r.push_str("\\r"),
             '\t' => r.push_str("\\t"),
+            '\x08' => r.push_str("\\b"),
+            '\x0c' => r.push_str("\\f"),
             c if (c as u32) < 32 => r.push('?'),
             c => r.push(c),
         }


### PR DESCRIPTION
Summary
- Make compiler/diag.vow the canonical self-hosted JSON string escaper, including named \b/\f escapes and generic control-byte fallback.
- Route self-hosted complexity and mutants JSON emission through diag_json_escape_str.
- Keep Rust complexity escaping policy-aligned for byte-identical output and add regression coverage for control-byte paths.

Closes #777

Verification
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- scripts/bootstrap.sh --skip-cargo
- build/vowc test compiler/ --filter json_escape
- complexity quote/backslash/backspace/form-feed path parity check: PASS
- VOWC_BIN=build/vowc bash tests/mutants/tests.sh
- scripts/full_test.sh: fails on pre-existing/unrelated checks: Section 6 math/verify reports function abs vs pow for lib/math/main.vow, and Section 13 aborts on tests/fixtures/complexity/contracts.vow with UnusedMut for mut hi. The implicated files are not changed by this branch.

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**