### PR TITLE
fix(test): keep complexity parity loop set-e safe

### DIFF
--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -1017,8 +1017,14 @@ section_begin "Section 13: vow complexity Parity"
 for vow_file in tests/fixtures/complexity/*.vow; do
     [ -f "$vow_file" ] || continue
     name=$(basename "$vow_file" .vow)
-    rust_json=$("$RUST" complexity "$vow_file" 2>/dev/null)
-    self_json=$(run_self complexity "$vow_file" 2>/dev/null)
+    rust_exit=0
+    self_exit=0
+    rust_json=$("$RUST" complexity "$vow_file" 2>/dev/null) || rust_exit=$?
+    self_json=$(run_self complexity "$vow_file" 2>/dev/null) || self_exit=$?
+    if [ "$rust_exit" != "0" ] || [ "$self_exit" != "0" ]; then
+        fail "complexity/${name}" "rust_exit=${rust_exit} self_exit=${self_exit} (expected both 0)"
+        continue
+    fi
     golden="tests/fixtures/complexity/${name}.expected.json"
     if [ "$rust_json" != "$self_json" ]; then
         fail "complexity/${name}" "JSON differs between compilers"

--- a/tests/fixtures/complexity/contracts.vow
+++ b/tests/fixtures/complexity/contracts.vow
@@ -11,7 +11,7 @@ fn bounded(lo: i64, hi: i64) -> i64 vow {
     requires: hi >= lo
 } {
     let mut lo: i64 = lo;
-    let mut hi: i64 = hi;
+    let hi: i64 = hi;
     while lo + 1 < hi vow {
         invariant: hi - lo >= 0
     } {


### PR DESCRIPTION
## Summary
- capture Section 13 complexity command exits explicitly so set -e does not abort the full_test.sh run before Summary
- remove the stale unused mut from tests/fixtures/complexity/contracts.vow so the fixture remains a valid complexity golden input
- confirmed the contracts complexity JSON remains byte-identical to the existing golden and between Rust/self-hosted compilers

Closes #790

## Testing
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test --all
- ./target/release/vow complexity tests/fixtures/complexity/contracts.vow (matches contracts.expected.json)
- temporary self-hosted vowc complexity tests/fixtures/complexity/contracts.vow (matches Rust output)
- scripts/full_test.sh (reaches Summary; complexity/contracts passes; exits 1 only because pre-existing math/verify parity mismatch remains: Rust reports abs, self-hosted reports pow)

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**