### PR TITLE
test(verify): lock libc-named user function modelability

### DIFF
--- a/vow-verify/src/c_emitter.rs
+++ b/vow-verify/src/c_emitter.rs
@@ -2596,6 +2596,40 @@ mod tests {
     }
 
     #[test]
+    fn libc_named_user_function_is_modelable() {
+        // A user function named like a libc/ESBMC stdlib symbol (`abs`) must
+        // still be modeled: it is emitted under a mangled `vow_user_fn_<id>`
+        // name, so it cannot collide with ESBMC's C stdlib model. Regression
+        // test for the `verify/libc_name_collision` verifier-eval fixture.
+        let func = make_func(
+            "abs",
+            vec![Ty::I64],
+            Ty::I64,
+            vec![
+                inst(0, Opcode::GetArg, Ty::I64, vec![], InstData::ArgIndex(0)),
+                inst(1, Opcode::Return, Ty::Unit, vec![0], InstData::None),
+            ],
+        );
+        let module = Module {
+            name: "test".to_string(),
+            functions: vec![func.clone()],
+            strings: vec![],
+            struct_layouts: vec![],
+            enum_layouts: vec![],
+            warnings: vec![],
+        };
+        assert_eq!(
+            non_modelable_reason(&func, &module, &HashMap::new()),
+            None,
+            "a libc-named user function should be modelable, not skipped as reserved"
+        );
+        // The genuine ESBMC/verifier intrinsic namespaces remain reserved.
+        assert!(is_reserved_verifier_symbol("__VERIFIER_nondet_int"));
+        assert!(is_reserved_verifier_symbol("__ESBMC_assume"));
+        assert!(!is_reserved_verifier_symbol("abs"));
+    }
+
+    #[test]
     fn emit_string_matches_literal_at_uses_static_bytes() {
         let func = Function {
             id: FuncId(0),


### PR DESCRIPTION
## Summary

> **Scope changed after rebase.** The source fix for the `verify/libc_name_collision` regression (stop reserving user functions named `abs`) landed on `main` independently in `2bf87f59` (part of #804) while this PR was in flight. After rebasing onto `main`, the duplicate source change collapses away and **this PR now adds only a unit-level regression test.**

`2bf87f59` dropped the `abs` clause in `is_reserved_verifier_symbol` (both compilers) but added no unit test, relying on the `tests/verify/libc_name_collision.vow` verifier-eval fixture to lock the behavior end-to-end.

This adds a focused unit test (`libc_named_user_function_is_modelable`) asserting:
- `non_modelable_reason` returns `None` for a libc-named pure function (`abs`) — i.e. it is modeled, not skipped;
- the genuine `__VERIFIER_*` / `__ESBMC_*` intrinsic namespaces remain reserved.

This locks the gating logic at the unit level (fast, no ESBMC) in addition to the e2e fixture.

## Validation
- `cargo test -p vow-verify`: passes, adds `libc_named_user_function_is_modelable`
- Net diff vs `main`: +34 lines in `vow-verify/src/c_emitter.rs` (test only)

**Merge with `gh pr merge --merge` (merge commit, not squash) per CLAUDE.md.**
