### PR TITLE
fix(cli): command-specific missing-source error + document complexity in --help --human

### DIFF
--- a/compiler/complexity_main.vow
+++ b/compiler/complexity_main.vow
@@ -202,7 +202,7 @@ fn run_complexity(argv: Vec<String>) -> i32 [io] {
     let mut thr: i64 = 80;
     if max_score >= 0 { thr = max_score; }
 
-    let path: String = frontend_path_from_argv(argv, true);
+    let path: String = frontend_path_from_argv(argv, true, String::from("complexity"));
     let fr: LoweredFrontend = frontend_lower_path(path);
     let checked: CheckedFrontend = fr.checked;
     let dctx: DiagCtx = checked.dctx;

--- a/compiler/main.vow
+++ b/compiler/main.vow
@@ -174,7 +174,7 @@ fn get_subcommand(argv: Vec<String>) -> i64 {
     CMD_NONE()
 }
 
-fn frontend_path_from_argv(argv: Vec<String>, sub: bool) -> String [io] {
+fn frontend_path_from_argv(argv: Vec<String>, sub: bool, cmd: String) -> String [io] {
     let path: String = {
         if sub {
             get_source_path_sub(argv)
@@ -183,7 +183,7 @@ fn frontend_path_from_argv(argv: Vec<String>, sub: bool) -> String [io] {
         }
     };
     if path.len() == 0 {
-        eprintln_str("usage: vowc <command> [options] <file.vow>");
+        eprintln_str(str3(String::from("vow "), cmd, String::from(": source file required (try --help)")));
         process_exit(1);
     }
     path
@@ -1311,7 +1311,7 @@ fn verify_collect_and_report(
 }
 
 fn run_verify(argv: Vec<String>) -> i32 [io] {
-    let path: String = frontend_path_from_argv(argv, true);
+    let path: String = frontend_path_from_argv(argv, true, String::from("verify"));
     let tctx: TraceCtx = {
         if has_flag(argv, "--perfetto") { trace_new(get_flag_arg(argv, "--perfetto")) }
         else { trace_off() }
@@ -1497,7 +1497,7 @@ fn build_codegen_phase(ir_mod: IrModule, out: String, mode: i64, trace: i64, dct
 }
 
 fn run_build(argv: Vec<String>) -> i32 [io] {
-    let path: String = frontend_path_from_argv(argv, true);
+    let path: String = frontend_path_from_argv(argv, true, String::from("build"));
     let tctx: TraceCtx = {
         if has_flag(argv, "--perfetto") { trace_new(get_flag_arg(argv, "--perfetto")) }
         else { trace_off() }
@@ -3185,6 +3185,7 @@ fn skill_human() -> String {
     r.push_str(String::from("  vow verify [OPTIONS] <source.vow>    Verify contracts only (no executable)\n"));
     r.push_str(String::from("  vow test [OPTIONS] [<path>]          Run tests with JSON results\n"));
     r.push_str(String::from("  vow contracts [OPTIONS] <source.vow> List all contracts\n"));
+    r.push_str(String::from("  vow complexity [OPTIONS] <source.vow> Report per-function complexity metrics (JSON)\n"));
     r.push_str(String::from("  vow decl [OPTIONS] <source.vow>    Emit declaration file (.vow.d)\n"));
     r.push_str(String::from("  vow skill [print [--bundle]|install [--local|--global]]\n"));
     r.push_str(String::from("                                        Generate or install Claude Code skill\n"));
@@ -3231,6 +3232,13 @@ fn skill_human() -> String {
     r.push_str(String::from("  --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver (with --verify)\n"));
     r.push_str(String::from("  --encoding <bv|ir|auto>  ESBMC encoding mode (with --verify); ir requires z3 (default: auto)\n"));
     r.push_str(String::from("  --verify-jobs <N>       Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)\n"));
+    r.push_str(String::from("\n"));
+    r.push_str(String::from("COMPLEXITY OPTIONS\n"));
+    r.push_str(String::from("  --cog-anchor <N>        Cognitive-complexity value mapped to sub-score 0.800 (SonarQube's default flag line). (default: 15)\n"));
+    r.push_str(String::from("  --nloc-anchor <N>       NLOC value mapped to sub-score 0.800 (~50–60 line guidance). (default: 60)\n"));
+    r.push_str(String::from("  --max-score <N>         CI gate: exit nonzero if any function's complexity_score exceeds N. The recommended line is 80, but gating is opt-in only. (default: (unset))\n"));
+    r.push_str(String::from("  --max-cognitive <N>     CI gate: exit nonzero if any function's cognitive exceeds N. (default: (unset))\n"));
+    r.push_str(String::from("  --max-cyclomatic <N>    CI gate: exit nonzero if any function's cyclomatic exceeds N. (default: (unset))\n"));
     r.push_str(String::from("\n"));
     r.push_str(String::from("DECL OPTIONS\n"));
     r.push_str(String::from("  -o, --output <path>     Output declaration file path (default: <source>.vow.d)\n"));
@@ -12753,7 +12761,7 @@ fn cq_classify(kind: String, desc: String) -> String {
 }
 
 fn run_contracts(argv: Vec<String>) -> i32 [io] {
-    let path: String = frontend_path_from_argv(argv, true);
+    let path: String = frontend_path_from_argv(argv, true, String::from("contracts"));
     let fr: LoweredFrontend = frontend_lower_path(path);
     let checked: CheckedFrontend = fr.checked;
     let dctx: DiagCtx = checked.dctx;
@@ -13077,7 +13085,7 @@ fn main() -> i32 [io, read, write] {
         return 0;
     }
     if argv.len() <= 1 {
-        eprintln_str("usage: vowc <command> [options] <file.vow>");
+        eprintln_str("vow: source file required (try --help or use a subcommand)");
         return 1;
     }
     let cmd: i64 = get_subcommand(argv);

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -1216,6 +1216,20 @@ if [ "$r_nosrc" != "0" ] && [ "$s_nosrc" != "0" ] \
 else
     fail "complexity/no-source-message" "rust=$r_nosrc self=$s_nosrc (expected nonzero + 'vow complexity: source file required')"
 fi
+# The same per-command message must hold for the other three subcommands this PR
+# fixed through the shared frontend_path_from_argv change, so a regression in any
+# of them is caught — not just complexity.
+for subcmd in build verify contracts; do
+    r_sub=0; "$RUST" "$subcmd" >/dev/null 2>"$TMPDIR/r_${subcmd}_nosrc.err" || r_sub=$?
+    s_sub=0; run_self "$subcmd" >/dev/null 2>"$TMPDIR/s_${subcmd}_nosrc.err" || s_sub=$?
+    if [ "$r_sub" != "0" ] && [ "$s_sub" != "0" ] \
+       && grep -q "vow ${subcmd}: source file required" "$TMPDIR/r_${subcmd}_nosrc.err" \
+       && grep -q "vow ${subcmd}: source file required" "$TMPDIR/s_${subcmd}_nosrc.err"; then
+        pass "${subcmd}/no-source-message (command-specific, both nonzero)"
+    else
+        fail "${subcmd}/no-source-message" "rust=$r_sub self=$s_sub (expected nonzero + 'vow ${subcmd}: source file required')"
+    fi
+done
 # `--help --human` must document the complexity command in BOTH compilers. The JSON
 # --help always listed it; the legacy human help previously omitted it.
 if "$RUST" --help --human 2>/dev/null | grep -q "vow complexity \[OPTIONS\]" \

--- a/scripts/full_test.sh
+++ b/scripts/full_test.sh
@@ -1204,6 +1204,26 @@ else
     fail "complexity/control-path-parity" "escaped control-byte path did not stay byte-identical and round-trip"
 fi
 rm -rf "$escape_dir"
+# Missing source file must produce a command-specific error in BOTH compilers and
+# exit nonzero. Regression: the self-hosted compiler previously printed a generic
+# `usage: vowc <command> ...` line for every subcommand (confusing `vow complexity` UX).
+r_nosrc=0; "$RUST" complexity >/dev/null 2>"$TMPDIR/r_nosrc.err" || r_nosrc=$?
+s_nosrc=0; run_self complexity >/dev/null 2>"$TMPDIR/s_nosrc.err" || s_nosrc=$?
+if [ "$r_nosrc" != "0" ] && [ "$s_nosrc" != "0" ] \
+   && grep -q "vow complexity: source file required" "$TMPDIR/r_nosrc.err" \
+   && grep -q "vow complexity: source file required" "$TMPDIR/s_nosrc.err"; then
+    pass "complexity/no-source-message (command-specific, both nonzero)"
+else
+    fail "complexity/no-source-message" "rust=$r_nosrc self=$s_nosrc (expected nonzero + 'vow complexity: source file required')"
+fi
+# `--help --human` must document the complexity command in BOTH compilers. The JSON
+# --help always listed it; the legacy human help previously omitted it.
+if "$RUST" --help --human 2>/dev/null | grep -q "vow complexity \[OPTIONS\]" \
+   && run_self --help --human 2>/dev/null | grep -q "vow complexity \[OPTIONS\]"; then
+    pass "complexity/human-help-documented (both compilers)"
+else
+    fail "complexity/human-help-documented" "vow complexity missing from --help --human"
+fi
 echo ""
 
 # ─── Section 6: Perfetto Trace (--perfetto, #784) ───────────────────

--- a/scripts/generate_help.py
+++ b/scripts/generate_help.py
@@ -652,6 +652,7 @@ def build_help_human(data: dict) -> str:
     lines.append("  vow verify [OPTIONS] <source.vow>    Verify contracts only (no executable)")
     lines.append("  vow test [OPTIONS] [<path>]          Run tests with JSON results")
     lines.append("  vow contracts [OPTIONS] <source.vow> List all contracts")
+    lines.append("  vow complexity [OPTIONS] <source.vow> Report per-function complexity metrics (JSON)")
     lines.append("  vow decl [OPTIONS] <source.vow>    Emit declaration file (.vow.d)")
     lines.append("  vow skill [print [--bundle]|install [--local|--global]]")
     lines.append("                                        Generate or install Claude Code skill")
@@ -682,6 +683,13 @@ def build_help_human(data: dict) -> str:
         pad = max(24, len(flag) + 2)
         lines.append(f"  {flag:<{pad}s}{desc}")
     lines.append("")
+
+    if data.get("complexity_options"):
+        lines.append("COMPLEXITY OPTIONS")
+        for flag, desc in data["complexity_options"].items():
+            pad = max(24, len(flag) + 2)
+            lines.append(f"  {flag:<{pad}s}{desc}")
+        lines.append("")
 
     if data.get("decl_options"):
         lines.append("DECL OPTIONS")

--- a/vow/src/main.rs
+++ b/vow/src/main.rs
@@ -1326,6 +1326,7 @@ USAGE
   vow verify [OPTIONS] <source.vow>    Verify contracts only (no executable)
   vow test [OPTIONS] [<path>]          Run tests with JSON results
   vow contracts [OPTIONS] <source.vow> List all contracts
+  vow complexity [OPTIONS] <source.vow> Report per-function complexity metrics (JSON)
   vow decl [OPTIONS] <source.vow>    Emit declaration file (.vow.d)
   vow skill [print [--bundle]|install [--local|--global]]
                                         Generate or install Claude Code skill
@@ -1372,6 +1373,13 @@ CONTRACTS OPTIONS
   --solver <boolector|z3|bitwuzla|auto>  ESBMC SMT solver (with --verify)
   --encoding <bv|ir|auto>  ESBMC encoding mode (with --verify); ir requires z3 (default: auto)
   --verify-jobs <N>       Accepted for CLI parity with build/verify/test; currently a no-op (the contracts verifier is serial)
+
+COMPLEXITY OPTIONS
+  --cog-anchor <N>        Cognitive-complexity value mapped to sub-score 0.800 (SonarQube's default flag line). (default: 15)
+  --nloc-anchor <N>       NLOC value mapped to sub-score 0.800 (~50–60 line guidance). (default: 60)
+  --max-score <N>         CI gate: exit nonzero if any function's complexity_score exceeds N. The recommended line is 80, but gating is opt-in only. (default: (unset))
+  --max-cognitive <N>     CI gate: exit nonzero if any function's cognitive exceeds N. (default: (unset))
+  --max-cyclomatic <N>    CI gate: exit nonzero if any function's cyclomatic exceeds N. (default: (unset))
 
 DECL OPTIONS
   -o, --output <path>     Output declaration file path (default: <source>.vow.d)


### PR DESCRIPTION
## Problem

Reported confusion using `vow complexity`:

1. **Generic, wrong-named usage on missing source.** `vow complexity` (no file)
   printed `usage: vowc <command> [options] <file.vow>` — generic across every
   subcommand, and naming `vowc` even when invoked as `vow`. (On a typical
   install `vow` is a symlink to the self-hosted `vowc`, so users hit the
   self-hosted message under both names.) The Rust compiler already printed a
   per-command message; the self-hosted compiler had drifted.

2. **`--human` help omitted `complexity`.** `vow --help` (JSON) documented the
   command, but `vow --help --human` had no `complexity` USAGE line and no
   options section.

## Changes

- **`compiler/main.vow` / `compiler/complexity_main.vow`**: `frontend_path_from_argv`
  takes the command name and emits `vow <cmd>: source file required (try --help)`
  for `build`/`verify`/`contracts`/`complexity`, matching the Rust reference. Bare
  `vow` now prints `vow: source file required (try --help or use a subcommand)`.
- **`scripts/generate_help.py`**: add `vow complexity` to the human USAGE block and
  a `COMPLEXITY OPTIONS` section (`--cog-anchor`, `--nloc-anchor`, `--max-score`,
  `--max-cognitive`, `--max-cyclomatic`). Regenerated into both compilers
  (`vow/src/main.rs`, `compiler/main.vow`).
- **`scripts/full_test.sh`**: regression coverage in Section 13 — command-specific
  missing-source message and human-help documentation, asserted on both compilers.

No language/semantics change; CLI ergonomics only. JSON `--help` is unchanged
(complexity was already present) and stays byte-identical across compilers.

## Verification

- Bootstrap fixed point **MATCH** (`sha256(vowc2) == sha256(vowc3)`) → the self-hosted binary is verified
- `cargo test -p vow`: 147 passed, 0 failed (+ all integration binaries)
- `check_help_coverage.py` passes for both compilers; `generate_help.py --check` clean (skills in sync)
- complexity parity: 14 fixtures byte-identical + matching exit codes; new regression assertions green
- Confirmed on the rebuilt self-hosted binary: per-command messages, `--help --human` lists complexity, complexity report still works
